### PR TITLE
feat: cosign sign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,6 +239,8 @@ COPY . /go/src/github.com/containerd/nerdctl
 WORKDIR /go/src/github.com/containerd/nerdctl
 VOLUME /tmp
 ENV CGO_ENABLED=0
+# copy cosign binary for integration test
+COPY --from=gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fdea547f4c9a27139276cc373165c26842bc594b8bd /ko-app/cosign /usr/local/bin/cosign
 # enable offline ipfs for integration test
 COPY ./Dockerfile.d/test-integration-etc_containerd-stargz-grpc_config.toml /etc/containerd-stargz-grpc/config.toml
 COPY ./Dockerfile.d/test-integration-ipfs-offline.service /usr/local/lib/systemd/system/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
  ✅ Supports [P2P image distribution (IPFS)](./docs/ipfs.md)
 
+ ✅ Supports [container image signing and verifying (cosign)](./docs/cosign.md)
+
 nerdctl is a **non-core** sub-project of containerd.
 
 ## Examples

--- a/cmd/nerdctl/pull_linux_test.go
+++ b/cmd/nerdctl/pull_linux_test.go
@@ -1,0 +1,120 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+type cosignKeyPair struct {
+	publicKey  string
+	privateKey string
+	cleanup    func()
+}
+
+func newCosignKeyPair(t testing.TB, path string) *cosignKeyPair {
+	td, err := os.MkdirTemp(t.TempDir(), path)
+	assert.NilError(t, err)
+
+	cmd := exec.Command("cosign", "generate-key-pair")
+	cmd.Dir = td
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to run %v: %v (%q)", cmd.Args, err, string(out))
+	}
+
+	publicKey := filepath.Join(td, "cosign.pub")
+	privateKey := filepath.Join(td, "cosign.key")
+
+	return &cosignKeyPair{
+		publicKey:  publicKey,
+		privateKey: privateKey,
+		cleanup: func() {
+			_ = os.RemoveAll(td)
+		},
+	}
+}
+
+func TestImageVerifyWithCosign(t *testing.T) {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		t.Skip()
+	}
+	testutil.DockerIncompatible(t)
+	t.Setenv("COSIGN_PASSWORD", "1")
+	keyPair := newCosignKeyPair(t, "cosign-key-pair")
+	defer keyPair.cleanup()
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-image-cosign")
+	defer reg.cleanup()
+	localhostIP := "127.0.0.1"
+	t.Logf("localhost IP=%q", localhostIP)
+	testImageRef := fmt.Sprintf("%s:%d/test-push-signed-image",
+		localhostIP, reg.listenPort)
+	t.Logf("testImageRef=%q", testImageRef)
+
+	dockerfile := fmt.Sprintf(`FROM %s
+CMD ["echo", "nerdctl-build-test-string"]
+	`, testutil.CommonImage)
+
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+
+	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
+	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.privateKey).AssertOK()
+	base.Cmd("pull", testImageRef, "--verify=cosign", "--cosign-key="+keyPair.publicKey).AssertOK()
+}
+
+func TestImageVerifyWithCosignShouldFailWhenKeyIsNotCorrect(t *testing.T) {
+	if _, err := exec.LookPath("cosign"); err != nil {
+		t.Skip()
+	}
+	testutil.DockerIncompatible(t)
+	t.Setenv("COSIGN_PASSWORD", "1")
+	keyPair := newCosignKeyPair(t, "cosign-key-pair")
+	defer keyPair.cleanup()
+	base := testutil.NewBase(t)
+	reg := newTestRegistry(base, "test-image-cosign")
+	defer reg.cleanup()
+	localhostIP := "127.0.0.1"
+	t.Logf("localhost IP=%q", localhostIP)
+	testImageRef := fmt.Sprintf("%s:%d/test-push-signed-image-wrong",
+		localhostIP, reg.listenPort)
+	t.Logf("testImageRef=%q", testImageRef)
+
+	dockerfile := fmt.Sprintf(`FROM %s
+CMD ["echo", "nerdctl-build-test-string"]
+	`, testutil.CommonImage)
+
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+
+	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
+	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.privateKey).AssertOK()
+	base.Cmd("pull", testImageRef, "--verify=cosign", "--cosign-key="+keyPair.publicKey).AssertOK()
+
+	t.Setenv("COSIGN_PASSWORD", "2")
+	newKeyPair := newCosignKeyPair(t, "cosign-key-pair-test")
+	base.Cmd("pull", testImageRef, "--verify=cosign", "--cosign-key="+newKeyPair.publicKey).AssertFail()
+}

--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -17,10 +17,13 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images/converter"
@@ -60,6 +63,11 @@ func newPushCommand() *cobra.Command {
 
 	pushCommand.Flags().Bool("estargz", false, "Convert the image into eStargz")
 	pushCommand.Flags().Bool("ipfs-ensure-image", true, "Ensure the entire contents of the image is locally available before push")
+
+	pushCommand.Flags().String("sign", "none", "Sign the image with none|cosign. Default none")
+
+	pushCommand.Flags().String("cosign-key", "",
+		"path to the private key file, KMS URI or Kubernetes Secret")
 
 	return pushCommand
 }
@@ -187,6 +195,30 @@ func pushAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
+	signer, err := cmd.Flags().GetString("sign")
+
+	if err != nil {
+		return err
+	}
+	switch signer {
+	case "cosign":
+		keyRef, err := cmd.Flags().GetString("cosign-key")
+		if err != nil {
+			return err
+		}
+
+		err = signCosign(rawRef, keyRef)
+		if err != nil {
+			return err
+		}
+	case "none":
+		logrus.Debugf("signing process skipped")
+	default:
+		return fmt.Errorf("no signers found: %s", signer)
+
+	}
+
 	return nil
 }
 
