### PR TITLE
Add --blkio-weight option to run subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Cgroup flags:
 - :whale: `--memory`: Memory limit
 - :whale: `--pids-limit`: Tune container pids limit
 - :nerd_face: `--cgroup-conf`: Configure cgroup v2 (key=value)
+- :whale: `blkio-weight`: Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
 - :whale: `--cgroupns=(host|private)`: Cgroup namespace to use
   - Default: "private" on cgroup v2 hosts, "host" on cgroup v1 hosts
 - :whale: `--device`: Add a host device to the container

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -135,6 +135,7 @@ func newRunCommand() *cobra.Command {
 	})
 	runCommand.Flags().Int("pids-limit", -1, "Tune container pids limit (set -1 for unlimited)")
 	runCommand.Flags().StringSlice("cgroup-conf", nil, "Configure cgroup v2 (key=value)")
+	runCommand.Flags().Uint16("blkio-weight", 0, "Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)")
 	runCommand.Flags().String("cgroupns", defaults.CgroupnsMode(), `Cgroup namespace to use, the default depends on the cgroup version ("host"|"private")`)
 	runCommand.RegisterFlagCompletionFunc("cgroupns", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"host", "private"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -209,6 +209,17 @@ func TestRunCgroupConf(t *testing.T) {
 		"sh", "-ec", "cd /sys/fs/cgroup && cat memory.high").AssertOutContains("33554432")
 }
 
+func TestRunBlkioWeightCgroupV2(t *testing.T) {
+	if cgroups.Mode() != cgroups.Unified {
+		t.Skip("test requires cgroup v2")
+	}
+	base := testutil.NewBase(t)
+
+	// when bfq io scheduler is used, the io.weight knob is exposed as io.bfq.weight
+	base.Cmd("run", "--rm", "--blkio-weight", "300", testutil.AlpineImage,
+		"sh", "-ec", "cd /sys/fs/cgroup && cat io.bfq.weight").AssertOutContains("300")
+}
+
 func TestRunAddHost(t *testing.T) {
 	base := testutil.NewBase(t)
 	base.Cmd("run", "--rm", "--add-host", "testing.example.com:10.0.0.1", testutil.AlpineImage, "sh", "-c", "cat /etc/hosts").AssertOutWithFunc(func(stdout string) error {


### PR DESCRIPTION
The PR aims to add the `--blkio-weight` option to `nerdctl run`, exposing the same behaviour as `docker run --blkio-weight`

Both cgroup v1 and cgroup v2 are supported. Besides, since the bfq IO scheduler exposes a different weight knob, a specific check is added for that.
Just like in docker, if the underlying kernel does not support blkio weight, a warning is generated and the weight is reset to 0.

Updates #215 