### PR TITLE
Support bind propagation options for `--volume`

### DIFF
--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -17,6 +17,15 @@
 package mountutil
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -52,4 +61,161 @@ func getUnprivilegedMountFlags(path string) ([]string, error) {
 	}
 
 	return flags, nil
+}
+
+// DefaultPropagationMode is the default propagation of mounts
+// where user doesn't specify mount propagation explicitly.
+// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/linux_parser.go#L145
+const DefaultPropagationMode = "rprivate"
+
+// parseVolumeOptions parses specified optsRaw with using information of
+// the volume type and the src directory when necessary.
+func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, error) {
+	return parseVolumeOptionsWithMountInfo(vType, src, optsRaw, getMountInfo)
+}
+
+// getMountInfo gets mount.Info of a directory.
+func getMountInfo(dir string) (mount.Info, error) {
+	sourcePath, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return mount.Info{}, err
+	}
+	return mount.Lookup(sourcePath)
+}
+
+// parseVolumeOptionsWithMountInfo is the testable implementation
+// of parseVolumeOptions.
+func parseVolumeOptionsWithMountInfo(vType, src, optsRaw string, getMountInfoFunc func(string) (mount.Info, error)) ([]string, []oci.SpecOpts, error) {
+	var (
+		writeModeRawOpts   []string
+		propagationRawOpts []string
+	)
+	for _, opt := range strings.Split(optsRaw, ",") {
+		switch opt {
+		case "rw":
+			writeModeRawOpts = append(writeModeRawOpts, opt)
+		case "ro":
+			writeModeRawOpts = append(writeModeRawOpts, opt)
+		case "private", "rprivate", "shared", "rshared", "slave", "rslave":
+			propagationRawOpts = append(propagationRawOpts, opt)
+		case "":
+			// NOP
+		default:
+			logrus.Warnf("unsupported volume option %q", opt)
+		}
+	}
+
+	var opts []string
+	var specOpts []oci.SpecOpts
+
+	if len(writeModeRawOpts) > 1 {
+		return nil, nil, fmt.Errorf("duplicated read/write volume option: %+v", writeModeRawOpts)
+	} else if len(writeModeRawOpts) > 0 && writeModeRawOpts[0] == "ro" {
+		opts = append(opts, "ro")
+	} // No need to return option when "rw"
+
+	if len(propagationRawOpts) > 1 {
+		return nil, nil, fmt.Errorf("duplicated volume propagation option: %+v", propagationRawOpts)
+	} else if len(propagationRawOpts) > 0 && vType != Bind {
+		return nil, nil, fmt.Errorf("volume propagation option is only supported for bind mount: %+v", propagationRawOpts)
+	} else if vType == Bind {
+		var pFlag string
+		var got string
+		if len(propagationRawOpts) > 0 {
+			got = propagationRawOpts[0]
+		}
+		switch got {
+		case "shared", "rshared":
+			pFlag = got
+			// a bind mount can be shared from shared mount
+			mi, err := getMountInfoFunc(src)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := ensureMountOptionalValue(mi, "shared:"); err != nil {
+				return nil, nil, err
+			}
+
+			// NOTE: Though OCI Runtime Spec doesn't explicitly describe, runc's default
+			//       of RootfsPropagtion is unix.MS_SLAVE | unix.MS_REC (i.e. runc applies
+			//       "slave" to all mount points in the container recursively). This ends
+			//       up marking the bind src directories "slave" and priventing it to shared
+			//      with the host. So we set RootfsPropagation to "shared" here.
+			//
+			// See also:
+			// - OCI Runtime Spec: https://github.com/opencontainers/runtime-spec/blob/v1.0.2/config-linux.md#rootfs-mount-propagation
+			// - runc implementation: https://github.com/opencontainers/runc/blob/v1.0.0/libcontainer/rootfs_linux.go#L771-L777
+			specOpts = append(specOpts, func(ctx context.Context, cli oci.Client, c *containers.Container, s *oci.Spec) error {
+				switch s.Linux.RootfsPropagation {
+				case "shared", "rshared":
+					// NOP
+				default:
+					s.Linux.RootfsPropagation = "shared"
+				}
+				return nil
+			})
+		case "slave", "rslave":
+			pFlag = got
+			// a bind mount can be a slave of shared or an existing slave mount
+			mi, err := getMountInfoFunc(src)
+			if err != nil {
+				return nil, nil, err
+			}
+			if err := ensureMountOptionalValue(mi, "shared:", "master:"); err != nil {
+				return nil, nil, err
+			}
+
+			// See above comments about RootfsPropagation. Here we make sure that
+			// the mountpoint can be a slave of the host mount.
+			specOpts = append(specOpts, func(ctx context.Context, cli oci.Client, c *containers.Container, s *oci.Spec) error {
+				switch s.Linux.RootfsPropagation {
+				case "shared", "rshared", "slave", "rslave":
+					// NOP
+				default:
+					s.Linux.RootfsPropagation = "rslave"
+				}
+				return nil
+			})
+		case "private", "rprivate":
+			pFlag = got
+		default:
+			// No propagation is specfied to this bind mount.
+			// NOTE: When RootfsPropagation is set (e.g. by other bind mount option), that
+			//       propagation mode will be applied to this bind mount as well. So we need
+			//       to set "rprivate" explicitly for priventing this bind mount from unexpectedly
+			//       shared with the host. This behaviour is compatible to docker:
+			//       https://github.com/moby/moby/blob/v20.10.7/volume/mounts/linux_parser.go#L320-L322
+			//
+			// TODO: directories managed by containerd (e.g. /var/lib/containerd, /run/containerd, ...)
+			//       should be marked as "rslave" instead of "rprivate". This is because allowing
+			//       containers to hold their private bind mounts will prevent containred from remove
+			//       them. See also: https://github.com/moby/moby/pull/36055.
+			//       Unfortunately, containerd doesn't expose the locations of directories where it manages.
+			//       Current workaround is explicitly add "rshared" or "rslave" option to these bind mounts.
+			pFlag = DefaultPropagationMode
+		}
+		opts = append(opts, pFlag)
+	}
+
+	return opts, specOpts, nil
+}
+
+// ensure the mount of the specified directory has either of the specified
+// "optional" value in the entry in the /proc/<pid>/mountinfo file.
+//
+// For more details about "optional" field:
+// - https://github.com/moby/sys/blob/mountinfo/v0.4.1/mountinfo/mountinfo.go#L52-L56
+func ensureMountOptionalValue(mi mount.Info, vals ...string) error {
+	var hasValue bool
+	for _, opt := range strings.Split(mi.Optional, " ") {
+		for _, mark := range vals {
+			if strings.HasPrefix(opt, mark) {
+				hasValue = true
+			}
+		}
+	}
+	if !hasValue {
+		return fmt.Errorf("mountpoint %q doesn't have optional field neither of %+v", mi.Mountpoint, vals)
+	}
+	return nil
 }

