### PR TITLE
create/run: add ipc flag to create and run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Logging flags:
           - :whale: `--log-opt=max-file=<MAX-FILE>`: The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. Only effective when `max-size` is also set. A positive integer. Defaults to 1.
 
 Shared memory flags:
+- :whale: `--ipc`: IPC namespace to use
 - :whale: `--shm-size`: Size of `/dev/shm`
 
 GPU flags:

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -175,5 +175,17 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 		opts = append(opts, oci.WithRdt(rdtClass, "", ""))
 	}
 
+	ipc, err := cmd.Flags().GetString("ipc")
+	if err != nil {
+		return nil, err
+	}
+	// if nothing is specified, or if private, default to normal behavior
+	if ipc == "host" {
+		opts = append(opts, oci.WithHostNamespace(specs.IPCNamespace))
+		opts = append(opts, withBindMountHostIPC)
+	} else if ipc != "" && ipc != "private" {
+		return nil, fmt.Errorf("error: %v", "invalid ipc value, supported values are 'private' or 'host'")
+	}
+
 	return opts, nil
 }

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -71,6 +71,20 @@ func TestRunPidHost(t *testing.T) {
 	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
 }
 
+func TestRunIpcHost(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	testFile, err := os.Create("/dev/shm/test")
+	assert.NilError(base.T, err)
+
+	defer func() {
+		testFile.Close()
+		os.Remove(testFile.Name())
+	}()
+
+	base.Cmd("run", "--rm", "--ipc=host", testutil.AlpineImage, "ls", testFile.Name()).AssertExitCode(0)
+}
+
 func TestRunAddHost(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -74,15 +74,13 @@ func TestRunPidHost(t *testing.T) {
 func TestRunIpcHost(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	testFile, err := os.Create("/dev/shm/test")
+	testFilePath := filepath.Join("/dev/shm",
+		fmt.Sprintf("%s-%d-%s", testutil.Identifier(t), os.Geteuid(), base.Target))
+	err := os.WriteFile(testFilePath, []byte(""), 0644)
 	assert.NilError(base.T, err)
+	defer os.Remove(testFilePath)
 
-	defer func() {
-		testFile.Close()
-		os.Remove(testFile.Name())
-	}()
-
-	base.Cmd("run", "--rm", "--ipc=host", testutil.AlpineImage, "ls", testFile.Name()).AssertExitCode(0)
+	base.Cmd("run", "--rm", "--ipc=host", testutil.AlpineImage, "ls", testFilePath).AssertOK()
 }
 
 func TestRunAddHost(t *testing.T) {


### PR DESCRIPTION
Right now nerdctl inspect does not have a --ipc flag similar to
docker and podman.

This PR aims to add this, allowing for the basic values:

    private
    host

It will default to private to match docker's behaviour

Example of the command:

```sh
./nerdctl create --ipc host --name test alpine:latest sleep infinity
./nerdctl start test
./nerdctl exec -ti test ls -la /dev
```

output:

```console
drwxrwxrwt    2 nobody   nobody          40 May 12 09:35 /dev/mqueue
drwxrwxrwt    2 nobody   nobody          80 May 12 10:35 /dev/shm
```

Run example:

```sh
./nerdctl run --ipc host --name test --rm -ti alpine:latest ls -lad /dev/{mqueue,shm}
```

output:

```console
drwxrwxrwt    2 nobody   nobody          40 May 12 09:35 /dev/mqueue
drwxrwxrwt    2 nobody   nobody          80 May 12 10:35 /dev/shm
```

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>