### PR TITLE
Refacto cobra cmd

### DIFF
--- a/cmd/nerdctl/commit.go
+++ b/cmd/nerdctl/commit.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -34,6 +33,7 @@ func newCommitCommand() *cobra.Command {
 	var commitCommand = &cobra.Command{
 		Use:               "commit [flags] CONTAINER REPOSITORY[:TAG]",
 		Short:             "Create a new image from a container's changes",
+		Args:              cobra.ExactArgs(2),
 		RunE:              commitAction,
 		ValidArgsFunction: commitShellComplete,
 		SilenceUsage:      true,
@@ -46,10 +46,6 @@ func newCommitCommand() *cobra.Command {
 }
 
 func commitAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return errors.New("need container and commit image name")
-	}
-
 	opts, err := newCommitOpts(cmd, args)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container_inspect.go
+++ b/cmd/nerdctl/container_inspect.go
@@ -33,6 +33,7 @@ func newContainerInspectCommand() *cobra.Command {
 		Use:               "inspect [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Display detailed information on one or more containers.",
 		Long:              "Hint: set `--mode=native` for showing the full output",
+		Args:              cobra.MinimumNArgs(1),
 		RunE:              containerInspectAction,
 		ValidArgsFunction: containerInspectShellComplete,
 		SilenceUsage:      true,
@@ -50,10 +51,6 @@ func newContainerInspectCommand() *cobra.Command {
 }
 
 func containerInspectAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/events.go
+++ b/cmd/nerdctl/events.go
@@ -62,10 +62,6 @@ type Out struct {
 
 // eventsActions is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go
 func eventsAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return fmt.Errorf("accepts no arguments")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -71,9 +71,6 @@ func execAction(cmd *cobra.Command, args []string) error {
 		newArg = append(newArg, args[2:]...)
 		args = newArg
 	}
-	if len(args) < 2 {
-		return fmt.Errorf("requires at least 2 arguments")
-	}
 
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {

--- a/cmd/nerdctl/image_inspect.go
+++ b/cmd/nerdctl/image_inspect.go
@@ -59,10 +59,6 @@ func newImageInspectCommand() *cobra.Command {
 }
 
 func imageInspectAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	var clientOpts []containerd.ClientOpt
 	platform, err := cmd.Flags().GetString("platform")
 	if err != nil {

--- a/cmd/nerdctl/images.go
+++ b/cmd/nerdctl/images.go
@@ -74,10 +74,6 @@ func newImagesCommand() *cobra.Command {
 func imagesAction(cmd *cobra.Command, args []string) error {
 	var filters []string
 
-	if len(args) > 1 {
-		return errors.New("cannot have more than one argument")
-	}
-
 	if len(args) > 0 {
 		canonicalRef, err := referenceutil.ParseAny(args[0])
 		if err != nil {

--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -30,6 +30,7 @@ func newInspectCommand() *cobra.Command {
 	var inspectCommand = &cobra.Command{
 		Use:               "inspect",
 		Short:             "Return low-level information on objects.",
+		Args:              cobra.MinimumNArgs(1),
 		RunE:              inspectAction,
 		ValidArgsFunction: inspectShellComplete,
 		SilenceUsage:      true,
@@ -53,10 +54,6 @@ func addInspectFlags(cmd *cobra.Command) {
 }
 
 func inspectAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/kill.go
+++ b/cmd/nerdctl/kill.go
@@ -36,6 +36,7 @@ func newKillCommand() *cobra.Command {
 	var killCommand = &cobra.Command{
 		Use:               "kill [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Kill one or more running containers",
+		Args:              cobra.MinimumNArgs(1),
 		RunE:              killAction,
 		ValidArgsFunction: killShellComplete,
 		SilenceUsage:      true,
@@ -57,10 +58,6 @@ func killAction(cmd *cobra.Command, args []string) error {
 	signal, err := containerd.ParseSignal(killSignal)
 	if err != nil {
 		return err
-	}
-
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
 	}
 
 	client, ctx, cancel, err := newClient(cmd)

--- a/cmd/nerdctl/logs.go
+++ b/cmd/nerdctl/logs.go
@@ -50,10 +50,6 @@ func newLogsCommand() *cobra.Command {
 }
 
 func logsAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("requires exactly 1 argument")
-	}
-
 	dataStore, err := getDataStore(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -46,9 +46,6 @@ func newNetworkCreateCommand() *cobra.Command {
 }
 
 func networkCreateAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("requires exactly 1 argument")
-	}
 	name := args[0]
 	if err := identifiers.Validate(name); err != nil {
 		return fmt.Errorf("malformed name %s: %w", name, err)

--- a/cmd/nerdctl/network_inspect.go
+++ b/cmd/nerdctl/network_inspect.go
@@ -49,10 +49,6 @@ func newNetworkInspectCommand() *cobra.Command {
 }
 
 func networkInspectAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	cniPath, err := cmd.Flags().GetString("cni-path")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -42,9 +42,6 @@ func newNetworkRmCommand() *cobra.Command {
 }
 
 func networkRmAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
 	cniPath, err := cmd.Flags().GetString("cni-path")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/pause.go
+++ b/cmd/nerdctl/pause.go
@@ -41,10 +41,6 @@ func newPauseCommand() *cobra.Command {
 }
 
 func pauseAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/port.go
+++ b/cmd/nerdctl/port.go
@@ -45,9 +45,6 @@ func newPortCommand() *cobra.Command {
 }
 
 func portAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 && len(args) != 2 {
-		return fmt.Errorf("requires at least 1 and at most 2 arguments")
-	}
 
 	argPort := -1
 	argProto := ""

--- a/cmd/nerdctl/pull.go
+++ b/cmd/nerdctl/pull.go
@@ -40,6 +40,7 @@ func newPullCommand() *cobra.Command {
 	var pullCommand = &cobra.Command{
 		Use:           "pull",
 		Short:         "Pull an image from a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS.",
+		Args:          cobra.ExactArgs(1),
 		RunE:          pullAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -70,9 +71,6 @@ func newPullCommand() *cobra.Command {
 }
 
 func pullAction(cmd *cobra.Command, args []string) error {
-	if len(args) < 1 {
-		return errors.New("image name needs to be specified")
-	}
 	rawRef := args[0]
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {

--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -19,7 +19,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -49,6 +48,7 @@ func newPushCommand() *cobra.Command {
 	var pushCommand = &cobra.Command{
 		Use:               "push NAME[:TAG]",
 		Short:             "Push an image or a repository to a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to push image to IPFS.",
+		Args:              cobra.ExactArgs(1),
 		RunE:              pushAction,
 		ValidArgsFunction: pushShellComplete,
 		SilenceUsage:      true,
@@ -76,9 +76,6 @@ func newPushCommand() *cobra.Command {
 }
 
 func pushAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return errors.New("image name needs to be specified")
-	}
 	rawRef := args[0]
 
 	client, ctx, cancel, err := newClient(cmd)

--- a/cmd/nerdctl/rm.go
+++ b/cmd/nerdctl/rm.go
@@ -51,10 +51,6 @@ func newRmCommand() *cobra.Command {
 }
 
 func rmAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/rmi.go
+++ b/cmd/nerdctl/rmi.go
@@ -44,10 +44,6 @@ func newRmiCommand() *cobra.Command {
 }
 
 func rmiAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -228,10 +228,6 @@ func runAction(cmd *cobra.Command, args []string) error {
 		args = newArg
 	}
 
-	if len(args) < 1 {
-		return errors.New("image name needs to be specified")
-	}
-
 	ns, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/save.go
+++ b/cmd/nerdctl/save.go
@@ -53,10 +53,6 @@ func newSaveCommand() *cobra.Command {
 }
 
 func saveAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	var (
 		images   = args
 		saveOpts = []archive.ExportOpt{}

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -45,10 +45,6 @@ func newStartCommand() *cobra.Command {
 }
 
 func startAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/stop.go
+++ b/cmd/nerdctl/stop.go
@@ -53,10 +53,6 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	}
 	timeoutStr = timeoutStr + "s"
 
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	timeout, err := time.ParseDuration(timeoutStr)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/tag.go
+++ b/cmd/nerdctl/tag.go
@@ -41,10 +41,6 @@ func newTagCommand() *cobra.Command {
 }
 
 func tagAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("requires exactly 2 arguments")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/top.go
+++ b/cmd/nerdctl/top.go
@@ -74,11 +74,6 @@ func newTopCommand() *cobra.Command {
 }
 
 func topAction(cmd *cobra.Command, args []string) error {
-
-	if len(args) < 1 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	// NOTE: rootless container does not rely on cgroupv1.
 	// more details about possible ways to resolve this concern: #223
 	if rootlessutil.IsRootless() && infoutil.CgroupsVersion() == "1" {

--- a/cmd/nerdctl/unpause.go
+++ b/cmd/nerdctl/unpause.go
@@ -41,10 +41,6 @@ func newUnpauseCommand() *cobra.Command {
 }
 
 func unpauseAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -39,9 +39,6 @@ func newVolumeCreateCommand() *cobra.Command {
 }
 
 func volumeCreateAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("requires exactly 1 argument")
-	}
 	name := args[0]
 	if err := identifiers.Validate(name); err != nil {
 		return fmt.Errorf("malformed name %s: %w", name, err)

--- a/cmd/nerdctl/volume_inspect.go
+++ b/cmd/nerdctl/volume_inspect.go
@@ -17,8 +17,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -40,9 +38,6 @@ func newVolumeInspectCommand() *cobra.Command {
 }
 
 func volumeInspectAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
 
 	volStore, err := getVolumeStore(cmd)
 	if err != nil {

--- a/cmd/nerdctl/volume_rm.go
+++ b/cmd/nerdctl/volume_rm.go
@@ -39,9 +39,6 @@ func newVolumeRmCommand() *cobra.Command {
 }
 
 func volumeRmAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
 	volStore, err := getVolumeStore(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/wait.go
+++ b/cmd/nerdctl/wait.go
@@ -42,10 +42,6 @@ func newWaitCommand() *cobra.Command {
 }
 
 func containerWaitAction(cmd *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		return fmt.Errorf("requires at least 1 argument")
-	}
-
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
 `Args` in `cobra.Command` level  makes check in `RunE` functions useless