### PR TITLE
Add Mounts field for nerdctl inspect

### DIFF
--- a/cmd/nerdctl/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container_inspect_linux_test.go
@@ -17,8 +17,10 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"github.com/docker/go-connections/nat"
 	"gotest.tools/v3/assert"
@@ -38,4 +40,101 @@ func TestContainerInspectContainsPortConfig(t *testing.T) {
 		HostPort: "8080",
 	}
 	assert.Equal(base.T, expected, inspect80TCP[0])
+}
+
+func TestContainerInspectContainsMounts(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+
+	testVolume := testutil.Identifier(t)
+
+	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
+	base.Cmd("volume", "create", "--label", "tag=testVolume", testVolume).AssertOK()
+	inspectVolume := base.InspectVolume(testVolume)
+	namedVolumeSource := inspectVolume.Mountpoint
+
+	defer base.Cmd("rm", "-f", testContainer).Run()
+	base.Cmd("run", "-d", "--privileged",
+		"--name", testContainer,
+		"--network", "none",
+		"-v", "/anony-vol",
+		"--tmpfs", "/app1:size=64m",
+		"--mount", "type=bind,src=/tmp,dst=/app2,ro",
+		"--mount", fmt.Sprintf("type=volume,src=%s,dst=/app3,readonly=false", testVolume),
+		testutil.NginxAlpineImage).AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	// convert array to map to get by key of Destination
+	actual := make(map[string]dockercompat.MountPoint)
+	for i := range inspect.Mounts {
+		actual[inspect.Mounts[i].Destination] = inspect.Mounts[i]
+	}
+
+	const localDriver = "local"
+
+	expected := []struct {
+		dest       string
+		mountPoint dockercompat.MountPoint
+	}{
+		// anonymous volume
+		{
+			dest: "/anony-vol",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "volume",
+				Name:        "",
+				Source:      "", // source of anonymous volume is a generated path, so here will not check it.
+				Destination: "/anony-vol",
+				Driver:      localDriver,
+				RW:          true,
+			},
+		},
+
+		// bind
+		{
+			dest: "/app2",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "bind",
+				Name:        "",
+				Source:      "/tmp",
+				Destination: "/app2",
+				Driver:      "",
+				RW:          false,
+			},
+		},
+
+		// named volume
+		{
+			dest: "/app3",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "volume",
+				Name:        testVolume,
+				Source:      namedVolumeSource,
+				Destination: "/app3",
+				Driver:      localDriver,
+				RW:          true,
+			},
+		},
+	}
+
+	for i := range expected {
+		testCase := expected[i]
+		t.Logf("test volume[dest=%q]", testCase.dest)
+
+		mountPoint, ok := actual[testCase.dest]
+		assert.Assert(base.T, ok)
+
+		assert.Equal(base.T, testCase.mountPoint.Type, mountPoint.Type)
+		assert.Equal(base.T, testCase.mountPoint.Driver, mountPoint.Driver)
+		assert.Equal(base.T, testCase.mountPoint.RW, mountPoint.RW)
+		assert.Equal(base.T, testCase.mountPoint.Destination, mountPoint.Destination)
+
+		if testCase.mountPoint.Source != "" {
+			assert.Equal(base.T, testCase.mountPoint.Source, mountPoint.Source)
+		}
+		if testCase.mountPoint.Name != "" {
+			assert.Equal(base.T, testCase.mountPoint.Name, mountPoint.Name)
+		}
+	}
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -74,6 +74,9 @@ const (
 	// Platform is the normalized platform string like "linux/ppc64le".
 	Platform = Prefix + "platform"
 
+	// Mounts is the mount points for the container.
+	Mounts = Prefix + "mounts"
+
 	// Bypass4netns is the flag for acceleration with bypass4netns
 	// Boolean value which can be parsed with strconv.ParseBool() is required.
 	// (like "nerdctl/bypass4netns=true" or "nerdctl/bypass4netns=false")

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -41,9 +41,11 @@ const (
 )
 
 type Processed struct {
-	Mount           specs.Mount
-	AnonymousVolume string // name
 	Type            string
+	Mount           specs.Mount
+	Name            string // name
+	AnonymousVolume string // anonymous volume name
+	Mode            string
 	Opts            []oci.SpecOpts
 }
 
@@ -71,6 +73,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		src, dst = split[0], split[1]
 		if !strings.Contains(src, "/") {
 			// assume src is a volume name
+			res.Name = src
 			vol, err := volStore.Get(src)
 			if err != nil {
 				if errors.Is(err, errdefs.ErrNotFound) {
@@ -101,6 +104,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		if len(split) == 3 {
 			rawOpts = split[2]
 		}
+		res.Mode = rawOpts
 
 		// always call parseVolumeOptions for bind mount to allow the parser to add some default options
 		var err error

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -267,6 +267,7 @@ func ProcessFlagTmpfs(s string) (*Processed, error) {
 			Options:     options,
 		},
 		Type: Tmpfs,
+		Mode: strings.Join(options, ","),
 	}
 	return res, nil
 }


### PR DESCRIPTION
This PR adds `Mounts` field for the output of `nerdctl inspect` command.

**To reviewers**: User-specified mounts are stored in labels like anonymous volumes until finding a suitable place to store them.

For example, start a container:

```bash
$ nerdctl run --name test -d \
  -v /anony-vol \
  --tmpfs /app1:size=64m \
  --mount type=bind,src=/tmp,dst=/app2,bind-propagation=rshared,ro \
  --mount type=volume,src=vol-1,dst=/app3,readonly=false \
  containerstack/alpine-stress:latest top
```

And get container info:

```bash
$ nerdctl inspect test
[
    {
        "Id": "384bdb0bededd9b879a3863bf5faea6a5f4714c37b19e6e7258322092e2d8df4",
        "Created": "2022-02-16T14:56:59.645505751Z",
        "Path": "top",
        "Args": null,
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Pid": 16254,
            "ExitCode": 0,
            "FinishedAt": "0001-01-01T00:00:00Z"
        },
        "Image": "docker.io/containerstack/alpine-stress:latest",
        "ResolvConfPath": "/var/lib/nerdctl/1935db59/containers/default/384bdb0bededd9b879a3863bf5faea6a5f4714c37b19e6e7258322092e2d8df4/resolv.conf",
        "HostnamePath": "/var/lib/nerdctl/1935db59/containers/default/384bdb0bededd9b879a3863bf5faea6a5f4714c37b19e6e7258322092e2d8df4/hostname",
        "LogPath": "/var/lib/nerdctl/1935db59/containers/default/384bdb0bededd9b879a3863bf5faea6a5f4714c37b19e6e7258322092e2d8df4/384bdb0bededd9b879a3863bf5faea6a5f4714c37b19e6e7258322092e2d8df4-json.log",
        "Name": "test",
        "Driver": "overlayfs",
        "Platform": "linux",
        "AppArmorProfile": "nerdctl-default",
        "Mounts": [
            {
                "Type": "volume",
                "Name": "46ccfe12b21b888a4707a129202cae7ab0308ca3ef69e79bc38a70154aece3aa",
                "Source": "/var/lib/nerdctl/1935db59/volumes/default/46ccfe12b21b888a4707a129202cae7ab0308ca3ef69e79bc38a70154aece3aa/_data",
                "Destination": "/anony-vol",
                "Driver": "local",
                "Mode": "",
                "RW": true,
                "Propagation": ""
            },
            {
                "Type": "tmpfs",
                "Source": "tmpfs",
                "Destination": "/app1",
                "Mode": "noexec,nosuid,nodev,size=64m",
                "RW": true,
                "Propagation": ""
            },
            {
                "Type": "bind",
                "Source": "/tmp",
                "Destination": "/app2",
                "Mode": "ro,rshared",
                "RW": false,
                "Propagation": "rshared"
            },
            {
                "Type": "volume",
                "Name": "vol-1",
                "Source": "/var/lib/nerdctl/1935db59/volumes/default/vol-1/_data",
                "Destination": "/app3",
                "Driver": "local",
                "Mode": "",
                "RW": true,
                "Propagation": ""
            }
        ],
        "NetworkSettings": {
            "GlobalIPv6Address": "",
            "GlobalIPv6PrefixLen": 0,
            "IPAddress": "10.4.0.88",
            "IPPrefixLen": 24,
            "MacAddress": "fa:83:07:08:e7:70",
            "Networks": {
                "unknown-eth0": {
                    "IPAddress": "10.4.0.88",
                    "IPPrefixLen": 24,
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "MacAddress": "fa:83:07:08:e7:70"
                }
            }
        }
    }
]


```
