### PR TITLE
Add default PATH Env variable to opts, if image inspect doesn't inclu…

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -336,6 +336,16 @@ func runAction(clicontext *cli.Context) error {
 		opts = append(opts, oci.WithProcessCwd(wd))
 	}
 
+	for ind, env := range ensuredImage.ImageConfig.Env {
+		if strings.HasPrefix(env, "PATH=") {
+			break
+		} else {
+			if ind == len(ensuredImage.ImageConfig.Env)-1 {
+				opts = append(opts, oci.WithEnv([]string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}))
+			}
+		}
+	}
+
 	if envFiles := strutil.DedupeStrSlice(clicontext.StringSlice("env-file")); len(envFiles) > 0 {
 		env, err := parseEnvVars(envFiles)
 		if err != nil {


### PR DESCRIPTION
fix #356 
Adding the PATH environmental variable to the opts passed to the container, if the image inspect is missing the PATH environment variable.

It was tested with:
- registry.fedoraproject.org/fedora:rawhide
- ubuntu:latest
- centos:latest

and it worked as expected.

Please let me know if you have any thoughts, concerns or modifications.