### PR TITLE
ps: show Kubernetes names (`k8s://NS/POD[/CONTAINER]`)

### DIFF
--- a/pkg/idutil/containerwalker/containerwalker.go
+++ b/pkg/idutil/containerwalker/containerwalker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/labels"
@@ -43,6 +44,9 @@ type ContainerWalker struct {
 // Req is name, short ID, or long ID.
 // Returns the number of the found entries.
 func (w *ContainerWalker) Walk(ctx context.Context, req string) (int, error) {
+	if strings.HasPrefix(req, "k8s://") {
+		return -1, fmt.Errorf("specifying \"k8s://...\" form is not supported (Hint: specify ID instead): %q", req)
+	}
 	filters := []string{
 		fmt.Sprintf("labels.%q==%s", labels.Name, req),
 		fmt.Sprintf("id~=^%s.*$", regexp.QuoteMeta(req)),

--- a/pkg/labels/k8slabels/k8slabels.go
+++ b/pkg/labels/k8slabels/k8slabels.go
@@ -1,0 +1,24 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package k8slabels defines Kubernetes container labels
+package k8slabels
+
+const (
+	PodNamespace  = "io.kubernetes.pod.namespace"
+	PodName       = "io.kubernetes.pod.name"
+	ContainerName = "io.kubernetes.container.name"
+)


### PR DESCRIPTION
```console
root@minikube:/# nerdctl -n k8s.io ps -a
CONTAINER ID    IMAGE                                                                                                PLATFORM    COMMAND                   CREATED           STATUS    PORTS    NAMES
0c82e6a41832    k8s.gcr.io/kube-scheduler@sha256:c76cb73debd5e37fe7ad42cea9a67e0bfdd51dd56be7b90bdc50dd1bc03c018b                "kube-scheduler --au…"    11 minutes ago    Up                 k8s://kube-system/kube-scheduler-minikube/kube-scheduler
0f73721b5ae9    k8s.gcr.io/kube-proxy:v1.22.2                                                                                    "/usr/local/bin/kube…"    11 minutes ago    Up                 k8s://kube-system/kube-proxy-c79qg/kube-proxy
28506f919cfe    k8s.gcr.io/coredns/coredns:v1.8.4                                                                                "/coredns -conf /etc…"    10 minutes ago    Up                 k8s://kube-system/coredns-78fcd69978-4fkkt/coredns
2979a9be3346    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  10 minutes ago    Up                 k8s://kube-system/coredns-78fcd69978-4fkkt
365da6dc8fba    docker.io/kindest/kindnetd:v20210326-1e038dc5                                                                    "/bin/kindnetd"           11 minutes ago    Up                 k8s://kube-system/kindnet-bfwt4/kindnet-cni
3c765a99540b    k8s.gcr.io/etcd:3.5.0-0                                                                                          "etcd --advertise-cl…"    11 minutes ago    Up                 k8s://kube-system/etcd-minikube/etcd
3e684e419901    k8s.gcr.io/kube-controller-manager:v1.22.2                                                                       "kube-controller-man…"    11 minutes ago    Up                 k8s://kube-system/kube-controller-manager-minikube/kube-controller-manager
4d8f064d73d9    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/etcd-minikube
5f92a2feee9c    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/kindnet-bfwt4
6892b49efcce    gcr.io/k8s-minikube/storage-provisioner:v5                                                                       "/storage-provisioner"    10 minutes ago    Up                 k8s://kube-system/storage-provisioner/storage-provisioner
7df2c1178013    k8s.gcr.io/kube-apiserver:v1.22.2                                                                                "kube-apiserver --ad…"    11 minutes ago    Up                 k8s://kube-system/kube-apiserver-minikube/kube-apiserver
91832deed72f    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/kube-apiserver-minikube
b7d57134a18f    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/kube-scheduler-minikube
ccfe73b0da5c    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/kube-proxy-c79qg
d32cec71e3e0    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  10 minutes ago    Up                 k8s://kube-system/storage-provisioner
f6fda23c32c2    k8s.gcr.io/pause:3.5                                                                                             "/pause"                  11 minutes ago    Up                 k8s://kube-system/kube-controller-manager-minikube
```

No support for specifying `nerdctl container inspect k8s://NS/POD[/CONTAINER]` and other similar commands
```console
root@minikube:/# nerdctl container inspect k8s://kube-system/coredns-78fcd69978-4fkkt/coredns
FATA[0000] 1 errors: [specifying "k8s://..." form is not supported (Hint: specify ID instead): "k8s://kube-system/coredns-78fcd69978-4fkkt/coredns"]
```

