### PR TITLE
completion: filter containers by their ProcessStatus

### DIFF
--- a/commit.go
+++ b/commit.go
@@ -111,5 +111,5 @@ func commitBashComplete(clicontext *cli.Context) {
 		return
 	}
 	// show container names
-	bashCompleteContainerNames(clicontext)
+	bashCompleteContainerNames(clicontext, nil)
 }

--- a/container_inspect.go
+++ b/container_inspect.go
@@ -132,5 +132,5 @@ func containerInspectBashComplete(clicontext *cli.Context) {
 		return
 	}
 	// show container names
-	bashCompleteContainerNames(clicontext)
+	bashCompleteContainerNames(clicontext, nil)
 }

--- a/exec.go
+++ b/exec.go
@@ -249,6 +249,9 @@ func execBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names
-	bashCompleteContainerNames(clicontext)
+	// show running container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st == containerd.Running
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }

--- a/kill.go
+++ b/kill.go
@@ -134,6 +134,9 @@ func killBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names (TODO: filter already stopped containers)
-	bashCompleteContainerNames(clicontext)
+	// show non-stopped container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st != containerd.Stopped && st != containerd.Created && st != containerd.Unknown
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }

--- a/logs.go
+++ b/logs.go
@@ -119,7 +119,7 @@ func logsBashComplete(clicontext *cli.Context) {
 		return
 	}
 	// show container names (TODO: only show containers with logs)
-	bashCompleteContainerNames(clicontext)
+	bashCompleteContainerNames(clicontext, nil)
 }
 
 func newTailReader(ctx context.Context, task containerd.Task, filePath string) (io.Reader, error) {

--- a/pause.go
+++ b/pause.go
@@ -100,6 +100,9 @@ func pauseBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names (TODO: filter already paused containers)
-	bashCompleteContainerNames(clicontext)
+	// show running container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st == containerd.Running
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }

--- a/port.go
+++ b/port.go
@@ -128,5 +128,5 @@ func portBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	bashCompleteContainerNames(clicontext)
+	bashCompleteContainerNames(clicontext, nil)
 }

--- a/rm.go
+++ b/rm.go
@@ -200,5 +200,5 @@ func rmBashComplete(clicontext *cli.Context) {
 		return
 	}
 	// show container names
-	bashCompleteContainerNames(clicontext)
+	bashCompleteContainerNames(clicontext, nil)
 }

--- a/start.go
+++ b/start.go
@@ -105,6 +105,9 @@ func startBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names (TODO: filter already running containers)
-	bashCompleteContainerNames(clicontext)
+	// show non-running container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st != containerd.Running && st != containerd.Unknown
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }

--- a/stop.go
+++ b/stop.go
@@ -185,6 +185,9 @@ func stopBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names (TODO: filter already stopped containers)
-	bashCompleteContainerNames(clicontext)
+	// show non-stopped container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st != containerd.Stopped && st != containerd.Created && st != containerd.Unknown
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }

--- a/unpause.go
+++ b/unpause.go
@@ -98,6 +98,9 @@ func unpauseBashComplete(clicontext *cli.Context) {
 		defaultBashComplete(clicontext)
 		return
 	}
-	// show container names (TODO: filter already unpaused containers)
-	bashCompleteContainerNames(clicontext)
+	// show paused container names
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st == containerd.Paused
+	}
+	bashCompleteContainerNames(clicontext, statusFilterFn)
 }


### PR DESCRIPTION
e.g., hide non-running containers from `nerdctl exec <TAB>`
