### PR TITLE
improve error message of ipfs api address could not be found

### DIFF
--- a/cmd/nerdctl/ipfs_registry_serve.go
+++ b/cmd/nerdctl/ipfs_registry_serve.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/containerd/nerdctl/pkg/ipfs"
@@ -79,7 +80,7 @@ func ipfsRegistryServeAction(cmd *cobra.Command, args []string) error {
 	} else {
 		ipfsClient, err = httpapi.NewLocalApi()
 		if err != nil {
-			return err
+			return fmt.Errorf("error encountered, '%w', Please setup ipfs daemon, see https://github.com/containerd/nerdctl/blob/master/docs/ipfs.md", err)
 		}
 	}
 	h, err := ipfs.NewRegistry(ipfsClient, ipfs.RegistryOptions{


### PR DESCRIPTION
Signed-off-by: Tanweer Noor <tanweer.noor@gmail.com>

This PR addresses: https://github.com/containerd/nerdctl/issues/564

before:- 
nerdctl ipfs registry serve
FATA[0000] ipfs api address could not be found

After:- 
nerdctl ipfs registry serve
FATA[0000] error encountered, 'ipfs api address could not be found', Please setup ipfs daemon, see https://github.com/containerd/nerdctl/blob/master/docs/ipfs.md




