### PR TITLE
Add --cgroup-conf option to run subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ Cgroup flags:
 - :whale: `--cpuset-cpus`: CPUs in which to allow execution (0-3, 0,1)
 - :whale: `--memory`: Memory limit
 - :whale: `--pids-limit`: Tune container pids limit
+- :nerd_face: `--cgroup-conf`: Configure cgroup v2 (key=value)
 - :whale: `--cgroupns=(host|private)`: Cgroup namespace to use
   - Default: "private" on cgroup v2 hosts, "host" on cgroup v1 hosts
 - :whale: `--device`: Add a host device to the container

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -134,6 +134,7 @@ func newRunCommand() *cobra.Command {
 		return []string{"host"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	runCommand.Flags().Int("pids-limit", -1, "Tune container pids limit (set -1 for unlimited)")
+	runCommand.Flags().StringSlice("cgroup-conf", nil, "Configure cgroup v2 (key=value)")
 	runCommand.Flags().String("cgroupns", defaults.CgroupnsMode(), `Cgroup namespace to use, the default depends on the cgroup version ("host"|"private")`)
 	runCommand.RegisterFlagCompletionFunc("cgroupns", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"host", "private"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/cgroups"
 	"github.com/containerd/nerdctl/pkg/testutil"
 
 	"gotest.tools/v3/assert"
@@ -196,6 +197,16 @@ func TestRunPidHost(t *testing.T) {
 	pid := os.Getpid()
 
 	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
+}
+
+func TestRunCgroupConf(t *testing.T) {
+	if cgroups.Mode() != cgroups.Unified {
+		t.Skip("test requires cgroup v2")
+	}
+	base := testutil.NewBase(t)
+
+	base.Cmd("run", "--rm", "--cgroup-conf", "memory.high=33554432", testutil.AlpineImage,
+		"sh", "-ec", "cd /sys/fs/cgroup && cat memory.high").AssertOutContains("33554432")
 }
 
 func TestRunAddHost(t *testing.T) {


### PR DESCRIPTION
The PR aims to add the `--cgroup-conf` option to `nerdctl run`.

The syntax for the option is the following:

```nerdctl run --cgroup-conf="KEY1=VALUE1,KEY2=VALUE2"```

just like the equivalent option in `podman run --cgroup-conf`.

Updates #215 