### PR TITLE
Support builds using base images on IPFS (`nerdctl build --ipfs`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose build](#whale-nerdctl-compose-build)
     - [:whale: nerdctl compose down](#whale-nerdctl-compose-down)
     - [:whale: nerdctl compose ps](#whale-nerdctl-compose-ps)
+  - [IPFS management](#ipfs-management)
+    - [:nerd_face: nerdctl ipfs registry up](#nerd_face-nerdctl-ipfs-registry-up)
+    - [:nerd_face: nerdctl ipfs registry down](#nerd_face-nerdctl-ipfs-registry-down)
+    - [:nerd_face: nerdctl ipfs registry serve](#nerd_face-nerdctl-ipfs-registry-serve)
   - [Global flags](#global-flags)
   - [Unimplemented Docker commands](#unimplemented-docker-commands)
 - [Additional documents](#additional-documents)
@@ -650,6 +654,7 @@ Flags:
 - :whale: `--cache-from=CACHE`: External cache sources (eg. user/app:cache, type=local,src=path/to/dir) (compatible with `docker buildx build`)
 - :whale: `--cache-to=CACHE`: Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir) (compatible with `docker buildx build`)
 - :whale: `--platform=(amd64|arm64|...)`: Set target platform for build (compatible with `docker buildx build`)
+- :nerd_face: `--ipfs`: Build image with pulling base images from IFPS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 
 Unimplemented `docker build` flags: `--add-host`, `--iidfile`, `--label`, `--network`, `--squash`
 
@@ -1051,6 +1056,7 @@ Flags:
 - :whale: `--no-color`: Produce monochrome output
 - :whale: `--no-log-prefix`: Don't print prefix in logs
 - :whale: `--build`: Build images before starting containers.
+- :nerd_face: `--ipfs`: Build images with pulling base images from IFPS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 
 Unimplemented `docker-compose up` (V1) flags: `--quiet-pull`, `--no-deps`, `--force-recreate`, `--always-recreate-deps`, `--no-recreate`,
 `--no-start`, `--abort-on-container-exit`, `--attach-dependencies`, `--timeout`, `--renew-anon-volumes`, `--remove-orphans`, `--exit-code-from`,
@@ -1080,6 +1086,7 @@ Flags:
 - :whale: `--build-arg`: Set build-time variables for services
 - :whale: `--no-cache`: Do not use cache when building the image
 - :whale: `--progress`: Set type of progress output (auto, plain, tty)
+- :nerd_face: `--ipfs`: Build images with pulling base images from IFPS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 
 Unimplemented `docker-compose build` (V1) flags:  `--compress`, `--force-rm`, `--memory`, `--no-rm`, `--parallel`, `--pull`, `--quiet`
 
@@ -1101,6 +1108,33 @@ Usage: `nerdctl compose ps`
 Unimplemented `docker-compose ps` (V1) flags: `--quiet`, `--services`, `--filter`, `--all`
 
 Unimplemented `docker compose ps` (V2) flags: `--format`, `--status`
+
+## IPFS management
+
+### :nerd_face: nerdctl ipfs registry up
+Start read-only local registry backed by IPFS.
+See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
+
+Usage: `nerdctl ipfs registry up [OPTIONS]`
+
+Flags:
+- :nerd_face: `--listen-registry`: Address to listen (default `localhost:5050`)
+
+### :nerd_face: nerdctl ipfs registry down
+Stop and remove read-only local registry backed by IPFS.
+See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
+
+Usage: `nerdctl ipfs registry down`
+
+### :nerd_face: nerdctl ipfs registry serve
+Serve read-only registry backed by IPFS on localhost.
+Use `nerdctl ipfs registry up`.
+
+Usage: `nerdctl ipfs registry serve [OPTIONS]`
+
+Flags:
+- :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default is pulled from `$IPFS_PATH/api` file. If `$IPFS_PATH` env var is not present, it defaults to `~/.ipfs`).
+- :nerd_face: `--listen-registry`: Address to listen (default `localhost:5050`).
 
 ## Global flags
 - :nerd_face: :blue_square: `--address`:  containerd address, optionally with "unix://" prefix

--- a/cmd/nerdctl/build_test.go
+++ b/cmd/nerdctl/build_test.go
@@ -47,6 +47,32 @@ CMD ["echo", "nerdctl-build-test-string"]
 	base.Cmd("run", "--rm", imageName).AssertOutContains("nerdctl-build-test-string")
 }
 
+func TestIPFSBuild(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	requiresIPFS(t)
+	testutil.RequiresBuild(t)
+	base := testutil.NewBase(t)
+	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
+	ipfsCIDBase := strings.TrimPrefix(ipfsCID, "ipfs://")
+
+	const imageName = "nerdctl-build-test"
+	defer base.Cmd("rmi", imageName).Run()
+
+	dockerfile := fmt.Sprintf(`FROM localhost:5050/ipfs/%s
+CMD ["echo", "nerdctl-build-test-string"]
+	`, ipfsCIDBase)
+
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+
+	defer base.Cmd("ipfs", "registry", "down").AssertOK()
+	base.Cmd("build", "--ipfs", "-t", imageName, buildCtx).AssertOK()
+	base.Cmd("build", buildCtx, "--ipfs", "-t", imageName).AssertOK()
+
+	base.Cmd("run", "--rm", imageName).AssertOutContains("nerdctl-build-test-string")
+}
+
 func TestBuildFromStdin(t *testing.T) {
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)

--- a/cmd/nerdctl/compose_build.go
+++ b/cmd/nerdctl/compose_build.go
@@ -34,6 +34,9 @@ func newComposeBuildCommand() *cobra.Command {
 	composeBuildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables for services.")
 	composeBuildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image.")
 	composeBuildCommand.Flags().String("progress", "", "Set type of progress output")
+
+	composeBuildCommand.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
+
 	return composeBuildCommand
 }
 
@@ -54,6 +57,10 @@ func composeBuildAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	enableIPFS, err := cmd.Flags().GetBool("ipfs")
+	if err != nil {
+		return err
+	}
 
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
@@ -69,6 +76,7 @@ func composeBuildAction(cmd *cobra.Command, args []string) error {
 		Args:     buildArg,
 		NoCache:  noCache,
 		Progress: progress,
+		IPFS:     enableIPFS,
 	}
 	return c.Build(ctx, bo)
 }

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -33,6 +33,7 @@ func newComposeUpCommand() *cobra.Command {
 	composeUpCommand.Flags().Bool("no-color", false, "Produce monochrome output")
 	composeUpCommand.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
 	composeUpCommand.Flags().Bool("build", false, "Build images before starting containers.")
+	composeUpCommand.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
 	return composeUpCommand
 }
 
@@ -53,6 +54,10 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 	if err != nil {
 		return err
 	}
+	enableIPFS, err := cmd.Flags().GetBool("ipfs")
+	if err != nil {
+		return err
+	}
 
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
@@ -69,6 +74,7 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 		NoColor:     noColor,
 		NoLogPrefix: noLogPrefix,
 		ForceBuild:  build,
+		IPFS:        enableIPFS,
 	}
 	return c.Up(ctx, uo, services)
 }

--- a/cmd/nerdctl/ipfs.go
+++ b/cmd/nerdctl/ipfs.go
@@ -1,0 +1,36 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newIPFSCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Annotations:   map[string]string{Category: Management},
+		Use:           "ipfs",
+		Short:         "Distributing images on IPFS",
+		RunE:          unknownSubcommandAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(
+		newIPFSRegistryCommand(),
+	)
+	return cmd
+}

--- a/cmd/nerdctl/ipfs_registry.go
+++ b/cmd/nerdctl/ipfs_registry.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newIPFSRegistryCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Annotations:   map[string]string{Category: Management},
+		Use:           "registry",
+		Short:         "Manage read-only registry backed by IPFS",
+		RunE:          unknownSubcommandAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.AddCommand(
+		newIPFSRegistryServeCommand(),
+		newIPFSRegistryUpCommand(),
+		newIPFSRegistryDownCommand(),
+	)
+	return cmd
+}

--- a/cmd/nerdctl/ipfs_registry_down.go
+++ b/cmd/nerdctl/ipfs_registry_down.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/spf13/cobra"
+)
+
+func newIPFSRegistryDownCommand() *cobra.Command {
+	var ipfsRegistryDownCommand = &cobra.Command{
+		Use:           "down",
+		Short:         "stop registry as a background container \"ipfs-registry\".",
+		RunE:          ipfsRegistryDownAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	return ipfsRegistryDownCommand
+}
+
+func ipfsRegistryDownAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			return nil
+		},
+	}
+	nc, err := walker.Walk(ctx, ipfsRegistryContainerName)
+	if err != nil {
+		return err
+	}
+	if nc == 0 {
+		return fmt.Errorf("ipfs registry %q doesn't exist", ipfsRegistryContainerName)
+	}
+	nerdctlCmd, nerdctlArgs := globalFlags(cmd)
+	if out, err := exec.Command(nerdctlCmd, append(nerdctlArgs, "stop", ipfsRegistryContainerName)...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to stop registry: %v: %v", string(out), err)
+	}
+	if out, err := exec.Command(nerdctlCmd, append(nerdctlArgs, "rm", ipfsRegistryContainerName)...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to remove registry: %v: %v", string(out), err)
+	}
+	return nil
+}

