### PR TITLE
Update golangci-lint version to 1.46.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.45.0
+        version: v1.46.2
         args: --verbose
 
   test-unit:


### PR DESCRIPTION
Update golangci-lint version to 1.46.2

Signed-off-by: Manu Gupta <manugupt1@gmail.com>