### PR TITLE
CI: remove integration test with contianerd v1.4.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        containerd: [v1.4.5, v1.6.1, main]
+        containerd: [v1.5.10, v1.6.1, main]
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
     steps:
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        containerd: [v1.4.5, v1.6.1, main]
+        containerd: [v1.5.10, v1.6.1, main]
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
     steps:


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

Since https://github.com/containerd/containerd/pull/6614, containerd v1.4.x reached EOL, we don't need to do integration tests for version 1.4.5 anymore.