### PR TITLE
Fix parsing flags with comma (`nerdctl run --env FOO=foo1,foo2`)

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -53,20 +53,21 @@ func newBuildCommand() *cobra.Command {
 			Value:   pflag.NewStringValue(defaults.BuildKitHost(), new(string)),
 		},
 	)
-	buildCommand.Flags().StringSliceP("tag", "t", nil, "Name and optionally a tag in the 'name:tag' format")
+	buildCommand.Flags().StringArrayP("tag", "t", nil, "Name and optionally a tag in the 'name:tag' format")
 	buildCommand.Flags().StringP("file", "f", "", "Name of the Dockerfile")
 	buildCommand.Flags().String("target", "", "Set the target build stage to build")
-	buildCommand.Flags().StringSlice("build-arg", nil, "Set build-time variables")
+	buildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables")
 	buildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image")
 	buildCommand.Flags().StringP("output", "o", "", "Output destination (format: type=local,dest=path)")
 	buildCommand.Flags().String("progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
-	buildCommand.Flags().StringSlice("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
-	buildCommand.Flags().StringSlice("ssh", nil, "SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])")
+	buildCommand.Flags().StringArray("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
+	buildCommand.Flags().StringArray("ssh", nil, "SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])")
 	buildCommand.Flags().BoolP("quiet", "q", false, "Suppress the build output and print image ID on success")
-	buildCommand.Flags().StringSlice("cache-from", nil, "External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
-	buildCommand.Flags().StringSlice("cache-to", nil, "Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)")
+	buildCommand.Flags().StringArray("cache-from", nil, "External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
+	buildCommand.Flags().StringArray("cache-to", nil, "Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)")
 
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	buildCommand.Flags().StringSlice("platform", []string{}, "Set target platform for build (e.g., \"amd64\", \"arm64\")")
 	buildCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	// #endregion
@@ -168,7 +169,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		}
 		needsLoading = true
 	}
-	tagValue, err := cmd.Flags().GetStringSlice("tag")
+	tagValue, err := cmd.Flags().GetStringArray("tag")
 	if err != nil {
 		return "", nil, false, nil, err
 	}
@@ -241,7 +242,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		buildctlArgs = append(buildctlArgs, "--opt=platform="+strings.Join(platform, ","))
 	}
 
-	buildArgsValue, err := cmd.Flags().GetStringSlice("build-arg")
+	buildArgsValue, err := cmd.Flags().GetStringArray("build-arg")
 	if err != nil {
 		return "", nil, false, cleanup, err
 	}
@@ -271,7 +272,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		buildctlArgs = append(buildctlArgs, "--no-cache")
 	}
 
-	secretValue, err := cmd.Flags().GetStringSlice("secret")
+	secretValue, err := cmd.Flags().GetStringArray("secret")
 	if err != nil {
 		return "", nil, false, cleanup, err
 	}
@@ -279,7 +280,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		buildctlArgs = append(buildctlArgs, "--secret="+s)
 	}
 
-	sshValue, err := cmd.Flags().GetStringSlice("ssh")
+	sshValue, err := cmd.Flags().GetStringArray("ssh")
 	if err != nil {
 		return "", nil, false, cleanup, err
 	}
@@ -287,7 +288,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		buildctlArgs = append(buildctlArgs, "--ssh="+s)
 	}
 
-	cacheFrom, err := cmd.Flags().GetStringSlice("cache-from")
+	cacheFrom, err := cmd.Flags().GetStringArray("cache-from")
 	if err != nil {
 		return "", nil, false, cleanup, err
 	}
@@ -298,7 +299,7 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 		buildctlArgs = append(buildctlArgs, "--import-cache="+s)
 	}
 
-	cacheTo, err := cmd.Flags().GetStringSlice("cache-to")
+	cacheTo, err := cmd.Flags().GetStringArray("cache-to")
 	if err != nil {
 		return "", nil, false, cleanup, err
 	}

