### PR TITLE
Support interactive debugging of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,8 @@ ARG CONTAINERD_FUSE_OVERLAYFS_VERSION=v1.0.4
 ARG IPFS_VERSION=v0.12.2
 # Extra deps: Init
 ARG TINI_VERSION=v0.19.0
+# Extra deps: Debug
+ARG BUILDG_VERSION=v0.0.3
 
 # Test deps
 ARG GO_VERSION=1.18
@@ -203,6 +205,13 @@ RUN fname="tini-static-${TARGETARCH:-amd64}" && \
   grep "${fname}" "/SHA256SUMS.d/tini-${TINI_VERSION}" | sha256sum -c && \
   cp -a "${fname}" /out/bin/tini && chmod +x /out/bin/tini && \
   echo "- Tini: ${TINI_VERSION}" >> /out/share/doc/nerdctl-full/README.md
+ARG BUILDG_VERSION
+RUN fname="buildg-${BUILDG_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz" && \
+  curl -o "${fname}" -fSL "https://github.com/ktock/buildg/releases/download/${BUILDG_VERSION}/${fname}" && \
+  grep "${fname}" "/SHA256SUMS.d/buildg-${BUILDG_VERSION}" | sha256sum -c && \
+  tar xzf "${fname}" -C /out/bin && \
+  rm -f "${fname}" && \
+  echo "- buildg: ${BUILDG_VERSION}" >> /out/share/doc/nerdctl-full/README.md
 
 RUN echo "" >> /out/share/doc/nerdctl-full/README.md && \
   echo "## License" >> /out/share/doc/nerdctl-full/README.md && \

--- a/Dockerfile.d/SHA256SUMS.d/buildg-v0.0.3
+++ b/Dockerfile.d/SHA256SUMS.d/buildg-v0.0.3
@@ -1,0 +1,2 @@
+3181c6e98cdd913fd24117288dfac5cea3a50232db7775a99a45f379f9a5e9e6  buildg-v0.0.3-linux-amd64.tar.gz
+650fbcfa761c353a8dd45f0f4506d2bc462f18cbafb9694e0f537d36ce1bddde  buildg-v0.0.3-linux-arm64.tar.gz

