### PR TITLE
Fixes #275 : use host dns with slirp4netns support in rootless mode

### DIFF
--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -1,0 +1,323 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package resolvconf provides utility code to query and update DNS configuration in /etc/resolv.conf
+// originally from https://github.com/moby/moby/blob/6014c1e29dc34dffa77fb5749cc3281c1b4854ac/libnetwork/resolvconf/resolvconf.go
+package resolvconf
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// defaultPath is the default path to the resolv.conf that contains information to resolve DNS. See Path().
+	defaultPath = "/etc/resolv.conf"
+	// alternatePath is a path different from defaultPath, that may be used to resolve DNS. See Path().
+	alternatePath = "/run/systemd/resolve/resolv.conf"
+)
+
+// constants for the IP address type
+const (
+	IP = iota // IPv4 and IPv6
+	IPv4
+	IPv6
+)
+
+var (
+	detectSystemdResolvConfOnce sync.Once
+	pathAfterSystemdDetection   = defaultPath
+)
+
+// Path returns the path to the resolv.conf file that libnetwork should use.
+//
+// When /etc/resolv.conf contains 127.0.0.53 as the only nameserver, then
+// it is assumed systemd-resolved manages DNS. Because inside the container 127.0.0.53
+// is not a valid DNS server, Path() returns /run/systemd/resolve/resolv.conf
+// which is the resolv.conf that systemd-resolved generates and manages.
+// Otherwise Path() returns /etc/resolv.conf.
+//
+// Errors are silenced as they will inevitably resurface at future open/read calls.
+//
+// More information at https://www.freedesktop.org/software/systemd/man/systemd-resolved.service.html#/etc/resolv.conf
+func Path() string {
+	detectSystemdResolvConfOnce.Do(func() {
+		candidateResolvConf, err := os.ReadFile(defaultPath)
+		if err != nil {
+			// silencing error as it will resurface at next calls trying to read defaultPath
+			return
+		}
+		ns := GetNameservers(candidateResolvConf, IP)
+		if len(ns) == 1 && ns[0] == "127.0.0.53" {
+			pathAfterSystemdDetection = alternatePath
+			logrus.Infof("detected 127.0.0.53 nameserver, assuming systemd-resolved, so using resolv.conf: %s", alternatePath)
+		}
+	})
+	return pathAfterSystemdDetection
+}
+
+const (
+	// ipLocalhost is a regex pattern for IPv4 or IPv6 loopback range.
+	ipLocalhost  = `((127\.([0-9]{1,3}\.){2}[0-9]{1,3})|(::1)$)`
+	ipv4NumBlock = `(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)`
+	ipv4Address  = `(` + ipv4NumBlock + `\.){3}` + ipv4NumBlock
+
+	// This is not an IPv6 address verifier as it will accept a super-set of IPv6, and also
+	// will *not match* IPv4-Embedded IPv6 Addresses (RFC6052), but that and other variants
+	// -- e.g. other link-local types -- either won't work in containers or are unnecessary.
+	// For readability and sufficiency for Docker purposes this seemed more reasonable than a
+	// 1000+ character regexp with exact and complete IPv6 validation
+	ipv6Address = `([0-9A-Fa-f]{0,4}:){2,7}([0-9A-Fa-f]{0,4})(%\w+)?`
+)
+
+var (
+	// Note: the default IPv4 & IPv6 resolvers are set to Google's Public DNS
+	defaultIPv4Dns = []string{"nameserver 8.8.8.8", "nameserver 8.8.4.4"}
+	defaultIPv6Dns = []string{"nameserver 2001:4860:4860::8888", "nameserver 2001:4860:4860::8844"}
+
+	localhostNSRegexp = regexp.MustCompile(`(?m)^nameserver\s+` + ipLocalhost + `\s*\n*`)
+	nsIPv6Regexp      = regexp.MustCompile(`(?m)^nameserver\s+` + ipv6Address + `\s*\n*`)
+	nsRegexp          = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `)|(` + ipv6Address + `))\s*$`)
+	nsIPv6Regexpmatch = regexp.MustCompile(`^\s*nameserver\s*((` + ipv6Address + `))\s*$`)
+	nsIPv4Regexpmatch = regexp.MustCompile(`^\s*nameserver\s*((` + ipv4Address + `))\s*$`)
+	searchRegexp      = regexp.MustCompile(`^\s*search\s*(([^\s]+\s*)*)$`)
+	optionsRegexp     = regexp.MustCompile(`^\s*options\s*(([^\s]+\s*)*)$`)
+)
+
+var lastModified struct {
+	sync.Mutex
+	sha256   string
+	contents []byte
+}
+
+// File contains the resolv.conf content and its hash
+type File struct {
+	Content []byte
+	Hash    string
+}
+
+// Get returns the contents of /etc/resolv.conf and its hash
+func Get() (*File, error) {
+	return GetSpecific(Path())
+}
+
+// GetSpecific returns the contents of the user specified resolv.conf file and its hash
+func GetSpecific(path string) (*File, error) {
+	resolv, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	hash, err := hashData(bytes.NewReader(resolv))
+	if err != nil {
+		return nil, err
+	}
+	return &File{Content: resolv, Hash: hash}, nil
+}
+
+// GetIfChanged retrieves the host /etc/resolv.conf file, checks against the last hash
+// and, if modified since last check, returns the bytes and new hash.
+// This feature is used by the resolv.conf updater for containers
+func GetIfChanged() (*File, error) {
+	lastModified.Lock()
+	defer lastModified.Unlock()
+
+	resolv, err := os.ReadFile(Path())
+	if err != nil {
+		return nil, err
+	}
+	newHash, err := hashData(bytes.NewReader(resolv))
+	if err != nil {
+		return nil, err
+	}
+	if lastModified.sha256 != newHash {
+		lastModified.sha256 = newHash
+		lastModified.contents = resolv
+		return &File{Content: resolv, Hash: newHash}, nil
+	}
+	// nothing changed, so return no data
+	return nil, nil
+}
+
+// GetLastModified retrieves the last used contents and hash of the host resolv.conf.
+// Used by containers updating on restart
+func GetLastModified() *File {
+	lastModified.Lock()
+	defer lastModified.Unlock()
+
+	return &File{Content: lastModified.contents, Hash: lastModified.sha256}
+}
+
+// FilterResolvDNS cleans up the config in resolvConf.  It has two main jobs:
+// 1. It looks for localhost (127.*|::1) entries in the provided
+//    resolv.conf, removing local nameserver entries, and, if the resulting
+//    cleaned config has no defined nameservers left, adds default DNS entries
+// 2. Given the caller provides the enable/disable state of IPv6, the filter
+//    code will remove all IPv6 nameservers if it is not enabled for containers
+//
+func FilterResolvDNS(resolvConf []byte, ipv6Enabled bool) (*File, error) {
+	cleanedResolvConf := localhostNSRegexp.ReplaceAll(resolvConf, []byte{})
+	// if IPv6 is not enabled, also clean out any IPv6 address nameserver
+	if !ipv6Enabled {
+		cleanedResolvConf = nsIPv6Regexp.ReplaceAll(cleanedResolvConf, []byte{})
+	}
+	// if the resulting resolvConf has no more nameservers defined, add appropriate
+	// default DNS servers for IPv4 and (optionally) IPv6
+	if len(GetNameservers(cleanedResolvConf, IP)) == 0 {
+		logrus.Infof("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: %v", defaultIPv4Dns)
+		dns := defaultIPv4Dns
+		if ipv6Enabled {
+			logrus.Infof("IPv6 enabled; Adding default IPv6 external servers: %v", defaultIPv6Dns)
+			dns = append(dns, defaultIPv6Dns...)
+		}
+		cleanedResolvConf = append(cleanedResolvConf, []byte("\n"+strings.Join(dns, "\n"))...)
+	}
+	hash, err := hashData(bytes.NewReader(cleanedResolvConf))
+	if err != nil {
+		return nil, err
+	}
+	return &File{Content: cleanedResolvConf, Hash: hash}, nil
+}
+
+// getLines parses input into lines and strips away comments.
+func getLines(input []byte, commentMarker []byte) [][]byte {
+	lines := bytes.Split(input, []byte("\n"))
+	var output [][]byte
+	for _, currentLine := range lines {
+		var commentIndex = bytes.Index(currentLine, commentMarker)
+		if commentIndex == -1 {
+			output = append(output, currentLine)
+		} else {
+			output = append(output, currentLine[:commentIndex])
+		}
+	}
+	return output
+}
+
+// GetNameservers returns nameservers (if any) listed in /etc/resolv.conf
+func GetNameservers(resolvConf []byte, kind int) []string {
+	nameservers := []string{}
+	for _, line := range getLines(resolvConf, []byte("#")) {
+		var ns [][]byte
+		if kind == IP {
+			ns = nsRegexp.FindSubmatch(line)
+		} else if kind == IPv4 {
+			ns = nsIPv4Regexpmatch.FindSubmatch(line)
+		} else if kind == IPv6 {
+			ns = nsIPv6Regexpmatch.FindSubmatch(line)
+		}
+		if len(ns) > 0 {
+			nameservers = append(nameservers, string(ns[1]))
+		}
+	}
+	return nameservers
+}
+
+// GetNameserversAsCIDR returns nameservers (if any) listed in
+// /etc/resolv.conf as CIDR blocks (e.g., "1.2.3.4/32")
+// This function's output is intended for net.ParseCIDR
+func GetNameserversAsCIDR(resolvConf []byte) []string {
+	nameservers := []string{}
+	for _, nameserver := range GetNameservers(resolvConf, IP) {
+		var address string
+		// If IPv6, strip zone if present
+		if strings.Contains(nameserver, ":") {
+			address = strings.Split(nameserver, "%")[0] + "/128"
+		} else {
+			address = nameserver + "/32"
+		}
+		nameservers = append(nameservers, address)
+	}
+	return nameservers
+}
+
+// GetSearchDomains returns search domains (if any) listed in /etc/resolv.conf
+// If more than one search line is encountered, only the contents of the last
+// one is returned.
+func GetSearchDomains(resolvConf []byte) []string {
+	domains := []string{}
+	for _, line := range getLines(resolvConf, []byte("#")) {
+		match := searchRegexp.FindSubmatch(line)
+		if match == nil {
+			continue
+		}
+		domains = strings.Fields(string(match[1]))
+	}
+	return domains
+}
+
+// GetOptions returns options (if any) listed in /etc/resolv.conf
+// If more than one options line is encountered, only the contents of the last
+// one is returned.
+func GetOptions(resolvConf []byte) []string {
+	options := []string{}
+	for _, line := range getLines(resolvConf, []byte("#")) {
+		match := optionsRegexp.FindSubmatch(line)
+		if match == nil {
+			continue
+		}
+		options = strings.Fields(string(match[1]))
+	}
+	return options
+}
+
+// Build writes a configuration file to path containing a "nameserver" entry
+// for every element in dns, a "search" entry for every element in
+// dnsSearch, and an "options" entry for every element in dnsOptions.
+func Build(path string, dns, dnsSearch, dnsOptions []string) (*File, error) {
+	content := bytes.NewBuffer(nil)
+	if len(dnsSearch) > 0 {
+		if searchString := strings.Join(dnsSearch, " "); strings.Trim(searchString, " ") != "." {
+			if _, err := content.WriteString("search " + searchString + "\n"); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, dns := range dns {
+		if _, err := content.WriteString("nameserver " + dns + "\n"); err != nil {
+			return nil, err
+		}
+	}
+	if len(dnsOptions) > 0 {
+		if optsString := strings.Join(dnsOptions, " "); strings.Trim(optsString, " ") != "" {
+			if _, err := content.WriteString("options " + optsString + "\n"); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	hash, err := hashData(bytes.NewReader(content.Bytes()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{Content: content.Bytes(), Hash: hash}, os.WriteFile(path, content.Bytes(), 0644)
+}
+
+func hashData(src io.Reader) (string, error) {
+	h := sha256.New()
+	if _, err := io.Copy(h, src); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/resolvconf/resolvconf_linux_test.go
+++ b/pkg/resolvconf/resolvconf_linux_test.go
@@ -1,0 +1,320 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// originally from https://github.com/moby/moby/blob/6014c1e29dc34dffa77fb5749cc3281c1b4854ac/libnetwork/resolvconf/resolvconf_linux_test.go
+package resolvconf
+
+import (
+	"bytes"
+	"os"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	resolvConfUtils, err := Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolvConfSystem, err := os.ReadFile("/run/systemd/resolve/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(resolvConfUtils.Content) != string(resolvConfSystem) {
+		t.Fatalf("/etc/resolv.conf and GetResolvConf have different content.")
+	}
+	hashSystem, err := hashData(bytes.NewReader(resolvConfSystem))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolvConfUtils.Hash != hashSystem {
+		t.Fatalf("/etc/resolv.conf and GetResolvConf have different hashes.")
+	}
+}
+
+func TestGetNameservers(t *testing.T) {
+	for resolv, result := range map[string][]string{`
+nameserver 1.2.3.4
+nameserver 40.3.200.10
+search example.com`: {"1.2.3.4", "40.3.200.10"},
+		`search example.com`: {},
+		`nameserver 1.2.3.4
+search example.com
+nameserver 4.30.20.100`: {"1.2.3.4", "4.30.20.100"},
+		``:                        {},
+		`  nameserver 1.2.3.4   `: {"1.2.3.4"},
+		`search example.com
+nameserver 1.2.3.4
+#nameserver 4.3.2.1`: {"1.2.3.4"},
+		`search example.com
+nameserver 1.2.3.4 # not 4.3.2.1`: {"1.2.3.4"},
+	} {
+		test := GetNameservers([]byte(resolv), IP)
+		if !strSlicesEqual(test, result) {
+			t.Fatalf("Wrong nameserver string {%s} should be %v. Input: %s", test, result, resolv)
+		}
+	}
+}
+
+func TestGetNameserversAsCIDR(t *testing.T) {
+	for resolv, result := range map[string][]string{`
+nameserver 1.2.3.4
+nameserver 40.3.200.10
+search example.com`: {"1.2.3.4/32", "40.3.200.10/32"},
+		`search example.com`: {},
+		`nameserver 1.2.3.4
+search example.com
+nameserver 4.30.20.100`: {"1.2.3.4/32", "4.30.20.100/32"},
+		``:                        {},
+		`  nameserver 1.2.3.4   `: {"1.2.3.4/32"},
+		`search example.com
+nameserver 1.2.3.4
+#nameserver 4.3.2.1`: {"1.2.3.4/32"},
+		`search example.com
+nameserver 1.2.3.4 # not 4.3.2.1`: {"1.2.3.4/32"},
+	} {
+		test := GetNameserversAsCIDR([]byte(resolv))
+		if !strSlicesEqual(test, result) {
+			t.Fatalf("Wrong nameserver string {%s} should be %v. Input: %s", test, result, resolv)
+		}
+	}
+}
+
+func TestGetSearchDomains(t *testing.T) {
+	for resolv, result := range map[string][]string{
+		`search example.com`:           {"example.com"},
+		`search example.com # ignored`: {"example.com"},
+		`	  search	 example.com	  `: {"example.com"},
+		`	  search	 example.com	  # ignored`: {"example.com"},
+		`search foo.example.com example.com`: {"foo.example.com", "example.com"},
+		`	   search	   foo.example.com	 example.com	`: {"foo.example.com", "example.com"},
+		`	   search	   foo.example.com	 example.com	# ignored`: {"foo.example.com", "example.com"},
+		``:          {},
+		`# ignored`: {},
+		`nameserver 1.2.3.4
+search foo.example.com example.com`: {"foo.example.com", "example.com"},
+		`nameserver 1.2.3.4
+search dup1.example.com dup2.example.com
+search foo.example.com example.com`: {"foo.example.com", "example.com"},
+		`nameserver 1.2.3.4
+search foo.example.com example.com
+nameserver 4.30.20.100`: {"foo.example.com", "example.com"},
+	} {
+		test := GetSearchDomains([]byte(resolv))
+		if !strSlicesEqual(test, result) {
+			t.Fatalf("Wrong search domain string {%s} should be %v. Input: %s", test, result, resolv)
+		}
+	}
+}
+
+func TestGetOptions(t *testing.T) {
+	for resolv, result := range map[string][]string{
+		`options opt1`:           {"opt1"},
+		`options opt1 # ignored`: {"opt1"},
+		`	  options	 opt1	  `: {"opt1"},
+		`	  options	 opt1	  # ignored`: {"opt1"},
+		`options opt1 opt2 opt3`:           {"opt1", "opt2", "opt3"},
+		`options opt1 opt2 opt3 # ignored`: {"opt1", "opt2", "opt3"},
+		`	   options	 opt1	 opt2	 opt3	`: {"opt1", "opt2", "opt3"},
+		`	   options	 opt1	 opt2	 opt3	# ignored`: {"opt1", "opt2", "opt3"},
+		``:                   {},
+		`# ignored`:          {},
+		`nameserver 1.2.3.4`: {},
+		`nameserver 1.2.3.4
+options opt1 opt2 opt3`: {"opt1", "opt2", "opt3"},
+		`nameserver 1.2.3.4
+options opt1 opt2
+options opt3 opt4`: {"opt3", "opt4"},
+	} {
+		test := GetOptions([]byte(resolv))
+		if !strSlicesEqual(test, result) {
+			t.Fatalf("Wrong options string {%s} should be %v. Input: %s", test, result, resolv)
+		}
+	}
+}
+
+func strSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestBuild(t *testing.T) {
+	file, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	_, err = Build(file.Name(), []string{"ns1", "ns2", "ns3"}, []string{"search1"}, []string{"opt1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "search search1\nnameserver ns1\nnameserver ns2\nnameserver ns3\noptions opt1\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+}
+
+func TestBuildWithZeroLengthDomainSearch(t *testing.T) {
+	file, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	_, err = Build(file.Name(), []string{"ns1", "ns2", "ns3"}, []string{"."}, []string{"opt1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "nameserver ns1\nnameserver ns2\nnameserver ns3\noptions opt1\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+	if notExpected := "search ."; bytes.Contains(content, []byte(notExpected)) {
+		t.Fatalf("Expected to not find '%s' got '%s'", notExpected, content)
+	}
+}
+
+func TestBuildWithNoOptions(t *testing.T) {
+	file, err := os.CreateTemp("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(file.Name())
+
+	_, err = Build(file.Name(), []string{"ns1", "ns2", "ns3"}, []string{"search1"}, []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(file.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if expected := "search search1\nnameserver ns1\nnameserver ns2\nnameserver ns3\n"; !bytes.Contains(content, []byte(expected)) {
+		t.Fatalf("Expected to find '%s' got '%s'", expected, content)
+	}
+	if notExpected := "search ."; bytes.Contains(content, []byte(notExpected)) {
+		t.Fatalf("Expected to not find '%s' got '%s'", notExpected, content)
+	}
+}
+
+func TestFilterResolvDns(t *testing.T) {
+	ns0 := "nameserver 10.16.60.14\nnameserver 10.16.60.21\n"
+
+	if result, _ := FilterResolvDNS([]byte(ns0), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed No Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	ns1 := "nameserver 10.16.60.14\nnameserver 10.16.60.21\nnameserver 127.0.0.1\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	ns1 = "nameserver 10.16.60.14\nnameserver 127.0.0.1\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	ns1 = "nameserver 127.0.1.1\nnameserver 10.16.60.14\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	ns1 = "nameserver ::1\nnameserver 10.16.60.14\nnameserver 127.0.2.1\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	ns1 = "nameserver 10.16.60.14\nnameserver ::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	// with IPv6 disabled (false param), the IPv6 nameserver should be removed
+	ns1 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost+IPv6 off: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	// with IPv6 disabled (false param), the IPv6 link-local nameserver with zone ID should be removed
+	ns1 = "nameserver 10.16.60.14\nnameserver FE80::BB1%1\nnameserver FE80::BB1%eth0\nnameserver 10.16.60.21\n"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost+IPv6 off: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	// with IPv6 enabled, the IPv6 nameserver should be preserved
+	ns0 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\n"
+	ns1 = "nameserver 10.16.60.14\nnameserver 2002:dead:beef::1\nnameserver 10.16.60.21\nnameserver ::1"
+	if result, _ := FilterResolvDNS([]byte(ns1), true); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed Localhost+IPv6 on: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	// with IPv6 enabled, and no non-localhost servers, Google defaults (both IPv4+IPv6) should be added
+	ns0 = "\nnameserver 8.8.8.8\nnameserver 8.8.4.4\nnameserver 2001:4860:4860::8888\nnameserver 2001:4860:4860::8844"
+	ns1 = "nameserver 127.0.0.1\nnameserver ::1\nnameserver 127.0.2.1"
+	if result, _ := FilterResolvDNS([]byte(ns1), true); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed no Localhost+IPv6 enabled: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+
+	// with IPv6 disabled, and no non-localhost servers, Google defaults (only IPv4) should be added
+	ns0 = "\nnameserver 8.8.8.8\nnameserver 8.8.4.4"
+	ns1 = "nameserver 127.0.0.1\nnameserver ::1\nnameserver 127.0.2.1"
+	if result, _ := FilterResolvDNS([]byte(ns1), false); result != nil {
+		if ns0 != string(result.Content) {
+			t.Fatalf("Failed no Localhost+IPv6 enabled: expected \n<%s> got \n<%s>", ns0, string(result.Content))
+		}
+	}
+}


### PR DESCRIPTION
This is a first draft written this afternoon. I need to test it more.
In rootless and rootful mode, parse host resolv.conf the 'docker' way : if non-local DNS are found, use them. If no non-local DNS is found, use default google DNS servers. In case DNS is 127.0.0.53, parse an alternative resolv file.
In rootless mode, add the slirp4netns dns as 1st nameserver