### PR TITLE
Add example manifest of `nerdctl ipfs registry` on Kubernetes

### DIFF
--- a/examples/nerdctl-ipfs-registry-kubernetes/README.md
+++ b/examples/nerdctl-ipfs-registry-kubernetes/README.md
@@ -1,0 +1,95 @@
+# Example: Node-to-Node image sharing on Kubernetes using `nerdctl ipfs registry`
+
+Usage:
+- Generate `bootstrap.yaml` by executing `bootstrap.yaml.sh` (e.g. `./bootstrap.yaml.sh > ${DIR_LOCATION}/bootstrap.yaml`)
+  - [`ipfs-swarm-key-gen`](https://github.com/Kubuxu/go-ipfs-swarm-key-gen) is required (see https://github.com/ipfs/go-ipfs/blob/v0.10.0/docs/experimental-features.md#private-networks)
+- Deploy `bootstrap.yaml` and `nerdctl-ipfs-registry.yaml` (e.g. using `kubectl apply`)
+- Make sure nodes contain containerd >= v1.5.8
+
+## Example on kind
+
+Prepare cluster (make sure kind nodes contain containerd >= v1.5.8).
+
+```console
+$ cat <<EOF > /tmp/kindconfig.yaml
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker
+EOF
+$ kind create cluster --image=kindest/node:v1.23.1 --config=/tmp/kindconfig.yaml
+$ ./bootstrap.yaml.sh > ./bootstrap.yaml
+$ kubectl apply -f .
+```
+
+Prepare `kind-worker` (1st node) for importing an image to IPFS
+
+(in `kind-worker`)
+
+```console
+$ docker exec -it kind-worker /bin/bash
+(kind-worker)# NERDCTL_VERSION=0.15.0
+(kind-worker)# curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-amd64.tar.gz
+(kind-worker)# tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/
+```
+
+Add an image to `kind-worker`.
+
+```console
+$ docker exec -it kind-worker /bin/bash
+(kind-worker)# mkdir -p /tmp/ipfsapi ; echo -n /ip4/127.0.0.1/tcp/5001 >  /tmp/ipfsapi/api
+(kind-worker)# export IPFS_PATH=/tmp/ipfsapi
+(kind-worker)# nerdctl pull ghcr.io/stargz-containers/jenkins:2.60.3-org
+(kind-worker)# nerdctl push ipfs://ghcr.io/stargz-containers/jenkins:2.60.3-org
+(kind-worker)# nerdctl rmi ghcr.io/stargz-containers/jenkins:2.60.3-org
+```
+
+The image added to `kind-worker` is shared to `kind-worker2` via IPFS.
+You can run this image on all worker nodes using the following manifest (assuming the image is added to IPFS as CID `localhost:5050/ipfs/bafkreife3j4tgtx23jcautprornrdp2p4g3j3ndnidzdlrpd7unbpnwkce`).
+
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: localhost:5050/ipfs/bafkreife3j4tgtx23jcautprornrdp2p4g3j3ndnidzdlrpd7unbpnwkce
+        resources:
+          requests:
+            cpu: 1
+EOF
+```
+
+The image runs on all nodes.
+
+```console
+$ kubectl get pods -owide | grep jenkins
+jenkins-7bd8f96d79-2jbc6          1/1     Running   0          69s    10.244.1.3   kind-worker    <none>           <none>
+jenkins-7bd8f96d79-jb5lm          1/1     Running   0          69s    10.244.2.4   kind-worker2   <none>           <none>
+```
+
+## Example Dockerfile of nerdctl
+
+```Dockerfile
+FROM ubuntu:20.04
+ARG NERDCTL_VERSION=0.16.0
+RUN apt-get update -y && apt-get install -y curl && \
+    curl -sSL --output /tmp/nerdctl.tgz https://github.com/containerd/nerdctl/releases/download/v${NERDCTL_VERSION}/nerdctl-${NERDCTL_VERSION}-linux-${TARGETARCH:-amd64}.tar.gz && \
+    tar zxvf /tmp/nerdctl.tgz -C /usr/local/bin/ && \
+    rm /tmp/nerdctl.tgz
+ENTRYPOINT [ "/usr/local/bin/nerdctl", "ipfs", "registry", "serve" ]
+```

--- a/examples/nerdctl-ipfs-registry-kubernetes/bootstrap.yaml.sh
+++ b/examples/nerdctl-ipfs-registry-kubernetes/bootstrap.yaml.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# Example script to prepare swarm key secret for IPFS bootstrap,
+# Example: ./bootstrap.yaml.sh > ./bootstrap.yaml
+
+set -eu -o pipefail
+
+for d in ipfs-swarm-key-gen ; do
+    if ! command -v $d >/dev/null 2>&1 ; then
+        echo "$d not found"
+        exit 1
+    fi
+done
+
+SWARM_KEY=$(ipfs-swarm-key-gen | base64 | tr -d '\n')
+
+cat <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-config
+type: Opaque
+data:
+  ipfs-swarm-key: $SWARM_KEY
+EOF

--- a/examples/nerdctl-ipfs-registry-kubernetes/nerdctl-ipfs-registry.yaml
+++ b/examples/nerdctl-ipfs-registry-kubernetes/nerdctl-ipfs-registry.yaml
@@ -1,0 +1,287 @@
+# Example YAML of IPFS-based node-to-node image sharing
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ipfs-bootstrap
+spec:
+  selector:
+    matchLabels:
+      app: ipfs-bootstrap
+  template:
+    metadata:
+      labels:
+        app: ipfs-bootstrap
+    spec:
+      initContainers:
+        - name: configure-ipfs
+          image: "ghcr.io/stargz-containers/ipfs/go-ipfs:v0.11.0"
+          command: ["sh", "/custom/configure-ipfs.sh"]
+          env:
+            - name: LIBP2P_FORCE_PNET
+              value: "1"
+            - name: IPFS_SWARM_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: secret-config
+                  key: ipfs-swarm-key
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+      containers:
+        - name: id
+          image: "ghcr.io/stargz-containers/ipfs/go-ipfs:v0.11.0"
+          command: ["sh", "/custom/id-server.sh"]
+          ports:
+            - name: id
+              protocol: TCP
+              containerPort: 8000
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+        - name: ipfs
+          image: "ghcr.io/stargz-containers/ipfs/go-ipfs:v0.11.0"
+          command: ["ipfs", "daemon"]
+          env:
+            - name: LIBP2P_FORCE_PNET
+              value: "1"
+          ports:
+            - name: swarm
+              protocol: TCP
+              containerPort: 4001
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+          livenessProbe:
+            tcpSocket:
+              port: swarm
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 15
+      volumes:
+      - name: configure-script
+        configMap:
+          name: ipfs-bootstrap-conf
+      - name: ipfs-storage
+        emptyDir: {}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: ipfs-bootstrap
+  labels:
+    app: ipfs-bootstrap
+spec:
+  type: ClusterIP
+  ports:
+    - name: id
+      targetPort: id
+      port: 8000
+    - name: swarm
+      targetPort: swarm
+      port: 4001
+  selector:
+    app: ipfs-bootstrap
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ipfs
+spec:
+  selector:
+    matchLabels:
+      app: ipfs
+  template:
+    metadata:
+      labels:
+        app: ipfs
+    spec:
+      initContainers:
+        - name: configure-ipfs
+          image: "ghcr.io/stargz-containers/ipfs/go-ipfs:v0.11.0"
+          command: ["sh", "/custom/configure-ipfs.sh"]
+          env:
+            - name: BOOTSTRAP_SVC_NAME
+              value: "ipfs-bootstrap"
+            - name: LIBP2P_FORCE_PNET
+              value: "1"
+            - name: IPFS_SWARM_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: secret-config
+                  key: ipfs-swarm-key
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+      containers:
+        - name: ipfs
+          image: "ghcr.io/stargz-containers/ipfs/go-ipfs:v0.11.0"
+          command: ["ipfs", "daemon"]
+          env:
+            - name: LIBP2P_FORCE_PNET
+              value: "1"
+          ports:
+            - name: swarm
+              protocol: TCP
+              containerPort: 4001
+            - name: api
+              protocol: TCP
+              containerPort: 5001
+              hostPort: 5001
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+          livenessProbe:
+            tcpSocket:
+              port: swarm
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+            periodSeconds: 15
+        - name: nerdctl-ipfs-registry
+          image: "ghcr.io/stargz-containers/nerdctl-ipfs-registry:v0.16.0"
+          command: ["sh", "/custom/nerdctl-ipfs-registry-entrypoint.sh"]
+          env:
+            - name: IPFS_PATH
+              value: "/data/ipfs"
+          ports:
+            - containerPort: 5050
+              hostPort: 5050
+          volumeMounts:
+            - name: ipfs-storage
+              mountPath: /data/ipfs
+            - name: configure-script
+              mountPath: /custom
+      volumes:
+      - name: configure-script
+        configMap:
+          name: ipfs-peer-conf
+      - name: ipfs-storage
+        hostPath:
+          path: /var/ipfs/
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ipfs-peer-conf
+data:
+  nerdctl-ipfs-registry-entrypoint.sh: |
+    #!/bin/sh
+    set -eu
+
+    # wait for ipfs daemon
+    ok=false
+    for i in $(seq 100) ; do
+        if curl localhost:5001/api/v0/id >/dev/null 2>&1 ; then
+            ok=true
+            break
+        fi
+        echo "Fail(${i}). Retrying..."
+        sleep 3
+    done
+    if [ "$ok" != "true" ] ; then
+      echo "failed to detect ipfs api"
+      exit 1
+    fi
+
+    exec /usr/local/bin/nerdctl ipfs registry serve --listen-registry 0.0.0.0:5050 --ipfs-address /ip4/127.0.0.1/tcp/5001 --read-retry-num 3 --read-timeout 500ms
+
+  configure-ipfs.sh: |
+    #!/bin/sh
+    set -eu -o pipefail
+
+    # wait for bootstrap node running
+    ok=false
+    for i in $(seq 100) ; do
+        if nc -z ${BOOTSTRAP_SVC_NAME} 4001 ; then
+            ok=true
+            break
+        fi
+        echo "Fail(${i}). Retrying..."
+        sleep 3
+    done
+    if [ "$ok" != "true" ] ; then
+      echo "failed to detect bootstrap node"
+      exit 1
+    fi
+
+    BOOTSTRAP_ID=$(wget -O - ${BOOTSTRAP_SVC_NAME}:8000/id)
+    if [ "${BOOTSTRAP_ID}" == "" ] ; then
+      echo "failed to get bootstrap peer id"
+      exit 1
+    fi
+    if [ "${IPFS_SWARM_KEY}" == "" ] || [ "${LIBP2P_FORCE_PNET}" != "1" ] ; then
+      echo "must be forced to private ipfs network (got LIBP2P_FORCE_PNET=${LIBP2P_FORCE_PNET})"
+      exit 1
+    fi
+
+    mkdir -p /data/ipfs
+    if ! [ -z "$(ls -A /data/ipfs)" ]; then
+      echo "IPFS already configured on this node; destroying the current repo and refreshing..."
+      rm -rf /data/ipfs/*
+    fi
+
+    ipfs init --profile=badgerds,server
+    ipfs bootstrap rm --all
+    ipfs bootstrap add /dns4/${BOOTSTRAP_SVC_NAME}/tcp/4001/ipfs/${BOOTSTRAP_ID}
+    ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+    ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+    ipfs config Datastore.StorageMax 100GB
+    ipfs config Addresses.NoAnnounce --json '[]'
+    ipfs config Swarm.AddrFilters --json '[]'
+    echo -n "${IPFS_SWARM_KEY}" > /data/ipfs/swarm.key
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ipfs-bootstrap-conf
+data:
+  id-server.sh: |
+    #!/bin/sh
+    set -eu -o pipefail
+
+    if [ ! -f /doc/id ]; then
+      mkdir /doc
+      ipfs config show | grep "PeerID" | sed -E 's/.*"PeerID": "([a-zA-Z0-9]*)".*/\1/' > /doc/id
+    fi
+    exec httpd -f -p 8000 -h /doc
+
+  configure-ipfs.sh: |
+    #!/bin/sh
+    set -eu -o pipefail
+
+    if [ "${IPFS_SWARM_KEY}" == "" ] || [ "${LIBP2P_FORCE_PNET}" != "1" ] ; then
+      echo "must be forced to private ipfs network (got LIBP2P_FORCE_PNET=${LIBP2P_FORCE_PNET})"
+    fi
+
+    mkdir -p /data/ipfs
+    if ! [ -z "$(ls -A /data/ipfs)" ]; then
+      echo "IPFS already configured on this node; destroying the current repo and refreshing..."
+      rm -rf /data/ipfs/*
+    fi
+
+    ipfs init --profile=badgerds,server
+    ipfs bootstrap rm --all
+    ipfs config Addresses.API /ip4/0.0.0.0/tcp/5001
+    ipfs config Addresses.Gateway /ip4/0.0.0.0/tcp/8080
+    ipfs config Addresses.NoAnnounce --json '[]'
+    ipfs config Swarm.AddrFilters --json '[]'
+    ipfs config Datastore.StorageMax 1GB
+    echo -n "${IPFS_SWARM_KEY}" > /data/ipfs/swarm.key


### PR DESCRIPTION
This commit adds example manifests for node-to-node image sharing on Kubernetes with nerdctl (`nerdctl ipfs registry`). In the future, kubernetes should support `ipfs://`-prefixed image reference.

These manifests create a private node-to-node IPFS network and runs `nerdctl ipfs registry` on each node as DaemonSet. CRI runtime can pull image from this IPFS network via `nerdctl ipfs registry` using `localhost:5050/ipfs/CID` image reference.

To add images to this IPFS network, users can connect a seeder node to this network and run `nerdctl push ipfs://` on that seeder (Or, you can add an image by running `nerdctl push ipfs://` directly on one of the k8s nodes).

### Benchmarking

Tested this manifest using 20 nodes GKE cluster + 1 private registry/seeder node.
Measured the time to take to pull images (in parallel) from the private seeder/registry to GKE nodes with emulating bendwidth restriction on the seeder/registry node using tc.

```
  source of images
+-----------------+                           +------------------------+
| registry/seeder | <-- limited bandwidth --> | GKE cluster (20 nodes) |
+-----------------+                           +------------------------+
                  pull via IPFS or registry API
```

- GKE (v1.21.5-gke.1302, 20 nodes)
  - instance: e2-standard-8 (asia-northeast1-a)
  - OS: ubuntu_containerd (upgraded containerd to v1.5.8 manually)
- private seeder/registry (1 node): used as a private container registry and IPFS node (seeder)
  - instance: e2-standard-8 (asia-northeast1-a)
  - OS: Ubuntu 20.04
- image: ghcr.io/stargz-containers/jenkins:2.60.3-org (726.4 MiB)
- benchmarking script (suggestions are very welcome): https://github.com/ktock/stargz-snapshotter/tree/nerdctl-ipfs-registry-kubernetes-benchmark/script/nerdctl-ipfs-registry-kubernetes-benchmark
- Measured the worst time to take to pull

latest: 20220113

#### 3.82 Gbits/sec (registry/seeder => node), 3.82 Gbits/sec (node => registry/seeder)

|num of images to pull|1|5|10|15|20|
|---|---|---|---|---|---|
|registry|9743 ms|12513 ms|14271 ms|16620 ms|19148 ms|
|ipfs|11355 ms|12648 ms|13283 ms|13866 ms|15471 ms|

#### 955 Mbits/sec (registry/seeder => node), 955 Mbits/sec (node => registry/seeder)

|num of images to pull|1|5|10|15|20|
|---|---|---|---|---|---|
|registry|11041 ms|18863 ms|31820 ms|44320 ms|57744 ms|
|ipfs|12164 ms|18725 ms|24152 ms|26035 ms|25421 ms|

#### 478 Mbits/sec (registry/seeder => node), 478 Mbits/sec (node => registry/seeder)

|num of images to pull|1|5|10|15|20|
|---|---|---|---|---|---|
|registry|10861 ms|31622 ms|57723 ms|84229 ms|110283 ms|
|ipfs|13518 ms|19182 ms|24737 ms|30685 ms|43373 ms|

According to the result, IPFS pulls images faster than registry when pulling many images under bandwidth-restricted situations.
As a future work, we shoud fix `nerdctl ipfs registry` (or ipfs?) to improve the performance of pulling small number of images or the performance of pulling on fast network.
