### PR TITLE
Support anonymous volumes (`nerdctl run -v /foo` and Dockerfile `VOLUME /foo`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,8 +463,9 @@ Usage: `nerdctl rm [OPTIONS] CONTAINER [CONTAINER...]`
 
 Flags:
 - :whale: `-f, --force`: Force the removal of a running|paused|unknown container (uses SIGKILL)
+- :whale: `-v, --volumes`: Remove anonymous volumes associated with the container
 
-Unimplemented `docker rm` flags: `--link`, `--volumes`
+Unimplemented `docker rm` flags: `--link`
 
 ### :whale: nerdctl stop
 Stop one or more running containers.

--- a/exec.go
+++ b/exec.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/pkg/cap"
+	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containerd/nerdctl/pkg/taskutil"
@@ -151,7 +152,7 @@ func execActionWithContainer(ctx context.Context, clicontext *cli.Context, conta
 	}
 	ioCreator = cio.NewCreator(cioOpts...)
 
-	execID := "exec-" + genID()
+	execID := "exec-" + idgen.GenerateID()
 	process, err := task.Exec(ctx, execID, pspec, ioCreator)
 	if err != nil {
 		return err

--- a/pkg/idgen/idgen.go
+++ b/pkg/idgen/idgen.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package idgen
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+)
+
+const IDLength = 64
+
+func GenerateID() string {
+	bytesLength := IDLength / 2
+	b := make([]byte, bytesLength)
+	n, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	if n != bytesLength {
+		panic(errors.Errorf("expected %d bytes, got %d bytes", bytesLength, n))
+	}
+	return hex.EncodeToString(b)
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -44,4 +44,7 @@ const (
 
 	// LogURI is the log URI
 	LogURI = Prefix + "log-uri"
+
+	// AnonymousVolumes is a JSON-marshalled string of []string
+	AnonymousVolumes = Prefix + "anonymous-volumes"
 )


### PR DESCRIPTION
Anonymous volumes are deleted on container deletion if `nerdctl run` is invoked with `--rm`.

However, anonymous volumes are NOT deleted on invocation of `nerdctl rm`, unless `--volumes` is specified.

Fix #67
