### PR TITLE
Fixed gosimple errors in issue #1134

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,7 @@ linters:
     # - gomodguard
     # - goprintffuncname
     # - gosec (gas)
-    # - gosimple (megacheck)
+    - gosimple # (megacheck)
     # - interfacer
     # - lll
     # - maligned

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -254,9 +254,7 @@ func generateExecProcessSpec(ctx context.Context, cmd *cobra.Command, args []str
 	if err != nil {
 		return nil, err
 	}
-	for _, e := range strutil.DedupeStrSlice(env) {
-		pspec.Env = append(pspec.Env, e)
-	}
+	pspec.Env = append(pspec.Env, strutil.DedupeStrSlice(env)...)
 
 	privileged, err := cmd.Flags().GetBool("privileged")
 	if err != nil {

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -143,5 +143,4 @@ func requiresIPFS(t *testing.T) {
 	if _, err := httpapi.NewLocalApi(); err != nil {
 		t.Skipf("test requires ipfs daemon, but got: %v", err)
 	}
-	return
 }

--- a/cmd/nerdctl/ipfs_registry_up.go
+++ b/cmd/nerdctl/ipfs_registry_up.go
@@ -118,7 +118,7 @@ func runRegistryAsContainer(cmd *cobra.Command) error {
 		"run", "-d", "--name", ipfsRegistryContainerName, "--net=host", "--entrypoint", "/mnt/nerdctl",
 		"--read-only", "-v", nerdctlCmd+":/mnt/nerdctl:ro", "--rootfs", registryRoot,
 		"ipfs", "registry", "serve", "--ipfs-address", ipfsAPIAddr.String(), "--listen-registry", listenAddress,
-		"--read-retry-num", fmt.Sprintf("%d", readRetryNum), "--read-timeout", fmt.Sprintf("%s", readTimeout),
+		"--read-retry-num", fmt.Sprintf("%d", readRetryNum), "--read-timeout", readTimeout.String(),
 	)...).CombinedOutput(); err != nil {
 		return fmt.Errorf("failed to execute registry: %v: %v", string(out), err)
 	}

--- a/cmd/nerdctl/main_unix.go
+++ b/cmd/nerdctl/main_unix.go
@@ -44,9 +44,7 @@ func shellCompleteNamespaceNames(cmd *cobra.Command, args []string, toComplete s
 		return nil, cobra.ShellCompDirectiveError
 	}
 	candidates := []string{}
-	for _, ns := range nsList {
-		candidates = append(candidates, ns)
-	}
+	candidates = append(candidates, nsList...)
 	return candidates, cobra.ShellCompDirectiveNoFileComp
 }
 
@@ -65,8 +63,6 @@ func shellCompleteSnapshotterNames(cmd *cobra.Command, args []string, toComplete
 		return nil, cobra.ShellCompDirectiveError
 	}
 	candidates := []string{}
-	for _, name := range snapshotterPlugins {
-		candidates = append(candidates, name)
-	}
+	candidates = append(candidates, snapshotterPlugins...)
 	return candidates, cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -117,7 +117,7 @@ func TestRunAddHost(t *testing.T) {
 			}
 		}
 		if found != 2 {
-			return errors.New(fmt.Sprintf("host was not added, found %d", found))
+			return fmt.Errorf("host was not added, found %d", found)
 		}
 		return nil
 	})

--- a/cmd/nerdctl/run_network.go
+++ b/cmd/nerdctl/run_network.go
@@ -120,7 +120,7 @@ func generateNetOpts(cmd *cobra.Command, dataStore, stateDir, ns, id string) ([]
 		return nil, nil, "", nil, err
 	}
 
-	if (netSlice == nil || len(netSlice) == 0) && (ipAddress != "") {
+	if (len(netSlice) == 0) && (ipAddress != "") {
 		logrus.Warnf("You have assign an IP address %s but no network, So we will use the default network", ipAddress)
 	}
 

--- a/cmd/nerdctl/run_network_linux_test.go
+++ b/cmd/nerdctl/run_network_linux_test.go
@@ -191,7 +191,7 @@ func TestRunPortWithNoHostPort(t *testing.T) {
 			result = portCmd.Run()
 			stdoutContent = result.Stdout() + result.Stderr()
 			assert.Assert(cmd.Base.T, result.ExitCode == 0, stdoutContent)
-			regexExpression := regexp.MustCompile("80\\/tcp.*?->.*?0.0.0.0:(?P<portNumber>\\d{1,5}).*?")
+			regexExpression := regexp.MustCompile(`80\/tcp.*?->.*?0.0.0.0:(?P<portNumber>\d{1,5}).*?`)
 			match := regexExpression.FindStringSubmatch(stdoutContent)
 			paramsMap := make(map[string]string)
 			for i, name := range regexExpression.SubexpNames() {

--- a/pkg/ipfs/registry.go
+++ b/pkg/ipfs/registry.go
@@ -88,7 +88,6 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.ServeContent(w, r, "", time.Now(), content)
 		logrus.WithField("CID", cid).Debugf("served file")
 	}
-	return
 }
 
 func (s *server) serve(r *http.Request) (string, io.ReadSeeker, string, int64, error) {

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -126,7 +126,6 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 			switch opt {
 			case "rbind", "bind":
 				found = true
-				break
 			}
 		}
 		if !found {

--- a/pkg/statsutil/stats.go
+++ b/pkg/statsutil/stats.go
@@ -160,42 +160,42 @@ func (s *StatsEntry) EntryID(noTrunc bool) string {
 
 func (s *StatsEntry) CPUPerc() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%.2f%%", s.CPUPercentage)
 }
 
 func (s *StatsEntry) MemUsage() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("-- / --")
+		return "-- / --"
 	}
 	return fmt.Sprintf("%s / %s", units.BytesSize(s.Memory), units.BytesSize(s.MemoryLimit))
 }
 
 func (s *StatsEntry) MemPerc() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%.2f%%", s.MemoryPercentage)
 }
 
 func (s *StatsEntry) NetIO() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(s.NetworkRx, 3), units.HumanSizeWithPrecision(s.NetworkTx, 3))
 }
 
 func (s *StatsEntry) BlockIO() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%s / %s", units.HumanSizeWithPrecision(s.BlockRead, 3), units.HumanSizeWithPrecision(s.BlockWrite, 3))
 }
 
 func (s *StatsEntry) PIDs() string {
 	if s.IsInvalid {
-		return fmt.Sprintf("--")
+		return "--"
 	}
 	return fmt.Sprintf("%d", s.PidsCurrent)
 }


### PR DESCRIPTION
#1134 

Fixed all the cases mentioned in the above issue.

Worth noting that running the same command used in the issue on my machine brought up some other errors that were not related to `gosimple`, but also a couple extra that were not highlighted in the issue. The former I left untouched but the latter I fixed up and you can see them in `stats.go`.

This is now what shows when running the command:

```
$ golangci-lint run -E "gosimple"
cmd/nerdctl/pull_linux_test.go:66:4: t.Setenv undefined (type *testing.T has no field or method Setenv) (typecheck)
        t.Setenv("COSIGN_PASSWORD", "1")
          ^
cmd/nerdctl/pull_linux_test.go:122:4: t.Setenv undefined (type *testing.T has no field or method Setenv) (typecheck)
        t.Setenv("COSIGN_PASSWORD", "1")
          ^
cmd/nerdctl/pull_linux_test.go:148:4: t.Setenv undefined (type *testing.T has no field or method Setenv) (typecheck)
        t.Setenv("COSIGN_PASSWORD", "2")
```

Signed-off-by: David Son <davbson@amazon.com>