### PR TITLE
fix inspect show more than one number

### DIFF
--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -70,7 +70,7 @@ func inspectAction(clicontext *cli.Context) error {
 			return err
 		}
 
-		if ni != 0 && nc != 0 {
+		if ni != 0 && nc != 0 || nc > 1 {
 			return errors.Errorf("multiple IDs found with provided prefix: %s", req)
 		}
 


### PR DESCRIPTION
**First**
 nerdctl -n k8s.io  ps -a|grep 21
214237255fea    k8s.gcr.io/pause:3.1                                                       "/pause"                  2 days ago     Up
21bf9ea81561    docker.io/calico/cni:v3.8.2                                                "/install-cni.sh"         2 days ago     Created
42174dbd8880    sha256:96047edc008f46c6f3a597012d58e356f06ac8b648122e2717946cfeebecefcf    "/usr/local/bin/flex…"    2 days ago     Created
**Then**
nerdctl -n k8s.io inspect 21  it will show double container, not like docker .