### PR TITLE
make `nerdctl network inspect` compatible with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,8 +721,6 @@ Unimplemented `docker network ls` flags: `--filter`, `--format`, `--no-trunc`, `
 ### :whale: nerdctl network inspect
 Display detailed information on one or more networks
 
-:warning: The output format is not compatible with Docker.
-
 Usage: `nerdctl network inspect [OPTIONS] NETWORK [NETWORK...]`
 
 Unimplemented `docker network inspect` flags: `--format`, `--verbose`

--- a/cmd/nerdctl/network_inspect_test.go
+++ b/cmd/nerdctl/network_inspect_test.go
@@ -19,23 +19,46 @@ package main
 import (
 	"testing"
 
+	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"gotest.tools/v3/assert"
 )
 
-func TestNetworkInspectContainsLabels(t *testing.T) {
-	// Skip docker, because docker support CNM not CNI
-	testutil.DockerIncompatible(t)
-
-	const testNetwork = "nerdctl-test-inspect-with-labels"
+func TestNetworkInspect(t *testing.T) {
+	const (
+		testNetwork = "nerdctl-test-network-inspect"
+		testSubnet  = "10.24.24.0/24"
+		testGateway = "10.24.24.1"
+	)
 
 	base := testutil.NewBase(t)
 	defer base.Cmd("network", "rm", testNetwork).Run()
 
-	base.Cmd("network", "create", "--label", "tag=testNetwork", testNetwork).AssertOK()
-	inspect := base.InspectNetwork(testNetwork)
-	inspectNerdctlLabels := (*inspect.NerdctlLabels)
-	expected := make(map[string]string, 1)
-	expected["tag"] = "testNetwork"
-	assert.DeepEqual(base.T, expected, inspectNerdctlLabels)
+	args := []string{
+		"network", "create", "--label", "tag=testNetwork", "--subnet", testSubnet,
+	}
+	if base.Target == testutil.Docker {
+		// trivial incompatibility: nerdctl computes gateway automatically, but docker does not
+		args = append(args, "--gateway", testGateway)
+	}
+	args = append(args, testNetwork)
+	base.Cmd(args...).AssertOK()
+	got := base.InspectNetwork(testNetwork)
+
+	assert.DeepEqual(base.T, testNetwork, got.Name)
+
+	expectedLabels := map[string]string{
+		"tag": "testNetwork",
+	}
+	assert.DeepEqual(base.T, expectedLabels, got.Labels)
+
+	expectedIPAM := dockercompat.IPAM{
+		Config: []dockercompat.IPAMConfig{
+			{
+				Subnet:  testSubnet,
+				Gateway: testGateway,
+			},
+		},
+	}
+	assert.DeepEqual(base.T, expectedIPAM, got.IPAM)
 }

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rootless-containers/rootlesskit v0.14.2
 	github.com/sirupsen/logrus v1.8.1
+	github.com/tidwall/gjson v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210426230700-d19ff857e887

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,12 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/tidwall/gjson v1.8.1 h1:8j5EE9Hrh3l9Od1OIEDAb7IpezNA20UdRngNAj5N0WU=
+github.com/tidwall/gjson v1.8.1/go.mod h1:5/xDoumyyDNerp2U36lyolv46b3uF/9Bu6OfyQ9GImk=
+github.com/tidwall/match v1.0.3 h1:FQUVvBImDutD8wJLN6c5eMzWtjgONK9MwIBCOrUJKeE=
+github.com/tidwall/match v1.0.3/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.1.0 h1:K3hMW5epkdAVwibsQEfR/7Zj0Qgt4DxtNumTq/VloO8=
+github.com/tidwall/pretty v1.1.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/u-root/u-root v7.0.0+incompatible/go.mod h1:RYkpo8pTHrNjW08opNd/U6p/RJE7K0D8fXO0d47+3YY=

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -175,10 +175,10 @@ func (b *Base) InspectImage(name string) dockercompat.Image {
 	return dc[0]
 }
 
-func (b *Base) InspectNetwork(name string) native.Network {
+func (b *Base) InspectNetwork(name string) dockercompat.Network {
 	cmdResult := b.Cmd("network", "inspect", name).Run()
 	assert.Equal(b.T, cmdResult.ExitCode, 0)
-	var dc []native.Network
+	var dc []dockercompat.Network
 	if err := json.Unmarshal([]byte(cmdResult.Stdout()), &dc); err != nil {
 		b.T.Fatal(err)
 	}


### PR DESCRIPTION
Now `nerdctl network inspect` uses `--mode=dockercompat` by default.

```console
$ nerdctl network inspect compose-wordpress_default
[
    {
        "Name": "compose-wordpress_default",
        "Id": "19",
        "IPAM": {
            "Config": [
                {
                    "Subnet": "10.4.19.0/24",
                    "Gateway": "10.4.19.1"
                }
            ]
        },
        "Labels": {
            "com.docker.compose.network": "default",
            "com.docker.compose.project": "compose-wordpress"
        }
    }
]
```

Can be rolled back to the old behavior by specifying `--mode=native`.
```console
$ nerdctl network inspect --mode=native compose-wordpress_default
[
    {
        "CNI": {
            "cniVersion": "0.4.0",
            "name": "compose-wordpress_default",
            "nerdctlID": 19,
            "nerdctlLabels": {
                "com.docker.compose.network": "default",
                "com.docker.compose.project": "compose-wordpress"
            },
            "plugins": [
                {
                    "type": "bridge",
                    "bridge": "nerdctl19",
                    "isGateway": true,
                    "ipMasq": true,
                    "hairpinMode": true,
                    "ipam": {
                        "type": "host-local",
                        "routes": [
                            {
                                "dst": "0.0.0.0/0"
                            }
                        ],
                        "ranges": [
                            [
                                {
                                    "subnet": "10.4.19.0/24",
                                    "gateway": "10.4.19.1"
                                }
                            ]
                        ]
                    }
                },
                {
                    "type": "portmap",
                    "capabilities": {
                        "portMappings": true
                    }
                },
                {
                    "type": "firewall"
                },
                {
                    "type": "tuning"
                },
                {
                    "type": "isolation"
                }
            ]
        },
        "NerdctlID": 19,
        "NerdctlLabels": {
            "com.docker.compose.network": "default",
            "com.docker.compose.project": "compose-wordpress"
        },
        "File": "/home/suda/.config/cni/net.d/nerdctl-compose-wordpress_default.conflist"
    }
]
```

