### PR TITLE
Makefile: clean up FreeBSD/amd64 nerdctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,11 @@ artifacts: clean
 
 	GOOS=windows GOARCH=amd64     make -C $(CURDIR) binaries
 	tar $(TAR_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-windows-amd64.tar.gz _output/nerdctl.exe
-	rm -f $(CURDIR)/_output/nerdctl $(CURDIR)/_output/nerdctl.exe
 
-	GOOS=freebsd GOARCH=amd64       make -C $(CURDIR)  binaries
-	tar $(TAR_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-freebsd-amd64.tar.gz   _output/nerdctl extras/rootless/*
+	GOOS=freebsd GOARCH=amd64     make -C $(CURDIR)  binaries
+	tar $(TAR_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-freebsd-amd64.tar.gz _output/nerdctl
+
+	rm -f $(CURDIR)/_output/nerdctl $(CURDIR)/_output/nerdctl.exe
 
 	$(call make_artifact_full_linux,amd64)
 	$(call make_artifact_full_linux,arm64)


### PR DESCRIPTION
FreeBSD/amd64 version of `nerdctl` binary was not cleaned up and was accidentally included in the GitHub artifacts.

Also, unneeded rootless scripts were also included in `nerdctl-0.12.0-freebsd-amd64.tar.gz`

