### PR TITLE
load: import all platforms (--all-platforms)

### DIFF
--- a/cmd/nerdctl/load.go
+++ b/cmd/nerdctl/load.go
@@ -38,6 +38,10 @@ var loadCommand = &cli.Command{
 			Aliases: []string{"i"},
 			Usage:   "Read from tar archive file, instead of STDIN",
 		},
+		&cli.BoolFlag{
+			Name:  "all-platforms",
+			Usage: "Imports content for all platforms",
+		},
 	},
 }
 
@@ -62,7 +66,7 @@ func loadImage(in io.Reader, clicontext *cli.Context) error {
 	defer cancel()
 
 	sn := clicontext.String("snapshotter")
-	imgs, err := client.Import(ctx, in, containerd.WithDigestRef(archive.DigestTranslator(sn)))
+	imgs, err := client.Import(ctx, in, containerd.WithDigestRef(archive.DigestTranslator(sn)), containerd.WithAllPlatforms(clicontext.Bool("all-platforms")))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently if you try to import a non-native image the blobs will get
GC'd and unpack fails with with "not found" on the blobs.

Import doesn't really have a way to select which platforms to important,
so I don't think it makes sense to make this optional. After all the tar
could just be modified with the desired platforms.