### PR TITLE
build: compare snapshotter label for `isImageSharable()`

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -33,7 +33,10 @@ This limitation can be avoided using containerd worker as mentioned later.
 
 ## Setting up BuildKit with containerd worker
 
-### Rootless (requires BuildKit v0.10.0 or later)
+### Rootless
+
+| :zap: Requirement | nerdctl >= 0.18, BuildKit >= 0.10 |
+|-------------------|-----------------------------------|
 
 ```
 $ CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh install-buildkit-containerd

--- a/docs/compose.md
+++ b/docs/compose.md
@@ -1,5 +1,8 @@
 # nerdctl compose
 
+| :zap: Requirement | nerdctl >= 0.8 |
+|-------------------|----------------|
+
 ## Usage
 
 The `nerdctl compose` CLI is designed to be compatible with `docker-compose`.

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -1,5 +1,8 @@
 # Container Image Sign and Verify with cosign tool
 
+| :zap: Requirement | nerdctl >= 0.15 |
+|-------------------|-----------------|
+
 [cosign](https://github.com/sigstore/cosign) is tool that allows you to sign and verify container images with the
 public/private key pairs or without them by providing
 a [Keyless support](https://github.com/sigstore/cosign/blob/main/KEYLESS.md).

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -1,5 +1,8 @@
 # Using GPUs inside containers
 
+| :zap: Requirement | nerdctl >= 0.9 |
+|-------------------|----------------|
+
 nerdctl provides docker-compatible NVIDIA GPU support.
 
 ## Prerequisites

--- a/docs/ipfs.md
+++ b/docs/ipfs.md
@@ -1,5 +1,8 @@
 # Distribute Container Images on IPFS (Experimental)
 
+| :zap: Requirement | nerdctl >= 0.14 |
+|-------------------|-----------------|
+
 You can distribute container images without registries, using IPFS.
 
 IPFS support is completely optional. Your host is NOT connected to any P2P network, unless you opt in to [install and run IPFS daemon](https://docs.ipfs.io/install/).

--- a/docs/multi-platform.md
+++ b/docs/multi-platform.md
@@ -1,5 +1,8 @@
 # Multi-platform
 
+| :zap: Requirement | nerdctl >= 0.13 |
+|-------------------|-----------------|
+
 nerdctl can execute non-native container images using QEMU.
 e.g., ARM on Intel, and vice versa.
 

--- a/docs/ocicrypt.md
+++ b/docs/ocicrypt.md
@@ -1,5 +1,8 @@
 # OCIcrypt
 
+| :zap: Requirement | nerdctl >= 0.7 |
+|-------------------|----------------|
+
 nerdctl supports encryption and decryption using [OCIcrypt](https://github.com/containers/ocicrypt)
 (aka [imgcrypt](https://github.com/containerd/imgcrypt) for containerd).
 

--- a/docs/stargz.md
+++ b/docs/stargz.md
@@ -1,5 +1,8 @@
 # Lazy-pulling using Stargz Snapshotter
 
+| :zap: Requirement | nerdctl >= 0.0.1 |
+|-------------------|------------------|
+
 Lazy-pulling is a technique to running containers before completion of pulling the images.
 
 See https://github.com/containerd/stargz-snapshotter to learn further information.


### PR DESCRIPTION
To minimize possibility of hitting issues related to unpacked images.
Not necessary, though.


Also update docs