### PR TITLE
containerd-rootless.sh: use `command -v` instead of `which`

### DIFF
--- a/extras/rootless/containerd-rootless.sh
+++ b/extras/rootless/containerd-rootless.sh
@@ -71,7 +71,7 @@ if [ -z $_CONTAINERD_ROOTLESS_CHILD ]; then
 	net=$CONTAINERD_ROOTLESS_ROOTLESSKIT_NET
 	mtu=$CONTAINERD_ROOTLESS_ROOTLESSKIT_MTU
 	if [ -z $net ]; then
-		if which slirp4netns >/dev/null 2>&1; then
+		if command -v slirp4netns >/dev/null 2>&1; then
 			# If --netns-type is present in --help, slirp4netns is >= v0.4.0.
 			if slirp4netns --help | grep -qw -- --netns-type; then
 				net=slirp4netns
@@ -83,7 +83,7 @@ if [ -z $_CONTAINERD_ROOTLESS_CHILD ]; then
 			fi
 		fi
 		if [ -z $net ]; then
-			if which vpnkit >/dev/null 2>&1; then
+			if command -v vpnkit >/dev/null 2>&1; then
 				net=vpnkit
 			else
 				echo "Either slirp4netns (>= v0.4.0) or vpnkit needs to be installed"


### PR DESCRIPTION
`which` binary is often missing



