### PR TITLE
Fixed volume mount issue(759) for Windows

### DIFF
--- a/cmd/nerdctl/run_mount.go
+++ b/cmd/nerdctl/run_mount.go
@@ -208,13 +208,21 @@ func generateMountOpts(cmd *cobra.Command, ctx context.Context, client *containe
 		return nil, nil, err
 	} else if len(parsed) > 0 {
 		ociMounts := make([]specs.Mount, len(parsed))
+		var target string
 		for i, x := range parsed {
 			ociMounts[i] = x.Mount
 			mounted[filepath.Clean(x.Mount.Destination)] = struct{}{}
+			if runtime.GOOS == "windows" {
+				target, err = securejoin.SecureJoin(tempDir, strings.Replace(x.Mount.Destination, ":", "", -1))
+				if err != nil {
+					return nil, nil, err
+				}
+			} else {
+				target, err = securejoin.SecureJoin(tempDir, x.Mount.Destination)
+				if err != nil {
+					return nil, nil, err
+				}
 
-			target, err := securejoin.SecureJoin(tempDir, x.Mount.Destination)
-			if err != nil {
-				return nil, nil, err
 			}
 
 			// Copying content in AnonymousVolume and namedVolume

--- a/cmd/nerdctl/run_mount_windows_test.go
+++ b/cmd/nerdctl/run_mount_windows_test.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"os"
+	"testing"
+)
+
+func TestRunVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+	rwDir, err := os.MkdirTemp(t.TempDir(), "rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roDir, err := os.MkdirTemp(t.TempDir(), "ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwVolName := tID + "-rw"
+	roVolName := tID + "-ro"
+	for _, v := range []string{rwVolName, roVolName} {
+		defer base.Cmd("volume", "rm", "-f", v).Run()
+		base.Cmd("volume", "create", v).AssertOK()
+	}
+
+	containerName := tID
+	defer base.Cmd("rm", "-f", containerName).Run()
+
+	base.Cmd("run",
+		"-d",
+		"--name", containerName,
+		"-v", fmt.Sprintf("%s:C:\\mnt1", rwDir),
+		"-v", fmt.Sprintf("%s:C:\\mnt2ro", roDir),
+		"-v", fmt.Sprintf("%s:C:\\mnt3", rwVolName),
+		"-v", fmt.Sprintf("%s:C:\\mnt4ro", roVolName),
+		testutil.WindowsNano).AssertOK()
+	base.Cmd("container", "inspect", containerName).AssertOK()
+
+}
+
+func TestRunAnonymousVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", "C:\\foo", testutil.WindowsNano).AssertOK()
+}
+
+func TestRunCopyingUpInitialContentsOnVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	imageName := testutil.WindowsNano
+	volName := testutil.Identifier(t) + "-vol"
+	defer base.Cmd("volume", "rm", volName).Run()
+
+	//AnonymousVolume
+	base.Cmd("run", "--rm", imageName).AssertOK()
+	base.Cmd("run", "-v", "C:\\mnt", "--rm", imageName).AssertOK()
+
+	//NamedVolume should be automatically created
+	base.Cmd("run", "-v", volName+""+":C:\\mnt", "--rm", imageName).AssertOK()
+}

--- a/go.mod
+++ b/go.mod
@@ -119,6 +119,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/moby/locker v1.0.1 // indirect
+	github.com/moby/moby v20.10.13+incompatible // indirect
 	github.com/moby/sys/mountinfo v0.6.0 // indirect
 	github.com/moby/sys/signal v0.6.0 // indirect
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1356,6 +1356,8 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/mitchellh/reflectwalk v1.0.1/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/locker v1.0.1 h1:fOXqR41zeveg4fFODix+1Ch4mj/gT0NE1XJbp/epuBg=
 github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