--- a/pkg/mountutil/mountutil_linux_test.go
+++ b/pkg/mountutil/mountutil_linux_test.go
@@ -1,0 +1,189 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mountutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/mount"
+	"github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
+)
+
+// TestParseVolumeOptions tests volume options are parsed as expected.
+func TestParseVolumeOptions(t *testing.T) {
+	tests := []struct {
+		name                     string
+		vType                    string
+		src                      string
+		optsRaw                  string
+		srcOptional              []string
+		initialRootfsPropagation string
+		wants                    []string
+		wantRootfsPropagation    string
+		wantFail                 bool
+	}{
+		{
+			name:    "unknown option is ignored (with warning)",
+			vType:   "volume",
+			src:     "dummy",
+			optsRaw: "ro,undefined",
+			wants:   []string{"ro"},
+		},
+
+		// tests for rw/ro flags
+		{
+			name:    "read write",
+			vType:   "bind",
+			src:     "dummy",
+			optsRaw: "rw",
+			wants:   []string{"rprivate"},
+		},
+		{
+			name:    "read only",
+			vType:   "volume",
+			src:     "dummy",
+			optsRaw: "ro",
+			wants:   []string{"ro"},
+		},
+		{
+			name:     "duplicated flags are not allowed",
+			vType:    "bind",
+			src:      "dummy",
+			optsRaw:  "ro,rw",
+			wantFail: true,
+		},
+		{
+			name:     "duplicated flags (ro/ro) are not allowed",
+			vType:    "volume",
+			src:      "dummy",
+			optsRaw:  "ro,ro",
+			wantFail: true,
+		},
+
+		// tests for propagation flags
+		{
+			name:     "volume doesn't accept propagation option",
+			vType:    "volume",
+			src:      "dummy",
+			optsRaw:  "private",
+			wantFail: true,
+		},
+		{
+			name:     "duplicated propagation option is not allowed",
+			vType:    "bind",
+			src:      "dummy",
+			optsRaw:  "private,shared",
+			wantFail: true,
+		},
+		{
+			name:  "default propagation type is rprivate",
+			vType: "bind",
+			src:   "dummy",
+			wants: []string{"rprivate"},
+		},
+		{
+			name:    "make bind private",
+			vType:   "bind",
+			src:     "dummy",
+			optsRaw: "ro,private",
+			wants:   []string{"ro", "private"},
+		},
+		{
+			name:                  "make bind shared",
+			vType:                 "bind",
+			src:                   "dummy",
+			optsRaw:               "ro,rshared",
+			srcOptional:           []string{"shared:xxx"},
+			wantRootfsPropagation: "shared",
+			wants:                 []string{"ro", "rshared"},
+		},
+		{
+			name:                     "make bind shared (unchange RootfsPropagation)",
+			vType:                    "bind",
+			src:                      "dummy",
+			optsRaw:                  "ro,rshared",
+			srcOptional:              []string{"shared:xxx"},
+			initialRootfsPropagation: "rshared",
+			wantRootfsPropagation:    "rshared",
+			wants:                    []string{"ro", "rshared"},
+		},
+		{
+			name:        "shared propagation is not allowed if the src is not shared",
+			vType:       "bind",
+			src:         "dummy",
+			optsRaw:     "ro,shared",
+			srcOptional: nil,
+			wantFail:    true,
+		},
+		{
+			name:                  "make bind slave",
+			vType:                 "bind",
+			src:                   "dummy",
+			optsRaw:               "ro,slave",
+			srcOptional:           []string{"master:xxx"},
+			wantRootfsPropagation: "rslave",
+			wants:                 []string{"ro", "slave"},
+		},
+		{
+			name:                     "make bind slave (unchange RootfsPropagation)",
+			vType:                    "bind",
+			src:                      "dummy",
+			optsRaw:                  "ro,slave",
+			srcOptional:              []string{"master:xxx"},
+			initialRootfsPropagation: "shared",
+			wantRootfsPropagation:    "shared",
+			wants:                    []string{"ro", "slave"},
+		},
+		{
+			name:        "slave propagation is not allowed if the src is not slave",
+			vType:       "bind",
+			src:         "dummy",
+			optsRaw:     "ro,slave",
+			srcOptional: nil,
+			wantFail:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts, specOpts, err := parseVolumeOptionsWithMountInfo(tt.vType, tt.src, tt.optsRaw, func(string) (mount.Info, error) {
+				return mount.Info{
+					Mountpoint: tt.src,
+					Optional:   strings.Join(tt.srcOptional, " "),
+				}, nil
+			})
+			if err != nil {
+				if tt.wantFail {
+					return
+				}
+				t.Errorf("failed to parse option %q: %v", tt.optsRaw, err)
+				return
+			}
+			s := oci.Spec{Linux: &specs.Linux{RootfsPropagation: tt.initialRootfsPropagation}}
+			for _, o := range specOpts {
+				assert.NilError(t, o(context.Background(), nil, nil, &s))
+			}
+			assert.Equal(t, tt.wantRootfsPropagation, s.Linux.RootfsPropagation)
+			assert.Equal(t, tt.wantFail, false)
+			assert.Check(t, is.DeepEqual(tt.wants, opts))
+		})
+	}
+}

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -16,7 +16,45 @@
 
 package mountutil
 
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/sirupsen/logrus"
+)
+
 func getUnprivilegedMountFlags(path string) ([]string, error) {
 	m := []string{}
 	return m, nil
+}
+
+// DefaultPropagationMode is the default propagation of mounts
+// where user doesn't specify mount propagation explicitly.
+// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/windows_parser.go#L440-L442
+const DefaultPropagationMode = ""
+
+// parseVolumeOptions parses specified optsRaw with using information of
+// the volume type and the src directory when necessary.
+func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, error) {
+	var writeModeRawOpts []string
+	for _, opt := range strings.Split(optsRaw, ",") {
+		switch opt {
+		case "rw":
+			writeModeRawOpts = append(writeModeRawOpts, opt)
+		case "ro":
+			writeModeRawOpts = append(writeModeRawOpts, opt)
+		case "":
+			// NOP
+		default:
+			logrus.Warnf("unsupported volume option %q", opt)
+		}
+	}
+	var opts []string
+	if len(writeModeRawOpts) > 1 {
+		return nil, nil, fmt.Errorf("duplicated read/write volume option: %+v", writeModeRawOpts)
+	} else if len(writeModeRawOpts) > 0 && writeModeRawOpts[0] == "ro" {
+		opts = append(opts, "ro")
+	} // No need to return option when "rw"
+	return opts, nil, nil
 }

