### PR TITLE
Add test for skipping cert verification (--insecure-registry)

### DIFF
--- a/cmd/nerdctl/push_test.go
+++ b/cmd/nerdctl/push_test.go
@@ -17,14 +17,26 @@
 package main
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"io/ioutil"
+	"math/big"
 	"net"
+	"net/http"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"github.com/pkg/errors"
+	"golang.org/x/crypto/bcrypt"
 	"gotest.tools/v3/assert"
 )
 
@@ -84,6 +96,93 @@ func newTestRegistry(base *testutil.Base, name string) *testRegistry {
 	}
 }
 
+func newTestInsecureRegistry(base *testutil.Base, name, user, pass string) *testRegistry {
+	hostIP, err := getNonLoopbackIPv4()
+	assert.NilError(base.T, err)
+	// listen on 0.0.0.0 to enable 127.0.0.1
+	listenIP := net.ParseIP("0.0.0.0")
+	const listenPort = 5000 // TODO: choose random empty port
+	const authPort = 5001   // TODO: choose random empty port
+	base.T.Logf("hostIP=%q, listenIP=%q, listenPort=%d, authPort=%d", hostIP, listenIP, listenPort, authPort)
+
+	registryCert, registryKey, registryClose := generateTestCert(base, hostIP.String())
+	authCert, authKey, authClose := generateTestCert(base, hostIP.String())
+
+	// Prepare configuration file for authentication server
+	// Details: https://github.com/cesanta/docker_auth/blob/1.7.1/examples/simple.yml
+	authConfigFile, err := ioutil.TempFile("", "authconfig")
+	assert.NilError(base.T, err)
+	bpass, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
+	assert.NilError(base.T, err)
+	authConfigFileName := authConfigFile.Name()
+	_, err = authConfigFile.Write([]byte(fmt.Sprintf(`
+server:
+  addr: ":5001"
+  certificate: "/auth/domain.crt"
+  key: "/auth/domain.key"
+token:
+  issuer: "Acme auth server"
+  expiration: 900
+users:
+  "%s":
+    password: "%s"
+acl:
+  - match: {account: "%s"}
+    actions: ["*"]
+`, user, string(bpass), user)))
+	assert.NilError(base.T, err)
+
+	// Run authentication server
+	authContainerName := "auth-" + name
+	cmd := base.Cmd("run",
+		"-d",
+		"-p", fmt.Sprintf("%s:%d:5001", listenIP, authPort),
+		"--name", authContainerName,
+		"-v", authCert+":/auth/domain.crt",
+		"-v", authKey+":/auth/domain.key",
+		"-v", authConfigFileName+":/config/auth_config.yml",
+		testutil.DockerAuthImage,
+		"/config/auth_config.yml")
+	cmd.AssertOK()
+
+	// Run docker_auth-enabled registry
+	// Details: https://github.com/cesanta/docker_auth/blob/1.7.1/examples/simple.yml
+	registryContainerName := "reg-" + name
+	cmd = base.Cmd("run",
+		"-d",
+		"-p", fmt.Sprintf("%s:%d:5000", listenIP, listenPort),
+		"--name", registryContainerName,
+		"-env", "REGISTRY_AUTH=token",
+		"-env", "REGISTRY_AUTH_TOKEN_REALM="+fmt.Sprintf("https://%s:%d/auth", hostIP.String(), authPort),
+		"-env", "REGISTRY_AUTH_TOKEN_SERVICE=Docker registry",
+		"-env", "REGISTRY_AUTH_TOKEN_ISSUER=Acme auth server",
+		"-env", "REGISTRY_AUTH_TOKEN_ROOTCERTBUNDLE=/auth/domain.crt",
+		"-env", "REGISTRY_HTTP_TLS_CERTIFICATE=/registry/domain.crt",
+		"-env", "REGISTRY_HTTP_TLS_KEY=/registry/domain.key",
+		"-v", authCert+":/auth/domain.crt",
+		"-v", registryCert+":/registry/domain.crt",
+		"-v", registryKey+":/registry/domain.key",
+		testutil.RegistryImage)
+	cmd.AssertOK()
+	if _, err = httpInsecureGet(fmt.Sprintf("https://%s:%d/v2", hostIP.String(), listenPort), 30); err != nil {
+		base.Cmd("rm", "-f", registryContainerName).Run()
+		base.T.Fatal(err)
+	}
+	return &testRegistry{
+		ip:         hostIP,
+		listenIP:   listenIP,
+		listenPort: listenPort,
+		cleanup: func() {
+			base.Cmd("rm", "-f", registryContainerName).AssertOK()
+			base.Cmd("rm", "-f", authContainerName).AssertOK()
+			assert.NilError(base.T, registryClose())
+			assert.NilError(base.T, authClose())
+			assert.NilError(base.T, authConfigFile.Close())
+			os.Remove(authConfigFileName)
+		},
+	}
+}
+
 func TestPushPlainHTTPFails(t *testing.T) {
 	base := testutil.NewBase(t)
 	reg := newTestRegistry(base, "test-push-plain-http-fails")
@@ -133,4 +232,97 @@ func TestPushPlainHTTPInsecure(t *testing.T) {
 	base.Cmd("tag", testutil.AlpineImage, testImageRef).AssertOK()
 
 	base.Cmd("--insecure-registry", "push", testImageRef).AssertOK()
+}
+
+func TestPushInsecureWithLogin(t *testing.T) {
+	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	reg := newTestInsecureRegistry(base, "test-push-insecure-tls", "admin", "badmin")
+	defer reg.cleanup()
+
+	base.Cmd("--insecure-registry", "login", "-u", "admin", "-p", "badmin",
+		fmt.Sprintf("%s:%d", reg.ip.String(), reg.listenPort)).AssertOK()
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	testImageRef := fmt.Sprintf("%s:%d/test-push-insecure-tls:%s",
+		reg.ip.String(), reg.listenPort, strings.Split(testutil.AlpineImage, ":")[1])
+	t.Logf("testImageRef=%q", testImageRef)
+	base.Cmd("tag", testutil.AlpineImage, testImageRef).AssertOK()
+
+	base.Cmd("--insecure-registry", "push", testImageRef).AssertOK()
+}
+
+func generateTestCert(base *testutil.Base, host string) (crtPath, keyPath string, closeFn func() error) {
+	certF, err := ioutil.TempFile("", "certtemp")
+	assert.NilError(base.T, err)
+	keyF, err := ioutil.TempFile("", "keytemp")
+	assert.NilError(base.T, err)
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 60)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	assert.NilError(base.T, err)
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject:      pkix.Name{Organization: []string{"test"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(365 * 24 * time.Hour),
+		DNSNames:     []string{host},
+	}
+	privatekey, err := rsa.GenerateKey(rand.Reader, 2048)
+	assert.NilError(base.T, err)
+	publickey := &privatekey.PublicKey
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, publickey, privatekey)
+	assert.NilError(base.T, err)
+	privBytes, err := x509.MarshalPKCS8PrivateKey(privatekey)
+	assert.NilError(base.T, err)
+
+	assert.NilError(base.T, pem.Encode(certF, &pem.Block{Type: "CERTIFICATE", Bytes: cert}))
+	assert.NilError(base.T, pem.Encode(keyF, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes}))
+
+	return certF.Name(), keyF.Name(), func() error {
+		var errors []error
+		certFName := certF.Name()
+		keyFName := keyF.Name()
+		for _, f := range []func() error{
+			certF.Close,
+			keyF.Close,
+			func() error { return os.Remove(certFName) },
+			func() error { return os.Remove(keyFName) },
+		} {
+			if err := f(); err != nil {
+				errors = append(errors, err)
+			}
+		}
+		if len(errors) > 0 {
+			return fmt.Errorf("failed to close tmpfile: %v", errors)
+		}
+		return nil
+	}
+}
+
+func httpInsecureGet(urlStr string, attempts int) (*http.Response, error) {
+	var (
+		resp *http.Response
+		err  error
+	)
+	if attempts < 1 {
+		return nil, errdefs.ErrInvalidArgument
+	}
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	for i := 0; i < attempts; i++ {
+		resp, err = client.Get(urlStr)
+		if err == nil {
+			return resp, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, errors.Wrapf(err, "error after %d attempts", attempts)
 }

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tidwall/gjson v1.8.1
 	github.com/urfave/cli/v2 v2.3.0
+	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -357,6 +357,7 @@ var (
 	WordpressImage              = mirrorOf("wordpress:5.7")
 	WordpressIndexHTMLSnippet   = "<title>WordPress &rsaquo; Installation</title>"
 	MariaDBImage                = mirrorOf("mariadb:10.5")
+	DockerAuthImage             = mirrorOf("cesanta/docker_auth:1.7")
 )
 
 const (


### PR DESCRIPTION
Following-up https://github.com/containerd/nerdctl/pull/287#issuecomment-877979416

This adds the test using https://github.com/cesanta/docker_auth with `simple` configuration (https://github.com/cesanta/docker_auth/blob/1.7.1/examples/simple.yml).