### PR TITLE
1117: specify needsLoading when types are specified in output

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -262,6 +262,10 @@ func generateBuildctlArgs(cmd *cobra.Command, buildkitHost string, platform, arg
 			}
 			needsLoading = true
 		}
+	} else {
+		if strings.Contains(output, "type=docker") || strings.Contains(output, "type=oci") {
+			needsLoading = true
+		}
 	}
 	tagValue, err := cmd.Flags().GetStringArray("tag")
 	if err != nil {

--- a/cmd/nerdctl/build_test.go
+++ b/cmd/nerdctl/build_test.go
@@ -44,8 +44,12 @@ CMD ["echo", "nerdctl-build-test-string"]
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 	base.Cmd("build", buildCtx, "-t", imageName).AssertOK()
+	ignoredImageNamed := imageName + "-" + "ignored"
+	outputOpt := fmt.Sprintf("--output=type=docker,name=%s", ignoredImageNamed)
+	base.Cmd("build", buildCtx, "-t", imageName, outputOpt).AssertOK()
 
 	base.Cmd("run", "--rm", imageName).AssertOutExactly("nerdctl-build-test-string\n")
+	base.Cmd("run", "--rm", ignoredImageNamed).AssertFail()
 }
 
 // TestBuildBaseImage tests if an image can be built on the previously built image.


### PR DESCRIPTION
When output is non-empty string, needsLoading is always false.
However, someone can specify type=docker in output in which
case you need needsLoading=true. This commit handles the guess.

Fixes: https://github.com/containerd/nerdctl/issues/1117 (Example 1 of the #1117)