### PR TITLE
Allow to authenticate with non-URL ServerAddress

### DIFF
--- a/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
@@ -18,13 +18,12 @@ package dockerconfigresolver
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
-	"net/url"
 
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	dockercliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/credentials"
 	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -141,14 +140,7 @@ func NewAuthCreds(refHostname string) (AuthCreds, error) {
 					logrus.Warnf("failed to get ac.ServerAddress for authConfigHostname=%q (refHostname=%q)",
 						authConfigHostname, refHostname)
 				} else {
-					acsaURL, err := url.Parse(ac.ServerAddress)
-					if err != nil {
-						return nil, errors.Wrapf(err, "failed to parse ac.ServerAddress %q", ac.ServerAddress)
-					}
-					acsaHostname := acsaURL.Hostname()
-					if acsaPort := acsaURL.Port(); acsaPort != "" {
-						acsaHostname = net.JoinHostPort(acsaHostname, acsaPort)
-					}
+					acsaHostname := credentials.ConvertToHostname(ac.ServerAddress)
 					if acsaHostname != authConfigHostname {
 						return nil, errors.Errorf("expected the hostname part of ac.ServerAddress (%q) to be authConfigHostname=%q, got %q",
 							ac.ServerAddress, authConfigHostname, acsaHostname)


### PR DESCRIPTION
Fixes: #121

Though `dockerconfigresolver` currently allows ServerAddress only to be URL, `docker/config.json` accepts non-URL ServerAddress that doesn't contain scheme (http://, https://). This results in nerdctl cannot authenticate to the registry using dockerconfig that contains non-URL ServerAddress.

This commit solves this issue by using `credentials.ConvertToHostname` of `github.com/docker/cli` instead of `net/url` pkg.

cc @AkihiroSuda 