### PR TITLE
Override image ENTRYPOINT on commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ Usage: `nerdctl commit [OPTIONS] CONTAINER [REPOSITORY[:TAG]]`
 Flags:
 - :whale: `-a, --author`: Author (e.g., "nerdctl contributor <nerdctl-dev@example.com>")
 - :whale: `-m, --message`: Commit message
-- :whale: `-c, --change`: Apply Dockerfile instruction to the created image (only CMD directive is supported)
+- :whale: `-c, --change`: Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])
 
 Unimplemented `docker commit` flags: `--pause`
 

--- a/cmd/nerdctl/commit_test.go
+++ b/cmd/nerdctl/commit_test.go
@@ -36,6 +36,10 @@ func TestCommit(t *testing.T) {
 
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "infinity").AssertOK()
 	base.Cmd("exec", testContainer, "sh", "-euxc", `echo hello-test-commit > /foo`).AssertOK()
-	base.Cmd("commit", "-c", `CMD ["cat", "/foo"]`, testContainer, testImage).AssertOK()
+	base.Cmd(
+		"commit",
+		"-c", `CMD ["/foo"]`,
+		"-c", `ENTRYPOINT ["cat"]`,
+		testContainer, testImage).AssertOK()
 	base.Cmd("run", "--rm", testImage).AssertOutExactly("hello-test-commit\n")
 }

--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -48,7 +48,7 @@ import (
 )
 
 type Changes struct {
-	CMD []string
+	CMD, Entrypoint []string
 }
 
 type Opts struct {
@@ -185,6 +185,9 @@ func generateCommitImageConfig(ctx context.Context, container containerd.Contain
 	// TODO(fuweid): support updating the USER/ENV/... fields?
 	if opts.Changes.CMD != nil {
 		baseConfig.Config.Cmd = opts.Changes.CMD
+	}
+	if opts.Changes.Entrypoint != nil {
+		baseConfig.Config.Entrypoint = opts.Changes.Entrypoint
 	}
 	if opts.Author == "" {
 		opts.Author = baseConfig.Author


### PR DESCRIPTION
Support supplying an ENTRYPOINT to override when committing an image

