### PR TITLE
examples: docker-compose.stargz.yaml: mount empty dir on /run

### DIFF
--- a/examples/compose-wordpress/docker-compose.stargz.yaml
+++ b/examples/compose-wordpress/docker-compose.stargz.yaml
@@ -4,12 +4,18 @@
 services:
   wordpress:
     image: ghcr.io/stargz-containers/wordpress:5.7-esgz
+    volumes:
+      # workaround for https://github.com/containerd/stargz-snapshotter/issues/444
+      - "/run"
     extends:
       file: docker-compose.yaml
       service: wordpress
 
   db:
     image: ghcr.io/stargz-containers/mariadb:10.5-esgz
+    volumes:
+      # workaround for https://github.com/containerd/stargz-snapshotter/issues/444
+      - "/run"
     extends:
       file: docker-compose.yaml
       service: db


### PR DESCRIPTION
Workaround for https://github.com/containerd/stargz-snapshotter/issues/444
