### PR TITLE
Enhancements for `compose up` command.

### DIFF
--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -41,6 +41,7 @@ func newComposeUpCommand() *cobra.Command {
 	composeUpCommand.Flags().Bool("build", false, "Build images before starting containers.")
 	composeUpCommand.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
 	composeUpCommand.Flags().Bool("quiet-pull", false, "Pull without printing progress information")
+	composeUpCommand.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 	composeUpCommand.Flags().StringArray("scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
 	return composeUpCommand
 }
@@ -77,6 +78,10 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 	if err != nil {
 		return err
 	}
+	removeOrphans, err := cmd.Flags().GetBool("remove-orphans")
+	if err != nil {
+		return err
+	}
 	scaleSlice, err := cmd.Flags().GetStringArray("scale")
 	if err != nil {
 		return err
@@ -105,14 +110,15 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 		return err
 	}
 	uo := composer.UpOptions{
-		Detach:      detach,
-		NoBuild:     noBuild,
-		NoColor:     noColor,
-		NoLogPrefix: noLogPrefix,
-		ForceBuild:  build,
-		IPFS:        enableIPFS,
-		QuietPull:   quietPull,
-		Scale:       scale,
+		Detach:        detach,
+		NoBuild:       noBuild,
+		NoColor:       noColor,
+		NoLogPrefix:   noLogPrefix,
+		ForceBuild:    build,
+		IPFS:          enableIPFS,
+		QuietPull:     quietPull,
+		RemoveOrphans: removeOrphans,
+		Scale:         scale,
 	}
 	return c.Up(ctx, uo, services)
 }

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -328,3 +328,67 @@ networks:
 
 	base.Cmd("inspect", "-f", `{{json .NetworkSettings.Networks }}`, projectName+"_foo_1").AssertOutContains("10.1.100.")
 }
+
+func TestComposeUpRemoveOrphans(t *testing.T) {
+	base := testutil.NewBase(t)
+
+	var (
+		dockerComposeYAMLOrphan = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  test:
+    image: %s
+    command: "sleep infinity"
+`, testutil.AlpineImage)
+
+		dockerComposeYAMLFull = fmt.Sprintf(`
+%s
+  orphan:
+    image: %s
+    command: "sleep infinity"
+`, dockerComposeYAMLOrphan, testutil.AlpineImage)
+	)
+
+	compOrphan := testutil.NewComposeDir(t, dockerComposeYAMLOrphan)
+	defer compOrphan.CleanUp()
+	compFull := testutil.NewComposeDir(t, dockerComposeYAMLFull)
+	defer compFull.CleanUp()
+
+	projectName := fmt.Sprintf("nerdctl-compose-test-%d", time.Now().Unix())
+	t.Logf("projectName=%q", projectName)
+
+	orphanContainer := fmt.Sprintf("%s_orphan_1", projectName)
+
+	base.ComposeCmd("-p", projectName, "-f", compFull.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-p", projectName, "-f", compFull.YAMLFullPath(), "down", "-v").Run()
+	base.ComposeCmd("-p", projectName, "-f", compOrphan.YAMLFullPath(), "up", "-d").AssertOK()
+	base.ComposeCmd("-p", projectName, "-f", compFull.YAMLFullPath(), "ps").AssertOutContains(orphanContainer)
+	base.ComposeCmd("-p", projectName, "-f", compOrphan.YAMLFullPath(), "up", "-d", "--remove-orphans").AssertOK()
+	base.ComposeCmd("-p", projectName, "-f", compFull.YAMLFullPath(), "ps").AssertOutNotContains(orphanContainer)
+}
+
+func TestComposeUpIdempotent(t *testing.T) {
+	base := testutil.NewBase(t)
+
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  test:
+    image: %s
+    command: "sleep infinity"
+`, testutil.AlpineImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "down").AssertOK()
+
+}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 
 	composecli "github.com/compose-spec/compose-go/cli"
-	"github.com/compose-spec/compose-go/types"
 	compose "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/identifiers"
@@ -172,7 +171,7 @@ func findComposeYAML(o *Options) (string, error) {
 
 func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, error) {
 	var services []*serviceparser.Service
-	if err := c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+	if err := c.project.WithServices(nil, func(svc compose.ServiceConfig) error {
 		parsed, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err
@@ -187,7 +186,7 @@ func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, erro
 
 func (c *Composer) ServiceNames(services ...string) ([]string, error) {
 	var names []string
-	if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
+	if err := c.project.WithServices(services, func(svc compose.ServiceConfig) error {
 		names = append(names, svc.Name)
 		return nil
 	}); err != nil {

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -290,6 +290,16 @@ func (c *Cmd) AssertOutContains(s string) {
 	c.Assert(expected)
 }
 
+func (c *Cmd) AssertOutNotContains(s string) {
+	c.AssertOutWithFunc(func(stdout string) error {
+		if strings.Contains(stdout, s) {
+			return fmt.Errorf("expected stdout to contain %q", s)
+		} else {
+			return nil
+		}
+	})
+}
+
 func (c *Cmd) AssertOutExactly(s string) {
 	c.Base.T.Helper()
 	fn := func(stdout string) error {


### PR DESCRIPTION
This PR contains the following updates to the `compose up` command:

* Idempotency: rather than failing when a container already exists and has been created by compose, recreate the container. This allows users to iterate rapidly with `compose up`, rather than deleting & recreating their compose stack to effect changes.
* Add support for `--remove-orphans` flag: remove containers for services not defined in the Compose file. This fixes #342 

Signed-off-by: fergal kearns <fhke@protonmail.com>