### PR TITLE
compose up services in args

### DIFF
--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -23,7 +23,7 @@ import (
 
 func newComposeUpCommand() *cobra.Command {
 	var composeUpCommand = &cobra.Command{
-		Use:           "up",
+		Use:           "up [SERVICE...]",
 		Short:         "Create and start containers",
 		RunE:          composeUpAction,
 		SilenceUsage:  true,
@@ -36,7 +36,7 @@ func newComposeUpCommand() *cobra.Command {
 	return composeUpCommand
 }
 
-func composeUpAction(cmd *cobra.Command, args []string) error {
+func composeUpAction(cmd *cobra.Command, services []string) error {
 	detach, err := cmd.Flags().GetBool("detach")
 	if err != nil {
 		return err
@@ -70,5 +70,5 @@ func composeUpAction(cmd *cobra.Command, args []string) error {
 		NoLogPrefix: noLogPrefix,
 		ForceBuild:  build,
 	}
-	return c.Up(ctx, uo)
+	return c.Up(ctx, uo, services)
 }

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -34,7 +34,7 @@ type UpOptions struct {
 	ForceBuild  bool
 }
 
-func (c *Composer) Up(ctx context.Context, uo UpOptions) error {
+func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) error {
 	for shortName := range c.project.Networks {
 		if err := c.upNetwork(ctx, shortName); err != nil {
 			return err
@@ -63,7 +63,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions) error {
 
 	var parsedServices []*serviceparser.Service
 	// use WithServices to sort the services in dependency order
-	if err := c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+	if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
 		ps, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err


### PR DESCRIPTION
Use the `nerdctl compose up` arguments to choose which services start. 
 - #271 