### PR TITLE
multi-platform

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
         sudo apt-get purge -y snapd
         sudo losetup -Dv
         sudo losetup -lv
+    - name: "Register QEMU (tonistiigi/binfmt)"
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: "Run integration tests"
       run: docker run -t --rm --privileged test-integration go test -v ./cmd/nerdctl/... -args -test.kill-daemon
 
@@ -85,6 +87,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
+    - name: "Register QEMU (tonistiigi/binfmt)"
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
       run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless --target test-integration-rootless --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
     - name: "Test    (network driver=slirp4netns, port driver=builtin)"
@@ -117,6 +121,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 1
+    - name: "Register QEMU (tonistiigi/binfmt)"
+      run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: "Ensure that the integration test suite is compatible with Docker"
       run: go test -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ $ limactl start
 $ lima nerdctl run -d --name nginx -p 127.0.0.1:8080:80 nginx:alpine
 ```
 
-NOTE: ARM Mac requires installing a patched version of QEMU, see [Lima](https://github.com/AkihiroSuda/lima) documentation.
-
 ### FreeBSD
 
 See [`./docs/freebsd.md`](docs/freebsd.md).
@@ -131,6 +129,7 @@ Minor:
 - Specifying a non-image rootfs: `nerdctl run -it --rootfs <ROOTFS> /bin/sh` . The CLI syntax conforms to Podman convention.
 - Connecting a container to multiple networks at once: `nerdctl run --net foo --net bar`
 - Running [FreeBSD jails](./docs/freebsd.md).
+- Better multi-platform support, e.g., `nerdctl pull --all-platforms IMAGE`
 
 Trivial:
 - Inspecting raw OCI config: `nerdctl container inspect --mode=native` .
@@ -290,6 +289,9 @@ Basic flags:
 - :whale: `--pull=(always|missing|never)`: Pull image before running
   - Default: "missing"
 - :whale: `--pid=(host)`: PID namespace to use
+
+Platform flags:
+- :whale: `--platform=(amd64|arm64|...)`: Set platform
 
 Network flags:
 - :whale: `--net, --network=(bridge|host|none|<CNI>)`: Connect a container to a network
@@ -620,8 +622,9 @@ Flags:
 - :whale: `-q, --quiet`: Suppress the build output and print image ID on success
 - :whale: `--cache-from=CACHE`: External cache sources (eg. user/app:cache, type=local,src=path/to/dir) (compatible with `docker buildx build`)
 - :whale: `--cache-to=CACHE`: Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir) (compatible with `docker buildx build`)
+- :whale: `--platform=(amd64|arm64|...)`: Set target platform for build (compatible with `docker buildx build`)
 
-Unimplemented `docker build` flags: `--add-host`, `--iidfile`, `--label`, `--network`, `--platform`, `--squash`
+Unimplemented `docker build` flags: `--add-host`, `--iidfile`, `--label`, `--network`, `--squash`
 
 ### :whale: nerdctl commit
 Create a new image from a container's changes
@@ -656,12 +659,21 @@ Pull an image from a registry.
 
 Usage: `nerdctl pull [OPTIONS] NAME[:TAG|@DIGEST]`
 
-Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true), `--platform`, `--quiet`
+Flags:
+- :whale: `--platform=(amd64|arm64|...)`: Pull content for a specific platform
+  - :nerd_face: Unlike Docker, this flag can be specified multiple times (`--platform=amd64 --platform=arm64`)
+- :nerd_face: `--all-platforms`: Pull content for all platforms
+
+Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true), `--quiet`
 
 ### :whale: nerdctl push
 Push an image to a registry.
 
 Usage: `nerdctl push [OPTIONS] NAME[:TAG]`
+
+Flags:
+- :nerd_face: `--platform=(amd64|arm64|...)`: Push content for a specific platform
+- :nerd_face: `--all-platforms`: Push content for all platforms
 
 Unimplemented `docker push` flags: `--all-tags`, `--disable-content-trust` (default true), `--quiet`
 
@@ -674,6 +686,8 @@ Usage: `nerdctl load [OPTIONS]`
 
 Flags:
 - :whale: `-i, --input`: Read from tar archive file, instead of STDIN
+- :nerd_face: `--platform=(amd64|arm64|...)`: Import content for a specific platform
+- :nerd_face: `--all-platforms`: Import content for all platforms
 
 Unimplemented `docker load` flags: `--quiet`
 
@@ -686,6 +700,8 @@ Usage: `nerdctl save [OPTIONS] IMAGE [IMAGE...]`
 
 Flags:
 - :whale: `-o, --output`: Write to a file, instead of STDOUT
+- :nerd_face: `--platform=(amd64|arm64|...)`: Export content for a specific platform
+- :nerd_face: `--all-platforms`: Export content for all platforms
 
 ### :whale: nerdctl tag
 Create a tag TARGET\_IMAGE that refers to SOURCE\_IMAGE.
@@ -707,6 +723,7 @@ Usage: `nerdctl image inspect [OPTIONS] NAME|ID [NAME|ID...]`
 Flags:
 - :nerd_face: `--mode=(dockercompat|native)`: Inspection mode. "native" produces more information.
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
+- :nerd_face: `--platform=(amd64|arm64|...)`: Inspect a specific platform
 
 ### :nerd_face: nerdctl image convert
 Convert an image format.
@@ -1025,4 +1042,5 @@ Others:
 - [`./docs/stargz.md`](./docs/stargz.md):     Lazy-pulling using Stargz Snapshotter
 - [`./docs/ocicrypt.md`](./docs/ocicrypt.md): Running encrypted images
 - [`./docs/freebsd.md`](./docs/freebsd.md):  Running FreeBSD jails
+- [`./docs/multi-platform.md`](./docs/multi-platform.md):  Multi-platform mode
 - [`./docs/experimental.md`](./docs/experimental.md):  Experimental features

--- a/cmd/nerdctl/commit.go
+++ b/cmd/nerdctl/commit.go
@@ -63,7 +63,7 @@ func commitAction(cmd *cobra.Command, args []string) error {
 			if found.MatchCount > 1 {
 				return errors.Errorf("ambiguous ID %q", found.Req)
 			}
-			imageID, err := commit.Commit(ctx, client, found.Container.ID(), opts)
+			imageID, err := commit.Commit(ctx, client, found.Container, opts)
 			if err != nil {
 				return err
 			}

--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -138,3 +138,17 @@ func shellCompleteVolumeNames(cmd *cobra.Command) ([]string, cobra.ShellCompDire
 	}
 	return candidates, cobra.ShellCompDirectiveNoFileComp
 }
+
+func shellCompletePlatforms(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	candidates := []string{
+		"amd64",
+		"arm64",
+		"riscv64",
+		"ppc64le",
+		"s390x",
+		"386",
+		"arm",          // alias of "linux/arm/v7"
+		"linux/arm/v6", // "arm/v6" is invalid (interpreted as OS="arm", Arch="v7")
+	}
+	return candidates, cobra.ShellCompDirectiveNoFileComp
+}

--- a/cmd/nerdctl/multi_platform_test.go
+++ b/cmd/nerdctl/multi_platform_test.go
@@ -1,0 +1,141 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+func testMultiPlatformRun(base *testutil.Base, alpineImage string) {
+	t := base.T
+	testutil.RequireExecPlatform(t, "linux/amd64", "linux/arm64", "linux/arm/v7")
+	testCases := map[string]string{
+		"amd64":        "x86_64",
+		"arm64":        "aarch64",
+		"arm":          "armv7l",
+		"linux/arm":    "armv7l",
+		"linux/arm/v7": "armv7l",
+	}
+	for plat, expectedUnameM := range testCases {
+		t.Logf("Testing %q (%q)", plat, expectedUnameM)
+		cmd := base.Cmd("run", "--rm", "--platform="+plat, alpineImage, "uname", "-m")
+		cmd.AssertOutContains(expectedUnameM)
+	}
+}
+
+func TestMultiPlatformRun(t *testing.T) {
+	base := testutil.NewBase(t)
+	testMultiPlatformRun(base, testutil.AlpineImage)
+}
+
+func TestMultiPlatformBuildPush(t *testing.T) {
+	testutil.DockerIncompatible(t) // non-buildx version of `docker build` lacks multi-platform. Also, `docker push` lacks --platform.
+	testutil.RequiresBuild(t)
+	testutil.RequireExecPlatform(t, "linux/amd64", "linux/arm64", "linux/arm/v7")
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, strings.ToLower(t.Name()))
+	defer reg.cleanup()
+
+	imageName := fmt.Sprintf("localhost:%d/nerdctl-multi-platform-build-test:latest", reg.listenPort)
+	defer base.Cmd("rmi", imageName).Run()
+
+	dockerfile := fmt.Sprintf(`FROM %s
+RUN echo dummy
+	`, testutil.AlpineImage)
+
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+
+	base.Cmd("build", "-t", imageName, "--platform=amd64,arm64,linux/arm/v7", buildCtx).AssertOK()
+	testMultiPlatformRun(base, imageName)
+	base.Cmd("push", "--platform=amd64,arm64,linux/arm/v7", imageName).AssertOK()
+}
+
+func TestMultiPlatformPullPushAllPlatforms(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, strings.ToLower(t.Name()))
+	defer reg.cleanup()
+
+	pushImageName := fmt.Sprintf("localhost:%d/nerdctl-multi-platform-pull-push-all-platforms:latest", reg.listenPort)
+	defer base.Cmd("rmi", pushImageName).Run()
+
+	base.Cmd("pull", "--all-platforms", testutil.AlpineImage).AssertOK()
+	base.Cmd("tag", testutil.AlpineImage, pushImageName).AssertOK()
+	base.Cmd("push", "--all-platforms", pushImageName).AssertOK()
+	testMultiPlatformRun(base, pushImageName)
+}
+
+func TestMultiPlatformComposeUpBuild(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	testutil.RequiresBuild(t)
+	testutil.RequireExecPlatform(t, "linux/amd64", "linux/arm64", "linux/arm/v7")
+	base := testutil.NewBase(t)
+
+	const dockerComposeYAML = `
+services:
+  svc0:
+    build: .
+    platform: amd64
+    ports:
+    - 8080:80
+  svc1:
+    build: .
+    platform: arm64
+    ports:
+    - 8081:80
+  svc2:
+    build: .
+    platform: linux/arm/v7
+    ports:
+    - 8082:80
+`
+	dockerfile := fmt.Sprintf(`FROM %s
+RUN uname -m > /usr/share/nginx/html/index.html
+`, testutil.NginxAlpineImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+
+	comp.WriteFile("Dockerfile", dockerfile)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d", "--build").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
+
+	testCases := map[string]string{
+		"http://127.0.0.1:8080": "x86_64",
+		"http://127.0.0.1:8081": "aarch64",
+		"http://127.0.0.1:8082": "armv7l",
+	}
+
+	for testURL, expectedIndexHTML := range testCases {
+		resp, err := httpGet(testURL, 50)
+		assert.NilError(t, err)
+		respBody, err := ioutil.ReadAll(resp.Body)
+		assert.NilError(t, err)
+		t.Logf("respBody=%q", respBody)
+		assert.Assert(t, strings.Contains(string(respBody), expectedIndexHTML))
+	}
+}

--- a/cmd/nerdctl/rmi.go
+++ b/cmd/nerdctl/rmi.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -57,9 +58,10 @@ func rmiAction(cmd *cobra.Command, args []string) error {
 	walker := &imagewalker.ImageWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found imagewalker.Found) error {
+			// digests is used only for emulating human-readable output of `docker rmi`
 			digests, err := found.Image.RootFS(ctx, cs, platforms.DefaultStrict())
 			if err != nil {
-				return err
+				logrus.WithError(err).Warning("failed to enumerate rootfs")
 			}
 
 			if err := is.Delete(ctx, found.Image.Name); err != nil {

--- a/docs/multi-platform.md
+++ b/docs/multi-platform.md
@@ -1,0 +1,51 @@
+# Multi-platform
+
+nerdctl can execute non-native container images using QEMU.
+e.g., ARM on Intel, and vice versa.
+
+## Preparation: Register QEMU to `/proc/sys/fs/binfmt_misc`
+
+```console
+$ sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all
+
+$ ls -1 /proc/sys/fs/binfmt_misc/qemu*
+/proc/sys/fs/binfmt_misc/qemu-aarch64
+/proc/sys/fs/binfmt_misc/qemu-arm
+/proc/sys/fs/binfmt_misc/qemu-mips64
+/proc/sys/fs/binfmt_misc/qemu-mips64el
+/proc/sys/fs/binfmt_misc/qemu-ppc64le
+/proc/sys/fs/binfmt_misc/qemu-riscv64
+/proc/sys/fs/binfmt_misc/qemu-s390x
+```
+
+The `tonistiigi/binfmt` container must be executed with `--privileged`.
+
+See also https://github.com/tonistiigi/binfmt
+
+## Usage
+### Pull & Run
+
+```console
+$ nerdctl pull --platform=arm64,s390x alpine
+
+$ nerdctl run --rm --platform=arm64 alpine uname -a
+Linux e6227935cf12 5.13.0-19-generic #19-Ubuntu SMP Thu Oct 7 21:58:00 UTC 2021 aarch64 Linux
+
+$ nerdctl run --rm --platform=s390x alpine uname -a
+Linux b39da08fbdbf 5.13.0-19-generic #19-Ubuntu SMP Thu Oct 7 21:58:00 UTC 2021 s390x Linux
+```
+
+### Build & Push
+```console
+$ nerdctl build --platform=amd64,arm64 --output type=image,name=example.com/foo:latest,push=true .
+```
+
+Or
+
+```console
+$ nerdctl build --platform=amd64,arm64 -t example.com/foo:latest .
+$ nerdctl push --all-platforms example.com/foo:latest
+```
+
+### Compose
+See [`../examples/compose-multi-platform`](../examples/compose-multi-platform)

--- a/examples/compose-multi-platform/Dockerfile
+++ b/examples/compose-multi-platform/Dockerfile
@@ -1,0 +1,16 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+FROM php:apache
+COPY index.php /var/www/html/

--- a/examples/compose-multi-platform/README.md
+++ b/examples/compose-multi-platform/README.md
@@ -1,0 +1,6 @@
+# Multi-platform compose demo
+
+- Make sure QEMU is configured, see [`../../docs/multi-platform.md`](../../docs/multi-platform.md)
+- Run `nerdctl compose up -d`
+- Open http://localhost:8080 , and confirm that "System" is ppc64le
+- Open http://localhost:8081 , and confirm that "System" is s390x

--- a/examples/compose-multi-platform/docker-compose.yaml
+++ b/examples/compose-multi-platform/docker-compose.yaml
@@ -1,0 +1,11 @@
+services:
+  svc0:
+    build: .
+    platform: s390x
+    ports:
+      - 8080:80
+  svc1:
+    build: .
+    platform: ppc64le
+    ports:
+      - 8081:80

--- a/examples/compose-multi-platform/index.php
+++ b/examples/compose-multi-platform/index.php
@@ -1,0 +1,1 @@
+<?php phpinfo(); ?>

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -39,16 +39,19 @@ func (c *Composer) Build(ctx context.Context, bo BuildOptions) error {
 			return err
 		}
 		if ps.Build != nil {
-			return c.buildServiceImage(ctx, ps.Image, ps.Build, bo)
+			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
 		return nil
 	})
 }
 
-func (c *Composer) buildServiceImage(ctx context.Context, image string, b *serviceparser.Build, bo BuildOptions) error {
+func (c *Composer) buildServiceImage(ctx context.Context, image string, b *serviceparser.Build, platform string, bo BuildOptions) error {
 	logrus.Infof("Building image %s", image)
 
 	var args []string // nolint: prealloc
+	if platform != "" {
+		args = append(args, "--platform="+platform)
+	}
 	for _, a := range bo.Args {
 		args = append(args, "--build-arg="+a)
 	}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -44,7 +44,7 @@ type Options struct {
 	NetworkExists  func(string) (bool, error)
 	VolumeExists   func(string) (bool, error)
 	ImageExists    func(ctx context.Context, imageName string) (bool, error)
-	EnsureImage    func(ctx context.Context, imageName, pullMode string) error
+	EnsureImage    func(ctx context.Context, imageName, pullMode, platform string) error
 	DebugPrintFull bool // full debug print, may leak secret env var to logs
 }
 

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -61,6 +61,7 @@ func warnUnknownFields(svc compose.ServiceConfig) {
 		"NetworkMode",
 		"Pid",
 		"PidsLimit",
+		"Platform",
 		"Ports",
 		"Privileged",
 		"PullPolicy",
@@ -507,6 +508,10 @@ func newContainer(project *compose.Project, parsed *Service, i int) (*Container,
 
 	if svc.PidsLimit > 0 {
 		c.RunArgs = append(c.RunArgs, fmt.Sprintf("--pids-limit=%d", svc.PidsLimit))
+	}
+
+	if svc.Platform != "" {
+		c.RunArgs = append(c.RunArgs, "--platform="+svc.Platform)
 	}
 
 	for _, p := range svc.Ports {

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -102,21 +102,21 @@ func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Ser
 	if ps.Build != nil {
 		var bo BuildOptions
 		if ps.Build.Force || force {
-			return c.buildServiceImage(ctx, ps.Image, ps.Build, bo)
+			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
 		if ok, err := c.ImageExists(ctx, ps.Image); err != nil {
 			return err
 		} else if ok {
 			logrus.Debugf("Image %s already exists, not building", ps.Image)
 		} else {
-			return c.buildServiceImage(ctx, ps.Image, ps.Build, bo)
+			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
 	}
 
 	// even when c.ImageExists returns true, we need to call c.EnsureImage
 	// because ps.PullMode can be "always".
 	logrus.Infof("Ensuring image %s", ps.Image)
-	if err := c.EnsureImage(ctx, ps.Image, ps.PullMode); err != nil {
+	if err := c.EnsureImage(ctx, ps.Image, ps.PullMode, ps.Unparsed.Platform); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/imageinspector/imageinspector.go
+++ b/pkg/imageinspector/imageinspector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Inspect inspects the image, for the platform specified in image.platform.
 func Inspect(ctx context.Context, client *containerd.Client, image images.Image) (*native.Image, error) {
 
 	n := &native.Image{}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -66,4 +66,7 @@ const (
 
 	// AnonymousVolumes is a JSON-marshalled string of []string
 	AnonymousVolumes = Prefix + "anonymous-volumes"
+
+	// Platform is the normalized platform string like "linux/ppc64le".
+	Platform = Prefix + "platform"
 )

--- a/pkg/platformutil/binfmt.go
+++ b/pkg/platformutil/binfmt.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platformutil
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/containerd/containerd/platforms"
+)
+
+func qemuArchFromOCIArch(ociArch string) (string, error) {
+	switch ociArch {
+	case "amd64":
+		return "x86_64", nil
+	case "arm64":
+		return "aarch64", nil
+	case "386":
+		return "i386", nil
+	case "arm", "s390x", "ppc64le", "riscv64", "mips64":
+		return ociArch, nil
+	case "mips64le":
+		return "mips64el", nil // NOT typo
+	}
+	return "", fmt.Errorf("unknown OCI architecture string: %q", ociArch)
+}
+
+func canExecProbably(s string) (bool, error) {
+	if s == "" {
+		return true, nil
+	}
+	p, err := platforms.Parse(s)
+	if err != nil {
+		return false, err
+	}
+	if platforms.Default().Match(p) {
+		return true, nil
+	}
+	if runtime.GOOS == "linux" {
+		qemuArch, err := qemuArchFromOCIArch(p.Architecture)
+		if err != nil {
+			return false, err
+		}
+		candidates := []string{
+			"/proc/sys/fs/binfmt_misc/qemu-" + qemuArch,
+			"/proc/sys/fs/binfmt_misc/buildkit-qemu-" + qemuArch,
+		}
+		for _, cand := range candidates {
+			if _, err := os.Stat(cand); err == nil {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func CanExecProbably(ss ...string) (bool, error) {
+	for _, s := range ss {
+		ok, err := canExecProbably(s)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/pkg/platformutil/platformutil.go
+++ b/pkg/platformutil/platformutil.go
@@ -1,0 +1,84 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platformutil
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/nerdctl/pkg/strutil"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// NewMatchComparerFromOCISpecPlatformSlice returns MatchComparer.
+// If platformz is empty, NewMatchComparerFromOCISpecPlatformSlice returns All (not DefaultStrict).
+func NewMatchComparerFromOCISpecPlatformSlice(platformz []ocispec.Platform) platforms.MatchComparer {
+	if len(platformz) == 0 {
+		return platforms.All
+	}
+	return platforms.Ordered(platformz...)
+}
+
+// NewMatchComparer returns MatchComparer.
+// If all is true, NewMatchComparer always returns All, regardless to the value of ss.
+// If all is false and ss is empty, NewMatchComparer returns DefaultStrict (not Default).
+// Otherwise NewMatchComparer returns Ordered MatchComparer.
+func NewMatchComparer(all bool, ss []string) (platforms.MatchComparer, error) {
+	if all {
+		return platforms.All, nil
+	}
+	if len(ss) == 0 {
+		// return DefaultStrict, not Default
+		return platforms.DefaultStrict(), nil
+	}
+	op, err := NewOCISpecPlatformSlice(false, ss)
+	return platforms.Ordered(op...), err
+}
+
+// NewOCISpecPlatformSlice returns a slice of ocispec.Platform
+// If all is true, NewOCISpecPlatformSlice always returns an empty slice, regardless to the value of ss.
+// If all is false and ss is empty, NewOCISpecPlatformSlice returns DefaultSpec.
+// Otherwise NewOCISpecPlatformSlice returns the slice that correspond to ss.
+func NewOCISpecPlatformSlice(all bool, ss []string) ([]ocispec.Platform, error) {
+	if all {
+		return nil, nil
+	}
+	if dss := strutil.DedupeStrSlice(ss); len(dss) > 0 {
+		var op []ocispec.Platform
+		for _, s := range dss {
+			p, err := platforms.Parse(s)
+			if err != nil {
+				return nil, fmt.Errorf("invalid platform: %q", s)
+			}
+			op = append(op, p)
+		}
+		return op, nil
+	}
+	return []ocispec.Platform{platforms.DefaultSpec()}, nil
+}
+
+func NormalizeString(s string) (string, error) {
+	if s == "" {
+		return platforms.DefaultString(), nil
+	}
+	parsed, err := platforms.Parse(s)
+	if err != nil {
+		return "", err
+	}
+	normalized := platforms.Normalize(parsed)
+	return platforms.Format(normalized), nil
+}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/pkg/errors"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
@@ -326,6 +327,17 @@ func RequiresBuild(t testing.TB) {
 		if err := buildkitutil.PingBKDaemon(buildkitHost); err != nil {
 			t.Skipf("test requires buildkitd: %+v", err)
 		}
+	}
+}
+
+func RequireExecPlatform(t testing.TB, ss ...string) {
+	ok, err := platformutil.CanExecProbably(ss...)
+	if !ok {
+		msg := fmt.Sprintf("test requires platform %v", ss)
+		if err != nil {
+			msg += fmt.Sprintf(": %v", err)
+		}
+		t.Skip(msg)
 	}
 }
 


### PR DESCRIPTION
 - [X] image convert (not new in this commit)
 - [X] image inspect
 - [X] rmi
 - [X] pull
 - [X] push
 - [X] load
 - [X] save
 - [X] run
 - [X] commit
 - [X] build
 - [X] compose
 - [X] docs
 - [x] tests


---

# Multi-platform

nerdctl can execute non-native container images using QEMU.
e.g., ARM on Intel, and vice versa.

## Preparation: Register QEMU to `/proc/sys/fs/binfmt_misc`

```console
$ sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all

