### PR TITLE
fix(hosts): Fix hosts file rewrite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ipfs/go-ipfs-files v0.0.9
 	github.com/ipfs/go-ipfs-http-client v0.1.0
 	github.com/ipfs/interface-go-ipfs-core v0.5.2
+	github.com/jaytaylor/go-hostsfile v0.0.0-20211120191712-f53f85d8b98f
 	github.com/mattn/go-isatty v0.0.14
 	github.com/moby/sys/mount v0.2.0
 	github.com/multiformats/go-multiaddr v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -808,6 +808,8 @@ github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQ
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
+github.com/jaytaylor/go-hostsfile v0.0.0-20211120191712-f53f85d8b98f h1:desbPBVIVr08zLD8xiatWzHdkwG5CaqfoLFw/abN9D8=
+github.com/jaytaylor/go-hostsfile v0.0.0-20211120191712-f53f85d8b98f/go.mod h1:ANWA9RN/851H77KWOsy4W0XD8JKZddOiF+sUNvLkTvM=
 github.com/jbenet/go-cienv v0.0.0-20150120210510-1bb1476777ec/go.mod h1:rGaEvXB4uRSZMmzKNLoXvTu1sfx+1kv/DojUlPrSZGs=
 github.com/jbenet/go-cienv v0.1.0/go.mod h1:TqNnHUmJgXau0nCzC7kXWeotg3J9W34CUv5Djy1+FlA=
 github.com/jbenet/go-temp-err-catcher v0.0.0-20150120210811-aac704a3f4f2/go.mod h1:8GXXJV31xl8whumTzdZsTt3RnUIiPqzkyf7mxToRCMs=

--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -102,7 +102,7 @@ type Meta struct {
 	ID         string
 	Networks   map[string]*types100.Result
 	Hostname   string
-	ExtraHosts []string
+	ExtraHosts map[string]string // ip:host
 	Name       string
 }
 
@@ -132,7 +132,7 @@ func (x *store) Acquire(meta Meta) error {
 		if err := os.WriteFile(metaPath, metaB, 0644); err != nil {
 			return err
 		}
-		return newUpdater(x.hostsD, meta.ExtraHosts).update()
+		return newUpdater(meta.ID, x.hostsD, meta.ExtraHosts).update()
 	}
 	return lockutil.WithDirLock(x.hostsD, fn)
 }
@@ -150,7 +150,7 @@ func (x *store) Release(ns, id string) error {
 		if err := os.RemoveAll(metaPath); err != nil {
 			return err
 		}
-		return newUpdater(x.hostsD, nil).update()
+		return newUpdater(id, x.hostsD, nil).update()
 	}
 	return lockutil.WithDirLock(x.hostsD, fn)
 }

--- a/pkg/dnsutil/hostsstore/updater_test.go
+++ b/pkg/dnsutil/hostsstore/updater_test.go
@@ -18,6 +18,7 @@ package hostsstore
 
 import (
 	"net"
+	"strings"
 	"testing"
 
 	types100 "github.com/containernetworking/cni/pkg/types/100"
@@ -40,14 +41,14 @@ func TestCreateLine(t *testing.T) {
 			thatHostname: "bar",
 			thatName:     "foo",
 			myNetwork:    "n1",
-			expected:     "10.4.2.2\tbar bar.n1 foo foo.n1\n",
+			expected:     "bar bar.n1 foo foo.n1",
 		},
 		{
 			thatIP:       "10.4.2.3",
 			thatNetwork:  "n1",
 			thatHostname: "bar",
 			myNetwork:    "n1",
-			expected:     "10.4.2.3\tbar bar.n1\n",
+			expected:     "bar bar.n1",
 		},
 		{
 			thatIP:       "10.4.2.4",
@@ -96,7 +97,8 @@ func TestCreateLine(t *testing.T) {
 		myNetworks := map[string]struct{}{
 			tc.myNetwork: {},
 		}
-		line := createLine(tc.thatIP, tc.thatNetwork, thatMeta, myNetworks)
+		lines := createLine(tc.thatNetwork, thatMeta, myNetworks)
+		line := strings.Join(lines, " ")
 		t.Logf("tc=%+v, line=%q", tc, line)
 		assert.Equal(t, tc.expected, line)
 	}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -95,15 +95,15 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 	}
 
 	//validate and format extraHosts
-	ensureExtraHosts := func(extraHosts []string) ([]string, error) {
-		hosts := []string{}
+	ensureExtraHosts := func(extraHosts []string) (map[string]string, error) {
+		hosts := make(map[string]string)
 		for _, host := range extraHosts {
 			hostIP, err := dopts.ValidateExtraHost(host)
 			if err != nil {
 				return nil, err
 			}
 			if v := strings.SplitN(hostIP, ":", 2); len(v) == 2 {
-				hosts = append(hosts, fmt.Sprintf("%s   %s", v[1], v[0]))
+				hosts[v[1]] = v[0]
 			}
 		}
 		return hosts, nil
@@ -209,7 +209,7 @@ type handlerOpts struct {
 	cniNames          []string
 	fullID            string
 	rootlessKitClient rlkclient.Client
-	extraHosts        []string
+	extraHosts        map[string]string // ip:host
 }
 
 // hookSpec is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/containerd/command/oci-hook.go#L59-L64


### PR DESCRIPTION
Before hosts file will rewrite before each container start, extra_hosts cannot write to hosts.

``` yaml
version: '2'
services:
  nginx-1:
    image: nginx:alpine
    container_name: nginx-1
    restart: always
  nginx-2:
    image: nginx:alpine
    container_name: nginx-2
    restart: always
    extra_hosts:
      - "test.example.io:172.19.39.1"
```

We should rewrite the host with the last hosts record.