### PR TITLE
Fix Kata Containers networking support

### DIFF
--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -44,6 +44,16 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const (
+	// NetworkNamespace is the network namespace path to be passed to the CNI plugins.
+	// When this annotation is set from the runtime spec.State payload, it takes
+	// precedence over the PID based resolution (/proc/<pid>/ns/net) where pid is
+	// spec.State.Pid.
+	// This is mostly used for VM based runtime, where the spec.State PID does not
+	// necessarily lives in the created container networking namespace.
+	NetworkNamespace = labels.Prefix + "network-namespace"
+)
+
 func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetconfPath string) error {
 	if stdin == nil || event == "" || dataStore == "" || cniPath == "" || cniNetconfPath == "" {
 		return errors.New("got insufficient args")


### PR DESCRIPTION
This PR defines a new annotation label for getting the networking namespace to use when calling the CNI plugins.
When set by the calling runtime (through `spec.State.Annotations`), this label takes precedence over the PID based networking namespace resolution.

This fixes the Kata Containers networking support, when running Kata with the following PR:
https://github.com/kata-containers/kata-containers/pull/3670