### PR TITLE
`nerdctl image inspect --mode=native`: fulfill Index and Manifest

### DIFF
--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -75,7 +75,7 @@ func Commit(ctx context.Context, client *containerd.Client, id string, opts *Opt
 		return emptyDigest, err
 	}
 
-	baseImgConfig, err := imgutil.ReadImageConfig(ctx, baseImg)
+	baseImgConfig, _, err := imgutil.ReadImageConfig(ctx, baseImg)
 	if err != nil {
 		return emptyDigest, err
 	}
@@ -169,7 +169,7 @@ func generateCommitImageConfig(ctx context.Context, container containerd.Contain
 		return ocispec.Image{}, err
 	}
 
-	baseConfig, err := imgutil.ReadImageConfig(ctx, img)
+	baseConfig, _, err := imgutil.ReadImageConfig(ctx, img)
 	if err != nil {
 		return ocispec.Image{}, err
 	}

--- a/pkg/inspecttypes/native/image.go
+++ b/pkg/inspecttypes/native/image.go
@@ -24,7 +24,11 @@ import (
 // Image corresponds to a containerd-native image object.
 // Not compatible with `docker image inspect`.
 type Image struct {
-	Image images.Image `json:"Image"`
+	Image        images.Image        `json:"Image"`
+	IndexDesc    *ocispec.Descriptor `json:"IndexDesc,omitempty"`
+	Index        *ocispec.Index      `json:"Index,omitempty"`
+	ManifestDesc *ocispec.Descriptor `json:"ManifestDesc,omitempty"`
+	Manifest     *ocispec.Manifest   `json:"Manifest,omitempty"`
 	// e.g., "application/vnd.docker.container.image.v1+json"
 	ImageConfigDesc ocispec.Descriptor `json:"ImageConfigDesc"`
 	ImageConfig     ocispec.Image      `json:"ImageConfig"`


### PR DESCRIPTION
<details>
<summary>
Example: <code>nerdctl image inspect --mode=native alpine</code>
</summary>

<p>

```json
[
    {
        "Image": {
            "Name": "docker.io/library/alpine:latest",
            "Labels": null,
            "Target": {
                "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
                "digest": "sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
                "size": 1638
            },
            "CreatedAt": "2021-10-19T07:56:25.956157762Z",
            "UpdatedAt": "2021-10-19T09:46:33.051913216Z"
        },
        "IndexDesc": {
            "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
            "digest": "sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
            "size": 1638
        },
        "Index": {
            "schemaVersion": 2,
            "manifests": [
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a",
                    "size": 528,
                    "platform": {
                        "architecture": "amd64",
                        "os": "linux"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:18c29393a090ba5cde8a5f00926e9e419f47cfcfd206cc3f7f590e91b19adfe9",
                    "size": 528,
                    "platform": {
                        "architecture": "arm",
                        "os": "linux",
                        "variant": "v6"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:e12ff876f0075740ed3d7bdf788107ae84c1b3dd6dc98b3baea41088aba5236f",
                    "size": 528,
                    "platform": {
                        "architecture": "arm",
                        "os": "linux",
                        "variant": "v7"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:b06a5cf61b2956088722c4f1b9a6f71dfe95f0b1fe285d44195452b8a1627de7",
                    "size": 528,
                    "platform": {
                        "architecture": "arm64",
                        "os": "linux",
                        "variant": "v8"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:a77adef9f69751add61080617e15e67aba9aa7a5fd5414b9fae84143210ee0ad",
                    "size": 528,
                    "platform": {
                        "architecture": "386",
                        "os": "linux"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:9bea59997a84beb47a8cc7ddb11abc957b141e8160852aa93b4cf60659016b53",
                    "size": 528,
                    "platform": {
                        "architecture": "ppc64le",
                        "os": "linux"
                    }
                },
                {
                    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
                    "digest": "sha256:e841d0f0881ea22080e84088337646ada15871abbc3ce19b3219e8fc2cb0cc22",
                    "size": 528,
                    "platform": {
                        "architecture": "s390x",
                        "os": "linux"
                    }
                }
            ]
        },
        "ManifestDesc": {
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "digest": "sha256:69704ef328d05a9f806b6b8502915e6a0a4faa4d72018dc42343f511490daf8a",
            "size": 528,
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            }
        },
        "Manifest": {
            "schemaVersion": 2,
            "config": {
                "mediaType": "application/vnd.docker.container.image.v1+json",
                "digest": "sha256:14119a10abf4669e8cdbdff324a9f9605d99697215a0d21c360fe8dfa8471bab",
                "size": 1471
            },
            "layers": [
                {
                    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
                    "digest": "sha256:a0d0a0d46f8b52473982a3c466318f479767577551a53ffc9074c9fa7035982e",
                    "size": 2814446
                }
            ]
        },
        "ImageConfigDesc": {
            "mediaType": "application/vnd.docker.container.image.v1+json",
            "digest": "sha256:14119a10abf4669e8cdbdff324a9f9605d99697215a0d21c360fe8dfa8471bab",
            "size": 1471
        },
        "ImageConfig": {
            "created": "2021-08-27T17:19:45.758611523Z",
            "architecture": "amd64",
            "os": "linux",
            "config": {
                "Env": [
                    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
                ],
                "Cmd": [
                    "/bin/sh"
                ]
            },
            "rootfs": {
                "type": "layers",
                "diff_ids": [
                    "sha256:e2eb06d8af8218cfec8210147357a68b7e13f7c485b991c288c2d01dc228bb68"
                ]
            },
            "history": [
                {
                    "created": "2021-08-27T17:19:45.553092363Z",
                    "created_by": "/bin/sh -c #(nop) ADD file:aad4290d27580cc1a094ffaf98c3ca2fc5d699fe695dfb8e6e9fac20f1129450 in / "
                },
                {
                    "created": "2021-08-27T17:19:45.758611523Z",
                    "created_by": "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]",
                    "empty_layer": true
                }
            ]
        }
    }
]
```

</p>

</details>