### PR TITLE
Workarounds for gVisor (and Kata)

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -788,8 +788,11 @@ func withNerdctlOCIHook(cmd *cobra.Command, id, stateDir string) (oci.SpecOpts, 
 		if s.Hooks == nil {
 			s.Hooks = &specs.Hooks{}
 		}
-		crArgs := append(args, "createRuntime")
-		s.Hooks.CreateRuntime = append(s.Hooks.CreateRuntime, specs.Hook{
+		// prestart is deprecated in favor of createRuntime added in OCI Runtime Spec v1.0.2,
+		// however, as of Feb 2022, gVisor and Kata still do not support createRuntime.
+		// https://github.com/containerd/nerdctl/issues/787
+		crArgs := append(args, "prestart")
+		s.Hooks.Prestart = append(s.Hooks.CreateRuntime, specs.Hook{
 			Path: selfExe,
 			Args: crArgs,
 			Env:  os.Environ(),

--- a/docs/cni.md
+++ b/docs/cni.md
@@ -7,7 +7,7 @@ either `--network` or `--net` option.
 
 nerdctl support some basic types of CNI plugins without any configuration
 needed(you should have CNI plugin be installed), for Linux systems the basic
-CNI plugin types are `bridge`, `portmap`, `firewall`, `tuning`, for Windows
+CNI plugin types are `bridge`, `portmap`, `firewall`, `tuning`, `loopback`, for Windows
 system, the supported CNI plugin types are `nat` only.
 
 The default network `bridge` for Linux and `nat` for Windows if you
@@ -50,6 +50,10 @@ Configuration of the default network `bridge` of Linux:
     },
     {
       "type": "tuning"
+    },
+    {
+      "type": "loopback",
+      "name": "lo"
     },
     {
       "type": "isolation"

--- a/pkg/netutil/cni_plugin_unix.go
+++ b/pkg/netutil/cni_plugin_unix.go
@@ -95,6 +95,23 @@ func (*tuningConfig) GetPluginType() string {
 	return "tuning"
 }
 
+// loopbackConfig describes the loopback plugin (required for gVisor)
+type loopbackConfig struct {
+	PluginType string `json:"type"`
+	Name       string `json:"name"`
+}
+
+func newLoopbackPlugin() *loopbackConfig {
+	return &loopbackConfig{
+		PluginType: "loopback",
+		Name:       "lo",
+	}
+}
+
+func (*loopbackConfig) GetPluginType() string {
+	return "loopback"
+}
+
 // https://github.com/containernetworking/plugins/blob/v1.0.1/plugins/ipam/host-local/backend/allocator/config.go#L47-L56
 type hostLocalIPAMConfig struct {
 	Type        string        `json:"type"`

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -55,7 +55,8 @@ func GenerateCNIPlugins(driver string, id int, ipam map[string]interface{}, opts
 		bridge.IsGW = true
 		bridge.IPMasq = true
 		bridge.HairpinMode = true
-		plugins = []CNIPlugin{bridge, newPortMapPlugin(), newFirewallPlugin(), newTuningPlugin()}
+		// gVisor needs "loopback" plugin to be added explicitly
+		plugins = []CNIPlugin{bridge, newPortMapPlugin(), newFirewallPlugin(), newTuningPlugin(), newLoopbackPlugin()}
 	default:
 		return nil, fmt.Errorf("unsupported cni driver %q", driver)
 	}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -73,8 +73,13 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 	}
 
 	switch event {
-	case "createRuntime":
-		return onCreateRuntime(opts)
+	// prestart is deprecated in favor of createRuntime added in OCI Runtime Spec v1.0.2,
+	// however, as of Feb 2022, gVisor and Kata still do not support createRuntime.
+	// https://github.com/containerd/nerdctl/issues/787
+	//
+	// "prestart" is NOT a typo of "preStart".
+	case "prestart":
+		return onPrestart(opts)
 	case "postStop":
 		return onPostStop(opts)
 	default:
@@ -290,7 +295,7 @@ func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 	return nil, nil
 }
 
-func onCreateRuntime(opts *handlerOpts) error {
+func onPrestart(opts *handlerOpts) error {
 	loadAppArmor()
 
 	if opts.cni != nil {


### PR DESCRIPTION
## Commit 1: `ocihook: use prestart (deprecated, though) instead of createRuntime`
`prestart` is deprecated in favor of `createRuntime` which was added in the OCI Runtime Spec v1.0.2,  however, gVisor and Kata still do not support createRuntime.
    
Workaround for #787
- https://github.com/kata-containers/kata-containers/issues/1935
- https://github.com/google/gvisor/issues/7149

## Commit 2: `ocihook: workaround for gVisor/Kata state annotations bug`
 gVisor and Kata do not propagate annotations automatically, so we have to copy the annotations from the spec to the state.

- https://github.com/kata-containers/kata-containers/issues/3629

## Commit 3: `CNI: enable "loopback" plugin by default`

gVisor requires "loopback" plugin to be enabled explicitly to bring up the loopback interface.

- - -

# gVisor

```console
# runsc --version
runsc version release-20220131.0
spec: 1.0.2-dev

# nerdctl run -it --rm --runtime=io.containerd.runsc.v1 alpine
/ # ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65522 
    link/loopback 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
    inet 127.0.0.1/8 scope global dynamic 
    inet6 ::1/128 scope global dynamic 
2: eth0: <UP,LOWER_UP> mtu 1500 
    link/ether 1e:a7:b5:7a:4b:d4 brd ff:ff:ff:ff:ff:ff
    inet 10.4.0.19/24 scope global dynamic 
    inet6 fe80::1ca7:b5ff:fe7a:4bd4/64 scope global dynamic 
/ # apk update
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
v3.15.0-258-gd5d32e35cf [https://dl-cdn.alpinelinux.org/alpine/v3.15/main]
v3.15.0-259-g8b98485bc8 [https://dl-cdn.alpinelinux.org/alpine/v3.15/community]
OK: 15857 distinct packages available
```

(still no support for rootless)

# Kata

```console
# /opt/kata/bin/kata-runtime --version
kata-runtime  : 2.3.2
   commit   : 1af292c9e693e9bc8e8324a9eb860dad45306fb5
   OCI specs: 1.0.2-dev

# nerdctl run -it --rm --runtime=io.containerd.kata.v2 alpine
FATA[0000] failed to create shim task: Unsupported network interface: bridge: unknown 
```

<details>
<summary>CNI config</summary>

<p>

```console
# nerdctl network inspect bridge --mode=native
[
    {
        "CNI": {
            "cniVersion": "0.4.0",
            "name": "bridge",
            "nerdctlID": 0,
            "nerdctlLabels": {},
            "plugins": [
                {
                    "type": "bridge",
                    "bridge": "nerdctl0",
                    "isGateway": true,
                    "ipMasq": true,
                    "hairpinMode": true,
                    "ipam": {
                        "ranges": [
                            [
                                {
                                    "gateway": "10.4.0.1",
                                    "subnet": "10.4.0.0/24"
                                }
                            ]
                        ],
                        "routes": [
                            {
                                "dst": "0.0.0.0/0"
                            }
                        ],
                        "type": "host-local"
                    }
                },
                {
                    "type": "portmap",
                    "capabilities": {
                        "portMappings": true
                    }
                },
                {
                    "type": "firewall"
                },
                {
                    "type": "tuning"
                },
                {
                    "type": "loopback",
                    "name": "lo"
                },
                {
                    "type": "isolation"
                }
            ]
        },
        "NerdctlID": 0,
        "NerdctlLabels": {}
    }
]
```

</p>

</details>
