### PR TITLE
Fix typo in instructions on how to run docker compat tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ docker build -t test-integration --target test-integration .
 docker run -t --rm --privileged test-integration
 ```
 #### Running integration test suite against Docker
-Run `go test -exec sudo -v ./cmd/nerdctl/... -args test.target=docker` to ensure that the test suite is compatible with Docker.
+Run `go test -exec sudo -v ./cmd/nerdctl/... -args -test.target=docker` to ensure that the test suite is compatible with Docker.
 
 ### Contributing to nerdctl
 


### PR DESCRIPTION
The command that was provided will not run and will default to
nerdctl. Providing `-` as the typo fixes updates the documentation
to reflect the same.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>