### PR TITLE
nerdctl: add `--env-file` to `exec`

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,9 +480,10 @@ Flags:
 - :whale: `-d, --detach`: Detached mode: run command in the background
 - :whale: `-w, --workdir`: Working directory inside the container
 - :whale: `-e, --env`: Set environment variables
+- :whale: `--env-file`: Set environment variables from file
 - :whale: `--privileged`: Give extended privileges to the command
 
-Unimplemented `docker exec` flags: `--detach-keys`, `--env-file`, `--user`
+Unimplemented `docker exec` flags: `--detach-keys`, `--user`
 
 ## Container management
 ### :whale: nerdctl ps

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -66,6 +66,10 @@ var execCommand = &cli.Command{
 			Aliases: []string{"e"},
 			Usage:   "Set environment variables",
 		},
+		&cli.StringSliceFlag{
+			Name:  "env-file",
+			Usage: "Set environment variables from file",
+		},
 		&cli.BoolFlag{
 			Name:  "privileged",
 			Usage: "Give extended privileges to the command",
@@ -217,6 +221,13 @@ func generateExecProcessSpec(ctx context.Context, clicontext *cli.Context, conta
 
 	if workdir := clicontext.String("workdir"); workdir != "" {
 		pspec.Cwd = workdir
+	}
+	if envFiles := strutil.DedupeStrSlice(clicontext.StringSlice("env-file")); len(envFiles) > 0 {
+		env, err := parseEnvVars(envFiles)
+		if err != nil {
+			return nil, err
+		}
+		pspec.Env = append(pspec.Env, env...)
 	}
 	for _, e := range strutil.DedupeStrSlice(clicontext.StringSlice("env")) {
 		pspec.Env = append(pspec.Env, e)


### PR DESCRIPTION
Reference: #215

```shell
vbatts@melisma:~$ sudo nerdctl --version
nerdctl version 0.12.0-6-g6ca74e6.m
vbatts@melisma:~$ sudo nerdctl exec -it --env FOO=bar farts sh
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
FOO=bar
PWD=/
vbatts@melisma:~$ cat > env.sh
FOO=VAT
vbatts@melisma:~$ sudo nerdctl exec -it --env-file ./env.sh farts sh
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
FOO=VAT
PWD=/
vbatts@melisma:~$ cat > env.sh
FOO=bar
Bif=BAZ
vbatts@melisma:~$ sudo nerdctl exec -it --env-file ./env.sh farts sh
Bif=BAZ
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
FOO=bar
PWD=/
BAZ
```

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>