### PR TITLE
info: add --mode=native to show full plugin info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1214,6 +1214,7 @@ Usage: `nerdctl info [OPTIONS]`
 
 Flags:
 - :whale: `-f, --format`: Format the output using the given Go template, e.g, `{{json .}}`
+- :nerd_face: `--mode=(dockercompat|native)`: Information mode. "native" produces more information.
 
 ### :whale: nerdctl version
 Show the nerdctl version information

--- a/cmd/nerdctl/info.go
+++ b/cmd/nerdctl/info.go
@@ -19,11 +19,15 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
+	"sort"
 	"strings"
 	"text/template"
 
+	"github.com/containerd/containerd/api/services/introspection/v1"
 	"github.com/containerd/nerdctl/pkg/infoutil"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/docker/go-units"
 	"github.com/sirupsen/logrus"
@@ -39,6 +43,10 @@ func newInfoCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	infoCommand.Flags().String("mode", "dockercompat", `Information mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
+	infoCommand.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"dockercompat", "native"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	infoCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
 	infoCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
@@ -47,8 +55,6 @@ func newInfoCommand() *cobra.Command {
 }
 
 func infoAction(cmd *cobra.Command, args []string) error {
-	var w io.Writer
-	w = os.Stdout
 	var (
 		tmpl *template.Template
 		err  error
@@ -70,27 +76,121 @@ func infoAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	snapshotter, err := cmd.Flags().GetString("snapshotter")
-	if err != nil {
-		return err
-	}
-	cgroupManager, err := cmd.Flags().GetString("cgroup-manager")
-	if err != nil {
-		return err
-	}
-	info, err := infoutil.Info(ctx, client, snapshotter, cgroupManager)
+	mode, err := cmd.Flags().GetString("mode")
 	if err != nil {
 		return err
 	}
 
+	var (
+		infoNative *native.Info
+		infoCompat *dockercompat.Info
+	)
+	switch mode {
+	case "native":
+		di, err := infoutil.NativeDaemonInfo(ctx, client)
+		if err != nil {
+			return err
+		}
+		infoNative, err = fulfillNativeInfo(cmd, di)
+		if err != nil {
+			return err
+		}
+	case "dockercompat":
+		snapshotter, err := cmd.Flags().GetString("snapshotter")
+		if err != nil {
+			return err
+		}
+		cgroupManager, err := cmd.Flags().GetString("cgroup-manager")
+		if err != nil {
+			return err
+		}
+		infoCompat, err = infoutil.Info(ctx, client, snapshotter, cgroupManager)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown mode %q", mode)
+	}
+
 	if tmpl != nil {
-		if err := tmpl.Execute(w, info); err != nil {
+		var x interface{} = infoNative
+		if infoCompat != nil {
+			x = infoCompat
+		}
+		w := cmd.OutOrStdout()
+		if err := tmpl.Execute(w, x); err != nil {
 			return err
 		}
 		_, err = fmt.Fprintf(w, "\n")
 		return err
 	}
 
+	switch mode {
+	case "native":
+		return prettyPrintInfoNative(cmd.OutOrStdout(), infoNative)
+	case "dockercompat":
+		return prettyPrintInfoDockerCompat(cmd, infoCompat)
+	}
+	return nil
+}
+
+func fulfillNativeInfo(cmd *cobra.Command, di *native.DaemonInfo) (*native.Info, error) {
+	info := &native.Info{
+		Daemon: di,
+	}
+	flags := cmd.Flags()
+	var err error
+	info.Namespace, err = flags.GetString("namespace")
+	if err != nil {
+		return nil, err
+	}
+	info.Snapshotter, err = flags.GetString("snapshotter")
+	if err != nil {
+		return nil, err
+	}
+	info.CgroupManager, err = flags.GetString("cgroup-manager")
+	if err != nil {
+		return nil, err
+	}
+	info.Rootless = rootlessutil.IsRootless()
+	return info, nil
+}
+
+func prettyPrintInfoNative(w io.Writer, info *native.Info) error {
+	fmt.Fprintf(w, "Namespace:          %s\n", info.Namespace)
+	fmt.Fprintf(w, "Snapshotter:        %s\n", info.Snapshotter)
+	fmt.Fprintf(w, "Cgroup Manager:     %s\n", info.CgroupManager)
+	fmt.Fprintf(w, "Rootless:           %v\n", info.Rootless)
+	fmt.Fprintf(w, "containerd Version: %s (%s)\n", info.Daemon.Version.Version, info.Daemon.Version.Revision)
+	fmt.Fprintf(w, "containerd UUID:    %s\n", info.Daemon.Server.UUID)
+	var disabledPlugins, enabledPlugins []introspection.Plugin
+	for _, f := range info.Daemon.Plugins.Plugins {
+		if f.InitErr == nil {
+			enabledPlugins = append(enabledPlugins, f)
+		} else {
+			disabledPlugins = append(disabledPlugins, f)
+		}
+	}
+	sorter := func(x []introspection.Plugin) func(int, int) bool {
+		return func(i, j int) bool {
+			return x[i].Type+"."+x[j].ID < x[j].Type+"."+x[j].ID
+		}
+	}
+	sort.Slice(enabledPlugins, sorter(enabledPlugins))
+	sort.Slice(disabledPlugins, sorter(disabledPlugins))
+	fmt.Fprintf(w, "containerd Plugins:\n")
+	for _, f := range enabledPlugins {
+		fmt.Fprintf(w, " - %s.%s\n", f.Type, f.ID)
+	}
+	fmt.Fprintf(w, "containerd Plugins (disabled):\n")
+	for _, f := range disabledPlugins {
+		fmt.Fprintf(w, " - %s.%s\n", f.Type, f.ID)
+	}
+	return nil
+}
+
+func prettyPrintInfoDockerCompat(cmd *cobra.Command, info *dockercompat.Info) error {
+	w := cmd.OutOrStdout()
 	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return err

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -26,9 +26,34 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/services/introspection"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/version"
 	ptypes "github.com/gogo/protobuf/types"
 )
+
+func NativeDaemonInfo(ctx context.Context, client *containerd.Client) (*native.DaemonInfo, error) {
+	introService := client.IntrospectionService()
+	plugins, err := introService.Plugins(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	server, err := introService.Server(ctx, &ptypes.Empty{})
+	if err != nil {
+		return nil, err
+	}
+	versionService := client.VersionService()
+	version, err := versionService.Version(ctx, &ptypes.Empty{})
+	if err != nil {
+		return nil, err
+	}
+
+	daemonInfo := &native.DaemonInfo{
+		Plugins: plugins,
+		Server:  server,
+		Version: version,
+	}
+	return daemonInfo, nil
+}
 
 func Info(ctx context.Context, client *containerd.Client, snapshotter, cgroupManager string) (*dockercompat.Info, error) {
 	daemonVersion, err := client.Version(ctx)

--- a/pkg/inspecttypes/native/info.go
+++ b/pkg/inspecttypes/native/info.go
@@ -1,0 +1,36 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package native
+
+import (
+	introspection "github.com/containerd/containerd/api/services/introspection/v1"
+	version "github.com/containerd/containerd/api/services/version/v1"
+)
+
+type Info struct {
+	Namespace     string      `json:"Namespace,omitempty"`
+	Snapshotter   string      `json:"Snapshotter,omitempty"`
+	CgroupManager string      `json:"CgroupManager,omitempty"`
+	Rootless      bool        `json:"Rootless,omitempty"`
+	Daemon        *DaemonInfo `json:"Daemon,omitempty"`
+}
+
+type DaemonInfo struct {
+	Plugins *introspection.PluginsResponse `json:"Plugins,omitempty"`
+	Server  *introspection.ServerResponse  `json:"Server,omitempty"`
+	Version *version.VersionResponse       `json:"Version,omitempty"`
+}


### PR DESCRIPTION
```console
$ nerdctl info --mode=native
Namespace:          default
Snapshotter:        overlayfs
Cgroup Manager:     systemd
Rootless:           true
containerd Version: v1.6.2 (de8046a5501db9e0e478e1c10cbcfb21af4c6b2d)
containerd UUID:    377468b5-090d-4ccf-b889-4e52e554035a
containerd Plugins:
 - io.containerd.content.v1.content
 - io.containerd.differ.v1.walking
 - io.containerd.event.v1.exchange
 - io.containerd.gc.v1.scheduler
 - io.containerd.grpc.v1.leases
 - io.containerd.grpc.v1.snapshots
 - io.containerd.grpc.v1.tasks
 - io.containerd.grpc.v1.namespaces
 - io.containerd.grpc.v1.version
 - io.containerd.grpc.v1.images
 - io.containerd.grpc.v1.healthcheck
 - io.containerd.grpc.v1.events
 - io.containerd.grpc.v1.diff
 - io.containerd.grpc.v1.content
 - io.containerd.grpc.v1.containers
 - io.containerd.grpc.v1.introspection
 - io.containerd.grpc.v1.cri
 - io.containerd.internal.v1.tracing
 - io.containerd.internal.v1.restart
 - io.containerd.internal.v1.opt
 - io.containerd.metadata.v1.bolt
 - io.containerd.monitor.v1.cgroups
 - io.containerd.runtime.v1.linux
 - io.containerd.runtime.v2.task
 - io.containerd.service.v1.images-service
 - io.containerd.service.v1.diff-service
 - io.containerd.service.v1.leases-service
 - io.containerd.service.v1.containers-service
 - io.containerd.service.v1.introspection-service
 - io.containerd.service.v1.namespaces-service
 - io.containerd.service.v1.snapshots-service
 - io.containerd.service.v1.tasks-service
 - io.containerd.service.v1.content-service
 - io.containerd.snapshotter.v1.overlayfs
 - io.containerd.snapshotter.v1.native
containerd Plugins (disabled):
 - io.containerd.snapshotter.v1.aufs
 - io.containerd.snapshotter.v1.btrfs
 - io.containerd.snapshotter.v1.devmapper
 - io.containerd.snapshotter.v1.zfs
 - io.containerd.tracing.processor.v1.otlp
```