### PR TITLE
Clarify the list of the experimental features

### DIFF
--- a/README.md
+++ b/README.md
@@ -969,3 +969,4 @@ Others:
 - [`./docs/stargz.md`](./docs/stargz.md):     Lazy-pulling using Stargz Snapshotter
 - [`./docs/ocicrypt.md`](./docs/ocicrypt.md): Running encrypted images
 - [`./docs/freebsd.md`](./docs/freebsd.md):  Running FreeBSD jails
+- [`./docs/experimental.md`](./docs/experimental.md):  Experimental features

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -67,6 +67,16 @@ var runCommand = &cli.Command{
 	Action:       runAction,
 	BashComplete: runBashComplete,
 	HideHelp:     true, // built-in "-h" help conflicts with the short form of `--hostname`
+	Description: func() string {
+		var description string
+		switch runtime.GOOS {
+		case "windows":
+			description += "WARNING: `nerdctl run` is experimental on Windows and currently broken (https://github.com/containerd/nerdctl/issues/28)"
+		case "freebsd":
+			description += "WARNING: `nerdctl run` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/master/docs/freebsd.md)"
+		}
+		return description
+	}(),
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name: "help",

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,8 @@
+# Experimental features of nerdctl
+
+The following features are experimental and subject to change:
+
+- [Windows containers](https://github.com/containerd/nerdctl/issues/28)
+- [FreeBSD containers](./freebsd.md)
+- Importing an external eStargz record JSON file with `nerdctl image convert --estargz-record-in=FILE` .
+  eStargz itself is out of experimental.


### PR DESCRIPTION
- Windows containers
- FreeBSD containers
- Importing an external eStargz record JSON file with `nerdctl image convert --estargz-record-in=FILE` .
  eStargz itself is out of experimental.

---

I'll release v0.12.0 after merging this