@@ -234,4 +266,48 @@ func isReusableESGZ(ctx context.Context, cs content.Store, desc ocispec.Descript
 		return false
 	}
 	return true
+}
+
+func signCosign(rawRef string, keyRef string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		logrus.WithError(err).Error("cosign executable not found in path $PATH")
+		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
+		return err
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd.Env = os.Environ()
+
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, rawRef)
+
+	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
+
+	stdout, _ := cosignCmd.StdoutPipe()
+	stderr, _ := cosignCmd.StderrPipe()
+	if err := cosignCmd.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		logrus.Info("cosign: " + scanner.Text())
+	}
+
+	errScanner := bufio.NewScanner(stderr)
+	for errScanner.Scan() {
+		logrus.Info("cosign: " + errScanner.Text())
+	}
+
+	if err := cosignCmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/nerdctl/run_windows.go
+++ b/cmd/nerdctl/run_windows.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"fmt"
+
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/docker/go-units"

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -1,0 +1,74 @@
+# Container Image Sign and Verify with cosign tool
+
+[cosign](https://github.com/sigstore/cosign) is tool that allows you to sign and verify container images with the
+public/private key pairs or without them by providing
+a [Keyless support](https://github.com/sigstore/cosign/blob/main/KEYLESS.md).
+
+Keyless uses ephemeral keys and certificates, which are signed automatically by
+the [fulcio](https://github.com/sigstore/fulcio) root CA. Signatures are stored in
+the [rekor](https://github.com/sigstore/rekor) transparency log, which automatically provides an attestation as to when
+the signature was created.
+
+You can enable container signing and verifying features with `push` and `pull` commands of `nerdctl` by using `cosign`
+under the hood with make use of flags `--sign` while pushing the container image, and `--verify` while pulling the
+container image.
+
+> * Ensure cosign executable in your `$PATH`.
+> * You can install cosign by following this page: https://docs.sigstore.dev/cosign/installation
+
+Prepare your environment:
+
+```shell
+# Create a sample Dockerfile
+$ cat <<EOF | tee Dockerfile.dummy
+FROM alpine:latest
+CMD [ "echo", "Hello World" ]
+EOF
+```
+
+> Please do not forget, we won't be validating the base images, which is `alpine:latest` in this case, of the container image that was built on,
+> we'll only verify the container image itself once we sign it.
+
+```shell
+
+# Build the image
+$ nerdctl build -t devopps/hello-world -f Dockerfile.dummy .
+
+# Generate a key-pair: cosign.key and cosign.pub
+$ cosign generate-key-pair
+
+# Export your COSIGN_PASSWORD to prevent CLI prompting
+$ export COSIGN_PASSWORD=$COSIGN_PASSWORD
+```
+
+Sign the container image while pushing:
+
+```
+# Sign the image with Keyless mode
+$ nerdctl push --sign=cosign devopps/hello-world
+
+# Sign the image and store the signature in the registry
+$ nerdctl push --sign=cosign --cosign-key cosign.key devopps/hello-world
+```
+
+Verify the container image while pulling:
+
+> REMINDER: Image won't be pulled if there are no matching signatures in case you passed `--verify` flag.
+
+```shell
+# Verify the image with Keyless mode
+$ nerdctl pull --verify=cosign devopps/hello-world
+INFO[0004] cosign:
+INFO[0004] cosign: [{"critical":{"identity":...}]
+docker.io/devopps/nginx-new:latest:                                               resolved       |++++++++++++++++++++++++++++++++++++++|
+manifest-sha256:0910d404e58dd320c3c0c7ea31bf5fbfe7544b26905c5eccaf87c3af7bcf9b88: done           |++++++++++++++++++++++++++++++++++++++|
+config-sha256:1de1c4fb5122ac8650e349e018fba189c51300cf8800d619e92e595d6ddda40e:   done           |++++++++++++++++++++++++++++++++++++++|
+elapsed: 1.4 s                                                                    total:  1.3 Ki (928.0 B/s)
+
+# You can not verify the image if it is not signed
+$ nerdctl pull --verify=cosign --cosign-key cosign.pub devopps/hello-world-bad
+INFO[0003] cosign: Error: no matching signatures:
+INFO[0003] cosign: failed to verify signature
+INFO[0003] cosign: main.go:46: error during command execution: no matching signatures:
+INFO[0003] cosign: failed to verify signature
+```

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -7,3 +7,4 @@ The following features are experimental and subject to change:
 - Importing an external eStargz record JSON file with `nerdctl image convert --estargz-record-in=FILE` .
   eStargz itself is out of experimental.
 - [Image Distribution on IPFS](./ipfs.md)
+- [Image Sign and Verify (cosign)](./cosign.md)


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>
Co-authored-by: Furkan Türkal <furkan.turkal@trendyol.com>

Fixes #423 

I forgot that we can't have a digest before pushing the image, so, we have to do it right after pushing the image. 🙋🏻‍♂️

```shell
## Keyless Mode
$ COSIGN_EXPERIMENTAL=1 _output/nerdctl push --sign devopps/bar:latest

## Without Keyless Mode
$ cosign generate-key-pair
$ _output/nerdctl push --sign --cosign-key cosign.key devopps/bar:latest
```