### PR TITLE
Make `compose up` command idempotent.

### DIFF
--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -114,6 +114,8 @@ func testComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string) 
 	}
 	t.Log("wordpress seems functional")
 
+	// test `compose up` twice for idempotency
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
 	base.Cmd("volume", "inspect", fmt.Sprintf("%s_db", projectName)).AssertFail()
 	base.Cmd("network", "inspect", fmt.Sprintf("%s_default", projectName)).AssertFail()

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 
 	composecli "github.com/compose-spec/compose-go/cli"
-	"github.com/compose-spec/compose-go/types"
 	compose "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/identifiers"
@@ -172,7 +171,7 @@ func findComposeYAML(o *Options) (string, error) {
 
 func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, error) {
 	var services []*serviceparser.Service
-	if err := c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+	if err := c.project.WithServices(nil, func(svc compose.ServiceConfig) error {
 		parsed, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err
@@ -187,7 +186,7 @@ func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, erro
 
 func (c *Composer) ServiceNames(services ...string) ([]string, error) {
 	var names []string
-	if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
+	if err := c.project.WithServices(services, func(svc compose.ServiceConfig) error {
 		names = append(names, svc.Name)
 		return nil
 	}); err != nil {

--- a/pkg/composer/container.go
+++ b/pkg/composer/container.go
@@ -41,3 +41,24 @@ func (c *Composer) Containers(ctx context.Context, services ...string) ([]contai
 	}
 	return containers, nil
 }
+
+func (c *Composer) containerExists(ctx context.Context, name, service string) (bool, error) {
+	// get list of containers for service
+	containers, err := c.Containers(ctx, service)
+	if err != nil {
+		return false, err
+	}
+
+	for _, container := range containers {
+		containerLabels, err := container.Labels(ctx)
+		if err != nil {
+			return false, err
+		}
+		if name == containerLabels[labels.Name] {
+			// container exists
+			return true, nil
+		}
+	}
+	// container doesn't exist
+	return false, nil
+}


### PR DESCRIPTION
This allows users to rapidly iterate with `compose up`, rather than deleting & recreating their compose stack to effect changes.

Signed-off-by: fergal kearns <fhke@protonmail.com>