### PR TITLE
Fixes 404 error when authenticating with v2 reg

### DIFF
--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -253,6 +253,12 @@ func tryLoginWithRegHost(ctx context.Context, rh docker.RegistryHost) error {
 		Host:   rh.Host,
 		Path:   rh.Path,
 	}
+	if rh.Path == "/v2" {
+		// If the path is using /v2 endpoint but lacks trailing slash add it
+		// https://docs.docker.com/registry/spec/api/#detail. Acts as a workaround
+		// for containerd issue https://github.com/containerd/containerd/blob/2986d5b077feb8252d5d2060277a9c98ff8e009b/remotes/docker/config/hosts.go#L110
+		rh.Path = "/v2/"
+	}
 	ctx = docker.WithScope(ctx, "")
 	var ress []*http.Response
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
After applying this fix I can successfully authenticate with github registry

```
[vagrant@localhost nerdctl]$ nerdctl login -u <USERNAME> ghcr.io
Enter Password:
Login Succeeded
[vagrant@localhost nerdctl]$

[vagrant@localhost ~]$ nerdctl pull ghcr.io/<IMAGE>
ghcr.io/<IMAGE>:                            resolved       |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:9d7715dd1e7a20a03c1fda6b625ab73aa8e1a9cacddad885b79876bd2a8ebce8: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:6f7f6bfd79125762caacefdb0e83ece7e101c85279d31fbc36f61d643f878a42:   done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:abd092694f3b3635a1642c6fed15a81f02bbcd44045fc5dfb138eda3531899bf:    done           |++++++++++++++++++++++++++++++++++++++|
layer-sha256:b53a42fddd847a0d1d550565601c9299fecae84e94ffcb8c9a9e5e98231e0ee0:    done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 3.8 s                                                                    total:  7.8 Mi (2.1 MiB/s)
[vagrant@localhost ~]$

```

This maybe a slightly naive approach so welcome feedback on a better place for this - Not sure who to ping from containerd 

Closes #715