### PR TITLE
rootless: fix "x509: certificate signed by unknown authority" on openSUSE Tumbleweed

### DIFF
--- a/extras/rootless/containerd-rootless.sh
+++ b/extras/rootless/containerd-rootless.sh
@@ -132,6 +132,14 @@ else
 	rm -f /run/containerd /run/xtables.lock \
 		/var/lib/containerd /var/lib/cni /etc/containerd
 
+	# Bind-mount /etc/ssl.
+	# Workaround for "x509: certificate signed by unknown authority" on openSUSE Tumbleweed.
+	# https://github.com/rootless-containers/rootlesskit/issues/225
+	realpath_etc_ssl=$(realpath /etc/ssl)
+	rm -f /etc/ssl
+	mkdir /etc/ssl
+	mount --rbind "${realpath_etc_ssl}" /etc/ssl
+
 	# Bind-mount /var/lib/containerd
 	mkdir -p "${XDG_DATA_HOME}/containerd" "/var/lib/containerd"
 	mount --bind "${XDG_DATA_HOME}/containerd" "/var/lib/containerd"


### PR DESCRIPTION
Equivalent of moby/moby#42457

openSUSE Tumbleweed was facing "x509: certificate signed by unknown authority" error, as `/etc/ssl/ca-bundle.pem` is provided as a symlink to `../../var/lib/ca-certificates/ca-bundle.pem`, which was not supported by `rootlesskit --copy-up=/etc` .

See rootless-containers/rootlesskit#225