--- a/pkg/mountutil/mountutil_windows_test.go
+++ b/pkg/mountutil/mountutil_windows_test.go
@@ -1,0 +1,78 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mountutil
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseVolumeOptions(t *testing.T) {
+	tests := []struct {
+		vType    string
+		src      string
+		optsRaw  string
+		wants    []string
+		wantFail bool
+	}{
+		{
+			vType:   "bind",
+			src:     "dummy",
+			optsRaw: "rw",
+			wants:   []string{},
+		},
+		{
+			vType:   "volume",
+			src:     "dummy",
+			optsRaw: "ro",
+			wants:   []string{"ro"},
+		},
+		{
+			vType:   "volume",
+			src:     "dummy",
+			optsRaw: "ro,undefined",
+			wants:   []string{"ro"},
+		},
+		{
+			vType:    "bind",
+			src:      "dummy",
+			optsRaw:  "ro,rw",
+			wantFail: true,
+		},
+		{
+			vType:    "volume",
+			src:      "dummy",
+			optsRaw:  "ro,ro",
+			wantFail: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(strings.Join([]string{tt.vType, tt.src, tt.optsRaw}, "-"), func(t *testing.T) {
+			opts, _, err := parseVolumeOptions(tt.vType, tt.src, tt.optsRaw)
+			if err != nil {
+				if tt.wantFail {
+					return
+				}
+				t.Errorf("failed to parse option %q: %v", tt.optsRaw, err)
+				return
+			}
+			assert.Equal(t, tt.wantFail, false)
+			assert.Check(t, is.DeepEqual(tt.wants, opts))
+		})
+	}
+}

--- a/run.go
+++ b/run.go
@@ -43,6 +43,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/logging"
+	"github.com/containerd/nerdctl/pkg/mountutil"
 	"github.com/containerd/nerdctl/pkg/namestore"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/netutil/nettype"
@@ -660,7 +661,7 @@ func withCustomResolvConf(src string) func(context.Context, oci.Client, *contain
 			Destination: "/etc/resolv.conf",
 			Type:        "bind",
 			Source:      src,
-			Options:     []string{"bind"}, // writable
+			Options:     []string{"bind", mountutil.DefaultPropagationMode}, // writable
 		})
 		return nil
 	}
