### PR TITLE
Support loading `nerdctl.toml` (`$NERDCTL_TOML`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,9 @@ Flags:
   - Default: "systemd" on cgroup v2 (rootful & rootless), "cgroupfs" on v1 rootful, "none" on v1 rootless
 - :nerd_face: `--insecure-registry`: skips verifying HTTPS certs, and allows falling back to plain HTTP
 
+The global flags can be also specified in `/etc/nerdctl/nerdctl.toml` (rootful) and `~/.config/nerdctl/nerdctl.toml` (rootless).
+See [`./docs/config.md`](./docs/config.md).
+
 ## Unimplemented Docker commands
 Container management:
 - `docker create`
@@ -1273,6 +1276,7 @@ Others:
 
 # Additional documents
 Configuration guide:
+- [`./docs/config.md`](./docs/config.md): Configuration (`/etc/nerdctl/nerdctl.toml`, `~/.config/nerdctl/nerdctl.toml`)
 - [`./docs/registry.md`](./docs/registry.md): Registry authentication (`~/.docker/config.json`)
 
 Basic features:

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -17,9 +17,13 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -37,4 +41,50 @@ func TestUnknownCommand(t *testing.T) {
 	base.Cmd("system").AssertOK() // show help without error
 	base.Cmd("system", "info").AssertOutContains("Kernel Version:")
 	base.Cmd("info").AssertOutContains("Kernel Version:")
+}
+
+// TestNerdctlConfig validates the configuration precedence [CLI, Env, TOML, Default].
+func TestNerdctlConfig(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	tomlPath := filepath.Join(t.TempDir(), "nerdctl.toml")
+	err := os.WriteFile(tomlPath, []byte(`
+snapshotter = "dummy-snapshotter-via-toml"
+`), 0400)
+	assert.NilError(t, err)
+	base := testutil.NewBase(t)
+
+	// [Default]
+	base.Cmd("info", "-f", "{{.Driver}}").AssertOutExactly(containerd.DefaultSnapshotter + "\n")
+
+	// [TOML, Default]
+	if len(base.Env) == 0 {
+		base.Env = os.Environ()
+	}
+	base.Env = append(base.Env, "NERDCTL_TOML="+tomlPath)
+	base.Cmd("info", "-f", "{{.Driver}}").AssertOutExactly("dummy-snapshotter-via-toml\n")
+
+	// [CLI, TOML, Default]
+	base.Cmd("info", "-f", "{{.Driver}}", "--snapshotter=dummy-snapshotter-via-cli").AssertOutExactly("dummy-snapshotter-via-cli\n")
+
+	// [Env, TOML, Default]
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=dummy-snapshotter-via-env")
+	base.Cmd("info", "-f", "{{.Driver}}").AssertOutExactly("dummy-snapshotter-via-env\n")
+
+	// [CLI, Env, TOML, Default]
+	base.Cmd("info", "-f", "{{.Driver}}", "--snapshotter=dummy-snapshotter-via-cli").AssertOutExactly("dummy-snapshotter-via-cli\n")
+}
+
+func TestNerdctlConfigBad(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	tomlPath := filepath.Join(t.TempDir(), "config.toml")
+	err := os.WriteFile(tomlPath, []byte(`
+# containerd config, not nerdctl config
+version = 2
+`), 0400)
+	assert.NilError(t, err)
+	base := testutil.NewBase(t)
+	base.Env = append(base.Env, "NERDCTL_TOML="+tomlPath)
+	base.Cmd("info").AssertFail()
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,55 @@
+# Configuring nerdctl with `nerdctl.toml`
+
+| :zap: Requirement | nerdctl >= 0.16 |
+|-------------------|-----------------|
+
+This document describes the configuration file of nerdctl (`nerdctl.toml`).
+This file is unrelated to the configuration file of containerd (`config.toml`) .
+
+## File path
+- Rootful mode:  `/etc/nerdctl/nerdctl.toml`
+- Rootless mode: `~/.config/nerdctl/nerdctl.toml`
+
+The path can be overridden with `$NERDCTL_TOML`.
+
+## Example
+
+```toml
+# This is an example of /etc/nerdctl/nerdctl.toml .
+# Unrelated to the daemon's /etc/containerd/config.toml .
+
+debug          = false
+debug_full     = false
+address        = "unix:///run/k3s/containerd/containerd.sock"
+namespace      = "k8s.io"
+snapshotter    = "stargz"
+cgroup_manager = "cgroupfs"
+```
+
+## Properties
+
+| TOML property       | CLI flag                           | Env var                   | Description                   | Availability \*1 |
+|---------------------|------------------------------------|---------------------------|-------------------------------|------------------|
+| `debug`             | `--debug`                          |                           | Debug mode                    | Since 0.16.0     |
+| `debug_full`        | `--debug-full`                     |                           | Debug mode (with full output) | Since 0.16.0     |
+| `address`           | `--address`,`--host`,`-a`,`-H`     | `$CONTAINERD_ADDRESS`     | containerd address            | Since 0.16.0     |
+| `namespace`         | `--namespace`,`-n`                 | `$CONTAINERD_NAMESPACE`   | containerd namespace          | Since 0.16.0     |
+| `snapshotter`       | `--snapshotter`,`--storage-driver` | `$CONTAINERD_SNAPSHOTTER` | containerd snapshotter        | Since 0.16.0     |
+| `cni_path`          | `--cni-path`                       | `$CNI_PATH`               | CNI binary directory          | Since 0.16.0     |
+| `cni_netconfpath`   | `--cni-netconfpath`                | `$NETCONFPATH`            | CNI config directory          | Since 0.16.0     |
+| `data_root`         | `--data-root`                      |                           | Persistent state directory    | Since 0.16.0     |
+| `cgroup_manager`    | `--cgroup-manager`                 |                           | cgroup manager                | Since 0.16.0     |
+| `insecure_registry` | `--insecure-registry`              |                           | Allow insecure registry       | Since 0.16.0     |
+
+The properties are parsed in the following precedence:
+1. CLI flag
+2. Env var
+3. TOML property
+4. Built-in default value (Run `nerdctl --help` to see the default values)
+
+\*1: Availability of the TOML properties
+
+## See also
+- [`registry.md`](registry.md)
+- [`faq.md`](faq.md)
+- https://github.com/containerd/containerd/blob/main/docs/ops.md#base-configuration (`/etc/containerd/config.toml`)

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -1,5 +1,14 @@
 # nerdctl directory layout
 
+## Config
+**Default**: `/etc/nerdctl/nerdctl.toml` (rootful), `~/.config/nerdctl/nerdctl.toml` (rootless)
+
+The configuration file of nerdctl. See [`config.md`](./config.md).
+
+Can be overridden with environment variable `$NERDCTL_TOML`.
+
+This file is unrelated to the daemon config file `/etc/containerd/config.toml`.
+
 ## Data
 ### `<DATAROOT>`
 **Default**: `/var/lib/nerdctl` (rootful), `~/.local/share/nerdctl` (rootless)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -101,14 +101,57 @@ Use `nerdctl --insecure-registry run <IMAGE>`. See also [`registry.md`](./regist
 
 ### How to change the cgroup driver?
 
-Use `nerdctl --cgroup-manager=(cgroupfs|systemd|none)`.
+- Option 1: `nerdctl --cgroup-manager=(cgroupfs|systemd|none)`.
+- Option 2: Set `cgroup_manager` property in [`nerdctl.toml`](config.md)
 
 The default value is `systemd` on cgroup v2 hosts (both rootful and rootless), `cgroupfs` on cgroup v1 rootful hosts, `none` on cgroup v1 rootless hosts.
 
+<details>
+<summary>Hint: The corresponding configuration for Kubernetes (<code>io.containerd.grpc.v1.cri</code>)</summary>
+
+<p>
+
+```toml
+# An example of /etc/containerd/config.toml for Kubernetes
+version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+  SystemdCgroup = true
+```
+
+In addition to containerd, you have to configure kubelet too:
+
+```yaml
+# An example of /var/lib/kubelet/config.yaml for Kubernetes
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+cgroupDriver: "systemd"
+```
+See also https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/
+
+</p>
+</details>
+
 ### How to change the snapshotter?
-Use `nerdctl --snapshotter=(overlayfs|native|btrfs|...)`, or set `$CONTAINERD_SNAPSHOTTER`.
+- Option 1: Use `nerdctl --snapshotter=(overlayfs|native|btrfs|...)`
+- Option 2: Set `$CONTAINERD_SNAPSHOTTER`
+- Option 3: Set `snapshotter` property in [`nerdctl.toml`](config.md)
 
 The default value is `overlayfs`.
+
+<details>
+<summary>Hint: The corresponding configuration for Kubernetes (<code>io.containerd.grpc.v1.cri</code>)</summary>
+
+<p>
+
+```toml
+# An example of /etc/containerd/config.toml for Kubernetes
+version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  snapshotter = "overlayfs"
+```
+
+</p>
+</details>
 
 ### How to change the runtime?
 Use `nerdctl run --runtime=<RUNTIME>`.
@@ -116,9 +159,32 @@ Use `nerdctl run --runtime=<RUNTIME>`.
 The `<RUNTIME>` string can be either a containerd runtime plugin name (such as `io.containerd.runc.v2`),
 or a path to a runc-compatible binary (such as `/usr/local/sbin/runc`).
 
+<details>
+<summary>Hint: The corresponding configuration for Kubernetes (<code>io.containerd.grpc.v1.cri</code>)</summary>
+
+<p>
+
+```toml
+# An example of /etc/containerd/config.toml for Kubernetes
+version = 2
+[plugins."io.containerd.grpc.v1.cri".containerd]
+  default_runtime_name = "crun"
+  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun]
+      runtime_type = "io.containerd.runc.v2"
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.crun.options]
+        BinaryName = "/usr/local/bin/crun"
+```
+
+</p>
+</details>
+
+
 ### How to change the CNI binary path?
 
-Use `nerdctl --cni-path=<PATH>`, or set `$CNI_PATH`.
+- Option 1: Use `nerdctl --cni-path=<PATH>`
+- Option 2: Set `$CNI_PATH`
+- Option 3: Set `cni_path` property in [`nerdctl.toml`](config.md).
 
 The default value is automatically detected by checking the following candidates:
 - `~/.local/libexec/cni`
@@ -129,6 +195,22 @@ The default value is automatically detected by checking the following candidates
 - `/usr/libexec/cni`
 - `/usr/lib/cni`
 - `/opt/cni/bin`
+
+<details>
+<summary>Hint: The corresponding configuration for Kubernetes (<code>io.containerd.grpc.v1.cri</code>)</summary>
+
+<p>
+
+```toml
+# An example of /etc/containerd/config.toml for Kubernetes
+version = 2
+[plugins."io.containerd.grpc.v1.cri".cni]
+   bin_dir = "/opt/cni/bin"
+```
+
+</p>
+</details>
+
 
 ## Kubernetes
 

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.3-0.20211215212317-ea0209f50ae1
 	github.com/opencontainers/runtime-spec v1.0.3-0.20211214071223-8958f93039ab
+	github.com/pelletier/go-toml v1.9.4
 	github.com/rootless-containers/rootlesskit v0.14.6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
@@ -132,7 +133,6 @@ require (
 	github.com/opencontainers/runc v1.0.3 // indirect
 	github.com/opencontainers/selinux v1.8.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
-	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/polydawn/refmt v0.0.0-20201211092308-30ac6d18308e // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -47,3 +47,7 @@ func CgroupManager() string {
 func CgroupnsMode() string {
 	return ""
 }
+
+func NerdctlTOML() string {
+	return "/etc/nerdctl/nerdctl.toml"
+}

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -93,3 +93,14 @@ func BuildKitHost() string {
 	}
 	return fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", xdr)
 }
+
+func NerdctlTOML() string {
+	if !rootlessutil.IsRootless() {
+		return "/etc/nerdctl/nerdctl.toml"
+	}
+	xch, err := rootlessutil.XDGConfigHome()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(xch, "nerdctl/nerdctl.toml")
+}

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -52,3 +52,11 @@ func CgroupManager() string {
 func CgroupnsMode() string {
 	return ""
 }
+
+func NerdctlTOML() string {
+	ucd, err := os.UserConfigDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(ucd, "nerdctl\\nerdctl.toml")
+}


### PR DESCRIPTION
See `docs/config.md`

Replace PR #470

## Example

```toml
# This is an example of /etc/nerdctl/nerdctl.toml .
# Unrelated to the daemon's /etc/containerd/config.toml .

debug          = false
debug_full     = false
address        = "unix:///run/k3s/containerd/containerd.sock"
namespace      = "k8s.io"
snapshotter    = "stargz"
cgroup_manager = "cgroupfs"
```