### PR TITLE
push: skip foreign layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ Flags:
 - :nerd_face: `--all-platforms`: Push content for all platforms
 - :nerd_face: `--sign`: Sign the image (none|cosign). See [`docs/cosign.md`](./docs/cosign.md) for details.
 - :nerd_face: `--cosign-key`: Path to the private key file, KMS, URI or Kubernetes Secret for `--sign=cosign`
+- :nerd_face: `--allow-nondistributable-artifacts`: Allow pushing images with non-distributable blobs
 
 Unimplemented `docker push` flags: `--all-tags`, `--disable-content-trust` (default true), `--quiet`
 

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -33,6 +33,11 @@ var (
 	MariaDBImage                = mirrorOf("mariadb:10.5")
 	DockerAuthImage             = mirrorOf("cesanta/docker_auth:1.7")
 
+	// Source: https://gist.github.com/cpuguy83/fcf3041e5d8fb1bb5c340915aabeebe0
+	NonDistBlobImage = "ghcr.io/cpuguy83/non-dist-blob:latest"
+	// Foreign layer digest
+	NonDistBlobDigest = "sha256:be691b1535726014cdf3b715ff39361b19e121ca34498a9ceea61ad776b9c215"
+
 	CommonImage = AlpineImage
 )
 


### PR DESCRIPTION
This changes the default behavior of push to skip non-distributable or
"foreign" layers as per the the spec.
It also adds a flag which enables pushing for cases where this is
needed.

This behavior is similar to docker's, except the flag to allow pushing these blobs is on the daemon rather than per-push.