### PR TITLE
add --mount option for nerdctl run

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,33 @@ Volume flags:
     Requires kernel >= 5.12, and crun >= 1.4 or runc >= 1.1 (PR [#3272](https://github.com/opencontainers/runc/pull/3272)). With older runc, `rro` just works as `ro`.
   - :whale:     option `shared`, `slave`, `private`: Non-recursive "shared" / "slave" / "private" propagation
   - :whale:     option `rshared`, `rslave`, `rprivate`: Recursive "shared" / "slave" / "private" propagation
-- :whale: `--tmpfs`: Mount a tmpfs directory
+- :whale: `--tmpfs`: Mount a tmpfs directory, e.g. `--tmpfs /tmp:size=64m,exec`.
+- :whale: `--mount`: Attach a filesystem mount to the container.
+  Consists of multiple key-value pairs, separated by commas and each
+  consisting of a `<key>=<value>` tuple.
+  e.g., `-- mount type=bind,source=/src,target=/app,bind-propagation=shared`.
+  - :whale: The `type` of the mount, which can be `bind`, `volume`, `tmpfs`.
+    The defaul type will be set to `volume` if not specified.
+    i.e., `--mount src=vol-1,dst=/app,readonly` equals `--mount type=volum,src=vol-1,dst=/app,readonly`
+  - :whale: The `source` of the mount. For bind mounts, this is the path to the file
+    or directory. May be specified as `source` or `src`.
+  - :whale: The `destination` takes as its value the path where the file or directory
+    is mounted in the container. May be specified as `destination`, `dst`,
+    or `target`.
+  - :whale: The `readonly` or `ro`, `rw`, `rro` option changes filesystem permissinos.
+    See description for `--volume` for more deails.
+  - :whale: The `bind-propagation` option is only for `bind` mount which is used to set the
+    bind propagation. May be one of `rprivate`, `private`, `rshared`, `shared`,
+    `rslave`, `slave`.
+    See description for `--volume` for more deails.
+  - :whale: The `tmpfs-size` and `tmpfs-mode` options are only for `tmpfs` bind mount,
+    e.g., `--mount type=tmpfs,target=/app,tmpfs-size=10m,tmpfs-mode=1770`.
+    - `tmpfs-size`: Size of the tmpfs mount in bytes. Unlimited by default.
+    - `tmpfs-mode`: File mode of the tmpfs in **octal**.
+      Defaults to `1777` or world-writable.
+
+Unimplemented `docker run --mount` flags: `bind-nonrecursive`, `volume-nocopy`,
+`volume-label`, `volume-driver`, `volume-opt`, `consistency`.
 
 Rootfs flags:
 - :whale: `--read-only`: Mount the container's root filesystem as read only

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -189,6 +189,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayP("volume", "v", nil, "Bind mount a volume")
 	// tmpfs needs to be StringArray, not StringSlice, to prevent "/foo:size=64m,exec" from being split to {"/foo:size=64m", "exec"}
 	cmd.Flags().StringArray("tmpfs", nil, "Mount a tmpfs directory")
+	cmd.Flags().StringArray("mount", nil, "Attach a filesystem mount to the container")
 	// #endregion
 
 	// rootfs flags

--- a/pkg/mountutil/mountutil_freebsd.go
+++ b/pkg/mountutil/mountutil_freebsd.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,5 +60,9 @@ func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, e
 }
 
 func ProcessFlagTmpfs(s string) (*Processed, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, error) {
 	return nil, errdefs.ErrNotImplemented
 }

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/sirupsen/logrus"
 )
 
@@ -61,5 +62,9 @@ func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, e
 }
 
 func ProcessFlagTmpfs(s string) (*Processed, error) {
+	return nil, errdefs.ErrNotImplemented
+}
+
+func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, error) {
 	return nil, errdefs.ErrNotImplemented
 }


### PR DESCRIPTION
Three types of mount(and examples):
  --mount type=bind,source="$(pwd)"/tmp,target=/app,bind-propagation=rslave
  --mount type=tmpfs,destination=/app,tmpfs-mode=1770,tmpfs-size=10m
  --mount type=volume,source=vol-1,destination=/app,readonly

If type is not specified, the default type will be set to volume
  --mount source=vol-1,destination=/app,readonly

Signed-off-by: bin liu <liubin0329@gmail.com>
