### PR TITLE
Attempt to deflake TestPushInsecureWithLogin

### DIFF
--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 
 	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
@@ -150,7 +151,7 @@ func pushAction(cmd *cobra.Command, args []string) error {
 			}
 			return fmt.Errorf("failed to create a tmp reduced-platform image %q (platform=%v): %w", pushRef, platform, err)
 		}
-		defer client.ImageService().Delete(ctx, platImg.Name)
+		defer client.ImageService().Delete(ctx, platImg.Name, images.SynchronousDelete())
 		logrus.Infof("pushing as a reduced-platform image (%s, %s)", platImg.Target.MediaType, platImg.Target.Digest)
 	}
 
@@ -160,7 +161,7 @@ func pushAction(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("failed to convert to eStargz: %v", err)
 		}
-		defer client.ImageService().Delete(ctx, esgzImg.Name)
+		defer client.ImageService().Delete(ctx, esgzImg.Name, images.SynchronousDelete())
 		logrus.Infof("pushing as an eStargz image (%s, %s)", esgzImg.Target.MediaType, esgzImg.Target.Digest)
 	}
 


### PR DESCRIPTION
```
=== RUN   TestPushInsecureWithLogin
    testregistry_linux.go:78: hostIP="10.4.0.1", listenIP="0.0.0.0", listenPort=5000, authPort=5100
    testregistry_linux.go:158: Writing "/tmp/TestPushInsecureWithLogin4158650372/004/certs.d1675364595/10.4.0.1:5000/hosts.toml": "\nserver = \"[https://10.4.0.1:5000\](https://10.4.0.1:5000/)"\n[host.\"[https://10.4.0.1:5000\](https://10.4.0.1:5000/)"]\n  ca = \"/tmp/TestPushInsecureWithLogin4158650372/001/ca997969720/ca.cert\"\n\t\t"
    push_linux_test.go:110: testImageRef="10.4.0.1:5000/nerdctl-testpushinsecurewithlogin:3.13-org"
    push_linux_test.go:114: assertion failed: expression is false: res.ExitCode == exitCode: index-sha256:83bf22e8705adaaaf38634266c57a41fb2fb9867f61bf942e13b8432b2d7cda4: waiting        |--------------------------------------|
        elapsed: 0.1 s                                                                 total:   0.0 B (0.0 B/s)
        time="2022-03-03T02:57:48Z" level=info msg="pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.list.v2+json, sha256:83bf22e8705adaaaf38634266c57a41fb2fb9867f61bf942e13b8432b2d7cda4)"
        time="2022-03-03T02:57:48Z" level=warning msg="skipping verifying HTTPS certs for \"10.4.0.1:5000\""
        time="2022-03-03T02:57:48Z" level=fatal msg="content digest sha256:83bf22e8705adaaaf38634266c57a41fb2fb9867f61bf942e13b8432b2d7cda4: not found"

--- FAIL: TestPushInsecureWithLogin (11.72s)
```

The failure was probably caused due to some async image deletion triggered by other tests that shares the tmp image ref.
~Randomize the image ref to deflake the test.~
Expected to fix #855

Thanks to @ktock for analysis.
