### PR TITLE
rootless: Support BuildKit containerd worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG CNI_PLUGINS_VERSION=v1.1.0
 # Extra deps: CNI isolation
 ARG CNI_ISOLATION_VERSION=v0.0.4
 # Extra deps: Build
-ARG BUILDKIT_VERSION=v0.9.3
+ARG BUILDKIT_VERSION=v0.10.0
 # Extra deps: Lazy-pulling
 ARG STARGZ_SNAPSHOTTER_VERSION=v0.11.2
 # Extra deps: Encryption
@@ -264,8 +264,9 @@ COPY --from=gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fde
 # enable offline ipfs for integration test
 COPY ./Dockerfile.d/test-integration-etc_containerd-stargz-grpc_config.toml /etc/containerd-stargz-grpc/config.toml
 COPY ./Dockerfile.d/test-integration-ipfs-offline.service /usr/local/lib/systemd/system/
+COPY ./Dockerfile.d/test-integration-buildkit-nerdctl-test.service /usr/local/lib/systemd/system/
 # install ipfs service. avoid using 5001(api)/8080(gateway) which are reserved by tests.
-RUN systemctl enable test-integration-ipfs-offline && \
+RUN systemctl enable test-integration-ipfs-offline test-integration-buildkit-nerdctl-test && \
     ipfs init && \
     ipfs config Addresses.API "/ip4/127.0.0.1/tcp/5888" && \
     ipfs config Addresses.Gateway "/ip4/127.0.0.1/tcp/5889"

--- a/Dockerfile.d/SHA256SUMS.d/buildkit-v0.10.0
+++ b/Dockerfile.d/SHA256SUMS.d/buildkit-v0.10.0
@@ -1,0 +1,2 @@
+ed9d3942ca3f1cbc4906577a2422e5084416dd2739f3d85b800a129d61557630  buildkit-v0.10.0.linux-amd64.tar.gz
+f201c30dca4877eca9598ae41c1c8934c98b37a9ad323cec8b30ce9138f957ac  buildkit-v0.10.0.linux-arm64.tar.gz

--- a/Dockerfile.d/SHA256SUMS.d/buildkit-v0.9.3
+++ b/Dockerfile.d/SHA256SUMS.d/buildkit-v0.9.3
@@ -1,2 +1,0 @@
-f60461abdf2aee8444a4cb0607e4766da3bd503859320819ea8c43fe4a02576c  buildkit-v0.9.3.linux-amd64.tar.gz
-3ee57ac33f8ff6ab1d187e25a217f8f2358826b14d707fd8fe0df6f536613aaf  buildkit-v0.9.3.linux-arm64.tar.gz

--- a/Dockerfile.d/test-integration-buildkit-nerdctl-test.service
+++ b/Dockerfile.d/test-integration-buildkit-nerdctl-test.service
@@ -1,0 +1,41 @@
+# Copyright The containerd Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Copied from released buildkit.service
+
+[Unit]
+After=network.target local-fs.target
+Description=buildkit daemon for integration test (namespace: nerdctl-test)
+
+[Service]
+ExecStartPre=-/sbin/modprobe overlay
+ExecStart=/usr/local/bin/buildkitd --oci-worker=false --containerd-worker=true --addr="unix:///run/buildkit-nerdctl-test/buildkitd.sock" --root=/var/lib/buildkit-nerdctl-test --containerd-worker-namespace=nerdctl-test
+
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+LimitNOFILE=infinity
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this version.
+TasksMax=infinity
+OOMScoreAdjust=-999
+
+[Install]
+WantedBy=docker-entrypoint.target

--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -38,7 +38,7 @@ else
 	if [[ -e /workaround-cirrus ]]; then
 		echo "WORKAROUND_CIRRUS: Not enabling BuildKit (https://github.com/containerd/nerdctl/issues/622)" >&2
 	else
-		containerd-rootless-setuptool.sh install-buildkit
+		CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-setuptool.sh install-buildkit-containerd
 	fi
 	containerd-rootless-setuptool.sh install-stargz
 	cat <<EOF >>/home/rootless/.config/containerd/config.toml

