### PR TITLE
logging: ensure that MagicArgv1 is always argv1

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Metadata flags:
 
 Logging flags:
 - :whale: `--log-driver=(json-file)`: Logging driver for the container (default `json-file`).
-    - :whale: `--log-driver=json-log`: The logs are formatted as JSON. The default logging driver for nerdctl.
+    - :whale: `--log-driver=json-file`: The logs are formatted as JSON. The default logging driver for nerdctl.
       - The `json-file` logging driver supports the following logging options:
           - :whale: `--log-opt=max-size=<MAX-SIZE>`: The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g). Defaults to unlimited.
           - :whale: `--log-opt=max-file=<MAX-FILE>`: The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. Only effective when `max-size` is also set. A positive integer. Defaults to 1.

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -71,22 +71,10 @@ func main() {
 }
 
 func xmain() error {
-	loggingMode := false
-	for _, arg := range os.Args {
-		if arg == logging.MagicArgv1 {
-			loggingMode = true
-			break
-		}
-	}
-	if len(os.Args) >= 3 && loggingMode {
+	if len(os.Args) == 3 && os.Args[1] == logging.MagicArgv1 {
 		// containerd runtime v2 logging plugin mode.
-		// "binary://BIN?KEY1=VALUE1&KEY2=VALUE2" URI is parsed into Args {BIN, KEY1, VALUE1, KEY2, VALUE2}.
-		argsMap := make(map[string]string)
-		args := os.Args[1:]
-		for i := 0; i < len(args); i += 2 {
-			argsMap[args[i]] = args[i+1]
-		}
-		return logging.Main(argsMap)
+		// "binary://BIN?KEY=VALUE" URI is parsed into Args {BIN, KEY, VALUE}.
+		return logging.Main(os.Args[2])
 	}
 	// nerdctl CLI mode
 	app, err := newApp()

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -31,6 +31,7 @@ e.g. `/var/lib/nerdctl/1935db59/containers/default/c4ed811cc361d26faffdee8d696dd
 Files:
 - `resolv.conf`: mounted to the container as `/etc/resolv.conf`
 - `hostname`: mounted to the container as `/etc/hostname`
+- `log-config.json`: used for storing the `--log-opts` map of `nerdctl run`
 - `<CID>-json.log`: used by `nerdctl logs`
 - `oci-hook.*.log`: logs of the OCI hook
 


### PR DESCRIPTION
Fix #1054 
Replace #1055 

The opts are now stored in `filepath.Join(dataStore, "containers", ns, id, "log-config.json")`