### PR TITLE
config path handled by cmd

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -134,6 +134,9 @@ func initRootCmdFlags(rootCmd *cobra.Command, tomlPath string) error {
 			return err
 		}
 	}
+
+    // Overriding config path for subcommands
+	rootCmd.PersistentFlags().String("config", tomlPath, "location of config file")
 	rootCmd.PersistentFlags().Bool("debug", cfg.Debug, "debug mode")
 	rootCmd.PersistentFlags().Bool("debug-full", cfg.DebugFull, "debug mode (with full output)")
 	// -a is nonPersistentAlias (conflicts with nerdctl images -a)


### PR DESCRIPTION
The config path should be handled by cobra cmd. This can be overridden by the user for subcommands

Signed-off-by: fahedouch <fahed.dorgaa@gmail.com>