### PR TITLE
Adding --attach flag to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,7 +732,10 @@ Start one or more running containers.
 
 Usage: `nerdctl start [OPTIONS] CONTAINER [CONTAINER...]`
 
-Unimplemented `docker start` flags: `--attach`, `--checkpoint`, `--checkpoint-dir`, `--detach-keys`, `--interactive`
+Flags:
+- :whale: `-a, --attach`: Attach STDOUT/STDERR and forward signals
+
+Unimplemented `docker start` flags: `--checkpoint`, `--checkpoint-dir`, `--detach-keys`, `--interactive`
 
 ### :whale: nerdctl restart
 Restart one or more running containers.

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -109,7 +109,7 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 			return err
 		}
 		if flagA {
-			logrus.Warn("attaching output instead of using the log-uri")
+			logrus.Debug("attaching output instead of using the log-uri")
 		} else {
 			taskCIO = cio.LogURI(logURI)
 		}

--- a/cmd/nerdctl/start_test.go
+++ b/cmd/nerdctl/start_test.go
@@ -1,0 +1,60 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestStart(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+	base.Cmd("run", "--name", containerName, testutil.CommonImage).AssertOK()
+	base.Cmd("start", containerName).AssertOutWithFunc(func(stdout string) error {
+		if !strings.Contains(stdout, containerName) {
+			t.Log(stdout)
+			return errors.New("got bad container name output on start")
+		}
+		return nil
+	})
+}
+
+func TestStartAttach(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("start attach test is not yet implemented on Windows")
+	}
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+	base.Cmd("run", "--name", containerName, testutil.CommonImage, "sh", "-euxc", "echo foo").AssertOK()
+	base.Cmd("start", "-a", containerName).AssertOutWithFunc(func(stdout string) error {
+		if !strings.Contains(stdout, "foo") {
+			return errors.New("got bad attached output on start")
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
This change adds the -a/--attach flag to attach to stdout/stderr
and os events. It follow the style used in run without -d to do
this.

One decision was if the user uses the -a flag and there is a log
label to choose -a and warn that the label is ignored.