### PR TITLE
fix ghcr login 404 again

### DIFF
--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -256,16 +256,16 @@ func tryLoginWithRegHost(ctx context.Context, rh docker.RegistryHost) error {
 	if rh.Authorizer == nil {
 		return errors.New("got nil Authorizer")
 	}
-	u := url.URL{
-		Scheme: rh.Scheme,
-		Host:   rh.Host,
-		Path:   rh.Path,
-	}
 	if rh.Path == "/v2" {
 		// If the path is using /v2 endpoint but lacks trailing slash add it
 		// https://docs.docker.com/registry/spec/api/#detail. Acts as a workaround
 		// for containerd issue https://github.com/containerd/containerd/blob/2986d5b077feb8252d5d2060277a9c98ff8e009b/remotes/docker/config/hosts.go#L110
 		rh.Path = "/v2/"
+	}
+	u := url.URL{
+		Scheme: rh.Scheme,
+		Host:   rh.Host,
+		Path:   rh.Path,
 	}
 	ctx = docker.WithScope(ctx, "")
 	var ress []*http.Response


### PR DESCRIPTION
I pulled the latest code and tested it locally, it seems doesn't work.
```
Enter Password:
DEBU[0000] Ignoring hosts dir "/etc/containerd/certs.d"  error="stat /etc/containerd/certs.d: no such file or directory"
DEBU[0000] Ignoring hosts dir "/etc/docker/certs.d"      error="stat /etc/docker/certs.d: no such file or directory"
DEBU[0000] len(regHosts)=1
/v2/
ERRO[0001] failed to call tryLoginWithRegHost            error="unexpected status code 404" i=0
FATA[0001] unexpected status code 404
```

_Originally posted by @Junnplus in https://github.com/containerd/nerdctl/issues/715#issuecomment-1021943642_

Fixes: https://github.com/containerd/nerdctl/issues/715

Thanks @dylanrhysscott 