### PR TITLE
follow-up to "setup docker top cmd" (#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ It does not necessarily mean that the corresponding features are missing in cont
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
   - [Run & Exec](#run--exec)
     - [:whale: nerdctl run](#whale-nerdctl-run)
     - [:whale: nerdctl exec](#whale-nerdctl-exec)
@@ -214,7 +215,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl events](#whale-nerdctl-events)
     - [:whale: nerdctl info](#whale-nerdctl-info)
     - [:whale: nerdctl version](#whale-nerdctl-version)
-  - [Stats management](#stats-management)
+  - [Stats](#stats)
     - [:whale: nerdctl top](#whale-nerdctl-top)
   - [Shell completion](#shell-completion)
     - [:nerd_face: nerdctl completion bash](#nerd_face-nerdctl-completion-bash)
@@ -755,7 +756,7 @@ Usage: `nerdctl version [OPTIONS]`
 
 Unimplemented `docker version` flags: `--format`
 
-## Stats management
+## Stats
 ### :whale: nerdctl top
 Display the running processes of a container.
 

--- a/top_test.go
+++ b/top_test.go
@@ -27,7 +27,7 @@ import (
 func TestTop(t *testing.T) {
 	//more details https://github.com/containerd/nerdctl/pull/223#issuecomment-851395178
 	if rootlessutil.IsRootless() && infoutil.CgroupsVersion() == "1" {
-		t.Skip("test skipped for rootless container with cgroup v1")
+		t.Skip("test skipped for rootless containers on cgroup v1")
 	}
 	const (
 		testContainerName = "nerdctl-test-top"


### PR DESCRIPTION
- Clarify the origin of the codes copied from Moby
- Fix the bash completion
- Fix the doc
- Fix cgroup manager check
- Fix wording
