### PR TITLE
build test-integration image in arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,9 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bullseye AS build-base-debia
 # libbtrfs: for containerd
 # libseccomp: for runc and bypass4netns
 RUN dpkg --add-architecture arm64 && \
+  dpkg --add-architecture amd64 && \
   apt-get update && \
-  apt-get install -y crossbuild-essential-arm64 git libbtrfs-dev libbtrfs-dev:arm64 libseccomp-dev libseccomp-dev:arm64
+  apt-get install -y crossbuild-essential-amd64 crossbuild-essential-arm64 git libbtrfs-dev:amd64 libbtrfs-dev:arm64 libseccomp-dev:amd64 libseccomp-dev:arm64
 
 FROM build-base-debian AS build-containerd
 ARG CONTAINERD_VERSION


### PR DESCRIPTION
Signed-off-by: ye.sijun <junnplus@gmail.com>

```
#50 4.536 cgo: C compiler "x86_64-linux-gnu-gcc" not found: exec: "x86_64-linux-gnu-gcc": executable file not found in $PATH
```
Build test-integration image in arm64.
```
# uname -a
Linux lima-default 5.13.0-30-generic #33-Ubuntu SMP Fri Feb 4 17:05:14 UTC 2022 aarch64 aarch64 aarch64 GNU/Linux
```