### PR TITLE
add `nerdctl run --shm-size <SIZE>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ Metadata flags:
 - :whale: `--label-file`: Read in a line delimited file of labels
 - :whale: `--cidfile`: Write the container ID to the file
 
+Shared memory flags:
+- :whale: `--shm-size`: Size of `/dev/shm`
+
 Other `docker run` flags are on plan but unimplemented yet.
 <details>
 <summary> Clicke here to show all the `docker run` flags (Docker 20.10)</summary>

--- a/run.go
+++ b/run.go
@@ -48,6 +48,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containerd/nerdctl/pkg/taskutil"
 	"github.com/docker/cli/opts"
+	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -230,6 +231,11 @@ var runCommand = &cli.Command{
 		&cli.StringFlag{
 			Name:  "cidfile",
 			Usage: "Write the container ID to the file",
+		},
+		// shared memory flags
+		&cli.StringFlag{
+			Name:  "shm-size",
+			Usage: "Size of /dev/shm",
 		},
 	},
 }
@@ -443,6 +449,14 @@ func runAction(clicontext *cli.Context) error {
 
 	if clicontext.Bool("privileged") {
 		opts = append(opts, privilegedOpts...)
+	}
+
+	if shmSize := clicontext.String("shm-size"); len(shmSize) > 0 {
+		shmBytes, err := units.RAMInBytes(shmSize)
+		if err != nil {
+			return err
+		}
+		opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
 	}
 
 	rtCOpts, err := generateRuntimeCOpts(clicontext)

--- a/run_test.go
+++ b/run_test.go
@@ -150,3 +150,10 @@ func TestRunCIDFile(t *testing.T) {
 
 	base.Cmd("run", "--rm", "--cidfile", fileName, testutil.AlpineImage).AssertFail()
 }
+
+func TestRunShmSize(t *testing.T) {
+	base := testutil.NewBase(t)
+	const shmSize = "32m"
+
+	base.Cmd("run", "--rm", "--shm-size", shmSize, testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts").AssertOutContains("size=32768k")
+}


### PR DESCRIPTION
Signed-off-by: Yuchen Cheng <rudeigerc@gmail.com>

Related to #215 

This pull request adds `nerdctl run --shm-size <SIZE>`.