### PR TITLE
Fix nerdctl ignores BUILDKIT_HOST

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -75,7 +75,7 @@ func newBuildCommand() *cobra.Command {
 }
 
 func getBuildkitHost(cmd *cobra.Command) (string, error) {
-	if cmd.Flags().Changed("buildkit-host") {
+	if cmd.Flags().Changed("buildkit-host") || os.Getenv("BUILDKIT_HOST") != "" {
 		// If address is explicitly specified, use it.
 		buildkitHost, err := cmd.Flags().GetString("buildkit-host")
 		if err != nil {


### PR DESCRIPTION
Fixes #930

This commit fixes `nerdctl build` no to ignore BUILDKIT_HOST value.