### PR TITLE
Create container and image prune command

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl kill](#whale-nerdctl-kill)
     - [:whale: nerdctl pause](#whale-nerdctl-pause)
     - [:whale: nerdctl unpause](#whale-nerdctl-unpause)
+    - [:whale: nerdctl container prune](#whale-nerdctl-container-prune)
   - [Build](#build)
     - [:whale: nerdctl build](#whale-nerdctl-build)
     - [:whale: nerdctl commit](#whale-nerdctl-commit)
@@ -252,6 +253,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl rmi](#whale-nerdctl-rmi)
     - [:whale: nerdctl image inspect](#whale-nerdctl-image-inspect)
     - [:whale: nerdctl image history](#whale-nerdctl-image-history)
+    - [:whale: nerdctl image prune](#whale-nerdctl-image-prune)
     - [:nerd_face: nerdctl image convert](#nerd_face-nerdctl-image-convert)
     - [:nerd_face: nerdctl image encrypt](#nerd_face-nerdctl-image-encrypt)
     - [:nerd_face: nerdctl image decrypt](#nerd_face-nerdctl-image-decrypt)
@@ -684,6 +686,16 @@ Unpause all processes within one or more containers.
 
 Usage: `nerdctl unpause CONTAINER [CONTAINER...]`
 
+### :whale: nerdctl container prune
+Remove all stopped containers.
+
+Usage: `nerdctl container prune [OPTIONS]`
+
+Flags:
+- :nerd_face: `-f, --force`: Ignore removal errors.
+
+Unimplemented `docker container prune` flags: `--filter`
+
 ## Build
 ### :whale: nerdctl build
 Build an image from a Dockerfile.
@@ -846,6 +858,16 @@ Flags:
 - :whale: `--no-trunc`: Don't truncate output
 - :whale: `-q, --quiet`: Only display snapshots IDs
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
+
+### :whale: nerdctl image prune
+Remove all unused images. Roughly equals with `docker image prune -a`.
+
+Usage: `nerdctl image prune [OPTIONS]`
+
+Flags:
+- :nerd_face: `-f, --force`: Ignore removal errors.
+
+Unimplemented `docker image prune` flags: `--filter`, `-a`, `--all`
 
 ### :nerd_face: nerdctl image convert
 Convert an image format.
@@ -1302,14 +1324,10 @@ Container management:
 - `docker diff`
 - `docker rename`
 
-- `docker container prune`
-
 - `docker checkpoint *`
 
 Image:
 - `docker export` and `docker import`
-
-- `docker image prune`
 
 - `docker trust *` (Instead, nerdctl supports `nerdctl pull --verify=cosign` and `nerdctl push --sign=cosign`. See [`./docs/cosign.md`](docs/cosign.md).)
 - `docker manifest *`

--- a/cmd/nerdctl/container.go
+++ b/cmd/nerdctl/container.go
@@ -47,6 +47,7 @@ func newContainerCommand() *cobra.Command {
 		newWaitCommand(),
 		newUnpauseCommand(),
 		newCommitCommand(),
+		newContainerPruneCommand(),
 	)
 	return containerCommand
 }

--- a/cmd/nerdctl/container_prune.go
+++ b/cmd/nerdctl/container_prune.go
@@ -1,0 +1,95 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newContainerPruneCommand() *cobra.Command {
+	containerPruneCommand := &cobra.Command{
+		Use:           "prune [flags]",
+		Short:         "Remove all stopped containers",
+		RunE:          containerPruneAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	containerPruneCommand.Flags().BoolP("force", "f", false, "Ignore removal errors")
+	return containerPruneCommand
+}
+
+func containerPruneAction(cmd *cobra.Command, _ []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
+	ns, err := cmd.Flags().GetString("namespace")
+	if err != nil {
+		return err
+	}
+
+	ctx = namespaces.WithNamespace(ctx, ns)
+
+	containers, err := client.Containers(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, container := range containers {
+		task, err := container.Task(ctx, cio.Load)
+		if err != nil {
+			return err
+		}
+
+		status, err := task.Status(ctx)
+		if err != nil {
+			return err
+		}
+
+		if status.Status == containerd.Stopped {
+			if _, err := task.Delete(ctx); err != nil && !errdefs.IsNotFound(err) {
+				return fmt.Errorf("failed to delete task %v: %w", task.ID(), err)
+			}
+			if err := container.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
+				err = container.Delete(ctx)
+				if err != nil {
+					if force {
+						logrus.WithError(err).WithField("id", container.ID()).Warn("unable to remove container")
+					} else {
+						return err
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/nerdctl/image.go
+++ b/cmd/nerdctl/image.go
@@ -44,6 +44,7 @@ func newImageCommand() *cobra.Command {
 		newImageInspectCommand(),
 		newImageEncryptCommand(),
 		newImageDecryptCommand(),
+		newImagePruneCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/image_prune.go
+++ b/cmd/nerdctl/image_prune.go
@@ -1,0 +1,106 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/platforms"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newImagePruneCommand() *cobra.Command {
+	imagePruneCommand := &cobra.Command{
+		Use:           "prune [flags]",
+		Short:         "Remove all unused images",
+		RunE:          imagePruneAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	imagePruneCommand.Flags().BoolP("force", "f", false, "Ignore removal errors")
+	return imagePruneCommand
+}
+
+func imagePruneAction(cmd *cobra.Command, _ []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+
+	ns, err := cmd.Flags().GetString("namespace")
+	if err != nil {
+		return err
+	}
+
+	ctx = namespaces.WithNamespace(ctx, ns)
+
+	imageService := client.ImageService()
+	contentStore := client.ContentStore()
+	containerService := client.ContainerService()
+
+	images, err := imageService.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	containers, err := containerService.List(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, image := range images {
+		used := false
+		for _, container := range containers {
+			if container.Image == image.Name {
+				used = true
+			}
+		}
+
+		if used {
+			continue
+		}
+
+		digests, err := image.RootFS(ctx, contentStore, platforms.All)
+		if err != nil {
+			return err
+		}
+
+		err = imageService.Delete(ctx, image.Name)
+		if err != nil {
+			if force {
+				logrus.WithError(err).Error("unable to remove image")
+			} else {
+				return err
+			}
+		} else {
+			fmt.Fprintf(cmd.OutOrStdout(), "Untagged: %s@%s\n", image.Name, image.Target.Digest)
+			for _, digest := range digests {
+				fmt.Fprintf(cmd.OutOrStdout(), "Deleted: %s\n", digest)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description
Add prune commands for image and containers (probably these commands used by most of the ex-docker users).

## Motivation and Context
We swapped docker to vanilla containerd + nerdctl and needed some of the basic prune functionality, saddly there wasn't any.
There was a discuisson in the issue #648 and the issue seemed approved to be worked on.
To provide the best possible user experience, I plan to implement `volume prune` and `namespace rm` aswell, in a separate PR.

Since there aren't many strict contribution guidelines like issue templates or code style for this project, I tried to follow the code style of similar parts of the code. (`rmi` and `rm` commands)

## Differences and similarities with Docker commands
### Similarities
Both commands implemented such a way that it is mostly compatible with Docker.
### Differences
- Currently `nerdctl image prune` is roughly equal with `docker image prune -a` because most of the time using `nerdctl` you don't end up with a lot of untagged images.
- The `-f` or `--force` flag in nerdctl mostly used for ignoring the error messages, yet in Docker it is used to a "Do not prompt for confirmation", in this commands it is used the nerdctl way, to ignore errors.