### PR TITLE
fix null authConfig bug

### DIFF
--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -104,7 +104,7 @@ func loginAction(cmd *cobra.Command, args []string) error {
 	}
 
 	authConfig, err := GetDefaultAuthConfig(options.username == "" && options.password == "", serverAddress, isDefaultRegistry)
-	if &authConfig == nil {
+	if authConfig == nil {
 		authConfig = &types.AuthConfig{}
 	}
 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {


### PR DESCRIPTION
How to reproduce bug : 

1- create this `config.json`
```
cat $HOME/.docker/config.json 
{
  "auths" : {
    "index.docker.io" : {

    }
  },
  "credsStore" : "desktop"
}
```
2- `docker-credential-desktop`  is not installed 
```
root@2bb12852dd43:/home/nerdctl# docker-credential-desktop
bash: docker-credential-desktop: command not found
```

3- try a login 
```
root@2bb12852dd43:/home/nerdctl# _output/nerdctl login
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xfd0b48]

goroutine 1 [running]:
main.ConfigureAuthentication(0x0, 0xc000320540)
        /home/nerdctl/cmd/nerdctl/login.go:305 +0x28
main.loginAction(0xc000633900, {0x1ece9f0, 0x0, 0x0})
        /home/nerdctl/cmd/nerdctl/login.go:116 +0x29a
github.com/spf13/cobra.(*Command).execute(0xc000633900, {0xc00003a070, 0x0, 0x0})
        /go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:856 +0x60e
github.com/spf13/cobra.(*Command).ExecuteC(0xc0000c5900)
        /go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
        /go/pkg/mod/github.com/spf13/cobra@v1.3.0/command.go:902
main.xmain()
        /home/nerdctl/cmd/nerdctl/main.go:84 +0x9f
main.main()
        /home/nerdctl/cmd/nerdctl/main.go:67 +0x19
```

What Happening ?

`authConfig` is not properly initialized here https://github.com/containerd/nerdctl/blob/ff432cac4b0ea0ccf7e765005605a9b35a34c230/cmd/nerdctl/login.go#L107 


Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>