### PR TITLE
validate output path

### DIFF
--- a/cmd/nerdctl/save.go
+++ b/cmd/nerdctl/save.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/containerd/containerd/images/archive"
+	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
 	"github.com/mattn/go-isatty"
@@ -68,6 +69,9 @@ func saveAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if output != "" {
+		if err := imgutil.ValidateOutputPath(output); err != nil {
+			return err
+		}
 		f, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
 			return err

--- a/cmd/nerdctl/save_linux_test.go
+++ b/cmd/nerdctl/save_linux_test.go
@@ -100,3 +100,10 @@ func extractTarFile(dirPath, tarFilePath string) error {
 	}
 	return nil
 }
+
+func TestSaveToIrregularFile(t *testing.T) {
+	const nullDeviceFile = "/dev/null"
+	base := testutil.NewBase(t)
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	base.Cmd("save", "-o", nullDeviceFile, testutil.AlpineImage).AssertFail()
+}


### PR DESCRIPTION
`ValidateOutputPath `  validate path before save/export. this will also be used in the `cp` command to validate the remote and local path

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>