### PR TITLE
pkg/defaults: Look at Debian's path for CNI plugins

### DIFF
--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -43,6 +43,7 @@ func CNIPath() string {
 	candidates := []string{
 		"/usr/local/libexec/cni",
 		"/usr/libexec/cni", // Fedora
+		"/usr/lib/cni",     // debian (containernetworking-plugins)
 	}
 	if rootlessutil.IsRootless() {
 		home := os.Getenv("HOME")


### PR DESCRIPTION
Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>