--- a/cmd/nerdctl/ipfs_registry_serve.go
+++ b/cmd/nerdctl/ipfs_registry_serve.go
@@ -1,0 +1,74 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+
+	"github.com/containerd/nerdctl/pkg/ipfs"
+	httpapi "github.com/ipfs/go-ipfs-http-client"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const defaultIPFSRegistry = "localhost:5050"
+
+func newIPFSRegistryServeCommand() *cobra.Command {
+	var ipfsRegistryServeCommand = &cobra.Command{
+		Use:           "serve",
+		Short:         "serve read-only registry backed by IPFS on localhost. Use \"nerdctl ipfs registry up\".",
+		RunE:          ipfsRegistryServeAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	ipfsRegistryServeCommand.PersistentFlags().String("listen-registry", defaultIPFSRegistry, "address to listen")
+	ipfsRegistryServeCommand.PersistentFlags().String("ipfs-address", "", "multiaddr of IPFS API (default is pulled from $IPFS_PATH/api file. If $IPFS_PATH env var is not present, it defaults to ~/.ipfs)")
+
+	return ipfsRegistryServeCommand
+}
+
+func ipfsRegistryServeAction(cmd *cobra.Command, args []string) error {
+	ipfsAddressStr, err := cmd.Flags().GetString("ipfs-address")
+	if err != nil {
+		return err
+	}
+	listenAddress, err := cmd.Flags().GetString("listen-registry")
+	if err != nil {
+		return err
+	}
+	var ipfsClient *httpapi.HttpApi
+	if ipfsAddressStr != "" {
+		a, err := multiaddr.NewMultiaddr(ipfsAddressStr)
+		if err != nil {
+			return err
+		}
+		ipfsClient, err = httpapi.NewApi(a)
+		if err != nil {
+			return err
+		}
+	} else {
+		ipfsClient, err = httpapi.NewLocalApi()
+		if err != nil {
+			return err
+		}
+	}
+	logrus.Infof("serving on %v", listenAddress)
+	http.Handle("/", ipfs.NewRegistry(ipfsClient))
+	return http.ListenAndServe(listenAddress, nil)
+}

--- a/cmd/nerdctl/ipfs_registry_test.go
+++ b/cmd/nerdctl/ipfs_registry_test.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestIPFSRegistry(t *testing.T) {
+	requiresIPFS(t)
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=overlayfs")
+	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
+	ipfsRegistryAddr := "localhost:5555"
+	ipfsRegistryRef := ipfsRegistryReference(ipfsRegistryAddr, ipfsCID)
+
+	base.Cmd("ipfs", "registry", "up", "--listen-registry", ipfsRegistryAddr).AssertOK()
+	base.Cmd("pull", ipfsRegistryRef).AssertOK()
+	base.Cmd("run", "--rm", ipfsRegistryRef, "echo", "hello").AssertOK()
+	base.Cmd("ipfs", "registry", "down").AssertOK()
+}
+
+func TestIPFSRegistryWithLazyPulling(t *testing.T) {
+	requiresIPFS(t)
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	requiresStargz(base)
+	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")
+	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
+	ipfsRegistryAddr := "localhost:5555"
+	ipfsRegistryRef := ipfsRegistryReference(ipfsRegistryAddr, ipfsCID)
+
+	base.Cmd("ipfs", "registry", "up", "--listen-registry", ipfsRegistryAddr).AssertOK()
+	base.Cmd("pull", ipfsRegistryRef).AssertOK()
+	base.Cmd("run", "--rm", ipfsRegistryRef, "ls", "/.stargz-snapshotter").AssertOK()
+	base.Cmd("ipfs", "registry", "down").AssertOK()
+}
+
+func ipfsRegistryReference(addr string, c string) string {
+	return addr + "/ipfs/" + strings.TrimPrefix(c, "ipfs://")
+}

--- a/cmd/nerdctl/ipfs_registry_up.go
+++ b/cmd/nerdctl/ipfs_registry_up.go
@@ -1,0 +1,129 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/hashicorp/go-multierror"
+	httpapi "github.com/ipfs/go-ipfs-http-client"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const ipfsRegistryContainerName = "ipfs-registry"
+
+func newIPFSRegistryUpCommand() *cobra.Command {
+	var ipfsRegistryUpCommand = &cobra.Command{
+		Use:           "up",
+		Short:         "start registry as a background container \"ipfs-registry\", backed by the current user's IPFS API",
+		RunE:          ipfsRegistryUpAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	ipfsRegistryUpCommand.PersistentFlags().String("listen-registry", defaultIPFSRegistry, "address to listen")
+
+	return ipfsRegistryUpCommand
+}
+
+func ipfsRegistryUpAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			return nil
+		},
+	}
+	nc, err := walker.Walk(ctx, ipfsRegistryContainerName)
+	if err != nil {
+		return err
+	}
+	if nc > 0 {
+		logrus.Infof("IPFS registry %q is already running. Using the existing one. Restart manually if needed.", ipfsRegistryContainerName)
+		return nil
+	}
+	if err := runRegistryAsContainer(cmd); err != nil {
+		logrus.Errorf("Failed to serve registry. Use \"nerdctl ipfs registry serve\" command instead")
+		return err
+	}
+	return nil
+}
+
+// runRegistryAsContainer runs "nerdctl ipfs registry serve" as a container with --net=host.
+// This function bind mounts nerdctl binary to a directory and runs that directory as the rootfs.
+func runRegistryAsContainer(cmd *cobra.Command) error {
+	listenAddress, err := cmd.Flags().GetString("listen-registry")
+	if err != nil {
+		return err
+	}
+	dataStore, err := getDataStore(cmd)
+	if err != nil {
+		return err
+	}
+	nerdctlCmd, nerdctlArgs := globalFlags(cmd)
+	registryRoot := filepath.Join(dataStore, "ipfs-registry", "rootfs")
+	if err := os.RemoveAll(registryRoot); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(registryRoot, 0700); err != nil {
+		return err
+	}
+	// Get IPFS API address in the same convention with IPFS client library does.
+	// https://github.com/ipfs/go-ipfs-http-client/blob/3af36210f80fb86aae50da582b494ceddd64c3de/api.go#L42-L54
+	baseDir := os.Getenv(httpapi.EnvDir)
+	if baseDir == "" {
+		baseDir = httpapi.DefaultPathRoot
+	}
+	ipfsAPIAddr, err := httpapi.ApiAddr(baseDir)
+	if err != nil {
+		return err
+	}
+	if out, err := exec.Command(nerdctlCmd, append(nerdctlArgs,
+		"run", "-d", "--name", ipfsRegistryContainerName, "--net=host", "--entrypoint", "/mnt/nerdctl",
+		"--read-only", "-v", nerdctlCmd+":/mnt/nerdctl:ro", "--rootfs", registryRoot,
+		"ipfs", "registry", "serve", "--ipfs-address", ipfsAPIAddr.String(), "--listen-registry", listenAddress,
+	)...).CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to execute registry: %v: %v", string(out), err)
+	}
+	client := &http.Client{
+		Timeout: 3 * time.Second,
+	}
+	logrus.Infof("Waiting for the registry being ready...")
+	var allErr error
+	for i := 0; i < 3; i++ {
+		_, err := client.Get("http://" + listenAddress + "/v2/")
+		if err == nil {
+			logrus.Infof("Registry is up-and-running")
+			return nil
+		}
+		allErr = multierror.Append(allErr, err)
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("started registry but failed to connect: %v", allErr)
+}

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -209,6 +209,9 @@ func newApp() *cobra.Command {
 
 		// Compose
 		newComposeCommand(),
+
+		// IPFS
+		newIPFSCommand(),
 	)
 	addApparmorCommand(rootCmd)
 	return rootCmd

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -94,6 +94,7 @@ func TestIPFSWithLazyPulling(t *testing.T) {
 	requiresIPFS(t)
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
+	requiresStargz(base)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
 
 	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")
@@ -109,6 +110,7 @@ func TestIPFSWithLazyPullingCommit(t *testing.T) {
 	}
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
+	requiresStargz(base)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
 
 	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/compose-spec/compose-go v1.0.4
 	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.6.0-beta.2
-	github.com/containerd/containerd/api v1.6.0-beta.1.0.20211112054404-aa1b0736165c
+	github.com/containerd/containerd v1.6.0-beta.2.0.20211112054404-aa1b0736165c
+	github.com/containerd/containerd/api v1.6.0-beta.2.0.20211112054404-aa1b0736165c
 	github.com/containerd/continuity v0.2.1
 	github.com/containerd/go-cni v1.1.1-0.20211026134925-aa8bf14323a5
 	github.com/containerd/imgcrypt v1.1.2
@@ -26,12 +26,14 @@ require (
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
 	github.com/fatih/color v1.13.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-ipfs-files v0.0.9
 	github.com/ipfs/go-ipfs-http-client v0.1.0
 	github.com/ipfs/interface-go-ipfs-core v0.5.2
 	github.com/mattn/go-isatty v0.0.14
 	github.com/moby/sys/mount v0.2.0
+	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2-0.20211102003311-9a7a9876500e
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211101234015-a3c33d663ebc

--- a/go.sum
+++ b/go.sum
@@ -239,11 +239,11 @@ github.com/containerd/containerd v1.5.0-rc.0/go.mod h1:V/IXoMqNGgBlabz3tHD2TWDoT
 github.com/containerd/containerd v1.5.1/go.mod h1:0DOxVqwDy2iZvrZp2JUx/E+hS0UNTVn7dJnIOwtYR4g=
 github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0QMhscqVp1AR9c=
 github.com/containerd/containerd v1.6.0-beta.1.0.20211101005050-f0d3ea96cf8c/go.mod h1:IpMnlp3lTTcEXqfpc/bTpvq8jAS/BWhbfb2N1QAK9m8=
-github.com/containerd/containerd v1.6.0-beta.2 h1:vGPOMIfbInmhBtD2inCTfVYf/aMzhDkOwIbcQtv77Lo=
-github.com/containerd/containerd v1.6.0-beta.2/go.mod h1:0AwP8LDBKEIaCT48IETmHkY1+YX7c/ALcN1kkLGBLtk=
+github.com/containerd/containerd v1.6.0-beta.2.0.20211112054404-aa1b0736165c h1:5aOUfQNGPCZVc84x1umuPD+J2FyMAOJ7rDoduUVJxmg=
+github.com/containerd/containerd v1.6.0-beta.2.0.20211112054404-aa1b0736165c/go.mod h1:0AwP8LDBKEIaCT48IETmHkY1+YX7c/ALcN1kkLGBLtk=
 github.com/containerd/containerd/api v1.6.0-beta.1/go.mod h1:XDzkCoLyj2hn24f13Jcuq/U2bHb2LjJ2qWlklgL0Ofg=
-github.com/containerd/containerd/api v1.6.0-beta.1.0.20211112054404-aa1b0736165c h1:hViOeD/l7vAatK87rOYv26H6aPUjlufbB7gLbU2Ukfk=
-github.com/containerd/containerd/api v1.6.0-beta.1.0.20211112054404-aa1b0736165c/go.mod h1:fkctx1jj7m92mQDI6mIEXF+SH3tt2Rv/azUHqrOxYPc=
+github.com/containerd/containerd/api v1.6.0-beta.2.0.20211112054404-aa1b0736165c h1:hvX/D+EF67AV5315BBfQPhRusu997q9Fiqm4K+2KR20=
+github.com/containerd/containerd/api v1.6.0-beta.2.0.20211112054404-aa1b0736165c/go.mod h1:fkctx1jj7m92mQDI6mIEXF+SH3tt2Rv/azUHqrOxYPc=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -622,6 +622,7 @@ github.com/hanwen/go-fuse/v2 v2.1.1-0.20210825171523-3ab5d95a30ae/go.mod h1:B1nG
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v0.0.0-20141028054710-7554cd9344ce/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
@@ -629,6 +630,7 @@ github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjh
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v0.0.0-20161216184304-ed905158d874/go.mod h1:JMRHfdO9jKNzS/+BTlxCjKNQHg/jZAft8U7LloJvN7I=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -31,6 +31,7 @@ type BuildOptions struct {
 	Args     []string // --build-arg strings
 	NoCache  bool
 	Progress string
+	IPFS     bool
 }
 
 func (c *Composer) Build(ctx context.Context, bo BuildOptions) error {
@@ -61,6 +62,9 @@ func (c *Composer) buildServiceImage(ctx context.Context, image string, b *servi
 	}
 	if bo.Progress != "" {
 		args = append(args, "--progress="+bo.Progress)
+	}
+	if bo.IPFS {
+		args = append(args, "--ipfs")
 	}
 	args = append(args, b.BuildArgs...)
 

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -33,6 +33,7 @@ type UpOptions struct {
 	NoColor     bool
 	NoLogPrefix bool
 	ForceBuild  bool
+	IPFS        bool
 }
 
 func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) error {

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -38,7 +38,7 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 
 	// TODO: parallelize loop for ensuring images (make sure not to mess up tty)
 	for _, ps := range parsedServices {
-		if err := c.ensureServiceImage(ctx, ps, uo.ForceBuild); err != nil {
+		if err := c.ensureServiceImage(ctx, ps, uo.ForceBuild, BuildOptions{IPFS: uo.IPFS}); err != nil {
 			return err
 		}
 	}
@@ -99,9 +99,8 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 	return nil
 }
 
-func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, force bool) error {
+func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, force bool, bo BuildOptions) error {
 	if ps.Build != nil {
-		var bo BuildOptions
 		if ps.Build.Force || force {
 			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}

--- a/pkg/ipfs/registry.go
+++ b/pkg/ipfs/registry.go
@@ -1,0 +1,269 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ipfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
+	"github.com/hashicorp/go-multierror"
+	"github.com/ipfs/go-cid"
+	files "github.com/ipfs/go-ipfs-files"
+	iface "github.com/ipfs/interface-go-ipfs-core"
+	ipath "github.com/ipfs/interface-go-ipfs-core/path"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+func NewRegistry(ipfsClient iface.CoreAPI) http.Handler {
+	return &server{ipfsClient}
+}
+
+// server is a read-only registry which converts OCI Distribution Spec's pull-related API to IPFS
+// https://github.com/opencontainers/distribution-spec/blob/v1.0/spec.md#pull
+type server struct {
+	api iface.CoreAPI
+}
+
+var manifestRegexp = regexp.MustCompile(`/v2/ipfs/([a-z0-9]+)/manifests/(.*)`)
+var blobsRegexp = regexp.MustCompile(`/v2/ipfs/([a-z0-9]+)/blobs/(.*)`)
+
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	content, mediaType, size, err := s.serve(r)
+	if err != nil {
+		logrus.WithError(err).Warnf("failed to serve %q %q", r.Method, r.URL.Path)
+		// TODO: support response body following OCI Distribution Spec's error response format spec:
+		// https://github.com/opencontainers/distribution-spec/blob/v1.0/spec.md#error-codes
+		http.Error(w, "", http.StatusNotFound)
+		return
+	}
+	if content == nil {
+		w.WriteHeader(200)
+		return
+	}
+	w.Header().Set("Content-Type", mediaType)
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+	if r.Method == "GET" {
+		http.ServeContent(w, r, "", time.Now(), content)
+	}
+	if err := content.Close(); err != nil {
+		logrus.WithError(err).Warnf("failed to close file")
+	}
+	return
+}
+
+func (s *server) serve(r *http.Request) (io.ReadSeekCloser, string, int64, error) {
+	if r.Method != "GET" && r.Method != "HEAD" {
+		return nil, "", 0, fmt.Errorf("unsupported method")
+	}
+
+	if r.URL.Path == "/v2/" {
+		return nil, "", 0, nil
+	}
+
+	if matches := manifestRegexp.FindStringSubmatch(r.URL.Path); len(matches) != 0 {
+		cidStr, ref := matches[1], matches[2]
+		if _, dgstErr := digest.Parse(ref); dgstErr == nil {
+			content, mediaType, size, err := s.serveContentByDigest(cidStr, ref)
+			if !images.IsManifestType(mediaType) && !images.IsIndexType(mediaType) {
+				return nil, "", 0, fmt.Errorf("cannot serve non-manifest from manifets API: %q", mediaType)
+			}
+			return content, mediaType, size, err
+		}
+		if ref != "latest" {
+			return nil, "", 0, fmt.Errorf("tag of %q must be latest but got %q", cidStr, ref)
+		}
+		return s.serveContentByCID(cidStr)
+	}
+
+	if matches := blobsRegexp.FindStringSubmatch(r.URL.Path); len(matches) != 0 {
+		rootCIDStr, dgstStr := matches[1], matches[2]
+		return s.serveContentByDigest(rootCIDStr, dgstStr)
+	}
+
+	return nil, "", 0, fmt.Errorf("unsupported path")
+}
+
+func (s *server) serveContentByCID(cidStr string) (r io.ReadSeekCloser, mediaType string, size int64, err error) {
+	targetCID, err := cid.Decode(cidStr)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	c, desc, err := s.resolveCIDOfRootBlob(targetCID)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	rc, err := s.getReadSeekCloser(c)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return rc, getMediaType(desc), desc.Size, nil
+}
+
+func (s *server) serveContentByDigest(rootCIDStr, digestStr string) (r io.ReadSeekCloser, mediaType string, size int64, err error) {
+	rootCID, err := cid.Decode(rootCIDStr)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	dgst, err := digest.Parse(digestStr)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	_, rootDesc, err := s.resolveCIDOfRootBlob(rootCID)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	targetCID, targetDesc, err := s.resolveCIDOfDigest(dgst, rootDesc)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	rc, err := s.getReadSeekCloser(targetCID)
+	if err != nil {
+		return nil, "", 0, err
+	}
+	return rc, getMediaType(targetDesc), targetDesc.Size, nil
+}
+
+func (s *server) getReadSeekCloser(c cid.Cid) (io.ReadSeekCloser, error) {
+	r, closeFunc, err := s.getFile(c)
+	if err != nil {
+		return nil, err
+	}
+	return &readSeekCloser{r, closeFunc}, nil
+}
+
+func (s *server) getFile(c cid.Cid) (*io.SectionReader, func() error, error) {
+	n, err := s.api.Unixfs().Get(context.Background(), ipath.IpfsPath(c)) // only IPFS CID is supported
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get file %q: %v", c.String(), err)
+	}
+	f := files.ToFile(n)
+	ra, ok := f.(interface {
+		io.ReaderAt
+	})
+	if !ok {
+		return nil, nil, fmt.Errorf("ReaderAt is not implemented")
+	}
+	size, err := f.Size()
+	if err != nil {
+		return nil, nil, err
+	}
+	return io.NewSectionReader(ra, 0, size), f.Close, nil
+}
+
+func (s *server) resolveCIDOfRootBlob(c cid.Cid) (cid.Cid, ocispec.Descriptor, error) {
+	rc, err := s.getReadSeekCloser(c)
+	if err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	defer rc.Close()
+	var desc ocispec.Descriptor
+	if err := json.NewDecoder(rc).Decode(&desc); err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	c, err = getIPFSCID(desc)
+	if err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	return c, desc, nil
+}
+
+func (s *server) resolveCIDOfDigest(dgst digest.Digest, desc ocispec.Descriptor) (cid.Cid, ocispec.Descriptor, error) {
+	c, err := getIPFSCID(desc)
+	if err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	if desc.Digest == dgst {
+		return c, desc, nil // hit
+	}
+	sr, closeFunc, err := s.getFile(c)
+	if err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	descs, err := images.Children(context.Background(), &readerProvider{desc, sr}, desc)
+	if err != nil {
+		closeFunc()
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	if err := closeFunc(); err != nil {
+		return cid.Cid{}, ocispec.Descriptor{}, err
+	}
+	var allErr error
+	for _, desc := range descs {
+		gotCID, gotDesc, err := s.resolveCIDOfDigest(dgst, desc)
+		if err != nil {
+			allErr = multierror.Append(allErr, err)
+			continue
+		}
+		return gotCID, gotDesc, nil
+	}
+	if allErr == nil {
+		return cid.Cid{}, ocispec.Descriptor{}, fmt.Errorf("not found")
+	}
+	return cid.Cid{}, ocispec.Descriptor{}, allErr
+}
+
+func getIPFSCID(desc ocispec.Descriptor) (cid.Cid, error) {
+	for _, u := range desc.URLs {
+		if strings.HasPrefix(u, "ipfs://") {
+			// support only content addressable URL (ipfs://<CID>)
+			return cid.Decode(u[7:])
+		}
+	}
+	return cid.Cid{}, fmt.Errorf("no CID is recorded in %s", desc.Digest)
+}
+
+func getMediaType(desc ocispec.Descriptor) string {
+	if images.IsManifestType(desc.MediaType) || images.IsIndexType(desc.MediaType) || images.IsConfigType(desc.MediaType) {
+		return desc.MediaType
+	}
+	return "application/octet-stream"
+}
+
+type readSeekCloser struct {
+	io.ReadSeeker
+	closeFunc func() error
+}
+
+func (r *readSeekCloser) Close() error { return r.closeFunc() }
+
+type readerProvider struct {
+	desc ocispec.Descriptor
+	r    *io.SectionReader
+}
+
+func (p *readerProvider) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	if desc.Digest != p.desc.Digest || desc.Size != p.desc.Size {
+		return nil, fmt.Errorf("unexpected content")
+	}
+	return &contentReaderAt{p.r}, nil
+}
+
+type contentReaderAt struct {
+	*io.SectionReader
+}
+
+func (r *contentReaderAt) Close() error { return nil }


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/465

This adds the ability to build images using base images on IPFS.
Now nerdctl can build, ship and run containers on IPFS, without registries.

To complete this patch, https://github.com/moby/buildkit/commit/bb2e7ce8a603f5f3a86858fa454f1c3152cc316b needs to be relesed in BuildKit.
~~Currently this PR uses binaries built in a forked repo https://github.com/ktock/buildkit/releases/tag/v0.9.x-20211117.3 .~~ 
**Released as v0.9.3** https://github.com/moby/buildkit/releases/tag/v0.9.3

### Dockerfile

In Dockerfile, instead of `ipfs://` prefix, you need to use the following image reference to point to an image on IPFS.

```
localhost:5050/ipfs/<CID>
```

Example Dockerfile:

```dockerfile
FROM localhost:5050/ipfs/bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze
RUN echo hello > /hello
```

### build

`--ipfs` options is required.

```console
> nerdctl build --ipfs -t hello .
[+] Building 5.3s (6/6) FINISHED
 => [internal] load build definition from Dockerfile                                                                                              0.0s
 => => transferring dockerfile: 146B                                                                                                              0.0s
 => [internal] load .dockerignore                                                                                                                 0.0s
 => => transferring context: 2B                                                                                                                   0.0s
 => [internal] load metadata for localhost:5050/ipfs/bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze:latest                           0.1s
 => [1/2] FROM localhost:5050/ipfs/bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze@sha256:28bfa1fc6d491d3bee91bab451cab29c747e72917e  3.8s
 => => resolve localhost:5050/ipfs/bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze@sha256:28bfa1fc6d491d3bee91bab451cab29c747e72917e  0.0s
 => => sha256:7b1a6ab2e44dbac178598dabe7cff59bd67233dba0b27e4fbd1f9d4b3c877a54 28.57MB / 28.57MB                                                  2.1s
 => => extracting sha256:7b1a6ab2e44dbac178598dabe7cff59bd67233dba0b27e4fbd1f9d4b3c877a54                                                         1.7s
 => [2/2] RUN echo hello > /hello                                                                                                                 0.6s
 => exporting to oci image format                                                                                                                 0.6s
 => => exporting layers                                                                                                                           0.1s
 => => exporting manifest sha256:b96d490d134221ab121af91a42b13195dd8c5bf941012d7bfe07eabcf5259eda                                                 0.0s
 => => exporting config sha256:bd706574eab19009585b98826b06e63cf6eacf8d7193504dae75caa760332ca2                                                   0.0s
 => => sending tarball                                                                                                                            0.5s
unpacking docker.io/library/hello:latest (sha256:b96d490d134221ab121af91a42b13195dd8c5bf941012d7bfe07eabcf5259eda)...done
> nerdctl run --rm -it hello cat /hello
hello
```

### compose

Compose also supports `--ipfs` option.

```
nerdctl compose up --build --ipfs
```

```
nerdctl compose build --ipfs
```

### Details about `localhost:5050/ipfs/<CID>`

As of now, BuildKit doesn't support `ipfs://` prefix. So nerdctl achieves builds on IPFS by having a read-only local registry backed by IPFS. This registry converts registry API requests to IPFS operations. IPFS-agnostic tools can pull images from IPFS via this registry.

When you specify `--ipfs` option to `nerdctl bulid`, it automatically starts the registry backed by the IPFS repo of the current `$IPFS_PATH`. By default, nerdctl exposes the registry at `localhost:5050`. You can change the address and can manually restart the registry using `nerdctl ipfs registry up` and `nerdctl ipfs registry down`.

The following example changes the registry API address to `localhost:5555` instead of `localhost:5050`.

```
nerdctl ipfs registry down
nerdctl ipfs registry up --registry-address=localhost:5555
```

You'll also need to restart the registry when you change `$IPFS_PATH` to use.

--------

- TODO
  - agreement on CLI design
  - ~~https://github.com/moby/buildkit/commit/bb2e7ce8a603f5f3a86858fa454f1c3152cc316b needs to be released in BuildKit and use the released binaries.~~
    - **Released as v0.9.3** https://github.com/moby/buildkit/releases/tag/v0.9.3 
  - (following-up) BuildKit should support `ipfs://` prefix in Dockerfile
