### PR TITLE
compose: implement config and secret objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ Others:
 - - -
 
 # Additional documents
+- [`./docs/compose.md`](./docs/compose.md):   Compose
 - [`./docs/dir.md`](./docs/dir.md):           Directory layout (`/var/lib/nerdctl`)
 - [`./docs/registry.md`](./docs/registry.md): Registry authentication (`~/.docker/config.json`)
 - [`./docs/rootless.md`](./docs/rootless.md): Rootless mode

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,0 +1,45 @@
+# nerdctl compose
+
+## Usage
+
+The `nerdctl compose` CLI is designed to be compatible with `docker-compose`.
+
+```console
+$ nerdctl compose up -d
+$ nerdctl compose down
+```
+
+See the Command Reference in [`../README.md`](../README.md).
+
+## Spec conformance
+
+`nerdctl compose` implements [The Compose Specification](https://github.com/compose-spec/compose-spec),
+which was derived from [Docker Compose file version 3 specification](https://docs.docker.com/compose/compose-file/compose-file-v3/).
+
+### Unimplemented YAML fields
+- Fields that correspond to unimplemented `docker run` flags, e.g., `services.<SERVICE>.links` (corresponds to `docker run --link`)
+- `services.<SERVICE>.build`
+- `services.<SERVICE>.credential_spec`
+- `services.<SERVICE>.deploy.update_config`
+- `services.<SERVICE>.deploy.rollback_config`
+- `services.<SERVICE>.deploy.resources.reservations`
+- `services.<SERVICE>.deploy.placement`
+- `services.<SERVICE>.deploy.endpoint_mode`
+- `services.<SERVICE>.healthcheck`
+- `services.<SERVICE>.profiles`
+- `services.<SERVICE>.stop_grace_period`
+- `services.<SERVICE>.stop_signal`
+- `configs.<CONFIG>.external`
+- `secrets.<SECRET>.external`
+
+### Incompatibility
+#### `services.<SERVICE>.entrypoint`
+- Multiple entrypoint strings cannot be specified.
+
+#### `services.<SERVICE>.networks`
+- Multiple networks cannot be specified.
+
+#### `services.<SERVICE>.secrets`, `services.<SERVICE>.configs`
+- `uid`, `gid`: Cannot be specified. The default value is not propagated from `USER` instruction of Dockerfile.
+  The file owner corresponds to the original file on the host.
+- `mode`: Cannot be specified. The file is mounted as read-only, with permission bits that correspond to the original file on the host.

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -26,6 +26,7 @@ import (
 	compose "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/nerdctl/pkg/composer/projectloader"
+	"github.com/containerd/nerdctl/pkg/reflectutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -74,6 +75,18 @@ func New(o Options) (*Composer, error) {
 		projectJSON, _ := json.MarshalIndent(project, "", "    ")
 		logrus.Debug("printing project JSON")
 		logrus.Debugf("%s", projectJSON)
+	}
+
+	if unknown := reflectutil.UnknownNonEmptyFields(project,
+		"Name",
+		"WorkingDir",
+		"Services",
+		"Networks",
+		"Volumes",
+		"Secrets",
+		"Configs",
+		"ComposeFiles"); len(unknown) > 0 {
+		logrus.Warnf("Ignoring: %+v", unknown)
 	}
 
 	c := &Composer{

--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -21,7 +21,6 @@ import (
 
 	compose "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
-	"github.com/containerd/nerdctl/pkg/reflectutil"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -31,10 +30,6 @@ type DownOptions struct {
 }
 
 func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
-	if unknown := reflectutil.UnknownNonEmptyFields(c.project, "Name", "WorkingDir", "Services", "Networks", "Volumes", "ComposeFiles"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: %+v", unknown)
-	}
-
 	for _, svc := range c.project.Services {
 		if err := c.downService(ctx, svc, downOptions.RemoveVolumes); err != nil {
 			return err

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -18,10 +18,12 @@ package composer
 
 import (
 	"context"
+	"os"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,10 +32,6 @@ type UpOptions struct {
 }
 
 func (c *Composer) Up(ctx context.Context, uo UpOptions) error {
-	if unknown := reflectutil.UnknownNonEmptyFields(c.project, "Name", "WorkingDir", "Services", "Networks", "Volumes", "ComposeFiles"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: %+v", unknown)
-	}
-
 	for shortName := range c.project.Networks {
 		if err := c.upNetwork(ctx, shortName); err != nil {
 			return err
@@ -42,6 +40,20 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions) error {
 
 	for shortName := range c.project.Volumes {
 		if err := c.upVolume(ctx, shortName); err != nil {
+			return err
+		}
+	}
+
+	for shortName, secret := range c.project.Secrets {
+		obj := types.FileObjectConfig(secret)
+		if err := validateFileObjectConfig(obj, shortName, "service", c.project); err != nil {
+			return err
+		}
+	}
+
+	for shortName, config := range c.project.Configs {
+		obj := types.FileObjectConfig(config)
+		if err := validateFileObjectConfig(obj, shortName, "config", c.project); err != nil {
 			return err
 		}
 	}
@@ -60,4 +72,21 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions) error {
 	}
 
 	return c.upServices(ctx, parsedServices, uo)
+}
+
+func validateFileObjectConfig(obj types.FileObjectConfig, shortName, objType string, project *types.Project) error {
+	if unknown := reflectutil.UnknownNonEmptyFields(&obj, "Name", "External", "File"); len(unknown) > 0 {
+		logrus.Warnf("Ignoring: %s %s: %+v", objType, shortName, unknown)
+	}
+	if obj.External.External || obj.External.Name != "" {
+		return errors.Errorf("%s %q: external object is not supported", objType, shortName)
+	}
+	if obj.File == "" {
+		return errors.Errorf("%s %q: lacks file path", objType, shortName)
+	}
+	fullPath := project.RelativePath(obj.File)
+	if _, err := os.Stat(fullPath); err != nil {
+		return errors.Wrapf(err, "%s %q: failed to open file %q", objType, shortName, fullPath)
+	}
+	return nil
 }


### PR DESCRIPTION
Only file-type objects are supported.
See also `./docs/compose.md` .
