### PR TITLE
Add support for --no-build to compose up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@ Usage: `nerdctl compose up [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `-d, --detach`: Detached mode: Run containers in the background
+- :whale: `--no-build`: Don't build an image, even if it's missing.
 - :whale: `--no-color`: Produce monochrome output
 - :whale: `--no-log-prefix`: Don't print prefix in logs
 - :whale: `--build`: Build images before starting containers.

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -30,6 +30,7 @@ func newComposeUpCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	composeUpCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
+	composeUpCommand.Flags().Bool("no-build", false, "Don't build an image, even if it's missing.")
 	composeUpCommand.Flags().Bool("no-color", false, "Produce monochrome output")
 	composeUpCommand.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
 	composeUpCommand.Flags().Bool("build", false, "Build images before starting containers.")
@@ -39,6 +40,10 @@ func newComposeUpCommand() *cobra.Command {
 
 func composeUpAction(cmd *cobra.Command, services []string) error {
 	detach, err := cmd.Flags().GetBool("detach")
+	if err != nil {
+		return err
+	}
+	noBuild, err := cmd.Flags().GetBool("no-build")
 	if err != nil {
 		return err
 	}
@@ -71,6 +76,7 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 	}
 	uo := composer.UpOptions{
 		Detach:      detach,
+		NoBuild:     noBuild,
 		NoColor:     noColor,
 		NoLogPrefix: noLogPrefix,
 		ForceBuild:  build,

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -17,6 +17,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/containerd/nerdctl/pkg/composer"
 	"github.com/spf13/cobra"
 )
@@ -58,6 +60,9 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 	build, err := cmd.Flags().GetBool("build")
 	if err != nil {
 		return err
+	}
+	if build && noBuild {
+		return errors.New("--build and --no-build can not be combined")
 	}
 	enableIPFS, err := cmd.Flags().GetBool("ipfs")
 	if err != nil {

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -30,6 +30,7 @@ import (
 
 type UpOptions struct {
 	Detach      bool
+	NoBuild     bool
 	NoColor     bool
 	NoLogPrefix bool
 	ForceBuild  bool

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -99,9 +99,9 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 	return nil
 }
 
-func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, build bool, force bool, bo BuildOptions) error {
-	if ps.Build != nil && build {
-		if ps.Build.Force || force {
+func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, allowBuild, forceBuild bool, bo BuildOptions) error {
+	if ps.Build != nil && allowBuild {
+		if ps.Build.Force || forceBuild {
 			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
 		if ok, err := c.ImageExists(ctx, ps.Image); err != nil {

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -38,7 +38,7 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 
 	// TODO: parallelize loop for ensuring images (make sure not to mess up tty)
 	for _, ps := range parsedServices {
-		if err := c.ensureServiceImage(ctx, ps, uo.ForceBuild, BuildOptions{IPFS: uo.IPFS}); err != nil {
+		if err := c.ensureServiceImage(ctx, ps, !uo.NoBuild, uo.ForceBuild, BuildOptions{IPFS: uo.IPFS}); err != nil {
 			return err
 		}
 	}
@@ -99,8 +99,8 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 	return nil
 }
 
-func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, force bool, bo BuildOptions) error {
-	if ps.Build != nil {
+func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Service, build bool, force bool, bo BuildOptions) error {
+	if ps.Build != nil && build {
 		if ps.Build.Force || force {
 			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}


### PR DESCRIPTION
Try to pull the image instead of building it.

Otherwise it would _always_ rebuild images.