### PR TITLE
Format created to be compatible with "docker image inspect"

### DIFF
--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -258,7 +258,7 @@ func ImageFromNative(n *native.Image) (*Image, error) {
 	}
 	if len(imgoci.History) > 0 {
 		i.Comment = imgoci.History[len(imgoci.History)-1].Comment
-		i.Created = imgoci.History[len(imgoci.History)-1].Created.String()
+		i.Created = imgoci.History[len(imgoci.History)-1].Created.Format(time.RFC3339Nano)
 		i.Author = imgoci.History[len(imgoci.History)-1].Author
 	}
 	i.Architecture = imgoci.Architecture


### PR DESCRIPTION
## Description
Please correct me if I'm missing something. Looks like `Created` in `ImageInspect` should be formatted by RFC3339Nano so that it can be compatible with `docker image inspect`.
https://github.com/moby/moby/blob/32e5fe5099d2806df489feb3e15d8e3e6eca73c1/daemon/images/image_inspect.go#L65

### Before

```
$ nerdctl inspect alpine:3.10.2 | jq -r .[0].Created
2019-08-20 20:19:55.211423266 +0000 UTC
```

### After

```
$ nerdctl inspect alpine:3.10.2 | jq -r .[0].Created
2019-08-20T20:19:55.211423266Z
```

### Docker

```
$ docker image inspect alpine:3.10.2 | jq -r '.[0].Created'
2019-08-20T20:19:55.211423266Z
```
