### PR TITLE
build: Add VERBOSE option in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet 
 
 export GO_BUILD=GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -ldflags "-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.Revision=$(REVISION)"
 
+ifdef VERBOSE
+	VERBOSE_FLAG := -v
+endif
+
 all: binaries
 
 help:
@@ -43,7 +47,7 @@ help:
 	@echo " * 'clean' - Clean artifacts."
 
 nerdctl:
-	$(GO_BUILD) -o $(CURDIR)/_output/nerdctl$(BIN_EXT) $(PACKAGE)/cmd/nerdctl
+	$(GO_BUILD) $(VERBOSE_FLAG) -o $(CURDIR)/_output/nerdctl$(BIN_EXT) $(PACKAGE)/cmd/nerdctl
 
 clean:
 	find . -name \*~ -delete


### PR DESCRIPTION
Adds a VERBOSE option in the Makefile to build the nerdctl binary with
the '-v' build flag to check on output of the go build

Usage:
```bash
nerdctl run --rm -it -v "$(pwd)":/v -w /v -e VERBOSE=1 golang make
```
Signed-off-by: Eli Uriegas <eliuriegas@fb.com>