### PR TITLE
Fix --help template

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -88,7 +88,7 @@ func newApp() *cobra.Command {
 		SilenceErrors:    true,
 		TraverseChildren: true, // required for global short hands like -a, -H, -n
 	}
-	rootCmd.SetHelpTemplate(mainHelpTemplate)
+	rootCmd.SetUsageTemplate(mainHelpTemplate)
 	rootCmd.PersistentFlags().Bool("debug", false, "debug mode")
 	rootCmd.PersistentFlags().Bool("debug-full", false, "debug mode (with full output)")
 	// -a is nonPersistentAlias (conflicts with nerdctl images -a)


### PR DESCRIPTION
Command description such as "Display system-wide information" of `nerdctl info --help` was not shown

Fix regression in PR #524