### PR TITLE
cmd/nerdctl: support (backport) zstdchunked convert

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,7 @@ Flags:
 -  `--estargz-record-in=<FILE>`         : read `ctr-remote optimize --record-out=<FILE>` record file. :warning: This flag is experimental and subject to change.
 -  `--estargz-compression-level=<LEVEL>`: eStargz compression level (default: 9)
 -  `--estargz-chunk-size=<SIZE>`        : eStargz chunk size
+-  `--zstdchunked                       : Use zstd compression instead of gzip (a.k.a zstd:chunked). Should be used in conjunction with '--oci'
 -  `--uncompress`                       : convert tar.gz layers to uncompressed tar layers
 -  `--oci`                              : convert Docker media types to OCI media types
 -  `--platform=<PLATFORM>`              : convert content for a specific platform

--- a/cmd/nerdctl/image_convert_test.go
+++ b/cmd/nerdctl/image_convert_test.go
@@ -32,3 +32,14 @@ func TestImageConvertEStargz(t *testing.T) {
 	base.Cmd("image", "convert", "--estargz", "--oci",
 		testutil.AlpineImage, convertedImage).AssertOK()
 }
+
+func TestImageConvertZstdChunked(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	convertedImage := "test-image-convert:zstdchunked"
+	base.Cmd("rmi", convertedImage).Run()
+	defer base.Cmd("rmi", convertedImage).Run()
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	base.Cmd("image", "convert", "--zstdchunked", "--oci",
+		testutil.AlpineImage, convertedImage).AssertOK()
+}


### PR DESCRIPTION
Support (actually, backport of `stargz-snapshotter/cmd/ctr-remote`) zstdchunked convert.