--- a/cmd/nerdctl/compose_build.go
+++ b/cmd/nerdctl/compose_build.go
@@ -31,7 +31,7 @@ func newComposeBuildCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeBuildCommand.Flags().StringSlice("build-arg", nil, "Set build-time variables for services.")
+	composeBuildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables for services.")
 	composeBuildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image.")
 	composeBuildCommand.Flags().String("progress", "", "Set type of progress output")
 	return composeBuildCommand
@@ -42,7 +42,7 @@ func composeBuildAction(cmd *cobra.Command, args []string) error {
 		// TODO: support specifying service names as args
 		return fmt.Errorf("arguments %v not supported", args)
 	}
-	buildArg, err := cmd.Flags().GetStringSlice("build-arg")
+	buildArg, err := cmd.Flags().GetStringArray("build-arg")
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -54,7 +54,9 @@ func newExecCommand() *cobra.Command {
 	execCommand.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
 	execCommand.Flags().BoolP("detach", "d", false, "Detached mode: run command in the background")
 	execCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
-	execCommand.Flags().StringSliceP("env", "e", nil, "Set environment variables")
+	// env needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}
+	execCommand.Flags().StringArrayP("env", "e", nil, "Set environment variables")
+	// env-file is defined as StringSlice, not StringArray, to allow specifying "--env-file=FILE1,FILE2" (compatible with Podman)
 	execCommand.Flags().StringSlice("env-file", nil, "Set environment variables from file")
 	execCommand.Flags().Bool("privileged", false, "Give extended privileges to the command")
 	return execCommand
@@ -238,7 +240,7 @@ func generateExecProcessSpec(ctx context.Context, cmd *cobra.Command, args []str
 		}
 		pspec.Env = append(pspec.Env, env...)
 	}
