### PR TITLE
Add test matrix for windows ctrd versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,13 @@ docker_builder:
   name: windows
   platform: windows
   os_version: 2019
+  matrix:
+    - name: Windows 1.5 tests
+      env:
+        ctrdVersion: 1.5.8
+    - name: Windows 1.6 tests
+      env:
+        ctrdVersion: 1.6.0-beta.3
   env:
     CGO_ENABLED: 0
   build_script:

--- a/hack/configure-windows-ci.ps1
+++ b/hack/configure-windows-ci.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = "Stop"
 choco install --limitoutput --no-progress -y golang
 
 #install containerd
-$Version="1.5.8"
-curl.exe -L https://github.com/containerd/containerd/releases/download/v$Version/containerd-$Version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
+$version=$env:ctrdVersion
+curl.exe -L https://github.com/containerd/containerd/releases/download/v$version/containerd-$version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
 tar xvf containerd-windows-amd64.tar.gz
 mkdir -force "$Env:ProgramFiles\containerd"
 mv ./bin/* "$Env:ProgramFiles\containerd"


### PR DESCRIPTION
Adds test matrix for the current windows ctrd versions

follow up from https://github.com/containerd/nerdctl/pull/533#issuecomment-982772530