### PR TITLE
Add --pid to enable host pid namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Basic flags:
 - :whale: `--rm`: Automatically remove the container when it exits
 - :whale: `--pull=(always|missing|never)`: Pull image before running
   - Default: "missing"
+- :whale: `--pid=(host)`: PID namespace to use
 
 Network flags:
 - :whale: `--net, --network=(bridge|host|none|<CNI>)`: Connect a container to a network

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -131,6 +131,11 @@ var runCommand = &cli.Command{
 			Aliases: []string{"m"},
 			Usage:   "Memory limit",
 		},
+		// Enable host pid namespace
+		&cli.StringFlag{
+			Name:  "pid",
+			Usage: "PID namespace to use",
+		},
 		&cli.IntFlag{
 			Name:  "pids-limit",
 			Usage: "Tune container pids limit (set -1 for unlimited)",
@@ -482,6 +487,15 @@ func runAction(clicontext *cli.Context) error {
 			return err
 		}
 		opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
+	}
+
+	pidNs := strings.ToLower(clicontext.String("pid"))
+	if pidNs != "" {
+		if pidNs != "host" {
+			return fmt.Errorf("Invalid pid namespace. Set --pid=host to enable host pid namespace.")
+		} else {
+			opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
+		}
 	}
 
 	rtCOpts, err := generateRuntimeCOpts(clicontext)


### PR DESCRIPTION
Tested the patch by launching a container with `--pid=host`, Both `/proc/<container_host_pid>/ns` and `/proc/$$/ns` has the same PID namespace iNode (which is the host PID namespace).

```
root@vagrant:~/go/src/github.com/containerd/nerdctl# ls /proc/27517/ns -lt
total 0
lrwxrwxrwx 1 root root 0 Jun 29 01:32 cgroup -> 'cgroup:[4026531835]'
....
lrwxrwxrwx 1 root root 0 Jun 29 01:32 pid -> 'pid:[4026531836]'
lrwxrwxrwx 1 root root 0 Jun 29 01:32 pid_for_children -> 'pid:[4026531836]'

root@vagrant:~/go/src/github.com/containerd/nerdctl# ls /proc/$$/ns -lt
total 0
lrwxrwxrwx 1 root root 0 Jun 29 01:32 cgroup -> 'cgroup:[4026531835]'
.....
lrwxrwxrwx 1 root root 0 Jun 29 01:32 pid -> 'pid:[4026531836]'
lrwxrwxrwx 1 root root 0 Jun 29 01:32 pid_for_children -> 'pid:[4026531836]'
```

Signed-off-by: Shishir Mahajan <smahajan@roblox.com>