### PR TITLE
Enhancement for container prune and volume prune(issue #648)

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -34,7 +34,7 @@ jobs:
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1.14.1
+        uses: docker/login-action@v2.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl cp](#whale-nerdctl-cp)
     - [:whale: :blue_square: nerdctl ps](#whale-blue_square-nerdctl-ps)
     - [:whale: :blue_square: nerdctl inspect](#whale-blue_square-nerdctl-inspect)
+    - [:whale: :blue_square: nerdctl container prune](#whale-blue_square-nerdctl-container-prune)
     - [:whale: nerdctl logs](#whale-nerdctl-logs)
     - [:whale: nerdctl port](#whale-nerdctl-port)
     - [:whale: nerdctl rm](#whale-nerdctl-rm)
@@ -297,6 +298,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl volume ls](#whale-nerdctl-volume-ls)
     - [:whale: nerdctl volume inspect](#whale-nerdctl-volume-inspect)
     - [:whale: nerdctl volume rm](#whale-nerdctl-volume-rm)
+    - [:whale: nerdctl volume prune](#whale-nerdctl-volume-prune)
   - [Namespace management](#namespace-management)
     - [:nerd_face: :blue_square: nerdctl namespace create](#nerd_face-blue_square-nerdctl-namespace-create)
     - [:nerd_face: :blue_square: nerdctl namespace inspect](#nerd_face-blue_square-nerdctl-namespace-inspect)
@@ -685,6 +687,15 @@ Flags:
 - :whale: `--type`: Return JSON for specified type
 
 Unimplemented `docker inspect` flags:  `--size`
+
+### :whale: :blue_square: nerdctl container prune
+Removes all stopped containers
+
+Usage: `nerdctl container prune [OPTIONS] NAME|ID [NAME|ID...]`
+
+Flags:
+- :whale: `-f, --force`: Do not prompt for confirmation
+- :whale: `--filter`: Provide filter values (e.g. 'until=<timestamp>')
 
 ### :whale: nerdctl logs
 Fetch the logs of a container.
@@ -1133,6 +1144,16 @@ Usage: `nerdctl volume rm [OPTIONS] VOLUME [VOLUME...]`
 - :whale: `-f, --force`: Force the removal of one or more volumes
   - :warning: WIP: currently, volumes are always forcibly removed, even when `--force` is not specified.
 
+### :whale: nerdctl volume prune
+Remove all unused local volumes. Unused local volumes are those which are not referenced by any containers
+
+Usage: `nerdctl volume prune [OPTIONS]`
+
+Flags:
+- :whale: `-f, --force`: Do not prompt for confirmation
+- :whale: `--filter`: Provide filter values (e.g. 'label=<label>')
+
+
 ## Namespace management
 
 ### :nerd_face: :blue_square: nerdctl namespace create
@@ -1457,7 +1478,6 @@ Container management:
 - `docker attach`
 - `docker diff`
 
-- `docker container prune`
 
 - `docker checkpoint *`
 

--- a/cmd/nerdctl/container.go
+++ b/cmd/nerdctl/container.go
@@ -47,6 +47,7 @@ func newContainerCommand() *cobra.Command {
 		newWaitCommand(),
 		newUnpauseCommand(),
 		newCommitCommand(),
+		newContainerPruneCommand(),
 		newRenameCommand(),
 	)
 	addCpCommand(containerCommand)

--- a/cmd/nerdctl/container_prune.go
+++ b/cmd/nerdctl/container_prune.go
@@ -1,0 +1,258 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/containerinspector"
+	"github.com/containerd/nerdctl/pkg/namestore"
+	"github.com/containerd/nerdctl/pkg/strutil"
+	"github.com/spf13/cobra"
+)
+
+func newContainerPruneCommand() *cobra.Command {
+	containerPruneCommand := &cobra.Command{
+		Use:           "prune [flags]",
+		Short:         "Removes all stopped containers",
+		RunE:          containerPruneAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	containerPruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	containerPruneCommand.Flags().StringArray("filter", nil, "Provide filter values (e.g. 'until=<timestamp>')")
+	return containerPruneCommand
+}
+
+func containerPruneAction(cmd *cobra.Command, _ []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	dataStore, err := getDataStore(cmd)
+	if err != nil {
+		return err
+	}
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+	filterMaps, err := checkFilter(cmd)
+	if err != nil {
+		return err
+	}
+
+	if !force {
+		var confirm string
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", "WARNING! This will remove all stopped containers.\nAre you sure you want to continue? [y/N] ")
+		fmt.Fscanf(cmd.InOrStdin(), "%s", &confirm)
+
+		if strings.ToLower(confirm) != "y" {
+			return nil
+		}
+	}
+	ns, err := cmd.Flags().GetString("namespace")
+	if err != nil {
+		return err
+	}
+
+	var deletedContainers []string
+	containers, err := client.Containers(ctx)
+	if err != nil {
+		return err
+	}
+	for _, container := range containers {
+		if filterMaps != nil {
+			ok, err := getFilteredContainers(container, filterMaps, ctx)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				continue
+			}
+		}
+		cont, err := containerinspector.Inspect(ctx, container)
+		if err != nil {
+			return err
+		}
+		if cont.Process == nil || (cont.Process != nil && cont.Process.Status.Status != containerd.Running) {
+			containerNameStore, err := namestore.New(dataStore, ns)
+			if err != nil {
+				return err
+			}
+			stateDir, err := getContainerStateDirPath(cmd, dataStore, container.ID())
+			if err != nil {
+				return err
+			}
+			err = removeContainer(cmd, ctx, container, ns, "", force, dataStore, stateDir, containerNameStore, true)
+			if err != nil {
+				return err
+			}
+			deletedContainers = append(deletedContainers, container.ID())
+		}
+	}
+	if deletedContainers != nil {
+		fmt.Fprintf(cmd.OutOrStdout(), "Deleted Containers: \n")
+		for _, elem := range deletedContainers {
+			fmt.Fprintln(cmd.OutOrStdout(), elem)
+		}
+	}
+
+	return nil
+}
+func checkFilter(cmd *cobra.Command) (map[string]map[string]string, error) {
+	filters, err := cmd.Flags().GetStringArray("filter")
+	if err != nil {
+		return nil, err
+	}
+	filters = strutil.DedupeStrSlice(filters)
+	filtersMap, err := convToMap(filters)
+	if err != nil {
+		return nil, err
+	}
+	return filtersMap, nil
+}
+
+func getFilteredContainers(container containerd.Container, filterMaps map[string]map[string]string, ctx context.Context) (bool, error) {
+	for label, filterKey := range filterMaps {
+		if label == "until" {
+			if ok, err := untilCheck(container, filterKey, ctx); ok {
+				continue
+			} else {
+				if err != nil {
+					return false, err
+				}
+				return false, nil
+			}
+
+		} else if strings.Contains(label, "label") {
+			if ok, err := labelCheck(container, filterKey, ctx, label); ok {
+				continue
+			} else {
+				if err != nil {
+					return false, err
+				}
+				return false, nil
+			}
+		}
+	}
+	return true, nil
+}
+
+func convToMap(values []string) (map[string]map[string]string, error) {
+	labelMap := make(map[string]map[string]string, len(values))
+	var once bool
+	for i, value := range values {
+		kv := strings.Split(value, "=")
+		if kv[0] == "label" || kv[0] == "label!" {
+			if len(kv) == 3 {
+				labels := kv[1] + "=" + kv[2]
+				labelMap[kv[0]+strconv.Itoa(i)] = strutil.ConvertKVStringsToMap([]string{labels})
+			} else {
+				labelMap[kv[0]+strconv.Itoa(i)] = strutil.ConvertKVStringsToMap([]string{kv[1]})
+			}
+		} else if kv[0] == "until" {
+			if !once {
+				labelMap[kv[0]] = strutil.ConvertKVStringsToMap([]string{kv[1]})
+				once = true
+			} else {
+				err := fmt.Errorf("more than one until filter specified")
+				return nil, err
+			}
+		} else {
+			err := fmt.Errorf("invalid filter %q", kv[0])
+			return nil, err
+		}
+	}
+	return labelMap, nil
+}
+
+func untilCheck(container containerd.Container, filterMap map[string]string, ctx context.Context) (bool, error) {
+	for filterValue, x := range filterMap {
+		log.Println(x)
+		infoCont, _ := container.Info(ctx)
+		dur, err := time.ParseDuration(filterValue)
+		if math.Abs(time.Until(infoCont.CreatedAt).Seconds()) >= dur.Seconds() {
+			return true, nil
+		}
+		if dur == 0 {
+			checkT, err := time.Parse("2006-01-02T15:04:05Z02:00", filterValue)
+			if err == nil {
+				goto check
+			}
+			checkT, err = time.Parse("2006-01-02T15:04:05", filterValue)
+			if err == nil {
+				goto check
+			}
+			checkT, err = time.Parse("2006-01-02", filterValue)
+			if err == nil {
+				goto check
+			}
+			checkT, err = time.Parse("2006-01-02Z02:00", filterValue)
+			if err == nil {
+				goto check
+			}
+			checkT, err = time.Parse("2006-01-02T15:04:05.999999999Z02:00", filterValue)
+			if err != nil {
+				return false, err
+			}
+		check:
+			if checkT.After(infoCont.CreatedAt) {
+				return true, nil
+			}
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+func labelCheck(container containerd.Container, filterMap map[string]string, ctx context.Context, filter string) (bool, error) {
+	for key, filterValue := range filterMap {
+		contLabels, err := container.Labels(ctx)
+		if err != nil {
+			return false, err
+		}
+		if strings.Contains(filter, "label!") {
+			if fVal, ok := contLabels[key]; ok {
+				if filterValue != "" && fVal != filterValue {
+					return true, nil
+				}
+				return false, nil
+			}
+			return true, nil
+		}
+		if fVal, ok := contLabels[key]; ok {
+			if filterValue != "" && fVal == filterValue {
+				return true, nil
+			} else if filterValue != "" && fVal != filterValue {
+				return false, nil
+			}
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/cmd/nerdctl/container_prune_test.go
+++ b/cmd/nerdctl/container_prune_test.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestContainerPrune(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+	}{
+		{
+			name:    "testContainer1",
+			command: "create",
+		},
+		{
+			name:    "testContainer2",
+			command: "run",
+		},
+	}
+	t.Parallel()
+	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+	for _, test := range tests {
+		base.Cmd(test.command, "--name", test.name+tID, testutil.CommonImage).AssertOK()
+
+	}
+	defer base.Cmd("container", "prune", "-f").Run()
+}

--- a/cmd/nerdctl/volume.go
+++ b/cmd/nerdctl/volume.go
@@ -35,6 +35,7 @@ func newVolumeCommand() *cobra.Command {
 		newVolumeInspectCommand(),
 		newVolumeCreateCommand(),
 		newVolumeRmCommand(),
+		newVolumePruneCommand(),
 	)
 	return volumeCommand
 }

--- a/cmd/nerdctl/volume_prune.go
+++ b/cmd/nerdctl/volume_prune.go
@@ -1,0 +1,145 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/containerinspector"
+	"github.com/containerd/nerdctl/pkg/strutil"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newVolumePruneCommand() *cobra.Command {
+	volumePruneCommand := &cobra.Command{
+		Use:           "prune",
+		Short:         "Remove all unused local volumes. Unused local volumes are those which are not referenced by any containers.",
+		Long:          "NOTE: volume in use is not deleted",
+		RunE:          volumePruneAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	volumePruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	volumePruneCommand.Flags().StringArray("filter", nil, "Provide filter values (e.g. 'label=<label>')")
+	return volumePruneCommand
+}
+
+func volumePruneAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+	if !force {
+		var confirm string
+		log.Println("check")
+		fmt.Fprintf(cmd.OutOrStdout(), "%s", "WARNING! This will remove all local volumes not used by at least one container.\nAre you sure you want to continue? [y/N] ")
+		fmt.Fscanf(cmd.InOrStdin(), "%s", &confirm)
+
+		if strings.ToLower(confirm) != "y" {
+			return nil
+		}
+	}
+	filterMaps, err := checkVolFilter(cmd)
+	if err != nil {
+		return err
+	}
+	containers, err := client.Containers(ctx)
+	if err != nil {
+		return err
+	}
+	var mount *specs.Spec
+	var removedNames []string
+	volumes, err := getVolumes(cmd)
+	if err != nil {
+		return err
+	}
+	volStore, err := getVolumeStore(cmd)
+	if err != nil {
+		return err
+	}
+	for name, volDetails := range volumes {
+		var found bool
+		if filterMaps != nil {
+			ok := getFilteredVolumes(*volDetails.Labels, filterMaps)
+			if !ok {
+				continue
+			}
+		}
+		for _, container := range containers {
+			n, err := containerinspector.Inspect(ctx, container)
+			if err != nil {
+				return err
+			}
+			err = json.Unmarshal(n.Container.Spec.GetValue(), &mount)
+			if err != nil {
+				return err
+			}
+			if found = checkVolume(&mount.Mounts, volDetails.Mountpoint); found {
+				found = true
+				logrus.WithError(fmt.Errorf("Volume %q is in use", name)).Error(fmt.Errorf("Remove Volume: %q failed", name))
+				break
+			}
+		}
+		if !found {
+			// volumes that are not mounted to any container
+			removedNames = append(removedNames, name)
+		}
+	}
+	if removedNames != nil {
+		rNames, err := volStore.Remove(removedNames)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), "Deleted Volumes:")
+		for _, elem := range rNames {
+			fmt.Fprintln(cmd.OutOrStdout(), elem)
+		}
+	}
+	return nil
+}
+func checkVolFilter(cmd *cobra.Command) (map[string]string, error) {
+	filters, err := cmd.Flags().GetStringArray("filter")
+	if err != nil {
+		return nil, err
+	}
+	filters = strutil.DedupeStrSlice(filters)
+	filtersMap := strutil.ConvertKVStringsToMap(filters)
+	if err != nil {
+		return nil, err
+	}
+	return filtersMap, nil
+}
+
+func getFilteredVolumes(labels map[string]string, filterMaps map[string]string) bool {
+	for _, key := range filterMaps {
+		if _, ok := labels[key]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/nerdctl/volume_prune_test.go
+++ b/cmd/nerdctl/volume_prune_test.go
@@ -1,0 +1,34 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestVolumePrune(t *testing.T) {
+	var tests = []string{"testVol1", "testVol2", "testVol3", "testVol4"}
+	t.Parallel()
+	base := testutil.NewBase(t)
+	for _, test := range tests {
+		base.Cmd("volume", "create", test).AssertOK()
+
+	}
+	defer base.Cmd("volume", "prune", "-f").AssertOK()
+}


### PR DESCRIPTION
Issue Fixed: #648 

Enhancements for container prune and volume prune. Only stopped and created containers are deleted and only unmounted volumes are deleted.

```
D:\GolandProjects\github.com\nerdctl\cmd\nerdctl>nerdctl container prune
WARNING! This will remove all stopped containers.
Are you sure you want to continue? [y/N] y



Deleted Containers
001251e3770003c5918a81513f7073377ba6a14089b607878fe82c377e097738
72fe18497ae4f9b0e42dc3c1fee236de781c100142b073385847d53871abd16b
7bdee6ba154ae1c7eb05201ff0deed21db16d1ade978a310b9a079e15a71b669

```

```
D:\GolandProjects\github.com\nerdctl\cmd\nerdctl>nerdctl volume prune
WARNING! This will remove all local volumes not used by at least one container.
Are you sure you want to continue? [y/N] y
Deleted Volumes
testVolume123
testVolume
testVolume007
```

Signed-off-by: Raymond Mathew <raymond.mathew@click2cloud.net>