### PR TITLE
ensure clean working tree

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,3 @@ build
 
 # vagrant
 /.vagrant
-
-# dockerfile itself
-Dockerfile


### PR DESCRIPTION
fixing https://github.com/containerd/nerdctl/issues/255

When copying a git repo in build context, keep Dockerfile to avoid having untracked files in copied git repo and then treat the working tree as dirty

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>