### PR TITLE
build: Allow to specify compression type of the result image

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,8 @@ Flags:
 - :whale: `--iidfile=FILE`: Write the image ID to the file
 - :nerd_face: `--ipfs`: Build image with pulling base images from IPFS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 - :whale: `--label`: Set metadata for an image
+- :nerd_face: `--compression`: Compression type of output image (`gzip`|`uncompressed`|`zstd`|`estargz`) (`zstd` and `estargz` requires BuildKit >= v0.10)
+- :nerd_face: `--force-compression`: Forcibly compress output image including layers from the base image (requires BuildKit >= v0.10)
 
 Unimplemented `docker build` flags: `--add-host`, `--network`, `--squash`
 

--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -52,6 +52,8 @@ func newBuildCommand() *cobra.Command {
 	buildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables")
 	buildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image")
 	buildCommand.Flags().StringP("output", "o", "", "Output destination (format: type=local,dest=path)")
+	buildCommand.Flags().String("compression", "", "Compression type of output image")
+	buildCommand.Flags().Bool("force-compression", false, "Forcibully compress output image including layers from the base image")
 	buildCommand.Flags().String("progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
 	buildCommand.Flags().StringArray("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
 	buildCommand.Flags().StringArray("ssh", nil, "SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])")
@@ -191,6 +193,16 @@ func generateBuildctlArgs(cmd *cobra.Command, platform, args []string) (string, 
 			output = "type=oci"
 		}
 		needsLoading = true
+		if compressionType, err := cmd.Flags().GetString("compression"); err != nil {
+			return "", nil, false, "", nil, err
+		} else if compressionType != "" {
+			output += ",compression=" + compressionType
+		}
+		if force, err := cmd.Flags().GetBool("force-compression"); err != nil {
+			return "", nil, false, "", nil, err
+		} else if force {
+			output += ",force-compression=true"
+		}
 	}
 	tagValue, err := cmd.Flags().GetStringArray("tag")
 	if err != nil {

--- a/cmd/nerdctl/build_test.go
+++ b/cmd/nerdctl/build_test.go
@@ -17,13 +17,21 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/nerdctl/pkg/testutil"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gotest.tools/v3/assert"
 )
 
@@ -46,6 +54,89 @@ CMD ["echo", "nerdctl-build-test-string"]
 	base.Cmd("build", buildCtx, "-t", imageName).AssertOK()
 
 	base.Cmd("run", "--rm", imageName).AssertOutExactly("nerdctl-build-test-string\n")
+}
+
+func TestBuildWithCompression(t *testing.T) {
+	t.Parallel()
+	testutil.RequiresBuild(t)
+	base := testutil.NewBase(t)
+	imageName := testutil.Identifier(t)
+	defer base.Cmd("rmi", imageName).Run()
+	const testFileName = "nerdctl-build-test"
+	const testContent = "nerdctl"
+
+	// Build an image
+	dockerfile := fmt.Sprintf(`FROM scratch
+COPY %s /`,
+		testFileName)
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+	if err := os.WriteFile(filepath.Join(buildCtx, testFileName), []byte(testContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	base.Cmd("build", "-t", imageName, "--compression=uncompressed", buildCtx).AssertOK()
+
+	// Check layer compression
+	layersNum := 0
+	forEachLayerInImageTar(t, base, imageName, 1, func(i int, desc ocispec.Descriptor, blob []byte) {
+		layersNum++
+		assert.Equal(t, images.MediaTypeDockerSchema2Layer, desc.MediaType) // layer must be tar
+		tr := tar.NewReader(bytes.NewReader(blob))                          // layer must be tar
+		h, err := tr.Next()
+		assert.NilError(t, err)
+		assert.Equal(t, testFileName, strings.TrimPrefix(path.Clean("/"+h.Name), "/"))
+		gotFile, err := io.ReadAll(tr)
+		assert.NilError(t, err)
+		assert.Equal(t, testContent, string(gotFile))
+	})
+	assert.Equal(t, 1, layersNum) // must contain only 1 layer
+}
+
+func forEachLayerInImageTar(t *testing.T, base *testutil.Base, imageName string, manifestsNum int, f func(int, ocispec.Descriptor, []byte)) {
+	imgTar := filepath.Join(t.TempDir(), "img.tar")
+	base.Cmd("save", "-o", imgTar, imageName).AssertOK()
+	img, err := os.ReadFile(imgTar)
+	assert.NilError(t, err)
+
+	var index ocispec.Index
+	blobs := make(map[digest.Digest][]byte)
+	tr := tar.NewReader(bytes.NewReader(img))
+	for {
+		h, err := tr.Next()
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			assert.NilError(t, err)
+		}
+		name := strings.TrimPrefix(path.Clean("/"+h.Name), "/")
+		if name == "index.json" {
+			assert.NilError(t, json.NewDecoder(tr).Decode(&index))
+		} else if strings.HasPrefix(name, "blobs/sha256/") {
+			d, err := digest.Parse("sha256:" + strings.TrimPrefix(name, "blobs/sha256/"))
+			assert.NilError(t, err)
+			c, err := io.ReadAll(tr)
+			assert.NilError(t, err)
+			blobs[d] = c
+		}
+	}
+	assert.Equal(t, manifestsNum, len(index.Manifests))
+	for _, m := range index.Manifests {
+		manifestB, ok := blobs[m.Digest]
+		if !ok {
+			t.Fatalf("manifest blob %q not found: %+v", m.Digest, index)
+		}
+		var manifest ocispec.Manifest
+		assert.NilError(t, json.Unmarshal(manifestB, &manifest))
+		for i, l := range manifest.Layers {
+			layerB, ok := blobs[l.Digest]
+			if !ok {
+				t.Fatalf("layer blob %q not found: index=%+v manifest=%+v", l.Digest, index, manifest)
+			}
+			f(i, l, layerB)
+		}
+	}
 }
 
 func TestBuildFromStdin(t *testing.T) {


### PR DESCRIPTION
BuildKit v0.10 will introduce some improvements for image compression. https://github.com/moby/buildkit/releases/tag/v0.10.0-rc1
This includes support for zstd and estargz compression types and support for `--force-compression` option.

It would be great for `nerdctl build` to have support for compression types.

```
nerdctl build -t test --compression=estargz --force-compression /tmp/ctx
```
