### PR TITLE
CI: use GHA ubuntu-22.04 for cgroup2 tests

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,38 +1,3 @@
-# GitHub Actions does not support cgroup v2, so we use Cirrus for cgroup v2.
-linux_cgroup2_task:
-  name: "Linux/cgroup2"
-  timeout_in: 60m
-  compute_engine_instance:
-    image_project: ubuntu-os-cloud
-    image: family/ubuntu-2110
-    # CPU limit: `16 / NTASK`: see https://cirrus-ci.org/faq/#are-there-any-limits
-    cpu: 4
-    # Memory limit: `4GB * NCPU`
-    memory: 16G
-    disk: 100
-  env:
-    DEBIAN_FRONTEND: noninteractive
-    DOCKER_BUILDKIT: 1
-  # Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)
-  remove_snapd_script:
-    - systemctl disable --now snapd.service snapd.socket
-    - apt-get purge -y snapd
-    - losetup -Dv
-    - losetup -lv
-  install_docker_script:
-    - apt-get update
-    - apt-get install -y docker.io
-    - docker info
-  rootful_build_script:
-    - docker build -t test-integration --target test-integration .
-  rootful_test_script:
-    - docker run -t --rm --privileged test-integration
-  rootless_build_script:
-    - docker build -t test-integration-rootless --target test-integration-rootless .
-  rootless_test_script:
-    # WORKAROUND_CIRRUS: Workaround for https://github.com/containerd/nerdctl/issues/622
-    - docker run -t --rm --privileged -e WORKAROUND_CIRRUS=1 test-integration-rootless
-
 freebsd_task:
   name: "FreeBSD (Unit tests only)"
   timeout_in: 20m

--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ env:
   GO111MODULE: on
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
     - uses: actions/setup-go@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   project:
     name: Project Checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
     - uses: actions/setup-go@v3
@@ -25,7 +25,7 @@ jobs:
         working-directory: src/github.com/containerd/nerdctl
 
   golangci-lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
     - uses: actions/checkout@v3.0.2
@@ -41,7 +41,7 @@ jobs:
         args: --verbose
 
   test-unit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
     - uses: actions/setup-go@v3
@@ -54,20 +54,30 @@ jobs:
       run: go test -v ./pkg/...
 
   test-integration:
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-${{ matrix.ubuntu }}"
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        containerd: [v1.5.11, v1.6.4, main]
+        # ubuntu-22.04: cgroup v1, ubuntu-22.04: cgroup v2
+        include:
+          - ubuntu: 20.04
+            containerd: v1.5.11
+          - ubuntu: 20.04
+            containerd: v1.6.4
+          - ubuntu: 22.04
+            containerd: v1.6.4
+          - ubuntu: 22.04
+            containerd: main
     env:
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
     steps:
     - uses: actions/checkout@v3.0.2
       with:
         fetch-depth: 1
     - name: "Prepare integration test environment"
-      run: DOCKER_BUILDKIT=1 docker build -t test-integration --target test-integration --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+      run: DOCKER_BUILDKIT=1 docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
     - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
       run: |
         sudo systemctl disable --now snapd.service snapd.socket
@@ -80,13 +90,23 @@ jobs:
       run: docker run -t --rm --privileged test-integration
 
   test-integration-rootless:
-    runs-on: ubuntu-20.04
+    runs-on: "ubuntu-${{ matrix.ubuntu }}"
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        containerd: [v1.5.11, v1.6.4, main]
+        # ubuntu-22.04: cgroup v1, ubuntu-22.04: cgroup v2
+        include:
+          - ubuntu: 20.04
+            containerd: v1.5.11
+          - ubuntu: 20.04
+            containerd: v1.6.4
+          - ubuntu: 22.04
+            containerd: v1.6.4
+          - ubuntu: 22.04
+            containerd: main
     env:
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
     steps:
     - uses: actions/checkout@v3.0.2
@@ -95,16 +115,16 @@ jobs:
     - name: "Register QEMU (tonistiigi/binfmt)"
       run: docker run --privileged --rm tonistiigi/binfmt --install all
     - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
-      run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless --target test-integration-rootless --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+      run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless --target test-integration-rootless --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
     - name: "Test    (network driver=slirp4netns, port driver=builtin)"
       run: docker run -t --rm --privileged test-integration-rootless
     - name: "Prepare (network driver=slirp4netns, port driver=slirp4netns)"
-      run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless-port-slirp4netns --target test-integration-rootless-port-slirp4netns --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+      run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless-port-slirp4netns --target test-integration-rootless-port-slirp4netns --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
     - name: "Test    (network driver=slirp4netns, port driver=slirp4netns)"
       run: docker run -t --rm --privileged test-integration-rootless-port-slirp4netns
 
   cross:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
     - uses: actions/setup-go@v3
@@ -117,7 +137,7 @@ jobs:
       run: make artifacts
 
   test-integration-docker-compatibility:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
     - uses: actions/setup-go@v3

--- a/cmd/nerdctl/run_cgroup_linux_test.go
+++ b/cmd/nerdctl/run_cgroup_linux_test.go
@@ -213,6 +213,7 @@ func TestRunCgroupConf(t *testing.T) {
 	if cgroups.Mode() != cgroups.Unified {
 		t.Skip("test requires cgroup v2")
 	}
+	testutil.DockerIncompatible(t) // Docker lacks --cgroup-conf
 	base := testutil.NewBase(t)
 	info := base.Info()
 	switch info.CgroupDriver {

--- a/cmd/nerdctl/run_cgroup_linux_test.go
+++ b/cmd/nerdctl/run_cgroup_linux_test.go
@@ -68,7 +68,15 @@ func TestRunCgroupV2(t *testing.T) {
 		"cat", "cpu.max", "memory.max", "pids.max", "cpu.weight", "cpuset.cpus", "cpuset.mems").AssertOutExactly(expected)
 
 	base.Cmd("run", "--name", testutil.Identifier(t)+"-testUpdate", "-w", "/sys/fs/cgroup", "-d", testutil.AlpineImage, "sleep", "infinity").AssertOK()
-	base.Cmd("update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000", "--memory", "42m", "--pids-limit", "42", "--cpu-shares", "2000", "--cpuset-cpus", "0-1", testutil.Identifier(t)+"-testUpdate").AssertOK()
+	update := []string{"update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000", "--memory", "42m", "--pids-limit", "42", "--cpu-shares", "2000", "--cpuset-cpus", "0-1"}
+	if base.Target == testutil.Docker && info.CgroupVersion == "2" && info.SwapLimit {
+		// Workaround for Docker with cgroup v2:
+		// > Error response from daemon: Cannot update container 67c13276a13dd6a091cdfdebb355aa4e1ecb15fbf39c2b5c9abee89053e88fce:
+		// > Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time
+		update = append(update, "--memory-swap=-1")
+	}
+	update = append(update, testutil.Identifier(t)+"-testUpdate")
+	base.Cmd(update...).AssertOK()
 	base.Cmd("exec", testutil.Identifier(t)+"-testUpdate", "cat", "cpu.max", "memory.max", "pids.max", "cpu.weight", "cpuset.cpus", "cpuset.mems").AssertOutExactly(expected)
 	base.Cmd("rm", "-f", testutil.Identifier(t)+"-testUpdate").AssertOK()
 }


### PR DESCRIPTION
~Docker is broken on GHA ubuntu-22.04 (https://github.com/actions/virtual-environments/issues/5490), so the CI longer uses Docker except for `test-integration-docker-compatibility` on ubuntu-20.04~