-	env, err := cmd.Flags().GetStringSlice("env")
+	env, err := cmd.Flags().GetStringArray("env")
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nerdctl/image_convert.go
+++ b/cmd/nerdctl/image_convert.go
@@ -69,6 +69,7 @@ func newImageConvertCommand() *cobra.Command {
 	// #endregion
 
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	imageConvertCommand.Flags().StringSlice("platform", []string{}, "Convert content for a specific platform")
 	imageConvertCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	imageConvertCommand.Flags().Bool("all-platforms", false, "Convert content for all platforms")

--- a/cmd/nerdctl/load.go
+++ b/cmd/nerdctl/load.go
@@ -44,6 +44,7 @@ func newLoadCommand() *cobra.Command {
 	loadCommand.Flags().StringP("input", "i", "", "Read from tar archive file, instead of STDIN")
 
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	loadCommand.Flags().StringSlice("platform", []string{}, "Import content for a specific platform")
 	loadCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	loadCommand.Flags().Bool("all-platforms", false, "Import content for all platforms")

--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -41,7 +41,7 @@ func newNetworkCreateCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	networkCreateCommand.Flags().String("subnet", "", `Subnet in CIDR format that represents a network segment, e.g. "10.5.0.0/16"`)
-	networkCreateCommand.Flags().StringSlice("label", nil, "Set metadata for a network")
+	networkCreateCommand.Flags().StringArray("label", nil, "Set metadata for a network")
 	return networkCreateCommand
 }
 
@@ -68,7 +68,7 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	labels, err := cmd.Flags().GetStringSlice("label")
+	labels, err := cmd.Flags().GetStringArray("label")
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/pull.go
+++ b/cmd/nerdctl/pull.go
@@ -36,6 +36,7 @@ func newPullCommand() *cobra.Command {
 	}
 
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	pullCommand.PersistentFlags().StringSlice("platform", nil, "Pull content for a specific platform")
 	pullCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	pullCommand.PersistentFlags().Bool("all-platforms", false, "Pull content for all platforms")

--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -41,6 +41,7 @@ func newPushCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	pushCommand.Flags().StringSlice("platform", []string{}, "Push content for a specific platform")
 	pushCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	pushCommand.Flags().Bool("all-platforms", false, "Push content for all platforms")

--- a/cmd/nerdctl/run_mount.go
+++ b/cmd/nerdctl/run_mount.go
@@ -44,7 +44,7 @@ import (
 // parseMountFlags will also parse --mount in a future release.
 func parseMountFlags(cmd *cobra.Command, volStore volumestore.VolumeStore) ([]*mountutil.Processed, error) {
 	var parsed []*mountutil.Processed
-	if flagVSlice, err := cmd.Flags().GetStringSlice("volume"); err != nil {
+	if flagVSlice, err := cmd.Flags().GetStringArray("volume"); err != nil {
 		return nil, err
 	} else {
 		for _, v := range strutil.DedupeStrSlice(flagVSlice) {

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -225,3 +225,32 @@ func TestRunUlimit(t *testing.T) {
 
 	base.Cmd("run", "--rm", "--ulimit", ulimit, testutil.AlpineImage, "sh", "-c", "ulimit -n").AssertOutContains("622")
 }
+
+func TestRunEnv(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm",
+		"--env", "FOO=foo1,foo2",
+		"--env", "BAR=bar1 bar2",
+		"--env", "BAZ=",
+		"--env", "QUX",
+		"--env", "QUUX=quux1",
+		"--env", "QUUX=quux2",
+		testutil.AlpineImage, "env").AssertOutWithFunc(func(stdout string) error {
+		if !strings.Contains(stdout, "\nFOO=foo1,foo2\n") {
+			return errors.New("got bad FOO")
+		}
+		if !strings.Contains(stdout, "\nBAR=bar1 bar2\n") {
+			return errors.New("got bad BAR")
+		}
+		if !strings.Contains(stdout, "\nBAZ=\n") {
+			return errors.New("got bad BAZ")
+		}
+		if strings.Contains(stdout, "QUX") {
+			return errors.New("got bad QUX (should not be set)")
+		}
+		if !strings.Contains(stdout, "\nQUUX=quux2\n") {
+			return errors.New("got bad QUUX")
+		}
+		return nil
+	})
+}

--- a/cmd/nerdctl/save.go
+++ b/cmd/nerdctl/save.go
@@ -43,6 +43,7 @@ func newSaveCommand() *cobra.Command {
 	saveCommand.Flags().StringP("output", "o", "", "Write to a file, instead of STDOUT")
 
 	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	saveCommand.Flags().StringSlice("platform", []string{}, "Export content for a specific platform")
 	saveCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
 	saveCommand.Flags().Bool("all-platforms", false, "Export content for all platforms")

--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -34,7 +34,7 @@ func newVolumeCreateCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	volumeCreateCommand.Flags().StringSlice("label", nil, "Set a label on the volume")
+	volumeCreateCommand.Flags().StringArray("label", nil, "Set a label on the volume")
 	return volumeCreateCommand
 }
 
@@ -51,7 +51,7 @@ func volumeCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	labels, err := cmd.Flags().GetStringSlice("label")
+	labels, err := cmd.Flags().GetStringArray("label")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`--env FOO=foo1,foo2` was accidentally parsed as an equivalent of `--env FOO=foo1 --env foo2`. (Regression due to Cobra migration)

Replace almost all [`StringSlice`](https://pkg.go.dev/github.com/spf13/pflag#StringSlice) to [`StringArray`](https://pkg.go.dev/github.com/spf13/pflag#StringArray) to prevent splitting, with the following exceptions:

- [N] nerdctl image (pull|push|save|load|convert) --platform=PLATFORM1,PLATFORM2
- [P] nerdctl run --add-host=HOST1:IP1,HOST2:IP2
- [P] nerdctl run --cap-add=CAP1,CAP2
- [P] nerdctl run --cap-drop=CAP1,CAP2
- [P] nerdctl run --device=DEV1,DEV2
- [P] nerdctl run --dns=DNS1,DNS2
- [P] nerdctl (run|exec) --env-file=FILE1,FILE2
- [P] nerdctl run --label-file=FILE1,FILE2
- [N] nerdctl run --net=NET1,NET2
- [N] nerdctl run --network=NET1,NET2
- [P] nerdctl run --publish=PUB1,PUB2
- [P] nerdctl run --ulimit=ULIMIT1,ULIMIT2

(N=nerdctl extension, P=for podman compatibility)

