### PR TITLE
Follow-up to `Add GitHub issue templates`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,0 @@
-<!--
-Please see FAQs before submitting an issue: https://github.com/containerd/nerdctl/tree/master/docs/faq.md
-
-When reporting a potential bug, please make sure to include:
-- The full command line to reproduce the issue
-- The version of nerdctl, containerd, host OS, and kernel
--->

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -34,7 +34,7 @@ body:
     validations:
       required: true
 
-  - type: input
+  - type: textarea
     attributes:
       label: What version of nerdctl are you using?
       placeholder: nerdctl version


### PR DESCRIPTION
- Fix the field type of `nerdctl version` field
- Remove old ISSUE_TEMPLATE.md

Follow-up to #911