### PR TITLE
CI: temporarily remove FreeBSD integration tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,7 +34,7 @@ linux_cgroup2_task:
     - docker run -t --rm --privileged -e WORKAROUND_CIRRUS=1 test-integration-rootless
 
 freebsd_task:
-  name: "FreeBSD"
+  name: "FreeBSD (Unit tests only)"
   timeout_in: 20m
   compute_engine_instance:
     image_project: freebsd-org-cloud-dev
@@ -42,16 +42,12 @@ freebsd_task:
     platform: freebsd
     cpu: 2
     memory: 4G
-  env:
-    NERDCTL_RUN_ARGS: --net none knast/freebsd:13-STABLE echo "Nerdctl is up and running."
   install_script:
-    - pkg install -y go containerd runj
-    - daemon -o containerd.out containerd
+    - pkg install -y go
   test_script:
     - go test -v ./pkg/...
-    - cd cmd/nerdctl
-    - sudo go run . run $NERDCTL_RUN_ARGS | grep running
 # TODO: run `go test -v ./cmd/...`
+# FIXME: `nerdctl run` is broken on FreeBSD: https://github.com/containerd/nerdctl/issues/868
 
 windows_task:
   name: "Windows"

--- a/docs/freebsd.md
+++ b/docs/freebsd.md
@@ -20,6 +20,8 @@ You can use the `knast/freebsd` image to run a standard FreeBSD 13 jail:
 nerdctl run --net none -it knast/freebsd:13-STABLE
 ```
 
+:warning: `nerdctl run` has been broken on FreeBSD (FIXME): https://github.com/containerd/nerdctl/issues/868
+
 ## Limitations & Bugs
 
 - :warning: CNI & CNI plugins are not yet ported to FreeBSD. The only supported


### PR DESCRIPTION
`nerdctl run` on FreeBSD turned out to be broken.
    
See:
- #868
    
Close #865