### PR TITLE
Import NOTICE from Docker/Moby

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,38 @@
+nerdctl
+Copyright The containerd Authors.
+
+This project contains portions of other projects that are licensed under the terms of Apache License 2.0.
+The NOTICE files of those projects are replicated here.
+
+=== https://github.com/moby/moby , https://github.com/docker/cli ===
+https://github.com/moby/moby/blob/v20.10.14/LICENSE , https://github.com/docker/cli/blob/v20.10.14/LICENSE
+https://github.com/moby/moby/blob/v20.10.14/NOTICE , https://github.com/docker/cli/blob/v20.10.14/NOTICE
+
+> Docker
+> Copyright 2012-2017 Docker, Inc.
+>
+> This product includes software developed at Docker, Inc. (https://www.docker.com).
+>
+> This product contains software (https://github.com/creack/pty) developed
+> by Keith Rarick, licensed under the MIT License.
+>
+> The following is courtesy of our legal counsel:
+>
+>
+> Use and transfer of Docker may be subject to certain restrictions by the
+> United States and other governments.
+> It is your responsibility to ensure that your use and/or transfer does not
+> violate applicable laws.
+>
+> For more information, please see https://www.bis.doc.gov
+>
+> See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.
+
+=== https://github.com/docker/compose ===
+https://github.com/docker/compose/blob/v2.4.1/LICENSE
+https://github.com/docker/compose/blob/v2.4.1/NOTICE
+
+> Docker Compose V2
+> Copyright 2020 Docker Compose authors
+>
+> This product includes software developed at Docker, Inc. (https://www.docker.com).

--- a/cmd/nerdctl/top.go
+++ b/cmd/nerdctl/top.go
@@ -20,6 +20,7 @@
    - https://github.com/moby/moby/blob/v20.10.6/daemon/top_unix.go
    Copyright (C) The Moby authors.
    Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/v20.10.6/NOTICE
 */
 
 package main

--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -18,6 +18,7 @@
 # Forked from https://github.com/moby/moby/blob/v20.10.3/contrib/dockerd-rootless-setuptool.sh
 # Copyright The Moby Authors.
 # Licensed under the Apache License, Version 2.0
+# NOTICE: https://github.com/moby/moby/blob/v20.10.3/NOTICE
 # -----------------------------------------------------------------------------
 
 # containerd-rootless-setuptool.sh: setup tool for containerd-rootless.sh

--- a/extras/rootless/containerd-rootless.sh
+++ b/extras/rootless/containerd-rootless.sh
@@ -18,6 +18,7 @@
 # Forked from https://github.com/moby/moby/blob/v20.10.3/contrib/dockerd-rootless.sh
 # Copyright The Moby Authors.
 # Licensed under the Apache License, Version 2.0
+# NOTICE: https://github.com/moby/moby/blob/v20.10.3/NOTICE
 # -----------------------------------------------------------------------------
 
 # containerd-rootless.sh executes containerd in rootless mode.

--- a/pkg/buildkitutil/buildkitutil.go
+++ b/pkg/buildkitutil/buildkitutil.go
@@ -14,6 +14,13 @@
    limitations under the License.
 */
 
+/*
+   Portions from https://github.com/docker/cli/blob/v20.10.9/cli/command/image/build/context.go
+   Copyright (C) Docker authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/docker/cli/blob/v20.10.9/NOTICE
+*/
+
 package buildkitutil
 
 import (

--- a/pkg/composer/config.go
+++ b/pkg/composer/config.go
@@ -14,6 +14,13 @@
    limitations under the License.
 */
 
+/*
+   Portions from https://github.com/docker/compose/blob/v2.2.2/pkg/compose/hash.go
+   Copyright (C) Docker Compose authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/docker/compose/blob/v2.2.2/NOTICE
+*/
+
 package composer
 
 import (

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -18,6 +18,7 @@
    Portions from https://github.com/moby/moby/blob/v20.10.1/api/types/types.go
    Copyright (C) Docker/Moby authors.
    Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/v20.10.1/NOTICE
 */
 
 // Package dockercompat mimics `docker inspect` objects.

--- a/pkg/inspecttypes/dockercompat/info.go
+++ b/pkg/inspecttypes/dockercompat/info.go
@@ -19,6 +19,7 @@
    Portions from https://github.com/docker/cli/blob/v20.10.8/cli/command/system/version.go
    Copyright (C) Docker/Moby authors.
    Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/v20.10.8/NOTICE , https://github.com/docker/cli/blob/v20.10.8/NOTICE
 */
 
 package dockercompat

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -35,6 +35,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+/*
+   Portions from https://github.com/moby/moby/blob/v20.10.5/daemon/oci_linux.go
+   Portions from https://github.com/moby/moby/blob/v20.10.5/volume/mounts/linux_parser.go
+   Copyright (C) Docker/Moby authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/v20.10.5/NOTICE
+*/
+
 // getUnprivilegedMountFlags is from https://github.com/moby/moby/blob/v20.10.5/daemon/oci_linux.go#L420-L450
 //
 // Get the set of mount flags that are set on the mount that contains the given

--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -14,6 +14,13 @@
    limitations under the License.
 */
 
+/*
+   Portions from https://github.com/moby/moby/blob/6014c1e29dc34dffa77fb5749cc3281c1b4854ac/libnetwork/resolvconf/resolvconf.go
+   Copyright (C) Docker/Moby authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/6014c1e29dc34dffa77fb5749cc3281c1b4854ac/NOTICE
+*/
+
 // Package resolvconf provides utility code to query and update DNS configuration in /etc/resolv.conf
 // originally from https://github.com/moby/moby/blob/6014c1e29dc34dffa77fb5749cc3281c1b4854ac/libnetwork/resolvconf/resolvconf.go
 package resolvconf

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -14,6 +14,19 @@
    limitations under the License.
 */
 
+/*
+   Portions from https://github.com/moby/moby/blob/v20.10.0-rc2/runconfig/opts/parse.go
+   Copyright (C) Docker/Moby authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/v20.10.0-rc2/NOTICE
+*/
+
+/*
+   Portions from https://github.com/moby/buildkit/blob/v0.9.1/cmd/buildkitd/config.go#L35-L42
+   Copyright (C) BuildKit authors.
+   Licensed under the Apache License, Version 2.0
+*/
+
 package strutil
 
 import (


### PR DESCRIPTION
For https://github.com/moby/moby/blob/61404de7df1a6c75c2cbdc2c3ce226c95bebcaad/LICENSE#L107-L122

> 
       (d) If the Work includes a "NOTICE" text file as part of its
          distribution, then any Derivative Works that You distribute must
          include a readable copy of the attribution notices contained
          within such NOTICE file, excluding those notices that do not
          pertain to any part of the Derivative Works, in at least one
          of the following places: within a NOTICE text file distributed
          as part of the Derivative Works; within the Source form or
          documentation, if provided along with the Derivative Works; or,
          within a display generated by the Derivative Works, if and
          wherever such third-party notices normally appear. The contents
          of the NOTICE file are for informational purposes only and
          do not modify the License. You may add Your own attribution
          notices within Derivative Works that You distribute, alongside
          or as an addendum to the NOTICE text from the Work, provided
          that such additional attribution notices cannot be construed
          as modifying the License.

- - -

```
nerdctl
Copyright The containerd Authors.

This project contains portions of other projects that are licensed under the terms of Apache License 2.0.
The NOTICE files of those projects are replicated here.

=== https://github.com/moby/moby , https://github.com/docker/cli ===
https://github.com/moby/moby/blob/v20.10.14/LICENSE , https://github.com/docker/cli/blob/v20.10.14/LICENSE
https://github.com/moby/moby/blob/v20.10.14/NOTICE , https://github.com/docker/cli/blob/v20.10.14/NOTICE

> Docker
> Copyright 2012-2017 Docker, Inc.
>
> This product includes software developed at Docker, Inc. (https://www.docker.com).
>
> This product contains software (https://github.com/creack/pty) developed
> by Keith Rarick, licensed under the MIT License.
>
> The following is courtesy of our legal counsel:
>
>
> Use and transfer of Docker may be subject to certain restrictions by the
> United States and other governments.
> It is your responsibility to ensure that your use and/or transfer does not
> violate applicable laws.
>
> For more information, please see https://www.bis.doc.gov
>
> See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

=== https://github.com/docker/compose ===
https://github.com/docker/compose/blob/v2.4.1/LICENSE
https://github.com/docker/compose/blob/v2.4.1/NOTICE

> Docker Compose V2
> Copyright 2020 Docker Compose authors
>
> This product includes software developed at Docker, Inc. (https://www.docker.com).
```