### PR TITLE
nerdctl logs flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,6 @@ It does not necessarily mean that the corresponding features are missing in cont
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
   - [Run & Exec](#run--exec)
     - [:whale: nerdctl run](#whale-nerdctl-run)
     - [:whale: nerdctl exec](#whale-nerdctl-exec)
@@ -464,8 +463,12 @@ Usage: `nerctl logs [OPTIONS] CONTAINER`
 
 Flags:
 - :whale: `--f, --follow`: Follow log output
+- :whale: `--since`: Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+- :whale: `--until`: Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
+- :whale: `-t, --timestamps`: Show timestamps
+- :whale: `-n, --tail`: Number of lines to show from the end of the logs (default "all")
 
-Unimplemented `docker logs` flags: `--details`, `--since`, `--tail`, `--timestamps`, `--until`
+Unimplemented `docker logs` flags: `--details`
 
 ### :whale: nerdctl port
 List port mappings or a specific mapping for the container.
@@ -792,8 +795,9 @@ Usage: `nerdctl compose logs [OPTIONS]`
 Flags:
 - :whale: `--no-color`: Produce monochrome output
 - :whale: `--no-log-prefix`: Don't print prefix in logs
+- :whale: `--timestamps`: Show timestamps
+- :whale: `--tail`: Number of lines to show from the end of the logs
 
-Unimplemented `docker-compose logs` flags:  `--timestamps`, `--tail`
 
 ### :whale: nerdctl compose build
 Build or rebuild services.

--- a/build_test.go
+++ b/build_test.go
@@ -42,7 +42,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 	defer os.RemoveAll(buildCtx)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
-	base.Cmd("run", "--rm", imageName).AssertOut("nerdctl-build-test-string")
+	base.Cmd("run", "--rm", imageName).AssertOutContains("nerdctl-build-test-string")
 }
 
 func createBuildContext(dockerfile string) (string, error) {

--- a/completion_test.go
+++ b/completion_test.go
@@ -27,46 +27,46 @@ func TestCompletion(t *testing.T) {
 	base := testutil.NewBase(t)
 	const gbc = "--generate-bash-completion"
 	// cmd is executed with base.Args={"--namespace=nerdctl-test"}
-	base.Cmd("--cgroup-manager", gbc).AssertOut("cgroupfs\n")
-	base.Cmd("--snapshotter", gbc).AssertOut("native\n")
-	base.Cmd(gbc).AssertOut("run\n")
-	base.Cmd(gbc, "--snapshotter", gbc).AssertOut("native\n")
-	base.Cmd("run", "-", gbc).AssertOut("--network\n")
+	base.Cmd("--cgroup-manager", gbc).AssertOutContains("cgroupfs\n")
+	base.Cmd("--snapshotter", gbc).AssertOutContains("native\n")
+	base.Cmd(gbc).AssertOutContains("run\n")
+	base.Cmd(gbc, "--snapshotter", gbc).AssertOutContains("native\n")
+	base.Cmd("run", "-", gbc).AssertOutContains("--network\n")
 	base.Cmd("run", "-", gbc).AssertNoOut("--namespace\n")      // --namespace is a global flag, not "run" flag
 	base.Cmd("run", "-", gbc).AssertNoOut("--cgroup-manager\n") // --cgroup-manager is a global flag, not "run" flag
-	base.Cmd("run", "-n", gbc).AssertOut("--network\n")
+	base.Cmd("run", "-n", gbc).AssertOutContains("--network\n")
 	base.Cmd("run", "-n", gbc).AssertNoOut("--namespace\n") // --namespace is a global flag, not "run" flag
-	base.Cmd("run", "--ne", gbc).AssertOut("--network\n")
-	base.Cmd("run", "--net", gbc).AssertOut("bridge\n")
-	base.Cmd("run", "--net", gbc).AssertOut("host\n")
-	base.Cmd("run", "-it", "--net", gbc).AssertOut("bridge\n")
-	base.Cmd("run", "-it", "--rm", "--net", gbc).AssertOut("bridge\n")
-	base.Cmd("run", "--restart", gbc).AssertOut("always\n")
-	base.Cmd("network", "inspect", gbc).AssertOut("bridge\n")
+	base.Cmd("run", "--ne", gbc).AssertOutContains("--network\n")
+	base.Cmd("run", "--net", gbc).AssertOutContains("bridge\n")
+	base.Cmd("run", "--net", gbc).AssertOutContains("host\n")
+	base.Cmd("run", "-it", "--net", gbc).AssertOutContains("bridge\n")
+	base.Cmd("run", "-it", "--rm", "--net", gbc).AssertOutContains("bridge\n")
+	base.Cmd("run", "--restart", gbc).AssertOutContains("always\n")
+	base.Cmd("network", "inspect", gbc).AssertOutContains("bridge\n")
 	base.Cmd("network", "rm", gbc).AssertNoOut("bridge\n") // bridge is unremovable
 	base.Cmd("network", "rm", gbc).AssertNoOut("host\n")   // host is unremovable
-	base.Cmd("run", "--cap-add", gbc).AssertOut("sys_admin\n")
+	base.Cmd("run", "--cap-add", gbc).AssertOutContains("sys_admin\n")
 	base.Cmd("run", "--cap-add", gbc).AssertNoOut("CAP_SYS_ADMIN\n") // invalid form
 
 	// Tests with an image
 	base.Cmd("pull", testutil.AlpineImage).AssertOK()
-	base.Cmd("run", "-i", gbc).AssertOut(testutil.AlpineImage)
-	base.Cmd("run", "-it", gbc).AssertOut(testutil.AlpineImage)
-	base.Cmd("run", "-it", "--rm", gbc).AssertOut(testutil.AlpineImage)
+	base.Cmd("run", "-i", gbc).AssertOutContains(testutil.AlpineImage)
+	base.Cmd("run", "-it", gbc).AssertOutContains(testutil.AlpineImage)
+	base.Cmd("run", "-it", "--rm", gbc).AssertOutContains(testutil.AlpineImage)
 
 	// Tests with an network
 	testNetworkName := "nerdctl-test-completion"
 	defer base.Cmd("network", "rm", testNetworkName).Run()
 	base.Cmd("network", "create", testNetworkName).AssertOK()
-	base.Cmd("network", "rm", gbc).AssertOut(testNetworkName)
-	base.Cmd("run", "--net", gbc).AssertOut(testNetworkName)
+	base.Cmd("network", "rm", gbc).AssertOutContains(testNetworkName)
+	base.Cmd("run", "--net", gbc).AssertOutContains(testNetworkName)
 
 	// Tests with raw base (without Args={"--namespace=nerdctl-test"})
 	rawBase := testutil.NewBase(t)
 	rawBase.Args = nil // unset "--namespace=nerdctl-test"
-	rawBase.Cmd("--cgroup-manager", gbc).AssertOut("cgroupfs\n")
-	rawBase.Cmd(gbc).AssertOut("run\n")
+	rawBase.Cmd("--cgroup-manager", gbc).AssertOutContains("cgroupfs\n")
+	rawBase.Cmd(gbc).AssertOutContains("run\n")
 	// mind {"--namespace=nerdctl-test"} vs {"--namespace", "nerdctl-test"}
-	rawBase.Cmd("--namespace", testutil.Namespace, gbc).AssertOut("run\n")
-	rawBase.Cmd("--namespace", testutil.Namespace, "run", "-i", gbc).AssertOut(testutil.AlpineImage)
+	rawBase.Cmd("--namespace", testutil.Namespace, gbc).AssertOutContains("run\n")
+	rawBase.Cmd("--namespace", testutil.Namespace, "run", "-i", gbc).AssertOutContains(testutil.AlpineImage)
 }

--- a/compose_logs.go
+++ b/compose_logs.go
@@ -33,6 +33,16 @@ var composeLogsCommand = &cli.Command{
 			Usage:   "Follow log output.",
 		},
 		&cli.BoolFlag{
+			Name:    "timestamps",
+			Aliases: []string{"t"},
+			Usage:   "Show timestamps",
+		},
+		&cli.StringFlag{
+			Name:  "tail",
+			Value: "all",
+			Usage: "Number of lines to show from the end of the logs",
+		},
+		&cli.BoolFlag{
 			Name:  "no-color",
 			Usage: "Produce monochrome output",
 		},
@@ -61,6 +71,8 @@ func composeLogsAction(clicontext *cli.Context) error {
 	}
 	lo := composer.LogsOptions{
 		Follow:      clicontext.Bool("follow"),
+		Timestamps:  clicontext.Bool("timestamps"),
+		Tail:        clicontext.String("tail"),
 		NoColor:     clicontext.Bool("no-color"),
 		NoLogPrefix: clicontext.Bool("no-log-prefix"),
 	}

--- a/pkg/composer/logs.go
+++ b/pkg/composer/logs.go
@@ -31,6 +31,8 @@ import (
 
 type LogsOptions struct {
 	Follow      bool
+	Timestamps  bool
+	Tail        string
 	NoColor     bool
 	NoLogPrefix bool
 }
@@ -80,6 +82,18 @@ func (c *Composer) logs(ctx context.Context, containers map[string]serviceparser
 		if lo.Follow {
 			args = append(args, "-f")
 		}
+		if lo.Timestamps {
+			args = append(args, "-t")
+		}
+		if lo.Tail != "" {
+			args = append(args, "-n")
+			if lo.Tail == "all" {
+				args = append(args, "+0")
+			} else {
+			}
+			args = append(args, lo.Tail)
+		}
+
 		args = append(args, id)
 		state.logCmd = c.createNerdctlCmd(ctx, args...)
 		stdout, err := state.logCmd.StdoutPipe()

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -205,7 +205,7 @@ func (c *Cmd) AssertExitCode(exitCode int) {
 	assert.Assert(c.Base.T, res.ExitCode == exitCode, res.Combined())
 }
 
-func (c *Cmd) AssertOut(s string) {
+func (c *Cmd) AssertOutContains(s string) {
 	c.Base.T.Helper()
 	expected := icmd.Expected{
 		Out: s,

--- a/run_cgroup_linux_test.go
+++ b/run_cgroup_linux_test.go
@@ -36,5 +36,5 @@ func TestRunCgroupV2(t *testing.T) {
 `
 	//In CgroupV2 CPUWeight replace CPUShares => weight := 1 + ((shares-2)*9999)/262142
 	base.Cmd("run", "--rm", "--cpus", "0.42", "--memory", "42m", "--pids-limit", "42", "--cpu-shares", "2000", "--cpuset-cpus", "0-1", testutil.AlpineImage,
-		"sh", "-ec", "cd /sys/fs/cgroup && cat cpu.max memory.max pids.max cpu.weight cpuset.cpus").AssertOut(expected)
+		"sh", "-ec", "cd /sys/fs/cgroup && cat cpu.max memory.max pids.max cpu.weight cpuset.cpus").AssertOutContains(expected)
 }

--- a/run_mount_test.go
+++ b/run_mount_test.go
@@ -69,7 +69,7 @@ func TestRunVolume(t *testing.T) {
 		"-v", fmt.Sprintf("%s:/mnt3", rwVolName),
 		testutil.AlpineImage,
 		"sh", "-exc", "cat /mnt1/file1 /mnt3/file3",
-	).AssertOut("str1str3")
+	).AssertOutContains("str1str3")
 }
 
 func TestRunAnonymousVolume(t *testing.T) {

--- a/run_network_test.go
+++ b/run_network_test.go
@@ -63,7 +63,7 @@ func TestRunInternetConnectivity(t *testing.T) {
 			args = append(args, tc.args...)
 			args = append(args, testutil.AlpineImage, "apk", "update")
 			cmd := base.Cmd(args...)
-			cmd.AssertOut("OK")
+			cmd.AssertOutContains("OK")
 		})
 	}
 }
@@ -114,7 +114,7 @@ func TestRunHostLookup(t *testing.T) {
 		t.Logf("resolving %q in container %q (should success: %+v)", targetHostname, srcContainer, expected)
 		cmd := base.Cmd("exec", srcContainer, "wget", "-qO-", "http://"+targetHostname)
 		if expected {
-			cmd.AssertOut(testutil.NginxAlpineIndexHTMLSnippet)
+			cmd.AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
 		} else {
 			cmd.AssertFail()
 		}

--- a/run_runtime_test.go
+++ b/run_runtime_test.go
@@ -25,5 +25,5 @@ import (
 func TestRuntimeResources(t *testing.T) {
 	base := testutil.NewBase(t)
 	const expected = `1`
-	base.Cmd("run", "--rm", "--sysctl", "net.ipv4.ip_forward=1", testutil.AlpineImage, "sh", "-ec", "cat /proc/sys/net/ipv4/ip_forward").AssertOut(expected)
+	base.Cmd("run", "--rm", "--sysctl", "net.ipv4.ip_forward=1", testutil.AlpineImage, "sh", "-ec", "cat /proc/sys/net/ipv4/ip_forward").AssertOutContains(expected)
 }

--- a/run_test.go
+++ b/run_test.go
@@ -83,7 +83,7 @@ CMD ["echo", "bar"]
 func TestRunWorkdir(t *testing.T) {
 	base := testutil.NewBase(t)
 	cmd := base.Cmd("run", "--rm", "--workdir=/foo", testutil.AlpineImage, "pwd")
-	cmd.AssertOut("/foo")
+	cmd.AssertOutContains("/foo")
 }
 
 func TestRunCustomRootfs(t *testing.T) {
@@ -91,8 +91,8 @@ func TestRunCustomRootfs(t *testing.T) {
 	base := testutil.NewBase(t)
 	rootfs := prepareCustomRootfs(base, testutil.AlpineImage)
 	defer os.RemoveAll(rootfs)
-	base.Cmd("run", "--rm", "--rootfs", rootfs, "/bin/cat", "/proc/self/environ").AssertOut("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
-	base.Cmd("run", "--rm", "--entrypoint", "/bin/echo", "--rootfs", rootfs, "echo", "foo").AssertOut("echo foo")
+	base.Cmd("run", "--rm", "--rootfs", rootfs, "/bin/cat", "/proc/self/environ").AssertOutContains("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin")
+	base.Cmd("run", "--rm", "--entrypoint", "/bin/echo", "--rootfs", rootfs, "echo", "foo").AssertOutContains("echo foo")
 }
 
 func prepareCustomRootfs(base *testutil.Base, imageName string) string {

--- a/run_user_test.go
+++ b/run_user_test.go
@@ -40,7 +40,7 @@ func TestRunUserGID(t *testing.T) {
 				cmd = append(cmd, "--user", userStr)
 			}
 			cmd = append(cmd, testutil.AlpineImage, "id", "-nG")
-			base.Cmd(cmd...).AssertOut(expected)
+			base.Cmd(cmd...).AssertOutContains(expected)
 		})
 	}
 }

--- a/wait_test.go
+++ b/wait_test.go
@@ -42,6 +42,6 @@ func TestWait(t *testing.T) {
 
 	base.Cmd("run", "--name", testContainerName3, testutil.AlpineImage, "sh", "-euxc", "sleep 3; exit 123").AssertExitCode(123)
 
-	base.Cmd("wait", testContainerName1, testContainerName2, testContainerName3).AssertOut(expected)
+	base.Cmd("wait", testContainerName1, testContainerName2, testContainerName3).AssertOutContains(expected)
 
 }


### PR DESCRIPTION
Hi,

Clearing logs flags

nerdctl : 

- [x]  --follow
- [x]  --since
- [x] --tail
- [x] --timestamps
- [x] --until

compose : 

- [x]  --follow
- [x] --no-color
- [x] --no-log-prefix
- [x] --timestamps
- [x] --tail

I will add tests for compose flags in an other PR.
`--details` will be done later too