+github.com/moby/moby v20.10.13+incompatible h1:EzlPdbJmYtz9QwFkLNvnEF8LoVFddaBzBsJjBH9eMHc=
+github.com/moby/moby v20.10.13+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/sys/mount v0.3.1 h1:RX1K0x95oR8j5P1YefKDt7tE1C2kCCixV0H8Aza3GaI=
 github.com/moby/sys/mount v0.3.1/go.mod h1:6IZknFQiqjLpwuYJD5Zk0qYEuJiws36M88MIXnZHya0=

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -17,21 +17,12 @@
 package mountutil
 
 import (
-	"errors"
-	"fmt"
-	"path/filepath"
-	"runtime"
-	"strings"
-
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/sys"
-	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
-
-	"github.com/sirupsen/logrus"
+	"runtime"
 )
 
 const (
@@ -48,78 +39,20 @@ type Processed struct {
 }
 
 func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error) {
-	var (
-		res      Processed
-		src, dst string
-		options  []string
-	)
-
-	split := strings.Split(s, ":")
-	switch len(split) {
-	case 1:
-		dst = s
-		res.AnonymousVolume = idgen.GenerateID()
-		logrus.Debugf("creating anonymous volume %q, for %q", res.AnonymousVolume, s)
-		anonVol, err := volStore.Create(res.AnonymousVolume, []string{})
-		if err != nil {
-			return nil, err
-		}
-		src = anonVol.Mountpoint
-		res.Type = Volume
-	case 2, 3:
-		res.Type = Bind
-		src, dst = split[0], split[1]
-		if !strings.Contains(src, "/") {
-			// assume src is a volume name
-			vol, err := volStore.Get(src)
-			if err != nil {
-				if errors.Is(err, errdefs.ErrNotFound) {
-					vol, err = volStore.Create(src, nil)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					return nil, err
-				}
-			}
-			// src is now full path
-			src = vol.Mountpoint
-			res.Type = Volume
-		}
-		if !filepath.IsAbs(src) {
-			logrus.Warnf("expected an absolute path, got a relative path %q (allowed for nerdctl, but disallowed for Docker, so unrecommended)", src)
-			var err error
-			src, err = filepath.Abs(src)
-			if err != nil {
-				return nil, err
-			}
-		}
-		if !filepath.IsAbs(dst) {
-			return nil, fmt.Errorf("expected an absolute path, got %q", dst)
-		}
-		rawOpts := ""
-		if len(split) == 3 {
-			rawOpts = split[2]
-		}
-
-		// always call parseVolumeOptions for bind mount to allow the parser to add some default options
-		var err error
-		var specOpts []oci.SpecOpts
-		options, specOpts, err = parseVolumeOptions(res.Type, src, rawOpts)
-		if err != nil {
-			return nil, err
-		}
-		res.Opts = append(res.Opts, specOpts...)
-	default:
-		return nil, fmt.Errorf("failed to parse %q", s)
-	}
 
 	fstype := "nullfs"
+	resp, err := ProcessSplit(s, volStore)
+	if err != nil {
+		return nil, err
+	}
 	if runtime.GOOS != "freebsd" {
 		fstype = "none"
+		if runtime.GOOS == "windows" {
+			fstype = ""
+		}
 		options = append(options, "rbind")
 	}
-	res.Mount = specs.Mount{
+	resp.Mount = specs.Mount{
 		Type:        fstype,
 		Source:      src,
 		Destination: dst,
@@ -130,7 +63,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		if err != nil {
 			return nil, err
 		}
-		res.Mount.Options = strutil.DedupeStrSlice(append(res.Mount.Options, unpriv...))
+		resp.Mount.Options = strutil.DedupeStrSlice(append(resp.Mount.Options, unpriv...))
 	}
-	return &res, nil
+	return &resp, nil
 }

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -1,12 +1,9 @@
 /*
    Copyright The containerd Authors.
-
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
-
        http://www.apache.org/licenses/LICENSE-2.0
-
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +14,21 @@
 package mountutil
 
 import (
+	"errors"
 	"fmt"
-	"strings"
-
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/sirupsen/logrus"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	res      Processed
+	src, dst string
+	options  []string
 )
 
 func getUnprivilegedMountFlags(path string) ([]string, error) {
@@ -67,4 +72,82 @@ func ProcessFlagTmpfs(s string) (*Processed, error) {
 
 func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, error) {
 	return nil, errdefs.ErrNotImplemented
+}
+
+func ProcessSplit(s string, volStore volumestore.VolumeStore) (Processed, error) {
+	split := strings.Split(s, ":")
+	switch len(split) {
+	case 2: //For anonymous volumes in Windows
+		dst = s
+		res.AnonymousVolume = idgen.GenerateID()
+		logrus.Debugf("creating anonymous volume %q, for %q", res.AnonymousVolume, s)
+		anonVol, err := volStore.Create(res.AnonymousVolume, []string{})
+		if err != nil {
+			return res, err
+		}
+		src = anonVol.Mountpoint
+		res.Type = Volume
+	case 3, 4, 5:
+		rawOpts := ""
+		res.Type = Bind
+		if len(split) == 3 {
+			src, dst = split[0], split[1]+":"+split[2]
+		} else if len(split) == 4 {
+			if strings.Contains(split[3], "\\") || strings.Contains(split[2], "/") {
+				src = split[0] + ":" + split[1]
+				dst = split[2] + ":" + split[3]
+			} else {
+				src = split[0]
+				dst = split[1] + ":" + split[2]
+				rawOpts = split[3]
+			}
+
+		} else if len(split) == 5 {
+			src = split[0] + ":" + split[1]
+			dst = split[2] + ":" + split[3]
+			rawOpts = split[4]
+		}
+		if !strings.Contains(src, "/") && !strings.Contains(src, "\\") {
+			// assume src is a volume name
+			vol, err := volStore.Get(src)
+			if err != nil {
+				if errors.Is(err, errdefs.ErrNotFound) {
+					vol, err = volStore.Create(src, nil)
+					if err != nil {
+						return res, err
+					}
+					src = vol.Mountpoint
+					res.Type = Volume
+				} else {
+					return res, err
+				}
+			} else {
+				// src is now full path
+				src = vol.Mountpoint
+			}
+		}
+		if !filepath.IsAbs(src) {
+			logrus.Warnf("expected an absolute path, got a relative path %q (allowed for nerdctl, but disallowed for Docker, so unrecommended)", src)
+			var err error
+			src, err = filepath.Abs(src)
+			if err != nil {
+				return res, err
+			}
+		}
+		if !filepath.IsAbs(dst) {
+			return res, fmt.Errorf("expected an absolute path, got %q", dst)
+		}
+
+		// always call parseVolumeOptions for bind mount to allow the parser to add some default options
+		var err error
+		var specOpts []oci.SpecOpts
+		options, specOpts, err = parseVolumeOptions(res.Type, src, rawOpts)
+		if err != nil {
+			return res, err
+		}
+		res.Opts = append(res.Opts, specOpts...)
+	default:
+		return res, fmt.Errorf("failed to parse %q", s)
+	}
+	return res, nil
 }


### PR DESCRIPTION
### Fixed issue #759 :
- volume binding issue in Windows containers
```
D:\GolandProjects\github.com\nerdctl2\cmd\nerdctl>nerdctl run -it -v C:\ProgramData\nerdctl\052055e3\volumes\default\test\_data:c:\src:rw,rprivate mcr.microsoft.com/windows/nanoserver:20H2
Microsoft Windows [Version 10.0.19042.1586]
(c) 2019 Microsoft Corporation. All rights reserved.

C:\Windows\system32>cd ../..

C:\>dir
 Volume in drive C has no label.
 Volume Serial Number is 7643-AF54

 Directory of C:\

03/03/2022  01:27 PM             5,510 License.txt
03/16/2022  07:00 PM    <DIR>          src
03/16/2022  07:50 PM    <DIR>          Users
03/16/2022  07:50 PM    <DIR>          Windows
               1 File(s)          5,510 bytes
               3 Dir(s)  21,302,005,760 bytes free

C:\>
 ```
When using nerdctl + containerd on Windows, I am able to mount volumes or bind mount to a new windows container and are also able to use bind propagation.

Signed-off-by: Raymond Mathew click2cloud-lamda@click2cloud.net