### PR TITLE
Fix "`nerdctl system non-existent-command` doesn't fail"

### DIFF
--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -37,6 +37,7 @@ func newComposeCommand() *cobra.Command {
 	var composeCommand = &cobra.Command{
 		Use:           "compose",
 		Short:         "Compose",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/container.go
+++ b/cmd/nerdctl/container.go
@@ -25,6 +25,7 @@ func newContainerCommand() *cobra.Command {
 		Category:      CategoryManagement,
 		Use:           "container",
 		Short:         "Manage containers",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/image.go
+++ b/cmd/nerdctl/image.go
@@ -25,6 +25,7 @@ func newImageCommand() *cobra.Command {
 		Category:      CategoryManagement,
 		Use:           "image",
 		Short:         "Manage images",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -26,6 +26,19 @@ func TestMain(m *testing.M) {
 	testutil.M(m)
 }
 
+// TestUnknownCommand tests https://github.com/containerd/nerdctl/issues/487
+func TestUnknownCommand(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("non-existent-command").AssertFail()
+	base.Cmd("non-existent-command", "info").AssertFail()
+	base.Cmd("system", "non-existent-command").AssertFail()
+	base.Cmd("system", "non-existent-command", "info").AssertFail()
+	base.Cmd("system").AssertOK() // show help without error
+	base.Cmd("system", "info").AssertOutContains("Kernel Version:")
+	base.Cmd("info").AssertOutContains("Kernel Version:")
+}
+
 // TestIssue108 tests https://github.com/containerd/nerdctl/issues/108
 // ("`nerdctl run --net=host -it` fails while `nerdctl run -it --net=host` works")
 func TestIssue108(t *testing.T) {

--- a/cmd/nerdctl/namespace.go
+++ b/cmd/nerdctl/namespace.go
@@ -33,6 +33,7 @@ func newNamespaceCommand() *cobra.Command {
 		Use:           "namespace",
 		Short:         "Manage containerd namespaces",
 		Long:          "Unrelated to Linux namespaces and Kubernetes namespaces",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/network.go
+++ b/cmd/nerdctl/network.go
@@ -25,6 +25,7 @@ func newNetworkCommand() *cobra.Command {
 		Category:      CategoryManagement,
 		Use:           "network",
 		Short:         "Manage networks",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/system.go
+++ b/cmd/nerdctl/system.go
@@ -25,6 +25,7 @@ func newSystemCommand() *cobra.Command {
 		Category:      CategoryManagement,
 		Use:           "system",
 		Short:         "Manage containerd",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/cmd/nerdctl/volume.go
+++ b/cmd/nerdctl/volume.go
@@ -26,6 +26,7 @@ func newVolumeCommand() *cobra.Command {
 		Category:      CategoryManagement,
 		Use:           "volume",
 		Short:         "Manage volumes",
+		RunE:          unknownSubcommandAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}


### PR DESCRIPTION
Fix #487

```console
$ nerdctl system non-existent-command
FATA[0000] unknown subcommand "non-existent-command" for "system" 

$ echo 1
1

$ nerdctl system event
FATA[0000] unknown subcommand "event" for "system"

Did you mean this?
        events 

$ echo 1
1
```


---

This should be the last blocker to release v0.13