### PR TITLE
logs: fix time format

### DIFF
--- a/pkg/logging/jsonfile/jsonfile.go
+++ b/pkg/logging/jsonfile/jsonfile.go
@@ -122,7 +122,7 @@ func Decode(stdout, stderr io.Writer, r io.Reader, timestamps bool, since string
 		}
 
 		if timestamps {
-			output = append(output, []byte(e.Time.String())...)
+			output = append(output, []byte(e.Time.Format(time.RFC3339Nano))...)
 			output = append(output, ' ')
 		}
 


### PR DESCRIPTION
`nerdctl logs -t` was using a wrong format.

Before: 2021-05-04 07:55:03.793126406 +0000 UTC
After:  2021-05-04T07:55:37.824054101Z
