### PR TITLE
run: add --rdt-class flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ Cgroup flags:
   - Default: "private" on cgroup v2 hosts, "host" on cgroup v1 hosts
 - :whale: `--device`: Add a host device to the container
 
+Intel RDT flags:
+- :nerd_face: `--rdt-class=CLASS`: Name of the RDT class (or CLOS) to associate the container wit
+
 User flags:
 - :whale: :blue_square: `-u, --user`: Username or UID (format: <name|uid>[:<group|gid>])
 

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -150,6 +150,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("device", nil, "Add a host device to the container")
 	// ulimit is defined as StringSlice, not StringArray, to allow specifying "--ulimit=ULIMIT1,ULIMIT2" (compatible with Podman)
 	cmd.Flags().StringSlice("ulimit", nil, "Ulimit options")
+	cmd.Flags().String("rdt-class", "", "Name of the RDT class (or CLOS) to associate the container with")
 	// #endregion
 
 	// user flags

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -156,5 +156,11 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 	}
 	opts = append(opts, gpuOpt...)
 
+	if rdtClass, err := cmd.Flags().GetString("rdt-class"); err != nil {
+		return nil, err
+	} else if rdtClass != "" {
+		opts = append(opts, oci.WithRdt(rdtClass, "", ""))
+	}
+
 	return opts, nil
 }


### PR DESCRIPTION
A new option for setting the RDT class (or CLOS) from the command line.

Complements https://github.com/containerd/containerd/pull/5439