### PR TITLE
Add `nerdctl image (encrypt|decrypt) SRC DST`

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,9 @@ Remove one or more images
 
 Usage: `nerdctl rmi [OPTIONS] IMAGE [IMAGE...]`
 
+Flags:
+- :nerd_face: `--async`: Asynchronous mode
+
 Unimplemented `docker rmi` flags: `--force`, `--no-prune`
 
 ### :whale: nerdctl image inspect

--- a/README.md
+++ b/README.md
@@ -648,12 +648,13 @@ List images
 Usage: `nerdctl images [OPTIONS] [REPOSITORY[:TAG]]`
 
 Flags:
+- :whale: `-a, --all`: Show all images (unimplemented)
 - :whale: `-q, --quiet`: Only show numeric IDs
 - :whale: `--no-trunc`: Don't truncate output
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
 - :whale: `--digests`: Show digests (compatible with Docker, unlike ID)
 
-Unimplemented `docker images` flags: `--all`, `--filter`
+Unimplemented `docker images` flags: `--filter`
 
 ### :whale: nerdctl pull
 Pull an image from a registry.
@@ -717,8 +718,10 @@ Usage: `nerdctl rmi [OPTIONS] IMAGE [IMAGE...]`
 
 Flags:
 - :nerd_face: `--async`: Asynchronous mode
+- :whale: `-f, --force`: Ignore removal errors
+  - :warning: WIP: currently, images are always forcibly removed, even when `--force` is not specified.
 
-Unimplemented `docker rmi` flags: `--force`, `--no-prune`
+Unimplemented `docker rmi` flags: `--no-prune`
 
 ### :whale: nerdctl image inspect
 Display detailed information on one or more images.

--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ Flags:
 - :whale: `--platform=(amd64|arm64|...)`: Pull content for a specific platform
   - :nerd_face: Unlike Docker, this flag can be specified multiple times (`--platform=amd64 --platform=arm64`)
 - :nerd_face: `--all-platforms`: Pull content for all platforms
+- :nerd_face: `--unpack`: Unpack the image for the current single platform (auto/true/false)
 
 Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true), `--quiet`
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -168,7 +168,7 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 			ocispecPlatforms = []ocispec.Platform{parsed} // no append
 		}
 		_, imgErr := imgutil.EnsureImage(ctx, client, cmd.OutOrStdout(), snapshotter, imageName,
-			pullMode, insecure, ocispecPlatforms)
+			pullMode, insecure, ocispecPlatforms, nil)
 		return imgErr
 	}
 

