### PR TITLE
Cirrus CI: remove "Windows 1.5 tests" due to flakiness

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,9 +19,6 @@ docker_builder:
   platform: windows
   os_version: 2019
   matrix:
-    - name: Windows 1.5 tests
-      env:
-        ctrdVersion: 1.5.8
     - name: Windows 1.6 tests
       env:
         ctrdVersion: 1.6.0-beta.3


### PR DESCRIPTION
cc @jsturtevant 