--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:nerd_face: nerdctl apparmor load](#nerd_face-nerdctl-apparmor-load)
     - [:nerd_face: nerdctl apparmor ls](#nerd_face-nerdctl-apparmor-ls)
     - [:nerd_face: nerdctl apparmor unload](#nerd_face-nerdctl-apparmor-unload)
+  - [Builder management](#builder-management)
+    - [:whale: nerdctl builder prune](#whale-nerdctl-builder-prune)
   - [System](#system)
     - [:whale: nerdctl events](#whale-nerdctl-events)
     - [:whale: nerdctl info](#whale-nerdctl-info)
@@ -1115,6 +1117,19 @@ Flags:
 Unload an AppArmor profile. The target profile name defaults to "nerdctl-default". Requires root.
 
 Usage: `nerdctl apparmor unload [PROFILE]`
+
+## Builder management
+### :whale: nerdctl builder prune
+Clean up BuildKit build cache.
+
+:warning: The output format is not compatible with Docker.
+
+Usage: `nerdctl builder prune`
+
+Flags:
+- :nerd_face: `--buildkit-host=<BUILDKIT_HOST>`: BuildKit address
+
+Unimplemented `docker builder prune` flags: `--all`, `--filter`, `--force`, `--keep-storage`
 
 ## System
 ### :whale: nerdctl events

--- a/cmd/nerdctl/builder.go
+++ b/cmd/nerdctl/builder.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/containerd/nerdctl/pkg/buildkitutil"
+	"github.com/containerd/nerdctl/pkg/defaults"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newBuilderCommand() *cobra.Command {
+	var builderCommand = &cobra.Command{
+		Annotations:   map[string]string{Category: Management},
+		Use:           "builder",
+		Short:         "Manage builds",
+		RunE:          unknownSubcommandAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	builderCommand.AddCommand(
+		newBuilderPruneCommand(),
+	)
+	return builderCommand
+}
+
+func newBuilderPruneCommand() *cobra.Command {
+	shortHelp := `Clean up BuildKit build cache`
+	var buildPruneCommand = &cobra.Command{
+		Use:           "prune",
+		Args:          cobra.NoArgs,
+		Short:         shortHelp,
+		RunE:          builderPruneAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	AddStringFlag(buildPruneCommand, "buildkit-host", nil, defaults.BuildKitHost(), "BUILDKIT_HOST", "BuildKit address")
+	return buildPruneCommand
+}
+
+func builderPruneAction(cmd *cobra.Command, args []string) error {
+	buildkitHost, err := getBuildkitHost(cmd)
+	if err != nil {
+		return err
+	}
+	buildctlBinary, err := buildkitutil.BuildctlBinary()
+	if err != nil {
+		return err
+	}
+	buildctlArgs := buildkitutil.BuildctlBaseArgs(buildkitHost)
+	buildctlArgs = append(buildctlArgs, "prune")
+	logrus.Debugf("running %s %v", buildctlBinary, buildctlArgs)
+	buildctlCmd := exec.Command(buildctlBinary, buildctlArgs...)
+	buildctlCmd.Env = os.Environ()
+	buildctlCmd.Stdout = cmd.OutOrStdout()
+	return buildctlCmd.Run()
+}

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -123,6 +123,7 @@ func testComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string) 
 func TestComposeUpBuild(t *testing.T) {
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 
 	const dockerComposeYAML = `
 services:

--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/nerdctl/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"github.com/containerd/nerdctl/pkg/testutil/testregistry"
 	"gotest.tools/v3/assert"
@@ -66,6 +67,9 @@ func newJWEKeyPair(t testing.TB) *jweKeyPair {
 func rmiAll(base *testutil.Base) {
 	imageIDs := base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
 	base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).AssertOK()
+	if _, err := buildkitutil.GetBuildkitHost(testutil.Namespace); err == nil {
+		base.Cmd("builder", "prune").AssertOK()
+	}
 }
 
 func TestImageEncryptJWE(t *testing.T) {

--- a/cmd/nerdctl/ipfs_build_linux_test.go
+++ b/cmd/nerdctl/ipfs_build_linux_test.go
@@ -32,6 +32,7 @@ func TestIPFSBuild(t *testing.T) {
 	requiresIPFS(t)
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
 	ipfsCIDBase := strings.TrimPrefix(ipfsCID, "ipfs://")
 

--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -105,6 +105,7 @@ func TestIPFSComposeUpBuild(t *testing.T) {
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	ipfsCID := pushImageToIPFS(t, base, testutil.NginxAlpineImage)
 	ipfsCIDBase := strings.TrimPrefix(ipfsCID, "ipfs://")
 

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -273,6 +273,7 @@ Config file ($NERDCTL_TOML): %s
 		newVolumeCommand(),
 		newSystemCommand(),
 		newNamespaceCommand(),
+		newBuilderCommand(),
 		// #endregion
 
 		// Internal

--- a/cmd/nerdctl/multi_platform_linux_test.go
+++ b/cmd/nerdctl/multi_platform_linux_test.go
@@ -56,6 +56,7 @@ func TestMultiPlatformBuildPush(t *testing.T) {
 	testutil.RequiresBuild(t)
 	testutil.RequireExecPlatform(t, "linux/amd64", "linux/arm64", "linux/arm/v7")
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	tID := testutil.Identifier(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()
@@ -97,6 +98,7 @@ func TestMultiPlatformComposeUpBuild(t *testing.T) {
 	testutil.RequiresBuild(t)
 	testutil.RequireExecPlatform(t, "linux/amd64", "linux/arm64", "linux/arm/v7")
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 
 	const dockerComposeYAML = `
 services:

--- a/cmd/nerdctl/pull_linux_test.go
+++ b/cmd/nerdctl/pull_linux_test.go
@@ -67,6 +67,7 @@ func TestImageVerifyWithCosign(t *testing.T) {
 	keyPair := newCosignKeyPair(t, "cosign-key-pair")
 	defer keyPair.cleanup()
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	tID := testutil.Identifier(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()
@@ -93,6 +94,7 @@ func TestImagePullPlainHttpWithDefaultPort(t *testing.T) {
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	reg := testregistry.NewPlainHTTP(base, 80)
 	defer reg.Cleanup()
 	testImageRef := fmt.Sprintf("%s/%s:%s",
@@ -121,6 +123,7 @@ func TestImageVerifyWithCosignShouldFailWhenKeyIsNotCorrect(t *testing.T) {
 	keyPair := newCosignKeyPair(t, "cosign-key-pair")
 	defer keyPair.cleanup()
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	tID := testutil.Identifier(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()

--- a/cmd/nerdctl/run_mount_linux_test.go
+++ b/cmd/nerdctl/run_mount_linux_test.go
@@ -83,6 +83,7 @@ func TestRunAnonymousVolumeWithBuild(t *testing.T) {
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).Run()
 
@@ -103,6 +104,7 @@ func TestRunCopyingUpInitialContentsOnVolume(t *testing.T) {
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).Run()
 	volName := testutil.Identifier(t) + "-vol"
@@ -131,6 +133,7 @@ func TestRunCopyingUpInitialContentsOnDockerfileVolume(t *testing.T) {
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).Run()
 	volName := testutil.Identifier(t) + "-vol"
@@ -166,6 +169,7 @@ func TestRunCopyingUpInitialContentsOnVolumeShouldRetainSymlink(t *testing.T) {
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).Run()
 
@@ -190,6 +194,7 @@ func TestRunCopyingUpInitialContentsShouldNotResetTheCopiedContents(t *testing.T
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	tID := testutil.Identifier(t)
 	imageName := tID + "-img"
 	volumeName := tID + "-vol"

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -34,6 +34,7 @@ func TestRunEntrypointWithBuild(t *testing.T) {
 	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).Run()
 

--- a/cmd/nerdctl/run_verify_linux_test.go
+++ b/cmd/nerdctl/run_verify_linux_test.go
@@ -37,6 +37,7 @@ func TestRunVerifyCosign(t *testing.T) {
 	keyPair := newCosignKeyPair(t, "cosign-key-pair")
 	defer keyPair.cleanup()
 	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
 	tID := testutil.Identifier(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()

--- a/cmd/nerdctl/system.go
+++ b/cmd/nerdctl/system.go
@@ -16,9 +16,7 @@
 
 package main
 
-import (
-	"github.com/spf13/cobra"
-)
+import "github.com/spf13/cobra"
 
 func newSystemCommand() *cobra.Command {
 	var systemCommand = &cobra.Command{

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
-	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/platformutil"
@@ -290,6 +289,12 @@ func (c *Cmd) AssertOutContains(s string) {
 	c.Assert(expected)
 }
 
+func (c *Cmd) AssertCombinedOutContains(s string) {
+	c.Base.T.Helper()
+	res := c.Run()
+	assert.Assert(c.Base.T, strings.Contains(res.Combined(), s))
+}
+
 func (c *Cmd) AssertOutNotContains(s string) {
 	c.AssertOutWithFunc(func(stdout string) error {
 		if strings.Contains(stdout, s) {
@@ -382,11 +387,11 @@ func DockerIncompatible(t testing.TB) {
 
 func RequiresBuild(t testing.TB) {
 	if GetTarget() == Nerdctl {
-		buildkitHost := defaults.BuildKitHost()
-		t.Logf("buildkitHost=%q", buildkitHost)
-		if err := buildkitutil.PingBKDaemon(buildkitHost); err != nil {
+		buildkitHost, err := buildkitutil.GetBuildkitHost(Namespace)
+		if err != nil {
 			t.Skipf("test requires buildkitd: %+v", err)
 		}
+		t.Logf("buildkitHost=%q", buildkitHost)
 	}
 }
 


### PR DESCRIPTION
Fixes: #434

This commit patches `containerd-rootless-setuptool.sh` to allow configuring nerdctl for BuildKit rootless containerd worker (BuildKit v0.10).

This enables nerdctl to share images into BuildKit which isn't possible with OCI worker (#434).
For example, this enables BuildKit to use images pulled by `nerdctl pull` as base images.

```console
$ nerdctl pull ghcr.io/stargz-containers/ubuntu:20.04-org
$ nerdctl tag ghcr.io/stargz-containers/ubuntu:20.04-org mybase
$ mkdir -p /tmp/ctx && cat <<EOF > /tmp/ctx/Dockerfile
FROM mybase
RUN echo hello > /hello
CMD ["cat", "/hello"]
EOF
$ nerdctl build -t mytest /tmp/ctx
[+] Building 5.4s (6/6) FINISHED                                                                                                                                                                                                                                                         
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                0.1s
 => => transferring dockerfile: 95B                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                   0.2s
 => => transferring context: 2B                                                                                                                                                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/mybase:latest                                                                                                                                                                                                                    2.6s
 => [1/2] FROM docker.io/library/mybase@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d                                                                                                                                                                     1.5s
 => => resolve docker.io/library/mybase@sha256:adf73ca014822ad8237623d388cedf4d5346aa72c270c5acc01431cc93e18e2d                                                                                                                                                                     1.3s
 => [2/2] RUN echo hello > /hello                                                                                                                                                                                                                                                   0.2s
 => exporting to oci image format                                                                                                                                                                                                                                                   0.8s
 => => exporting layers                                                                                                                                                                                                                                                             0.2s
 => => exporting manifest sha256:4b8d0218edd5c342e1a7c3bc9cb3adfeec480563ff06535b85c0fd85fc1bbad2                                                                                                                                                                                   0.0s
 => => exporting config sha256:b6cbc7ea26b1fd045d589f7fef3d011165f3b0f146c32ca6bae06d47199a5a7b                                                                                                                                                                                     0.0s
 => => sending tarball                                                                                                                                                                                                                                                              0.5s
unpacking docker.io/library/mytest:latest (sha256:4b8d0218edd5c342e1a7c3bc9cb3adfeec480563ff06535b85c0fd85fc1bbad2)...done
$ nerdctl run --rm -it mytest
hello
```

Note that 1 containerd worker can use 1 containerd namespace so buildkitd needs to be launched for each namespace the user wants to use.

## setup (rootless)

Rootless user can enable containerd worker (in "default" namespace of containerd) like the following:

```console
$ CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh install-buildkit-containerd
```

NOTE1: `containerd-rootless-setuptool.sh` is aware of `CONTAINERD_NAMESPACE` and `CONTAINERD_SNPASHOTTER`.
User can launch additional buildkitd processes by executing this script with different `CONTAINERD_NAMESPACE` values.
NOTE2: If `CONTAINERD_NAMESPACE` is not specified, buildkitd installed in "buildkit" namespace which is the default of buildkitd. If a user wants to give buildkitd access to the images in "default" namespace, this command should be run with `CONTAINERD_NAMESPACE=default`.

When $BUILDKIT_HOST is unset, nerdctl (both rootless and rootful) tries to use `buildkit-<NS>/buildkitd.sock` by default and then try to fall back to `buildkit-default/buildkitd.sock`, `buildkit/buildkitd.sock`

~Maybe we can add an option to allow rootless nerdctl automatically detecting BuildKit socket location for a namespace (i.e. `unix://${XDG_RUNTIME_DIR}/buildkit-${CONTAINERD_NAMESPACE}/buildkitd.sock`) without manually configuring `BUILDKIT_HOST`.~ **Added this**

## setup (rootful)

Rootful containerd worker has been available even without this patch.
Use the configuration (`/etc/buildkit/buildkitd.toml`) suggested at https://github.com/containerd/nerdctl/issues/434#issuecomment-998702312.

```toml
[worker.oci]
  enabled = false

[worker.containerd]
  enabled = true
  # namespace should be "k8s.io" for Kubernetes (including Rancher Desktop)
  namespace = "default"
```