--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:nerd_face: nerdctl apparmor unload](#nerd_face-nerdctl-apparmor-unload)
   - [Builder management](#builder-management)
     - [:whale: nerdctl builder prune](#whale-nerdctl-builder-prune)
+    - [:nerd_face: nerdctl builder debug](#nerd_face-nerdctl-builder-debug)
   - [System](#system)
     - [:whale: nerdctl events](#whale-nerdctl-events)
     - [:whale: nerdctl info](#whale-nerdctl-info)
@@ -1207,6 +1208,21 @@ Usage: `nerdctl builder prune`
 Flags:
 - :nerd_face: `--buildkit-host=<BUILDKIT_HOST>`: BuildKit address
 
+### :nerd_face: nerdctl builder debug
+Interactive debugging of Dockerfile using [buildg](https://github.com/ktock/buildg).
+Please refer to [`./docs/builder-debug.md`](./docs/builder-debug.md) for details.
+This is an [experimental](./docs/experimental.md) feature.
+
+:warning: This command currently doesn't use the host's `buildkitd` daemon but uses the patched version of BuildKit provided by buildg. This should be fixed in the future.
+
+Usage: `nerdctl builder debug PATH`
+
+Flags:
+- :nerd_face: `-f`, `--file`: Name of the Dockerfile
+- :nerd_face: `--image`: Image to use for debugging stage
+- :nerd_face: `--target`: Set the target build stage to build
+- :nerd_face: `--build-arg`: Set build-time variables
+
 Unimplemented `docker builder prune` flags: `--all`, `--filter`, `--force`, `--keep-storage`
 
 ## System
@@ -1510,6 +1526,7 @@ Experimental features:
 - [`./docs/experimental.md`](./docs/experimental.md):  Experimental features
 - [`./docs/freebsd.md`](./docs/freebsd.md):  Running FreeBSD jails
 - [`./docs/ipfs.md`](./docs/ipfs.md): Distributing images on IPFS
+- [`./docs/builder-debug.md`](./docs/builder-debug.md): Interactive debugging of Dockerfile
 
 Implementation details:
 - [`./docs/dir.md`](./docs/dir.md):           Directory layout (`/var/lib/nerdctl`)

--- a/cmd/nerdctl/builder_linux_test.go
+++ b/cmd/nerdctl/builder_linux_test.go
@@ -1,0 +1,41 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+func TestBuilderDebug(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+
+	dockerfile := fmt.Sprintf(`FROM %s
+CMD ["echo", "nerdctl-builder-debug-test-string"]
+	`, testutil.CommonImage)
+
+	buildCtx, err := createBuildContext(dockerfile)
+	assert.NilError(t, err)
+	defer os.RemoveAll(buildCtx)
+
+	base.Cmd("builder", "debug", buildCtx).AssertOK()
+}

--- a/docs/builder-debug.md
+++ b/docs/builder-debug.md
@@ -1,0 +1,87 @@
+# Interactive debugging of Dockerfile (Experimental)
+
+nerdctl supports interactive debugging of Dockerfile as `nerdctl builder debug`.
+
+```
+$ nerdctl builder debug /path/to/context
+```
+
+This feature leverages [buildg](https://github.com/ktock/buildg), interactive debugger of Dockerfile.
+For command reference, please refer to the [Command reference doc in buildg repo](https://github.com/ktock/buildg#command-reference).
+
+:warning: This command currently doesn't use the host's `buildkitd` daemon but uses the patched version of BuildKit provided by buildg. This should be fixed to use the host's `buildkitd` in the future.
+
+## Example
+
+Example Dockerfile:
+
+```Dockerfile
+FROM busybox AS build1
+RUN echo a > /a
+RUN echo b > /b
+RUN echo c > /c
+```
+
+Example debugging:
+
+```console
+$ nerdctl builder debug --image=ubuntu:22.04 /tmp/ctx/
+WARN[2022-05-10T12:49:43Z] using host network as the default
+#1 [internal] load .dockerignore
+#1 transferring context: 2B done
+#1 DONE 0.1s
+
+#2 [internal] load build definition from Dockerfile
+#2 transferring dockerfile: 108B done
+#2 DONE 0.1s
+
+#3 [internal] load metadata for docker.io/library/busybox:latest
+#3 DONE 3.0s
+
+#4 [1/4] FROM docker.io/library/busybox@sha256:d2b53584f580310186df7a2055ce3ff83cc0df6caacf1e3489bff8cf5d0af5d8
+#4 resolve docker.io/library/busybox@sha256:d2b53584f580310186df7a2055ce3ff83cc0df6caacf1e3489bff8cf5d0af5d8 0.0s done
+#4 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0B / 772.81kB 0.2s
+Filename: "Dockerfile"
+      1| FROM busybox AS build1
+ =>   2| RUN echo a > /a
+      3| RUN echo b > /b
+      4| RUN echo c > /c
+>>> break 3
+>>> breakpoints
+[0]: line: Dockerfile:3
+[on-fail]: breaks on fail
+>>> continue
+#4 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 772.81kB / 772.81kB 0.3s done
+#4 extracting sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0.0s done
+#4 DONE 0.4s
+
+#5 [2/4] RUN echo a > /a
+#5 DONE 15.1s
+Breakpoint: line: Dockerfile:3: reached
+Filename: "Dockerfile"
+      1| FROM busybox AS build1
+      2| RUN echo a > /a
+*=>   3| RUN echo b > /b
+      4| RUN echo c > /c
+>>> exec --image sh
+# cat /etc/os-release
+PRETTY_NAME="Ubuntu 22.04 LTS"
+NAME="Ubuntu"
+VERSION_ID="22.04"
+VERSION="22.04 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=jammy
+# ls /debugroot/
+a  b  bin  dev	etc  home  proc  root  tmp  usr  var
+# cat /debugroot/a /debugroot/b
+a
+b
+#
+>>> quit
+```

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -9,3 +9,4 @@ The following features are experimental and subject to change:
 - [Image Distribution on IPFS](./ipfs.md)
 - [Image Sign and Verify (cosign)](./cosign.md)
 - [Rootless container networking acceleration with bypass4netns](./rootless.md#bypass4netns)
+- [Interactive debugging of Dockerfile](./builder-debug.md)


### PR DESCRIPTION
`nerdctl builder debug` provides interacive debugging of Dockerfile using [buildg](https://github.com/ktock/buildg).

Example Dockerfile:

```Dockerfile
FROM busybox AS build1
RUN echo a > /a
RUN echo b > /b
RUN echo c > /c
```

Example debugging:

```console
$ nerdctl builder debug --image=ubuntu:22.04 /tmp/ctx/
WARN[2022-05-10T12:49:43Z] using host network as the default            
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.1s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 108B done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/busybox:latest
#3 DONE 3.0s

#4 [1/4] FROM docker.io/library/busybox@sha256:d2b53584f580310186df7a2055ce3ff83cc0df6caacf1e3489bff8cf5d0af5d8
#4 resolve docker.io/library/busybox@sha256:d2b53584f580310186df7a2055ce3ff83cc0df6caacf1e3489bff8cf5d0af5d8 0.0s done
#4 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0B / 772.81kB 0.2s
Filename: "Dockerfile"
      1| FROM busybox AS build1
 =>   2| RUN echo a > /a
      3| RUN echo b > /b
      4| RUN echo c > /c
>>> break 3
>>> breakpoints
[0]: line: Dockerfile:3
[on-fail]: breaks on fail
>>> continue
#4 sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 772.81kB / 772.81kB 0.3s done
#4 extracting sha256:50e8d59317eb665383b2ef4d9434aeaa394dcd6f54b96bb7810fdde583e9c2d1 0.0s done
#4 DONE 0.4s

#5 [2/4] RUN echo a > /a
#5 DONE 15.1s
Breakpoint: line: Dockerfile:3: reached
Filename: "Dockerfile"
      1| FROM busybox AS build1
      2| RUN echo a > /a
*=>   3| RUN echo b > /b
      4| RUN echo c > /c
>>> exec --image sh
# cat /etc/os-release
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04 LTS (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
# ls /debugroot/
a  b  bin  dev	etc  home  proc  root  tmp  usr  var
# cat /debugroot/a /debugroot/b
a
b
# 
>>> quit
```