@@ -672,7 +673,7 @@ func withCustomHosts(src string) func(context.Context, oci.Client, *containers.C
 			Destination: "/etc/hosts",
 			Type:        "bind",
 			Source:      src,
-			Options:     []string{"bind"}, // writable
+			Options:     []string{"bind", mountutil.DefaultPropagationMode}, // writable
 		})
 		return nil
 	}

--- a/run_mount.go
+++ b/run_mount.go
@@ -124,6 +124,7 @@ func generateMountOpts(clicontext *cli.Context, ctx context.Context, client *con
 			if x.AnonymousVolume != "" {
 				anonVolumes = append(anonVolumes, x.AnonymousVolume)
 			}
+			opts = append(opts, x.Opts...)
 		}
 		opts = append(opts, oci.WithMounts(ociMounts))
 	}


### PR DESCRIPTION
Fixes https://github.com/containerd/nerdctl/issues/261

This PR adds the following [docker-compatible propagation option](https://docs.docker.com/storage/bind-mounts/#configure-bind-propagation) to bind mounts:

- `shared`: The host and the container share mount events in the bind mount each other.
- `slave`: The container receives mount events in the bind mount from the host. But the host doesn't receive events from the container.
- `private`: Mount events in the bind mount doesn't propagate each other.
- `rshared`: Similar as `shared` but the propagation type is applied to all mounts under the bind mount.
- `rslave`:  Similar as `slave` but the propagation type is applied to all mounts under the bind mount.
- `rprivate` (default): Similar as `private` but the propagation type is applied to all mounts under the bind mount.

For more details about propagation, please see also [shared subtree document of linux kernel](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt).

```console
# nerdctl run --rm -it \
          -v /tmp/shared-dir:/shared-dir:shared \
          -v /tmp/slave-dir:/slave-dir:slave \
          -v /tmp/non-shared-dir:/non-shared-dir \
          ubuntu:20.04 /bin/bash
root@01302060790a:/# cat /proc/$$/mountinfo | grep -- "-dir"
2080 1905 0:113 /shared-dir /shared-dir rw,nosuid,nodev,relatime shared:865 - tmpfs tmpfs rw,mode=777
2081 1905 0:113 /slave-dir /slave-dir rw,nosuid,nodev,relatime master:865 - tmpfs tmpfs rw,mode=777
2082 1905 0:113 /non-shared-dir /non-shared-dir rw,nosuid,nodev,relatime - tmpfs tmpfs rw,mode=777
```
