### PR TITLE
Support os env var compose

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -68,6 +68,10 @@ func New(o Options) (*Composer, error) {
 		o.ProjectOptions.ConfigPaths = append(o.ProjectOptions.ConfigPaths, composeYaml)
 	}
 
+	if err := composecli.WithOsEnv(&o.ProjectOptions); err != nil {
+		return nil, err
+	}
+
 	if err := composecli.WithDotEnv(&o.ProjectOptions); err != nil {
 		return nil, err
 	}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -79,6 +79,7 @@ func (b *Base) ComposeCmd(args ...string) *Cmd {
 		binaryArgs = append(b.Args, append([]string{"compose"}, args...)...)
 	}
 	icmdCmd := icmd.Command(binary, binaryArgs...)
+	icmdCmd.Env = b.Env
 	cmd := &Cmd{
 		Cmd:  icmdCmd,
 		Base: b,


### PR DESCRIPTION
Hello,

fixing https://github.com/containerd/nerdctl/issues/542

`nerdctl  -e ADDRESS=0.0.0.0 compose up -d` is not supported 