### PR TITLE
add `nerdctl run --ip ipv4 --ip6 ipv6` ; add compose network subnet

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -113,6 +113,8 @@ func newRunCommand() *cobra.Command {
 	runCommand.Flags().StringSlice("dns", nil, "Set custom DNS servers")
 	runCommand.Flags().StringSliceP("publish", "p", nil, "Publish a container's port(s) to the host")
 	runCommand.Flags().StringP("hostname", "h", "", "Container host name")
+	runCommand.Flags().StringSlice("ip", nil, "IPv4 address")
+	runCommand.Flags().StringSlice("ip6", nil, "IPv6 address")
 	// #endregion
 
 	// #region cgroups, namespaces, and ulimits flags

--- a/cmd/nerdctl/run_network_test.go
+++ b/cmd/nerdctl/run_network_test.go
@@ -343,3 +343,17 @@ func httpGet(urlStr string, attempts int) (*http.Response, error) {
 	}
 	return nil, errors.Wrapf(err, "error after %d attempts", attempts)
 }
+
+func TestRunIp(t *testing.T) {
+	const (
+		testSubnet = "10.1.0.0/24"
+		testIPV4   = "10.1.0.100"
+	)
+
+	base := testutil.NewBase(t)
+	customNet := "customnet1"
+	base.Cmd("network", "create", "--subnet", testSubnet, customNet).AssertOK()
+	defer base.Cmd("network", "rm", customNet).Run()
+
+	base.Cmd("run", "--rm", "--net", customNet, "--ip", testIPV4, testutil.AlpineImage, "ifconfig").AssertOutContains("inet addr:10.1.0.100")
+}

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -499,6 +499,14 @@ func newContainer(project *compose.Project, parsed *Service, i int) (*Container,
 		for _, net := range networks {
 			c.RunArgs = append(c.RunArgs, "--net="+net)
 		}
+		for _, config := range svc.Networks {
+			if config.Ipv4Address != "" {
+				c.RunArgs = append(c.RunArgs, "--ip="+config.Ipv4Address)
+			}
+			if config.Ipv6Address != "" {
+				c.RunArgs = append(c.RunArgs, "--ip6="+config.Ipv6Address)
+			}
+		}
 	}
 
 	if svc.Pid != "" {


### PR DESCRIPTION
fix #432
Signed-off-by: Piotr Belina <piotr@piotrbelina.com>

Hello, I tried to add network configuration for compose and `--ip` and `--ip6` flags for run command.
The compose part is done, but I can't make `nerdctl run --ip 10.1.0.100` to run.
Maybe somebody can help me