### PR TITLE
Enhancement for container rename

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -222,6 +222,7 @@ Config file ($NERDCTL_TOML): %s
 		newRunCommand(),
 		newUpdateCommand(),
 		newExecCommand(),
+		newRenameCommand(),
 		// #endregion
 
 		// #region Container management

--- a/cmd/nerdctl/rename.go
+++ b/cmd/nerdctl/rename.go
@@ -1,0 +1,124 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/nerdctl/pkg/dnsutil/hostsstore"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/spf13/cobra"
+)
+
+func newRenameCommand() *cobra.Command {
+	var renameCommand = &cobra.Command{
+		Use:           "rename [flags] CONTAINER [CONTAINER, ...]",
+		Args:          cobra.MaximumNArgs(2),
+		Short:         "Rename container",
+		RunE:          renameAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	return renameCommand
+}
+func renameAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	ns, err := cmd.Flags().GetString("namespace")
+	if err != nil {
+		return err
+	}
+
+	var found bool
+	oldName := args[0]
+	newName := args[1]
+
+	containers, err := client.Containers(ctx)
+	if err != nil {
+		return err
+	}
+
+	dataStore, err := getDataStore(cmd)
+	if err != nil {
+		return err
+	}
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			contLabel, err := found.Container.Labels(ctx)
+			if err != nil {
+				return err
+			}
+			err = fmt.Errorf("error when allocating new name: The container name %q is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name", contLabel["nerdctl/name"], found.Container.ID())
+			return err
+		},
+	}
+	_, err = walker.Walk(ctx, newName)
+	if err != nil {
+		return err
+	}
+	for _, container := range containers {
+		labels, err := container.Labels(ctx)
+		if err != nil {
+			return err
+		}
+		if labels["nerdctl/name"] == oldName {
+			found = true
+			if labels["nerdctl/name"] == newName {
+				err = fmt.Errorf("failed to rename container named %q", newName)
+				return fmt.Errorf("renaming a container with the same name as its current name:%w", err)
+			}
+			labels["nerdctl/name"] = newName
+			_, err := container.SetLabels(ctx, labels)
+			if err != nil {
+				return err
+			}
+			err = os.Rename(filepath.Join(dataStore, "names", ns, oldName), filepath.Join(dataStore, "names", ns, newName))
+			if err != nil {
+				fmt.Println("error in renaming container file")
+				return err
+			}
+
+			hostsstorePath := hostsstore.HostsPath(dataStore, ns, container.ID())
+			metafile, err := os.ReadFile(hostsstorePath)
+			if err != nil {
+				fmt.Print(err)
+				return nil
+			}
+			metafile = bytes.Replace(metafile, []byte(oldName), []byte(newName), 1)
+
+			err = os.WriteFile(hostsstorePath, metafile, 0777)
+			if err != nil {
+				return err
+			}
+
+		}
+
+	}
+	if !found {
+		return fmt.Errorf("container name not found:%q", oldName)
+	}
+	return nil
+}

--- a/cmd/nerdctl/rename_test.go
+++ b/cmd/nerdctl/rename_test.go
@@ -1,0 +1,67 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestRename(t *testing.T) {
+	tests := []struct {
+		containerName    string
+		containerNewName string
+		wantFail         bool
+	}{
+		{
+			containerName:    "testContainer0",
+			containerNewName: "testContainerNew0",
+			wantFail:         false,
+		},
+		{
+			containerName:    "testContainer1",
+			containerNewName: "testContainerNew1",
+			wantFail:         false,
+		},
+		{
+			containerName:    "testContainerSame",
+			containerNewName: "testContainerSame",
+			wantFail:         true,
+		},
+	}
+	t.Parallel()
+	base := testutil.NewBase(t)
+	imageName := testutil.CommonImage
+	for _, test := range tests {
+		id := base.Cmd("run", "-d", "--name", test.containerName, imageName).OutLines()
+
+		result := base.Cmd("rename", test.containerName, test.containerNewName).Run()
+		if result.Error != nil {
+			if test.wantFail {
+				fmt.Println(test.containerName, "container cannot be renamed to", test.containerNewName, ": Renaming a container with the same name as its current name")
+			}
+		} else {
+			cont := base.InspectContainer(id[0])
+			if test.containerNewName == cont.Name {
+				fmt.Println(test.containerName, "Container Renamed to", test.containerNewName)
+			}
+		}
+		base.Cmd("rm", test.containerNewName).AssertOK()
+	}
+}


### PR DESCRIPTION
Signed-off-by: Raymond Mathew <raymond.mathew@click2cloud.net>

I have added enhancements for container rename where I have made changes to label as well as to namestore and etchosts.

```
root@server-1:~/nerdctl/cmd/nerdctl# nerdctl run -d --name test001 alpine:3.14
9a9f346ba1d18889e207eb56c5d6960a1be20dc42de4ff9cca2cf6d215f38600

root@server-1:~/nerdctl/cmd/nerdctl# nerdctl container ls -a
CONTAINER ID    IMAGE                              COMMAND        CREATED               STATUS                           PORTS    NAMES
9a9f346ba1d1    docker.io/library/alpine:3.14      "/bin/sh"      27 seconds ago        Exited (0) 26 seconds ago                 test001

root@server-1:~/nerdctl/cmd/nerdctl# nerdctl rename test001 test002

root@server-1:~/nerdctl/cmd/nerdctl# nerdctl container ls -a
CONTAINER ID    IMAGE                              COMMAND        CREATED               STATUS                           PORTS    NAMES
9a9f346ba1d1    docker.io/library/alpine:3.14      "/bin/sh"      About a minute ago    Exited (0) About a minute ago             test002

```

However, container rename works does not fully work for windows .

I have also tried to imitate docker's error where : 
* old name and the new name cant be same
* it wont accept the new name if it matches with the already existing containers.