### PR TITLE
run: automatically generate a container name from image ref

### DIFF
--- a/cmd/nerdctl/ps.go
+++ b/cmd/nerdctl/ps.go
@@ -30,9 +30,11 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/labels/k8slabels"
+	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -158,11 +160,19 @@ func printContainers(ctx context.Context, cmd *cobra.Command, containers []conta
 	for _, c := range containers {
 		info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				logrus.Warn(err)
+				continue
+			}
 			return err
 		}
 
 		spec, err := c.Spec(ctx)
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				logrus.Warn(err)
+				continue
+			}
 			return err
 		}
 

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -51,6 +51,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/netutil/nettype"
 	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/containerd/nerdctl/pkg/portutil"
+	"github.com/containerd/nerdctl/pkg/referenceutil"
 	"github.com/containerd/nerdctl/pkg/resolvconf"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
@@ -522,6 +523,14 @@ func createContainer(cmd *cobra.Command, ctx context.Context, client *containerd
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
 		return nil, "", nil, err
+	}
+	if name == "" && !cmd.Flags().Changed("name") {
+		// Automatically set the container name, unless `--name=""` was explicitly specified.
+		var imageRef string
+		if ensuredImage != nil {
+			imageRef = ensuredImage.Ref
+		}
+		name = referenceutil.SuggestContainerName(imageRef, id)
 	}
 	if name != "" {
 		containerNameStore, err = namestore.New(dataStore, ns)

--- a/pkg/referenceutil/referenceutil_test.go
+++ b/pkg/referenceutil/referenceutil_test.go
@@ -1,0 +1,35 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package referenceutil
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSuggestContainerName(t *testing.T) {
+	const containerID = "16f6d167d4f4743e48affb86e7097222b7992b34a29dab5f8c10cd6a90cdd990"
+	assert.Equal(t, "alpine-16f6d", SuggestContainerName("alpine", containerID))
+	assert.Equal(t, "alpine-16f6d", SuggestContainerName("alpine:3.15", containerID))
+	assert.Equal(t, "alpine-16f6d", SuggestContainerName("docker.io/library/alpine:3.15", containerID))
+	assert.Equal(t, "alpine-16f6d", SuggestContainerName("docker.io/library/alpine:latest", containerID))
+	assert.Equal(t, "ipfs-bafkr-16f6d", SuggestContainerName("bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze", containerID))
+	assert.Equal(t, "ipfs-bafkr-16f6d", SuggestContainerName("ipfs://bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze", containerID))
+	assert.Equal(t, "untitled-16f6d", SuggestContainerName("invalid://alpine", containerID))
+	assert.Equal(t, "untitled-16f6d", SuggestContainerName("", containerID))
+}


### PR DESCRIPTION
e.g., `nerdctl run nginx` creates a container named "nginx-62edd".
See `pkg/referenceutil/referenceutil_test.go` for more examples.

The generated names are more meaningful than Docker/Podman-generated names such as "jolly_kepler". However, the generated names MUST NOT be parsed.

The name can be unset by specifying `--name=""` explicitly.
