### PR TITLE
AkihiroSuda/containerd-fuse-overlayfs -> containerd/fuse-overlayfs-snapshotter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ ARG ROOTLESSKIT_VERSION=0.14.0
 ARG SLIRP4NETNS_VERSION=1.1.9
 # Extra deps: FUSE-OverlayFS
 ARG FUSE_OVERLAYFS_VERSION=1.4.0
-ARG CONTAINERD_FUSE_OVERLAYFS_VERSION=1.0.1
+ARG CONTAINERD_FUSE_OVERLAYFS_VERSION=1.0.2
 
 # Test deps
 ARG GO_VERSION=1.16
@@ -104,7 +104,7 @@ RUN curl -L -o /out/bin/fuse-overlayfs https://github.com/containers/fuse-overla
   chmod +x /out/bin/fuse-overlayfs && \
   echo "- fuse-overlayfs: v${FUSE_OVERLAYFS_VERSION}" >> /out/share/doc/nerdctl-full/README.md
 ARG CONTAINERD_FUSE_OVERLAYFS_VERSION
-RUN curl -L https://github.com/AkihiroSuda/containerd-fuse-overlayfs/releases/download/v${CONTAINERD_FUSE_OVERLAYFS_VERSION}/containerd-fuse-overlayfs-${CONTAINERD_FUSE_OVERLAYFS_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz | tar xzvC /out/bin && \
+RUN curl -L https://github.com/containerd/fuse-overlayfs-snapshotter/releases/download/v${CONTAINERD_FUSE_OVERLAYFS_VERSION}/containerd-fuse-overlayfs-${CONTAINERD_FUSE_OVERLAYFS_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz | tar xzvC /out/bin && \
   echo "- containerd-fuse-overlayfs: v${CONTAINERD_FUSE_OVERLAYFS_VERSION}" >> /out/share/doc/nerdctl-full/README.md
 RUN echo "" >> /out/share/doc/nerdctl-full/README.md && \
   echo "## License" >> /out/share/doc/nerdctl-full/README.md && \

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,8 +54,8 @@ Vagrant.configure("2") do |config|
     curl -sSL https://github.com/rootless-containers/rootlesskit/releases/download/v${ROOTLESSKIT_VERSION}/rootlesskit-$(uname -m).tar.gz | tar Cxzv /usr/local/bin
 
     # Install containerd-fuse-overlayfs (TODO: remove this after release of Fedora 34)
-    CONTAINERD_FUSE_OVERLAYFS_VERSION=1.0.1
-    curl -sSL https://github.com/AkihiroSuda/containerd-fuse-overlayfs/releases/download/v${CONTAINERD_FUSE_OVERLAYFS_VERSION}/containerd-fuse-overlayfs-${CONTAINERD_FUSE_OVERLAYFS_VERSION}-linux-${GOARCH}.tar.gz | tar Cxzv /usr/local/bin
+    CONTAINERD_FUSE_OVERLAYFS_VERSION=1.0.2
+    curl -sSL https://github.com/containerd/fuse-overlayfs-snapshotter/releases/download/v${CONTAINERD_FUSE_OVERLAYFS_VERSION}/containerd-fuse-overlayfs-${CONTAINERD_FUSE_OVERLAYFS_VERSION}-linux-${GOARCH}.tar.gz | tar Cxzv /usr/local/bin
     mkdir -p /home/vagrant/.config/containerd
     cat <<EOF >/home/vagrant/.config/containerd/config.toml
 [proxy_plugins]

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -51,7 +51,7 @@ The `overlayfs` snapshotter only works on the following hosts:
 - Ubuntu since 2015
 - Debian since 10
 
-For other hosts, [`fuse-overlayfs` snapshotter](https://github.com/AkihiroSuda/containerd-fuse-overlayfs) needs to be used instead.
+For other hosts, [`fuse-overlayfs` snapshotter](https://github.com/containerd/fuse-overlayfs-snapshotter) needs to be used instead.
 
 To enable `fuse-overlayfs` snapshotter, run the following command:
 ```console

--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -274,7 +274,7 @@ cmd_entrypoint_install_buildkit() {
 cmd_entrypoint_install_fuse_overlayfs() {
 	init
 	if ! command -v "containerd-fuse-overlayfs-grpc" >/dev/null 2>&1; then
-		ERROR "containerd-fuse-overlayfs-grpc (https://github.com/AkihiroSuda/containerd-fuse-overlayfs) needs to be present under \$PATH"
+		ERROR "containerd-fuse-overlayfs-grpc (https://github.com/containerd/fuse-overlayfs-snapshotter) needs to be present under \$PATH"
 		exit 1
 	fi
 	if ! command -v "fuse-overlayfs" >/dev/null 2>&1; then

--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -277,7 +277,7 @@ cmd_entrypoint_install_fuse_overlayfs() {
 		ERROR "containerd-fuse-overlayfs-grpc (https://github.com/AkihiroSuda/containerd-fuse-overlayfs) needs to be present under \$PATH"
 		exit 1
 	fi
-	if ! command -v "containerd-fuse-overlayfs-grpc" >/dev/null 2>&1; then
+	if ! command -v "fuse-overlayfs" >/dev/null 2>&1; then
 		ERROR "fuse-overlayfs (https://github.com/containers/fuse-overlayfs) needs to be present under \$PATH"
 		exit 1
 	fi


### PR DESCRIPTION
`github.com/AkihiroSuda/containerd-fuse-overlayfs` was moved to https://github.com/containerd/fuse-overlayfs-snapshotter along with nerdctl.