### PR TITLE
Fix login registry host with different schemas

### DIFF
--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -87,6 +87,22 @@ func loginAction(cmd *cobra.Command, args []string) error {
 	var responseIdentityToken string
 	ctx := cmd.Context()
 	isDefaultRegistry := serverAddress == registry.IndexServer
+
+	// Ensure that URL contains scheme for a good parsing process
+	if strings.Contains(serverAddress, "://") {
+		u, err := url.Parse(serverAddress)
+		if err != nil {
+			return err
+		}
+		serverAddress = u.Host
+	} else {
+		u, err := url.Parse("https://" + serverAddress)
+		if err != nil {
+			return err
+		}
+		serverAddress = u.Host
+	}
+
 	authConfig, err := GetDefaultAuthConfig(options.username == "" && options.password == "", serverAddress, isDefaultRegistry)
 	if &authConfig == nil {
 		authConfig = &types.AuthConfig{}
@@ -180,21 +196,6 @@ func GetDefaultAuthConfig(checkCredStore bool, serverAddress string, isDefaultRe
 
 func loginClientSide(ctx context.Context, cmd *cobra.Command, auth types.AuthConfig) (string, error) {
 	host := auth.ServerAddress
-
-	// Ensure that URL contains scheme for a good parsing process
-	if strings.Contains(host, "://") {
-		u, err := url.Parse(host)
-		if err != nil {
-			return "", err
-		}
-		host = u.Host
-	} else {
-		u, err := url.Parse("https://" + host)
-		if err != nil {
-			return "", err
-		}
-		host = u.Host
-	}
 
 	var dOpts []dockerconfigresolver.Opt
 	insecure, err := cmd.Flags().GetBool("insecure-registry")


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

Fixes: https://github.com/containerd/nerdctl/issues/742


It seems that logins with https and non-https logins produce inconsistent configurations.
```
> lima nerdctl login --username AWS  https://xxxxx.dkr.ecr.ap-southeast-1.amazonaws.com
> lima nerdctl login --username AWS  xxxxx.dkr.ecr.ap-southeast-1.amazonaws.com
> cat ~/.docker/config.json
{
        "auths": {
                "xxxxx.dkr.ecr.ap-southeast-1.amazonaws.com": {
                        "auth": TOKEN,
                },
                "https://xxxxx.dkr.ecr.ap-southeast-1.amazonaws.com": {
                        "auth": TOKEN,
                }
        }
}
```
This is inconsistent with the docker command, we will fix this.

_Originally posted by @Junnplus in https://github.com/containerd/nerdctl/issues/742#issuecomment-1024936891_