### PR TITLE
purge useless login func

### DIFF
--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -123,9 +123,6 @@ func loginAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("error saving credentials: %w", err)
 	}
 
-	if _, err = loginClientSide(ctx, cmd, *authConfig); err != nil {
-		return err
-	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Login Succeeded")
 
 	return nil
@@ -217,9 +214,6 @@ func loginClientSide(ctx context.Context, cmd *cobra.Command, auth types.AuthCon
 				// Even containerd/CRI does not support RegistryToken as of v1.4.3,
 				// so, nobody is actually using RegistryToken?
 				logrus.Warnf("RegistryToken (for %q) is not supported yet (FIXME)", host)
-			}
-			if auth.IdentityToken != "" {
-				return "", auth.IdentityToken, nil
 			}
 			return auth.Username, auth.Password, nil
 		}


### PR DESCRIPTION
I don't see any need in redoing a loginClientSide here since it's already been done before

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>