### PR TITLE
Validation for nerdctl load to fail when stdin is empty.

### DIFF
--- a/cmd/nerdctl/load.go
+++ b/cmd/nerdctl/load.go
@@ -67,8 +67,16 @@ func loadAction(cmd *cobra.Command, args []string) error {
 		}
 		defer f.Close()
 		in = f
+	} else {
+		// check if stdin is empty.
+		stdinStat, err := os.Stdin.Stat()
+		if err != nil {
+			return err
+		}
+		if stdinStat.Size() == 0 {
+			return errors.New("stdin is empty and input flag is not specified")
+		}
 	}
-
 	decompressor, err := compression.DecompressStream(in)
 	if err != nil {
 		return err


### PR DESCRIPTION
When running nerdctl load gets an empty stdin, it gets stuck.
This adds a validation letting the user immediately know that
stdin is empty and input flag is not specified.


This PR adds validation to return error when stdin is empty and input is not 
specified.

Fixes https://github.com/containerd/nerdctl/issues/1138