### PR TITLE
MAINTAINERS: add Kohei Tokunaga as a COMMITTER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -5,6 +5,7 @@
 #
 # COMMITTERS
 # GitHub ID, Name, Email address
+"ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com"
 
 # REVIEWERS
 # GitHub ID, Name, Email address


### PR DESCRIPTION
@ktock has made significant contributions (https://github.com/containerd/nerdctl/issues?q=author%3Aktock) including IPFS, so I'd like to invite @ktock to be a Committer.

He has been also a Core Reviewer of the entire containerd project: https://github.com/containerd/project/blob/f2cf9227ad6b058d40026930fc15afa67b65c4fd/MAINTAINERS#L35

Needs explicit LGTM from:
- [x] @ktock 

I'd also like to get a few LGTMs from the Core Committers too.

