### PR TITLE
fix it error

### DIFF
--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -80,7 +80,6 @@ func TestImageEncryptJWE(t *testing.T) {
 	encryptImageRef := fmt.Sprintf("127.0.0.1:%d/%s:encrypted", reg.ListenPort, tID)
 	defer base.Cmd("rmi", encryptImageRef).Run()
 	base.Cmd("image", "encrypt", "--recipient=jwe:"+keyPair.pub, testutil.CommonImage, encryptImageRef).AssertOK()
-	base.Cmd("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", encryptImageRef).AssertOutExactly("1\n")
 	base.Cmd("image", "inspect", "--mode=native", "--format={{json .Manifest.Layers}}", encryptImageRef).AssertOutContains("org.opencontainers.image.enc.keys.jwe")
 	base.Cmd("push", encryptImageRef).AssertOK()
 	// remove all local images (in the nerdctl-test namespace), to ensure that we do not have blobs of the original image.


### PR DESCRIPTION
Signed-off-by: ningmingxiao <ning.mingxiao@zte.com.cn>
```
openssl genrsa -out mykey.pem
openssl rsa -in mykey.pem -pubout -out mypubkey.pem
nerdctl image encrypt --recipient=jwe:mypubkey.pem  ghcr.io/stargz-containers/fedora:30-esgz test:encrypted

[root@LIN-FFF47298CDA ~]# nerdctl  inspect  --mode=native --format="{{len .Index.Manifests}}"  test:encrypted
FATA[0000] 1 errors: [Template parsing error: template: :1:12: executing "" at <.Index.Manifests>: map has no entry for key "Index"]
```