### PR TITLE
inspect: fix `nerdctl inspect IMAGE`

### DIFF
--- a/cmd/nerdctl/image_inspect.go
+++ b/cmd/nerdctl/image_inspect.go
@@ -59,11 +59,15 @@ func newImageInspectCommand() *cobra.Command {
 }
 
 func imageInspectAction(cmd *cobra.Command, args []string) error {
-	var clientOpts []containerd.ClientOpt
 	platform, err := cmd.Flags().GetString("platform")
 	if err != nil {
 		return err
 	}
+	return imageInspectActionWithPlatform(cmd, args, platform)
+}
+
+func imageInspectActionWithPlatform(cmd *cobra.Command, args []string, platform string) error {
+	var clientOpts []containerd.ClientOpt
 	if platform != "" {
 		platformParsed, err := platforms.Parse(platform)
 		if err != nil {

--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -93,7 +93,7 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no such object %s", req)
 		}
 		if ni != 0 {
-			if err := imageInspectAction(cmd, args); err != nil {
+			if err := imageInspectActionWithPlatform(cmd, args, ""); err != nil {
 				return err
 			}
 		} else {


### PR DESCRIPTION
`nerdctl inspect IMAGE` was failing:
```
$ nerdctl  inspect busybox
FATA[0001] flag accessed but not defined: platform
```

Thanks to @ningmingxiao for reporting this issue in PR #629

Replace #629
