### PR TITLE
ipfs: rootless: Allow optionally exposing ports used by ipfs

### DIFF
--- a/docs/ipfs.md
+++ b/docs/ipfs.md
@@ -17,6 +17,8 @@ In rootless mode, you need to install ipfs daemon using `containerd-rootless-set
 containerd-rootless-setuptool.sh -- install-ipfs --init
 ```
 
+:information_source: If you want to expose some ports of ipfs daemon (e.g. 4001), you can install rootless containerd using `containerd-rootless-setuptool.sh install` with `CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS="--publish=0.0.0.0:4001:4001/tcp"` environment variable.
+
 :information_source: If you don't want IPFS to communicate with nodes on the internet, you can run IPFS daemon in offline mode using `--offline` flag or you can create a private IPFS network as described [here](https://github.com/containerd/stargz-snapshotter/blob/main/docs/ipfs.md#appendix-1-creating-ipfs-private-network).
 
 ## IPFS-enabled image and OCI Compatibility

--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -216,6 +216,7 @@ cmd_entrypoint_install() {
 
 		[Service]
 		Environment=PATH=$BIN:/sbin:/usr/sbin:$PATH
+		Environment=CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS=${CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS:-}
 		ExecStart=$BIN/${CONTAINERD_ROOTLESS_SH}
 		ExecReload=/bin/kill -s HUP \$MAINPID
 		TimeoutSec=0
@@ -407,6 +408,7 @@ cmd_entrypoint_install_ipfs() {
 		ipfs = true
 		###  END  ###
 	EOT
+	INFO "If you want to expose the port 4001 of ipfs daemon, re-install rootless containerd with CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS=\"--publish=0.0.0.0:4001:4001/tcp\" environment variable."
 	INFO "Set \`export IPFS_PATH=\"${IPFS_PATH}\"\` to use ipfs."
 }
 


### PR DESCRIPTION
Ipfs daemon optionally requires some port to expose (e.g. 4001).
This commit allows users to expose ports from rootlesskit namespace by specifying `CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS` to `containerd-rootless-setuptool.sh`.