--- a/cmd/nerdctl/image.go
+++ b/cmd/nerdctl/image.go
@@ -40,6 +40,8 @@ func newImageCommand() *cobra.Command {
 		imageRmCommand(),
 		newImageConvertCommand(),
 		newImageInspectCommand(),
+		newImageEncryptCommand(),
+		newImageDecryptCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/image_convert.go
+++ b/cmd/nerdctl/image_convert.go
@@ -41,6 +41,8 @@ e.g., 'nerdctl image convert --estargz --oci example.com/foo:orig example.com/fo
 
 Use '--platform' to define the output platform.
 When '--all-platforms' is given all images in a manifest list must be available.
+
+For encryption and decryption, use 'nerdctl image (encrypt|decrypt)' command.
 `
 
 // imageConvertCommand is from https://github.com/containerd/stargz-snapshotter/blob/d58f43a8235e46da73fb94a1a35280cb4d607b2c/cmd/ctr-remote/commands/convert.go

--- a/cmd/nerdctl/image_cryptutil.go
+++ b/cmd/nerdctl/image_cryptutil.go
@@ -1,0 +1,200 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images/converter"
+	refdocker "github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/imgcrypt/images/encryption"
+	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
+	"github.com/containerd/nerdctl/pkg/platformutil"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/cobra"
+)
+
+// registerImgcryptFlags register flags that correspond to parseImgcryptFlags().
+// Platform flags are registered too.
+//
+// From:
+// - https://github.com/containerd/imgcrypt/blob/v1.1.2/cmd/ctr/commands/flags/flags.go#L23-L44 (except skip-decrypt-auth)
+// - https://github.com/containerd/imgcrypt/blob/v1.1.2/cmd/ctr/commands/images/encrypt.go#L52-L55
+func registerImgcryptFlags(cmd *cobra.Command, encrypt bool) {
+	flags := cmd.Flags()
+
+	// #region platform flags
+	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
+	flags.StringSlice("platform", []string{}, "Convert content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
+	flags.Bool("all-platforms", false, "Convert content for all platforms")
+	// #endregion
+
+	flags.String("gpg-homedir", "", "The GPG homedir to use; by default gpg uses ~/.gnupg")
+	flags.String("gpg-version", "", "The GPG version (\"v1\" or \"v2\"), default will make an educated guess")
+	flags.StringSlice("key", []string{}, "A secret key's filename and an optional password separated by colon; this option may be provided multiple times")
+	// While --recipient can be specified only for `nerdctl image encrypt`,
+	// --dec-recipient can be specified for both `nerdctl image encrypt` and `nerdctl image decrypt`.
+	flags.StringSlice("dec-recipient", []string{}, "Recipient of the image; used only for PKCS7 and must be an x509 certificate")
+
+	if encrypt {
+		// recipient is defined as StringSlice, not StringArray, to allow specifying "--recipient=jwe:FILE1,jwe:FILE2"
+		flags.StringSlice("recipient", []string{}, "Recipient of the image is the person who can decrypt it in the form specified above (i.e. jwe:/path/to/pubkey)")
+	}
+}
+
+// parseImgcryptFlags corresponds to https://github.com/containerd/imgcrypt/blob/v1.1.2/cmd/ctr/commands/images/crypt_utils.go#L244-L252
+func parseImgcryptFlags(cmd *cobra.Command, encrypt bool) (parsehelpers.EncArgs, error) {
+	var err error
+	flags := cmd.Flags()
+	var a parsehelpers.EncArgs
+
+	a.GPGHomedir, err = flags.GetString("gpg-homedir")
+	if err != nil {
+		return a, err
+	}
+	a.GPGVersion, err = flags.GetString("gpg-version")
+	if err != nil {
+		return a, err
+	}
+	a.Key, err = flags.GetStringSlice("key")
+	if err != nil {
+		return a, err
+	}
+	if encrypt {
+		a.Recipient, err = flags.GetStringSlice("recipient")
+		if err != nil {
+			return a, err
+		}
+		if len(a.Recipient) == 0 {
+			return a, errors.New("at least one recipient must be specified (e.g., --recipient=jwe:mypubkey.pem)")
+		}
+	}
+	// While --recipient can be specified only for `nerdctl image encrypt`,
+	// --dec-recipient can be specified for both `nerdctl image encrypt` and `nerdctl image decrypt`.
+	a.DecRecipient, err = flags.GetStringSlice("dec-recipient")
+	if err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
+func getImgcryptAction(encrypt bool) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		var convertOpts = []converter.Opt{}
+		srcRawRef := args[0]
+		targetRawRef := args[1]
+		if srcRawRef == "" || targetRawRef == "" {
+			return errors.New("src and target image need to be specified")
+		}
+
+		srcNamed, err := refdocker.ParseDockerRef(srcRawRef)
+		if err != nil {
+			return err
+		}
+		srcRef := srcNamed.String()
+
+		targetNamed, err := refdocker.ParseDockerRef(targetRawRef)
+		if err != nil {
+			return err
+		}
+		targetRef := targetNamed.String()
+
+		allPlatforms, err := cmd.Flags().GetBool("all-platforms")
+		if err != nil {
+			return err
+		}
+		platform, err := cmd.Flags().GetStringSlice("platform")
+		if err != nil {
+			return err
+		}
+		platMC, err := platformutil.NewMatchComparer(allPlatforms, platform)
+		if err != nil {
+			return err
+		}
+		convertOpts = append(convertOpts, converter.WithPlatform(platMC))
+
+		imgcryptFlags, err := parseImgcryptFlags(cmd, encrypt)
+		if err != nil {
+			return err
+		}
+
+		client, ctx, cancel, err := newClient(cmd)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
+		srcImg, err := client.ImageService().Get(ctx, srcRef)
+		if err != nil {
+			return err
+		}
+		layerDescs, err := platformutil.LayerDescs(ctx, client.ContentStore(), srcImg.Target, platMC)
+		if err != nil {
+			return err
+		}
+		layerFilter := func(desc ocispec.Descriptor) bool {
+			return true
+		}
+		var convertFunc converter.ConvertFunc
+		if encrypt {
+			cc, err := parsehelpers.CreateCryptoConfig(imgcryptFlags, layerDescs)
+			if err != nil {
+				return err
+			}
+			convertFunc = encryption.GetImageEncryptConverter(&cc, layerFilter)
+		} else {
+			cc, err := parsehelpers.CreateDecryptCryptoConfig(imgcryptFlags, layerDescs)
+			if err != nil {
+				return err
+			}
+			convertFunc = encryption.GetImageDecryptConverter(&cc, layerFilter)
+		}
+		// we have to compose the DefaultIndexConvertFunc here to match platforms.
+		convertFunc = composeConvertFunc(converter.DefaultIndexConvertFunc(nil, false, platMC), convertFunc)
+		convertOpts = append(convertOpts, converter.WithIndexConvertFunc(convertFunc))
+
+		// converter.Convert() gains the lease by itself
+		newImg, err := converter.Convert(ctx, client, targetRef, srcRef, convertOpts...)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), newImg.Target.Digest.String())
+		return nil
+	}
+}
+
+func composeConvertFunc(a, b converter.ConvertFunc) converter.ConvertFunc {
+	return func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+		newDesc, err := a(ctx, cs, desc)
+		if err != nil {
+			return newDesc, err
+		}
+		if newDesc == nil {
+			return b(ctx, cs, desc)
+		}
+		return b(ctx, cs, *newDesc)
+	}
+}
+
+func imgcryptShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// show image names
+	return shellCompleteImageNames(cmd)
+}

--- a/cmd/nerdctl/image_decrypt.go
+++ b/cmd/nerdctl/image_decrypt.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const imageDecryptHelp = `Decrypt an image locally.
+
+Use '--key' to specify the private keys.
+Private keys in PEM format may be encrypted and the password may be passed
+along in any of the following formats:
+- <filename>:<password>
+- <filename>:pass=<password>
+- <filename>:fd=<file descriptor> (not available for rootless mode)
+- <filename>:filename=<password file>
+
+Use '--platform' to define the platforms to decrypt. Defaults to the host platform.
+When '--all-platforms' is given all images in a manifest list must be available.
+Unspecified platforms are omitted from the output image.
+
+Example (encrypt):
+  openssl genrsa -out mykey.pem
+  openssl rsa -in mykey.pem -pubout -out mypubkey.pem
+  nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
+  nerdctl push example.com/foo:encrypted
+
+Example (decrypt):
+  nerdctl pull --unpack=false example.com/foo:encrypted
+  nerdctl image decrypt --key=mykey.pem example.com/foo:encrypted foo:decrypted
+`
+
+func newImageDecryptCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "decrypt [flags] <source_ref> <target_ref>...",
+		Short:             "decrypt an image",
+		Long:              imageDecryptHelp,
+		Args:              cobra.MinimumNArgs(2),
+		RunE:              getImgcryptAction(false),
+		ValidArgsFunction: imgcryptShellComplete,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+	}
+	registerImgcryptFlags(cmd, false)
+	return cmd
+}

--- a/cmd/nerdctl/image_encrypt.go
+++ b/cmd/nerdctl/image_encrypt.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+const imageEncryptHelp = `Encrypt image layers.
+
+Use '--recipient' to specify the recipients.
+The following protocol prefixes are supported:
+- pgp:<email-address>
+- jwe:<public-key-file-path>
+- pkcs7:<x509-file-path>
+
+Use '--platform' to define the platforms to encrypt. Defaults to the host platform.
+When '--all-platforms' is given all images in a manifest list must be available.
+Unspecified platforms are omitted from the output image.
+
+Example:
+  openssl genrsa -out mykey.pem
+  openssl rsa -in mykey.pem -pubout -out mypubkey.pem
+  nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
+  nerdctl push example.com/foo:encrypted
+
+To run the encrypted image, put the private key file (mykey.pem) to /etc/containerd/ocicrypt/keys (rootful) or ~/.config/containerd/ocicrypt/keys (rootless).
+containerd before v1.4 requires extra configuration steps, see https://github.com/containerd/nerdctl/blob/master/docs/ocicrypt.md
+
+CAUTION: This command only encrypts image layers, but does NOT encrypt container configuration such as 'Env' and 'Cmd'.
+To see non-encrypted information, run 'nerdctl image inspect --mode=native --platform=PLATFORM example.com/foo:encrypted' .
+`
+
+func newImageEncryptCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:               "encrypt [flags] <source_ref> <target_ref>...",
+		Short:             "encrypt image layers",
+		Long:              imageEncryptHelp,
+		Args:              cobra.MinimumNArgs(2),
+		RunE:              getImgcryptAction(true),
+		ValidArgsFunction: imgcryptShellComplete,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+	}
+	registerImgcryptFlags(cmd, true)
+	return cmd
+}

--- a/cmd/nerdctl/image_encrypt_test.go
+++ b/cmd/nerdctl/image_encrypt_test.go
@@ -1,0 +1,89 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+type jweKeyPair struct {
+	prv     string
+	pub     string
+	cleanup func()
+}
+
+func newJWEKeyPair(t testing.TB) *jweKeyPair {
+	td, err := os.MkdirTemp(t.TempDir(), "jwe-key-pair")
+	assert.NilError(t, err)
+	prv := filepath.Join(td, "mykey.pem")
+	pub := filepath.Join(td, "mypubkey.pem")
+	cmds := [][]string{
+		// Exec openssl commands to ensure that nerdctl is compatible with the output of openssl commands.
+		// Do NOT refactor this function to use "crypto/rsa" stdlib.
+		{"openssl", "genrsa", "-out", prv},
+		{"openssl", "rsa", "-in", prv, "-pubout", "-out", pub},
+	}
+	for _, f := range cmds {
+		cmd := exec.Command(f[0], f[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("failed to run %v: %v (%q)", cmd.Args, err, string(out))
+		}
+	}
+	return &jweKeyPair{
+		prv: prv,
+		pub: pub,
+		cleanup: func() {
+			_ = os.RemoveAll(td)
+		},
+	}
+}
+
+func rmiAll(base *testutil.Base) {
+	imageIDs := base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
+	base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).AssertOK()
+}
+
+func TestImageEncryptJWE(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	keyPair := newJWEKeyPair(t)
+	defer keyPair.cleanup()
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-image-encrypt-jwe")
+	defer reg.cleanup()
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	encryptImageRef := fmt.Sprintf("127.0.0.1:%d/test-image-encrypt-jwe:encrypted", reg.listenPort)
+	defer base.Cmd("rmi", encryptImageRef).Run()
+	base.Cmd("image", "encrypt", "--recipient=jwe:"+keyPair.pub, testutil.AlpineImage, encryptImageRef).AssertOK()
+	base.Cmd("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", encryptImageRef).AssertOutExactly("1\n")
+	base.Cmd("image", "inspect", "--mode=native", "--format={{json .Manifest.Layers}}", encryptImageRef).AssertOutContains("org.opencontainers.image.enc.keys.jwe")
+	base.Cmd("push", encryptImageRef).AssertOK()
+	// remove all local images (in the nerdctl-test namespace), to ensure that we do not have blobs of the original image.
+	rmiAll(base)
+	base.Cmd("pull", encryptImageRef).AssertFail() // defaults to --unpack=true, and fails due to missing prv key
+	base.Cmd("pull", "--unpack=false", encryptImageRef).AssertOK()
+	decryptImageRef := "test-image-encrypt-jwe:decrypted"
+	defer base.Cmd("rmi", decryptImageRef).Run()
+	base.Cmd("image", "decrypt", "--key="+keyPair.pub, encryptImageRef, decryptImageRef).AssertFail() // decryption needs prv key, not pub key
+	base.Cmd("image", "decrypt", "--key="+keyPair.prv, encryptImageRef, decryptImageRef).AssertOK()
+}

--- a/cmd/nerdctl/images.go
+++ b/cmd/nerdctl/images.go
@@ -66,6 +66,7 @@ func newImagesCommand() *cobra.Command {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	imagesCommand.Flags().Bool("digests", false, "Show digests (compatible with Docker, unlike ID)")
+	imagesCommand.Flags().BoolP("all", "a", true, "(unimplemented yet, always true)")
 
 	return imagesCommand
 }

--- a/cmd/nerdctl/rmi.go
+++ b/cmd/nerdctl/rmi.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -37,13 +37,21 @@ func newRmiCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-
+	// Alias `-a` is reserved for `--all`. Should be compatible with `podman rmi --all`.
+	rmiCommand.Flags().Bool("async", false, "Asynchronous mode")
 	return rmiCommand
 }
 
 func rmiAction(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("requires at least 1 argument")
+	}
+
+	var delOpts []images.DeleteOpt
+	if async, err := cmd.Flags().GetBool("async"); err != nil {
+		return err
+	} else if !async {
+		delOpts = append(delOpts, images.SynchronousDelete())
 	}
 
 	client, ctx, cancel, err := newClient(cmd)
@@ -64,7 +72,7 @@ func rmiAction(cmd *cobra.Command, args []string) error {
 				logrus.WithError(err).Warning("failed to enumerate rootfs")
 			}
 
-			if err := is.Delete(ctx, found.Image.Name); err != nil {
+			if err := is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Untagged: %s@%s\n", found.Image.Name, found.Image.Target.Digest)

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -803,7 +803,7 @@ func generateRootfsOpts(ctx context.Context, client *containerd.Client, platform
 			return nil, nil, nil, err
 		}
 		ensured, err = imgutil.EnsureImage(ctx, client, os.Stdout, snapshotter, args[0],
-			pull, insecureRegistry, ocispecPlatforms)
+			pull, insecureRegistry, ocispecPlatforms, nil)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/docs/ocicrypt.md
+++ b/docs/ocicrypt.md
@@ -1,15 +1,30 @@
 # OCIcrypt
 
+nerdctl supports encryption and decryption using [OCIcrypt](https://github.com/containers/ocicrypt)
+(aka [imgcrypt](https://github.com/containerd/imgcrypt) for containerd).
 
-See https://github.com/containerd/imgcrypt to learn further information.
+## JWE mode
 
-## Encryption
+### Encryption
 
-See https://github.com/containerd/imgcrypt
+Use `openssl` to create a private key (`mykey.pem`) and the corresponding public key (`mypubkey.pem`):
+```bash
+openssl genrsa -out mykey.pem
+openssl rsa -in mykey.pem -pubout -out mypubkey.pem
+```
 
-## Decryption
+Use `nerdctl image encrypt` to create an encrypted image:
+```bash
+nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
+nerdctl push example.com/foo:encrypted
+```
 
-### Configuration
+:warning: CAUTION: This command only encrypts image layers, but does NOT encrypt [container configuration such as `Env` and `Cmd`](https://github.com/opencontainers/image-spec/blob/v1.0.1/config.md#example).
+To see non-encrypted information, run `nerdctl image inspect --mode=native --platform=PLATFORM example.com/foo:encrypted` .
+
+### Decryption
+
+#### Configuration
 Put the private key files to `/etc/containerd/ocicrypt/keys` (for rootless `~/.config/containerd/ocicrypt/keys`).
 
 <details>
@@ -42,8 +57,31 @@ version = 2
 
 </details>
 
-### nerdctl run
+#### Running nerdctl
 
-No flag is needed for running encrypted images with `nerdctl run`.
+No flag is needed for running encrypted images with `nerdctl run`, as long as the private key is stored
+in `/etc/containerd/ocicrypt/keys` (for rootless `~/.config/containerd/ocicrypt/keys`).
 
 Just run `nerdctl run example.com/encrypted-image`.
+
+To decrypt an image without running a container, use `nerdctl image decrypt` command:
+```bash
+nerdctl pull --unpack=false example.com/foo:encrypted
+nerdctl image decrypt --key=mykey.pem example.com/foo:encrypted foo:decrypted
+```
+
+## PGP (GPG) mode
+(Undocumented yet)
+
+## PKCS7 mode
+(Undocumented yet)
+
+## PKCS11 mode
+(Undocumented yet)
+
+## More information
+- https://github.com/containerd/imgcrypt (High-level library for containerd, using `containers/ocicrypt`)
+- https://github.com/containers/ocicrypt (Low-level library, used by `containerd/imgcrypt`)
+- https://github.com/opencontainers/image-spec/pull/775 (Proposal for OCI Image Spec)
+- https://github.com/containerd/containerd/blob/main/docs/cri/decryption.md (configuration guide)
+  - The `plugins."io.containerd.grpc.v1.cri"` section does not apply to nerdctl, as nerdctl does not use CRI

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/containerd/api v0.0.0 // replaced, see the bottom of this file
 	github.com/containerd/continuity v0.2.1
 	github.com/containerd/go-cni v1.1.0
-	github.com/containerd/imgcrypt v1.1.1
+	github.com/containerd/imgcrypt v1.1.2
 	github.com/containerd/stargz-snapshotter v0.9.0
 	github.com/containerd/stargz-snapshotter/estargz v0.9.0
 	github.com/containerd/typeurl v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,9 @@ github.com/containerd/go-cni v1.1.0 h1:kAe75MdTddsLCZDqP2BJn6e1ovD+il9oFkNlfGULE
 github.com/containerd/go-cni v1.1.0/go.mod h1:Rflh2EJ/++BA2/vY5ao3K6WJRR/bZKsX123aPk+kUtA=
 github.com/containerd/go-runc v0.0.0-20201020171139-16b287bc67d0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
 github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
-github.com/containerd/imgcrypt v1.1.1 h1:LBwiTfoUsdiEGAR1TpvxE+Gzt7469oVu87iR3mv3Byc=
 github.com/containerd/imgcrypt v1.1.1/go.mod h1:xpLnwiQmEUJPvQoAapeb2SNCxz7Xr6PJrXQb0Dpc4ms=
+github.com/containerd/imgcrypt v1.1.2 h1:UpzJWNIXynv55M1TNAP7kwUwSSbNbo89aAilpvWUJu0=
+github.com/containerd/imgcrypt v1.1.2/go.mod h1:maqDE8PxC8IpBdEIXVe5Y0nghLVMv6wkAbcFRyvO+1M=
 github.com/containerd/nri v0.1.0/go.mod h1:lmxnXF6oMkbqs39FiCt1s0R2HSMhcLel9vNL3m4AaeY=
 github.com/containerd/stargz-snapshotter v0.9.0 h1:J69Orkr6I1p6zJS6MFBa+xB9HebjQIxQEpvJkLxcWvw=
 github.com/containerd/stargz-snapshotter v0.9.0/go.mod h1:m5KYAX74rwuLdV7KZswDNINvVSPYJkA+kE/adANzpPw=

--- a/hack/Vagrantfile.fedora34
+++ b/hack/Vagrantfile.fedora34
@@ -35,7 +35,8 @@ Vagrant.configure("2") do |config|
       containernetworking-plugins \
       iptables \
       slirp4netns \
-      fuse-overlayfs
+      fuse-overlayfs \
+      openssl
     systemctl enable --now containerd
 
     # Install RootlessKit

--- a/pkg/platformutil/layers.go
+++ b/pkg/platformutil/layers.go
@@ -1,0 +1,37 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package platformutil
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/platforms"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func LayerDescs(ctx context.Context, provider content.Provider, imageTarget ocispec.Descriptor, platform platforms.MatchComparer) ([]ocispec.Descriptor, error) {
+	var descs []ocispec.Descriptor
+	err := images.Walk(ctx, images.Handlers(images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if images.IsLayerType(desc.MediaType) {
+			descs = append(descs, desc)
+		}
+		return nil, nil
+	}), images.FilterPlatforms(images.ChildrenHandler(provider), platform)), imageTarget)
+	return descs, err
+}

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -20,6 +20,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
@@ -105,4 +106,14 @@ func ReverseStrSlice(in []string) []string {
 		out[len(in)-i-1] = v
 	}
 	return out
+}
+
+// ParseBoolOrAuto returns (nil, nil) if s is "auto"
+// https://github.com/moby/buildkit/blob/v0.9.1/cmd/buildkitd/config.go#L35-L42
+func ParseBoolOrAuto(s string) (*bool, error) {
+	if s == "" || strings.ToLower(s) == "auto" {
+		return nil, nil
+	}
+	b, err := strconv.ParseBool(s)
+	return &b, err
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -265,6 +265,17 @@ func (c *Cmd) AssertOutContains(s string) {
 	c.Assert(expected)
 }
 
+func (c *Cmd) AssertOutExactly(s string) {
+	c.Base.T.Helper()
+	fn := func(stdout string) error {
+		if stdout != s {
+			return fmt.Errorf("expected %q, got %q", s, stdout)
+		}
+		return nil
+	}
+	c.AssertOutWithFunc(fn)
+}
+
 func (c *Cmd) AssertNoOut(s string) {
 	c.Base.T.Helper()
 	fn := func(stdout string) error {
@@ -281,6 +292,20 @@ func (c *Cmd) AssertOutWithFunc(fn func(stdout string) error) {
 	res := c.Run()
 	assert.Equal(c.Base.T, 0, res.ExitCode, res.Combined())
 	assert.NilError(c.Base.T, fn(res.Stdout()), res.Combined())
+}
+
+func (c *Cmd) Out() string {
+	c.Base.T.Helper()
+	res := c.Run()
+	assert.Equal(c.Base.T, 0, res.ExitCode, res.Combined())
+	return res.Stdout()
+}
+
+func (c *Cmd) OutLines() []string {
+	c.Base.T.Helper()
+	out := c.Out()
+	// FIXME: improve memory efficiency
+	return strings.Split(out, "\n")
 }
 
 type Target = string


### PR DESCRIPTION
`nerdctl run` has been supporting decryption, but we didn't have the command to encrypt images.

This will be probably beneficial for IPFS (#465)


Encrypt:
```bash
openssl genrsa -out mykey.pem
openssl rsa -in mykey.pem -pubout -out mypubkey.pem
nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
nerdctl push example.com/foo:encrypted
```

Decrypt:
```bash
nerdctl pull --unpack=false example.com/foo:encrypted
nerdctl decrypt --key=mykey.pem example.com/foo:encrypted foo:decrypted
```


See also `docs/ocicrypt.md`

<details>
<summary><code>nerctl image encrypt</code></summary>

<p>

```console
$ nerdctl image encrypt --help
Encrypt image layers.

Use '--recipient' to specify the recipients.
The following protocol prefixes are supported:
- pgp:<email-address>
- jwe:<public-key-file-path>
- pkcs7:<x509-file-path>

Use '--platform' to define the platforms to encrypt. Defaults to the host platform.
When '--all-platforms' is given all images in a manifest list must be available.
Unspecified platforms are omitted from the output image.

Example:
  openssl genrsa -out mykey.pem
  openssl rsa -in mykey.pem -pubout -out mypubkey.pem
  nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
  nerdctl push example.com/foo:encrypted

To run the encrypted image, put the private key file (mykey.pem) to /etc/containerd/ocicrypt/keys (rootful) or ~/.config/containerd/ocicrypt/keys (rootless).
containerd before v1.4 requires extra configuration steps, see https://github.com/containerd/nerdctl/blob/master/docs/ocicrypt.md

CAUTION: This command only encrypt image layers, but does NOT encrypt container config information such as 'Env' and 'Cmd'.
To see non-encrypted information, run 'nerdctl image inspect --mode=native --platform=PLATFORM example.com/foo:encrypted' .

Usage:
  nerdctl image encrypt [flags] <source_ref> <target_ref>...

Flags:
      --all-platforms           Convert content for all platforms
      --dec-recipient strings   Recipient of the image; used only for PKCS7 and must be an x509 certificate
      --gpg-homedir string      The GPG homedir to use; by default gpg uses ~/.gnupg
      --gpg-version string      The GPG version ("v1" or "v2"), default will make an educated guess
  -h, --help                    help for encrypt
      --key strings             A secret key's filename and an optional password separated by colon; this option may be provided multiple times
      --platform strings        Convert content for a specific platform
      --recipient strings       Recipient of the image is the person who can decrypt it in the form specified above (i.e. jwe:/path/to/pubkey)

Global Flags:
...
```


</p>


</details>

<details>

<summary><code>nerctl image decrypt</code></summary>

<p>

```console
$ nerdctl image decrypt --help
Decrypt an image locally.

Use '--key' to specify the private keys.
Private keys in PEM format may be encrypted and the password may be passed
along in any of the following formats:
- <filename>:<password>
- <filename>:pass=<password>
- <filename>:fd=<file descriptor> (not available for rootless mode)
- <filename>:filename=<password file>

Use '--platform' to define the platforms to decrypt. Defaults to the host platform.
When '--all-platforms' is given all images in a manifest list must be available.
Unspecified platforms are omitted from the output image.

Example (encrypt):
  openssl genrsa -out mykey.pem
  openssl rsa -in mykey.pem -pubout -out mypubkey.pem
  nerdctl image encrypt --recipient=jwe:mypubkey.pem --platform=linux/amd64,linux/arm64 foo example.com/foo:encrypted
  nerdctl push example.com/foo:encrypted

Example (decrypt):
  nerdctl pull --unpack=false example.com/foo:encrypted
  nerdctl decrypt --key=mykey.pem example.com/foo:encrypted foo:decrypted

Usage:
  nerdctl image decrypt [flags] <source_ref> <target_ref>...

Flags:
      --all-platforms           Convert content for all platforms
      --dec-recipient strings   Recipient of the image; used only for PKCS7 and must be an x509 certificate
      --gpg-homedir string      The GPG homedir to use; by default gpg uses ~/.gnupg
      --gpg-version string      The GPG version ("v1" or "v2"), default will make an educated guess
  -h, --help                    help for decrypt
      --key strings             A secret key's filename and an optional password separated by colon; this option may be provided multiple times
      --platform strings        Convert content for a specific platform

Global Flags:
...
```

</p>

</details>
