### PR TITLE
Dockerfile.d/SHA256SUMS.d/containerd-1.5.1

### DIFF
--- a/Dockerfile.d/SHA256SUMS.d/containerd-1.5.1
+++ b/Dockerfile.d/SHA256SUMS.d/containerd-1.5.1
@@ -1,4 +1,4 @@
 # From https://github.com/kind-ci/containerd-nightlies/releases/tag/containerd-1.5.1
-bb3c6803e68f296b334d5ed1fa32fc25365c1b39e0c91f8dddcd53eb8b369426  containerd-1.5.1.linux-amd64.tar.gz
-aa1251b16ca2ae57a93fd3db5dd34478740bbdf830fede625ead6b3f9cb5a4c2  containerd-1.5.1.linux-arm64.tar.gz
+1852b73687fb4ee0ab25426c909c5d38f6f123281a29e657dffbf569169c6d53  containerd-1.5.1.linux-amd64.tar.gz
+a800c384a4382feb3bbe2ea14fce2672c2c11cb64e7ba2f6a0c2b84f2d24fef7  containerd-1.5.1.linux-arm64.tar.gz
 16a9e9fed866ad36246239582a1d72eb2f815b6b10298a8ae493dca72af71b31  containerd.service


### PR DESCRIPTION
kind-ci/containerd-nightlies@containerd-1.5.1 was recreated due to a bug
in the release pipeline. https://github.com/kind-ci/containerd-nightlies/issues/19#issuecomment-842729044

There was no known compromisation.
