### PR TITLE
fix default driver capability for gpus

### DIFF
--- a/cmd/nerdctl/run_gpus.go
+++ b/cmd/nerdctl/run_gpus.go
@@ -78,9 +78,9 @@ func parseGPUOpt(value string) (oci.SpecOpts, error) {
 	if len(nvidiaCaps) != 0 {
 		gpuOpts = append(gpuOpts, nvidia.WithCapabilities(nvidiaCaps...))
 	} else {
-		// Add "utility" capability if unset.
+		// Add "utility", "compute" capability if unset.
 		// Please see also: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
-		gpuOpts = append(gpuOpts, nvidia.WithCapabilities(nvidia.Utility))
+		gpuOpts = append(gpuOpts, nvidia.WithCapabilities(nvidia.Utility, nvidia.Compute))
 	}
 
 	if rootlessutil.IsRootless() {

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -27,12 +27,12 @@ You can also pass detailed configuration to `--gpus` option as a list of key-val
 
 - `count`: number of GPUs to use. `all` exposes all available GPUs.
 - `device`: IDs of GPUs to use. UUID or numbers of GPUs can be specified.
-- `capabilities`: [Driver capabilities](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities). If unset, `utility` is used.
+- `capabilities`: [Driver capabilities](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities). If unset, use default driver `utility`, `compute`.
 
 The following example exposes a specific GPU to the container.
 
 ```
-nerdctl run -it --rm --gpus capabilities=utility,device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a nvidia/cuda:9.0-base nvidia-smi
+nerdctl run -it --rm --gpus '"capabilities=utility,compute",device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a' nvidia/cuda:9.0-base nvidia-smi
 ```
 
 ## Fields for `nerdctl compose`


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#driver-capabilities
```
empty or unset | use default driver capability: utility, compute
```

fixes: https://github.com/containerd/nerdctl/issues/1023