$ ls -1 /proc/sys/fs/binfmt_misc/qemu*
/proc/sys/fs/binfmt_misc/qemu-aarch64
/proc/sys/fs/binfmt_misc/qemu-arm
/proc/sys/fs/binfmt_misc/qemu-mips64
/proc/sys/fs/binfmt_misc/qemu-mips64el
/proc/sys/fs/binfmt_misc/qemu-ppc64le
/proc/sys/fs/binfmt_misc/qemu-riscv64
/proc/sys/fs/binfmt_misc/qemu-s390x
```

The `tonistiigi/binfmt` container must be executed with `--privileged`.

See also https://github.com/tonistiigi/binfmt

## Usage
### Pull & Run

```console
$ nerdctl pull --platform=arm64,s390x alpine

$ nerdctl run --rm --platform=arm64 alpine uname -a
Linux e6227935cf12 5.13.0-19-generic #19-Ubuntu SMP Thu Oct 7 21:58:00 UTC 2021 aarch64 Linux

$ nerdctl run --rm --platform=s390x alpine uname -a
Linux b39da08fbdbf 5.13.0-19-generic #19-Ubuntu SMP Thu Oct 7 21:58:00 UTC 2021 s390x Linux
```

### Build & Push
```console
$ nerdctl build --platform=amd64,arm64 --output type=image,name=example.com/foo:latest,push=true .
```

Or

```console
$ nerdctl build --platform=amd64,arm64 -t example.com/foo:latest .
$ nerdctl push --all-platforms example.com/foo:latest
```

### Compose
See `examples/compose-multi-platform`

---
Fix #103
Fix #280