### PR TITLE
nerdctl do not support ipv6 yet

### DIFF
--- a/container_inspect_test.go
+++ b/container_inspect_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestContainerInspectContainsPortConfig(t *testing.T) {
+	//nerdctl do not support yet ipv6
+	testutil.DockerIncompatible(t)
 	const (
 		testContainer0 = "nerdctl-test-inspect-with-port-config"
 	)


### PR DESCRIPTION
fixing https://github.com/containerd/nerdctl/issues/182

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>