### PR TITLE
fix copying up initial contents of the mount point directory

### DIFF
--- a/cmd/nerdctl/run_mount.go
+++ b/cmd/nerdctl/run_mount.go
@@ -107,18 +107,15 @@ func generateMountOpts(clicontext *cli.Context, ctx context.Context, client *con
 			mounted[filepath.Clean(x.Mount.Destination)] = struct{}{}
 
 			//copying up initial contents of the mount point directory
-			for imgVolRaw := range imageVolumes {
-				imgVol := filepath.Clean(imgVolRaw)
-				target, err := securejoin.SecureJoin(tempDir, imgVol)
-				if err != nil {
-					return nil, nil, err
-				}
+			target, err := securejoin.SecureJoin(tempDir, x.Mount.Destination)
+			if err != nil {
+				return nil, nil, err
+			}
 
-				//Coyping content in AnonymousVolume and namedVolume
-				if x.Mount.Destination == imgVol && x.Type == "volume" {
-					if err := copyExistingContents(target, x.Mount.Source); err != nil {
-						return nil, nil, err
-					}
+			//Coyping content in AnonymousVolume and namedVolume
+			if x.Type == "volume" {
+				if err := copyExistingContents(target, x.Mount.Source); err != nil {
+					return nil, nil, err
 				}
 			}
 			if x.AnonymousVolume != "" {

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/sys"
 	"github.com/containerd/nerdctl/pkg/idgen"
@@ -67,7 +68,14 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 			// assume src is a volume name
 			vol, err := volStore.Get(src)
 			if err != nil {
-				return nil, err
+				if errors.Is(err, errdefs.ErrNotFound) {
+					vol, err = volStore.Create(src)
+					if err != nil {
+						return nil, err
+					}
+				} else {
+					return nil, err
+				}
 			}
 			// src is now full path
 			src = vol.Mountpoint


### PR DESCRIPTION
copying up initial contents of the mount point directory when using `-v` flag

automatically create not found volumes 

fixing https://github.com/containerd/nerdctl/issues/262

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>