### PR TITLE
testutil: stop using mirror.gcr.io

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -273,10 +273,10 @@ func NewBase(t *testing.T) *Base {
 	return base
 }
 
-// use GCR mirror to avoid hitting Docker Hub rate limit
+// TODO: do not use Docker Hub nor GCR mirror: https://github.com/containerd/nerdctl/issues/146
 const (
-	AlpineImage                 = "mirror.gcr.io/library/alpine:3.13"
-	NginxAlpineImage            = "mirror.gcr.io/library/nginx:1.19-alpine"
+	AlpineImage                 = "alpine:3.13"
+	NginxAlpineImage            = "nginx:1.19-alpine"
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"
-	RegistryImage               = "mirror.gcr.io/library/registry:2"
+	RegistryImage               = "registry:2"
 )


### PR DESCRIPTION
mirror.gcr.io seems unstable, so Docker Hub seems still better, though it has tight rate limits at least on macOS instances as far as we know.

Workaround for #146
