### PR TITLE
refactor netutil

### DIFF
--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -104,19 +104,14 @@ func shellCompleteNetworkNames(cmd *cobra.Command, exclude []string) ([]string, 
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
-	e := &netutil.CNIEnv{
-		Path:        cniPath,
-		NetconfPath: cniNetconfpath,
-	}
-
-	configLists, err := netutil.ConfigLists(e)
+	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 	candidates := []string{}
-	for _, configList := range configLists {
-		if _, ok := excludeMap[configList.Name]; !ok {
-			candidates = append(candidates, configList.Name)
+	for _, n := range e.Networks {
+		if _, ok := excludeMap[n.Name]; !ok {
+			candidates = append(candidates, n.Name)
 		}
 	}
 	for _, s := range []string{"host", "none"} {

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -117,17 +117,13 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 		DebugPrintFull:   debugFull,
 	}
 
-	cniEnv := &netutil.CNIEnv{
-		Path:        cniPath,
-		NetconfPath: cniNetconfpath,
-	}
-	configLists, err := netutil.ConfigLists(cniEnv)
+	cniEnv, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
 	if err != nil {
 		return nil, err
 	}
 
 	o.NetworkExists = func(netName string) (bool, error) {
-		for _, f := range configLists {
+		for _, f := range cniEnv.Networks {
 			if f.Name == netName {
 				return true, nil
 			}

--- a/cmd/nerdctl/network_inspect.go
+++ b/cmd/nerdctl/network_inspect.go
@@ -57,27 +57,19 @@ func networkInspectAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	e := &netutil.CNIEnv{
-		Path:        cniPath,
-		NetconfPath: cniNetconfpath,
-	}
-
-	ll, err := netutil.ConfigLists(e)
+	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
 	if err != nil {
 		return err
 	}
 
-	llMap := make(map[string]*netutil.NetworkConfigList, len(ll))
-	for _, l := range ll {
-		llMap[l.Name] = l
-	}
+	netMap := e.NetworkMap()
 
 	result := make([]interface{}, len(args))
 	for i, name := range args {
 		if name == "host" || name == "none" {
 			return fmt.Errorf("pseudo network %q cannot be inspected", name)
 		}
-		l, ok := llMap[name]
+		l, ok := netMap[name]
 		if !ok {
 			return fmt.Errorf("no such network: %s", name)
 		}

--- a/cmd/nerdctl/network_ls.go
+++ b/cmd/nerdctl/network_ls.go
@@ -94,25 +94,21 @@ func networkLsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	e := &netutil.CNIEnv{
-		Path:        cniPath,
-		NetconfPath: cniNetconfpath,
-	}
-	ll, err := netutil.ConfigLists(e)
+	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
 	if err != nil {
 		return err
 	}
-	pp := make([]networkPrintable, len(ll))
-	for i, l := range ll {
+	pp := make([]networkPrintable, len(e.Networks))
+	for i, n := range e.Networks {
 		p := networkPrintable{
-			Name: l.Name,
-			file: l.File,
+			Name: n.Name,
+			file: n.File,
 		}
-		if l.NerdctlID != nil {
-			p.ID = strconv.Itoa(*l.NerdctlID)
+		if n.NerdctlID != nil {
+			p.ID = strconv.Itoa(*n.NerdctlID)
 		}
-		if l.NerdctlLabels != nil {
-			p.Labels = formatLabels(*l.NerdctlLabels)
+		if n.NerdctlLabels != nil {
+			p.Labels = formatLabels(*n.NerdctlLabels)
 		}
 		pp[i] = p
 	}

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -50,26 +50,18 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	e := &netutil.CNIEnv{
-		Path:        cniPath,
-		NetconfPath: cniNetconfpath,
+	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	if err != nil {
+		return err
 	}
 	fn := func() error {
-		ll, err := netutil.ConfigLists(e)
-		if err != nil {
-			return err
-		}
-
-		llMap := make(map[string]*netutil.NetworkConfigList, len(ll))
-		for _, l := range ll {
-			llMap[l.Name] = l
-		}
+		netMap := e.NetworkMap()
 
 		for _, name := range args {
 			if name == "host" || name == "none" {
 				return fmt.Errorf("pseudo network %q cannot be removed", name)
 			}
-			l, ok := llMap[name]
+			l, ok := netMap[name]
 			if !ok {
 				return fmt.Errorf("no such network: %s", name)
 			}

--- a/cmd/nerdctl/run_network.go
+++ b/cmd/nerdctl/run_network.go
@@ -137,24 +137,15 @@ func generateNetOpts(cmd *cobra.Command, dataStore, stateDir, ns, id string) ([]
 		if err != nil {
 			return nil, nil, nil, err
 		}
-		e := &netutil.CNIEnv{
-			Path:        cniPath,
-			NetconfPath: cniNetconfpath,
-		}
-		ll, err := netutil.ConfigLists(e)
+		e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
 		if err != nil {
 			return nil, nil, nil, err
 		}
+		netMap := e.NetworkMap()
 		for _, netstr := range netSlice {
-			var netconflist *netutil.NetworkConfigList
-			for _, f := range ll {
-				if f.Name == netstr {
-					netconflist = f
-					break
-				}
-			}
-			if netconflist == nil {
-				return nil, nil, nil, fmt.Errorf("no such network: %q", netstr)
+			_, ok := netMap[netstr]
+			if !ok {
+				return nil, nil, nil, fmt.Errorf("network %s not found", netstr)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

This PR attempts to refactor netutli:
- Rename `NetworkConfigList` to `networkConfig`, hide details.
- Add `NetCNIEnv` for load network config list, easy to use.