### PR TITLE
Add namespace use command

### DIFF
--- a/cmd/nerdctl/namespace_ls.go
+++ b/cmd/nerdctl/namespace_ls.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newNamespaceLsCommand() *cobra.Command {
+	namespaceLsCommand := &cobra.Command{
+		Use:           "ls",
+		Aliases:       []string{"list"},
+		Short:         "List containerd namespaces",
+		RunE:          namespaceLsAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	namespaceLsCommand.Flags().BoolP("quiet", "q", false, "Only display names")
+	return namespaceLsCommand
+}
+
+func namespaceLsAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	nsService := client.NamespaceService()
+	nsList, err := nsService.List(ctx)
+	if err != nil {
+		return err
+	}
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return err
+	}
+	if quiet {
+		for _, ns := range nsList {
+			fmt.Fprintln(cmd.OutOrStdout(), ns)
+		}
+		return nil
+	}
+
+	dataStore, err := getDataStore(cmd)
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 4, 8, 4, ' ', 0)
+	// no "NETWORKS", because networks are global objects
+	fmt.Fprintln(w, "NAME\tCONTAINERS\tIMAGES\tVOLUMES")
+	for _, ns := range nsList {
+		ctx = namespaces.WithNamespace(ctx, ns)
+		var numContainers, numImages, numVolumes int
+
+		containers, err := client.Containers(ctx)
+		if err != nil {
+			logrus.Warn(err)
+		}
+		numContainers = len(containers)
+
+		images, err := client.ImageService().List(ctx)
+		if err != nil {
+			logrus.Warn(err)
+		}
+		numImages = len(images)
+
+		volStore, err := volumestore.Path(dataStore, ns)
+		if err != nil {
+			logrus.Warn(err)
+		} else {
+			volEnts, err := os.ReadDir(volStore)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					logrus.Warn(err)
+				}
+			}
+			numVolumes = len(volEnts)
+		}
+
+		fmt.Fprintf(w, "%s\t%d\t%d\t%d\n", ns, numContainers, numImages, numVolumes)
+	}
+	return w.Flush()
+}

--- a/cmd/nerdctl/namespace_use.go
+++ b/cmd/nerdctl/namespace_use.go
@@ -1,0 +1,84 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+const (
+	LastNamespace = "last-namespace"
+)
+
+func newNamespaceUseCommand() *cobra.Command {
+	namespaceUseCommand := &cobra.Command{
+		Use:           "use",
+		Short:         "use a namespace",
+		RunE:          namespaceUseAction,
+		Args:          cobra.ExactArgs(1),
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	return namespaceUseCommand
+}
+
+func namespaceUseAction(cmd *cobra.Command, args []string) error {
+	tomlPath := ncdefaults.NerdctlTOML()
+	if v, ok := os.LookupEnv("NERDCTL_TOML"); ok {
+		tomlPath = v
+	}
+	cfg, err := NewConfigFromTOML(tomlPath)
+	if err != nil {
+		return err
+	}
+	namespace := args[0]
+	if namespace == "-" {
+		lastNS, err := os.ReadFile(filepath.Join(ncdefaults.NerdctlPath(), LastNamespace))
+		if err == nil {
+			namespace = string(lastNS)
+		} else {
+			logrus.Debugf("missing last namespace: %v", err)
+			namespace = "default"
+		}
+	}
+	if err := writeLastNamespace(cfg.Namespace); err != nil {
+		return err
+	}
+	cfg.Namespace = namespace
+	if err := cfg.MarshalToTOML(tomlPath); err != nil {
+		return err
+	}
+	logrus.Infof("using namespace %q", namespace)
+	return nil
+}
+
+func writeLastNamespace(namespace string) error {
+	path := ncdefaults.NerdctlPath()
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return err
+	}
+	last := filepath.Join(path, LastNamespace)
+	if err := os.WriteFile(last, []byte(namespace), 0644); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -14,23 +14,10 @@
    limitations under the License.
 */
 
-package main
+package defaults
 
-import (
-	"github.com/spf13/cobra"
-)
+import "path/filepath"
 
-func newNamespaceCommand() *cobra.Command {
-	namespaceCommand := &cobra.Command{
-		Annotations:   map[string]string{Category: Management},
-		Use:           "namespace",
-		Short:         "Manage containerd namespaces",
-		Long:          "Unrelated to Linux namespaces and Kubernetes namespaces",
-		RunE:          unknownSubcommandAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-	namespaceCommand.AddCommand(newNamespaceLsCommand())
-	namespaceCommand.AddCommand(newNamespaceUseCommand())
-	return namespaceCommand
+func NerdctlTOML() string {
+	return filepath.Join(NerdctlPath(), "nerdctl.toml")
 }

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -48,8 +48,8 @@ func CgroupnsMode() string {
 	return ""
 }
 
-func NerdctlTOML() string {
-	return "/etc/nerdctl/nerdctl.toml"
+func NerdctlPath() string {
+	return "/etc/nerdctl"
 }
 
 func HostsDirs() []string {

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -94,15 +94,15 @@ func BuildKitHost() string {
 	return fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", xdr)
 }
 
-func NerdctlTOML() string {
+func NerdctlPath() string {
 	if !rootlessutil.IsRootless() {
-		return "/etc/nerdctl/nerdctl.toml"
+		return "/etc/nerdctl"
 	}
 	xch, err := rootlessutil.XDGConfigHome()
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(xch, "nerdctl/nerdctl.toml")
+	return filepath.Join(xch, "nerdctl")
 }
 
 func HostsDirs() []string {

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -53,12 +53,12 @@ func CgroupnsMode() string {
 	return ""
 }
 
-func NerdctlTOML() string {
+func NerdctlPath() string {
 	ucd, err := os.UserConfigDir()
 	if err != nil {
 		panic(err)
 	}
-	return filepath.Join(ucd, "nerdctl\\nerdctl.toml")
+	return filepath.Join(ucd, "nerdctl")
 }
 
 func HostsDirs() []string {


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

Fixes: https://github.com/containerd/nerdctl/issues/624

Why not use `nerdctl context use`?
1. `namespace use` is more direct
2. If the `context create context --namespace ns1` command is added later, also can use `namespace use ns2` to switch the namespace of the current context