### PR TITLE
Add support for push and pull to compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,8 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose build](#whale-nerdctl-compose-build)
     - [:whale: nerdctl compose down](#whale-nerdctl-compose-down)
     - [:whale: nerdctl compose ps](#whale-nerdctl-compose-ps)
+    - [:whale: nerdctl compose pull](#whale-nerdctl-compose-pull)
+    - [:whale: nerdctl compose push](#whale-nerdctl-compose-push)
   - [IPFS management](#ipfs-management)
     - [:nerd_face: nerdctl ipfs registry up](#nerd_face-nerdctl-ipfs-registry-up)
     - [:nerd_face: nerdctl ipfs registry down](#nerd_face-nerdctl-ipfs-registry-down)
@@ -1109,6 +1111,16 @@ Unimplemented `docker-compose ps` (V1) flags: `--quiet`, `--services`, `--filter
 
 Unimplemented `docker compose ps` (V2) flags: `--format`, `--status`
 
+### :whale: nerdctl compose pull
+Pull service images
+
+Usage: `nerdctl compose pull`
+
+### :whale: nerdctl compose push
+Push service images
+
+Usage: `nerdctl compose push`
+
 ## IPFS management
 
 ### :nerd_face: nerdctl ipfs registry up
@@ -1180,7 +1192,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose config|create|events|exec|images|kill|pause|port|pull|push|restart|rm|run|scale|start|stop|top|unpause`
+- `docker-compose config|create|events|exec|images|kill|pause|port|restart|rm|run|scale|start|stop|top|unpause`
 
 Others:
 - `docker system df`

--- a/README.md
+++ b/README.md
@@ -1116,10 +1116,14 @@ Pull service images
 
 Usage: `nerdctl compose pull`
 
+Unimplemented `docker-compose pull` (V1) flags: `--ignore-pull-failures`, `--parallel`, `--no-parallel`, `quiet`, `include-deps`
+
 ### :whale: nerdctl compose push
 Push service images
 
 Usage: `nerdctl compose push`
+
+Unimplemented `docker-compose pull` (V1) flags: `--ignore-push-failures`
 
 ## IPFS management
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -54,6 +54,8 @@ func newComposeCommand() *cobra.Command {
 		newComposeUpCommand(),
 		newComposeLogsCommand(),
 		newComposeBuildCommand(),
+		newComposePushCommand(),
+		newComposePullCommand(),
 		newComposeDownCommand(),
 		newComposePsCommand(),
 	)

--- a/cmd/nerdctl/compose_pull.go
+++ b/cmd/nerdctl/compose_pull.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/spf13/cobra"
+)
+
+func newComposePullCommand() *cobra.Command {
+	var composePullCommand = &cobra.Command{
+		Use:           "pull [SERVICE]...",
+		Short:         "Pull service images",
+		RunE:          composePullAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	return composePullCommand
+}
+
+func composePullAction(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		// TODO: support specifying service names as args
+		return fmt.Errorf("arguments %v not supported", args)
+	}
+
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+	po := composer.PullOptions{}
+	return c.Pull(ctx, po)
+}

--- a/cmd/nerdctl/compose_push.go
+++ b/cmd/nerdctl/compose_push.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/spf13/cobra"
+)
+
+func newComposePushCommand() *cobra.Command {
+	var composePushCommand = &cobra.Command{
+		Use:           "push [SERVICE]...",
+		Short:         "Push service images",
+		RunE:          composePushAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	return composePushCommand
+}
+
+func composePushAction(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		// TODO: support specifying service names as args
+		return fmt.Errorf("arguments %v not supported", args)
+	}
+
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+	po := composer.PushOptions{}
+	return c.Push(ctx, po)
+}

--- a/pkg/composer/pull.go
+++ b/pkg/composer/pull.go
@@ -1,0 +1,63 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
+
+	"github.com/sirupsen/logrus"
+)
+
+type PullOptions struct {
+}
+
+func (c *Composer) Pull(ctx context.Context, po PullOptions) error {
+	return c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+		ps, err := serviceparser.Parse(c.project, svc)
+		if err != nil {
+			return err
+		}
+		return c.pullServiceImage(ctx, ps.Image, ps.Unparsed.Platform, po)
+	})
+}
+
+func (c *Composer) pullServiceImage(ctx context.Context, image string, platform string, po PullOptions) error {
+	logrus.Infof("Pulling image %s", image)
+
+	var args []string // nolint: prealloc
+	if platform != "" {
+		args = append(args, "--platform="+platform)
+	}
+	args = append(args, image)
+
+	cmd := c.createNerdctlCmd(ctx, append([]string{"pull"}, args...)...)
+	if c.DebugPrintFull {
+		logrus.Debugf("Running %v", cmd.Args)
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error while pulling image %s: %w", image, err)
+	}
+	return nil
+}

--- a/pkg/composer/push.go
+++ b/pkg/composer/push.go
@@ -1,0 +1,63 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
+
+	"github.com/sirupsen/logrus"
+)
+
+type PushOptions struct {
+}
+
+func (c *Composer) Push(ctx context.Context, po PushOptions) error {
+	return c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+		ps, err := serviceparser.Parse(c.project, svc)
+		if err != nil {
+			return err
+		}
+		return c.pushServiceImage(ctx, ps.Image, ps.Unparsed.Platform, po)
+	})
+}
+
+func (c *Composer) pushServiceImage(ctx context.Context, image string, platform string, po PushOptions) error {
+	logrus.Infof("Pushing image %s", image)
+
+	var args []string // nolint: prealloc
+	if platform != "" {
+		args = append(args, "--platform="+platform)
+	}
+	args = append(args, image)
+
+	cmd := c.createNerdctlCmd(ctx, append([]string{"push"}, args...)...)
+	if c.DebugPrintFull {
+		logrus.Debugf("Running %v", cmd.Args)
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("error while pushing image %s: %w", image, err)
+	}
+	return nil
+}


### PR DESCRIPTION
Like the other commands, this is missing support for service names...

It also doesn't run in parallell like the `docker-compose` implementation.