### PR TITLE
add scale flag for compose up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1086,10 +1086,10 @@ Flags:
 - :whale: `--build`: Build images before starting containers.
 - :nerd_face: `--ipfs`: Build images with pulling base images from IPFS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 - :whale: `--quiet-pull`: Pull without printing progress information
+- :whale: `--scale`: Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
 
 Unimplemented `docker-compose up` (V1) flags: `--no-deps`, `--force-recreate`, `--always-recreate-deps`, `--no-recreate`,
-`--no-start`, `--abort-on-container-exit`, `--attach-dependencies`, `--timeout`, `--renew-anon-volumes`, `--remove-orphans`, `--exit-code-from`,
-`--scale`
+`--no-start`, `--abort-on-container-exit`, `--attach-dependencies`, `--timeout`, `--renew-anon-volumes`, `--remove-orphans`, `--exit-code-from`
 
 Unimplemented `docker compose up` (V2) flags: `--environment`
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -190,5 +190,5 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 		return imgErr
 	}
 
-	return composer.New(o)
+	return composer.New(o, client)
 }

--- a/cmd/nerdctl/compose_logs.go
+++ b/cmd/nerdctl/compose_logs.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/containerd/nerdctl/pkg/composer"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +25,6 @@ func newComposeLogsCommand() *cobra.Command {
 	var composeLogsCommand = &cobra.Command{
 		Use:           "logs",
 		Short:         "Show logs of a running container",
-		Args:          cobra.NoArgs,
 		RunE:          composeLogsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -41,10 +38,6 @@ func newComposeLogsCommand() *cobra.Command {
 }
 
 func composeLogsAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		// TODO: support specifying service names as args
-		return fmt.Errorf("arguments %v not supported", args)
-	}
 	follow, err := cmd.Flags().GetBool("follow")
 	if err != nil {
 		return err
@@ -83,5 +76,5 @@ func composeLogsAction(cmd *cobra.Command, args []string) error {
 		NoColor:     noColor,
 		NoLogPrefix: noLogPrefix,
 	}
-	return c.Logs(ctx, lo)
+	return c.Logs(ctx, lo, args)
 }

--- a/pkg/composer/container.go
+++ b/pkg/composer/container.go
@@ -1,0 +1,43 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/sirupsen/logrus"
+)
+
+func (c *Composer) Containers(ctx context.Context, services ...string) ([]containerd.Container, error) {
+	projectLabel := fmt.Sprintf("labels.%q==%s", labels.ComposeProject, c.project.Name)
+	filters := []string{}
+	for _, service := range services {
+		filters = append(filters, fmt.Sprintf("%s,labels.%q==%s", projectLabel, labels.ComposeService, service))
+	}
+	if len(services) == 0 {
+		filters = append(filters, projectLabel)
+	}
+	logrus.Debugf("filters: %v", filters)
+	containers, err := c.client.Containers(ctx, filters...)
+	if err != nil {
+		return nil, err
+	}
+	return containers, nil
+}

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -36,6 +36,7 @@ type UpOptions struct {
 	ForceBuild  bool
 	IPFS        bool
 	QuietPull   bool
+	Scale       map[string]uint64 // map of service name to replicas
 }
 
 func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) error {
@@ -68,6 +69,13 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 	var parsedServices []*serviceparser.Service
 	// use WithServices to sort the services in dependency order
 	if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
+		replicas, ok := uo.Scale[svc.Name]
+		if ok {
+			if svc.Deploy == nil {
+				svc.Deploy = &types.DeployConfig{}
+			}
+			svc.Deploy.Replicas = &replicas
+		}
 		ps, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -45,10 +45,13 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 
 	var (
 		containers   = make(map[string]serviceparser.Container) // key: container ID
+		services     = []string{}
 		containersMu sync.Mutex
 		runEG        errgroup.Group
 	)
 	for _, ps := range parsedServices {
+		ps := ps
+		services = append(services, ps.Unparsed.Name)
 		for _, container := range ps.Containers {
 			container := container
 			runEG.Go(func() error {
@@ -77,7 +80,7 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 		NoColor:     uo.NoColor,
 		NoLogPrefix: uo.NoLogPrefix,
 	}
-	if err := c.logs(ctx, containers, lo); err != nil {
+	if err := c.Logs(ctx, lo, services); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

Add scale flag for compose up.

```
./nerdctl compose up -d --scale wordpress=3
INFO[0000] Creating network nerdctl_default
INFO[0000] Ensuring image mariadb:10.5
INFO[0001] Ensuring image wordpress:5.7
INFO[0001] Creating container nerdctl_wordpress_3
INFO[0001] Creating container nerdctl_wordpress_2
INFO[0001] Creating container nerdctl_wordpress_1
INFO[0001] Creating container nerdctl_db_1
```