### PR TITLE
prevent drop of the default capabilities when --cap-add used

### DIFF
--- a/run_security.go
+++ b/run_security.go
@@ -102,7 +102,7 @@ func generateCapOpts(capAdd, capDrop []string) ([]oci.SpecOpts, error) {
 		for _, c := range capAdd {
 			capsAdd = append(capsAdd, "CAP_"+strings.ToUpper(c))
 		}
-		opts = append(opts, oci.WithCapabilities(capsAdd))
+		opts = append(opts, oci.WithAddedCapabilities(capsAdd))
 	}
 
 	if !strutil.InStringSlice(capDrop, "ALL") {


### PR DESCRIPTION
Current release of `nerdctl` drops default capabilities set when `--cap-add` argument used.