### PR TITLE
MAINTAINERS: promote Fahed Dorgaa from a REVIEWER to a COMMITTER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -6,8 +6,8 @@
 # COMMITTERS
 # GitHub ID, Name, Email address
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com"
+"fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com"
 
 # REVIEWERS
 # GitHub ID, Name, Email address
-"fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com"
 "jsturtevant","James Sturtevant","jstur@microsoft.com"


### PR DESCRIPTION
@fahedouch has made significant contributions (https://github.com/containerd/nerdctl/issues?q=author%3Afahedouch), so I'd like to promote @fahedouch from a Reviewer to be a Committer.

Needs explicit LGTM from:
- [x] @fahedouch

I'd also like to get a few LGTMs from the Core Committers too.

