### PR TITLE
MAINTAINERS: add James Sturtevant as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,3 +9,4 @@
 # REVIEWERS
 # GitHub ID, Name, Email address
 "fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com"
+"jsturtevant","James Sturtevant","jstur@microsoft.com"


### PR DESCRIPTION
@jsturtevant has made significant contributions for supporting Windows (https://github.com/containerd/nerdctl/issues?q=author%3Ajsturtevant), so I'd like to invite @jsturtevant to be a Reviewer.

Needs explicit LGTM from:
- [x] @jsturtevant

I'd also like to get a few LGTMs from the Core Committers too.

