### PR TITLE
inspect: add type flag to inspect command

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,8 +650,9 @@ Usage: `nerdctl inspect [OPTIONS] NAME|ID [NAME|ID...]`
 Flags:
 - :nerd_face: `--mode=(dockercompat|native)`: Inspection mode. "native" produces more information.
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
+- :whale: `--type`: Return JSON for specified type
 
-Unimplemented `docker inspect` flags:  `--size`, `--type`
+Unimplemented `docker inspect` flags:  `--size`
 
 ### :whale: nerdctl logs
 Fetch the logs of a container.


### PR DESCRIPTION
Right now nerdctl inspect does not have a --type flag similar to
docker and podman.

This PR aims to add this, allowing for the basic values:

- container
- image

It will default to container to match docker's behaviour

Example of the command:

```sh
./nerdctl inspect --format '{{json .}}' --type image registry.fedoraproject.org/fedora-toolbox:35
./nerdctl inspect --format '{{json .}}' --type container fedora-toolbox-35
```

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>