### PR TITLE
show name for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,6 +870,7 @@ Flags:
   - :nerd_face: `--format=wide`: Wide table
   - :nerd_face: `--format=json`: Alias of `--format='{{json .}}'`
 - :whale: `--digests`: Show digests (compatible with Docker, unlike ID)
+- :nerd_face: `--names`: Show image names
 
 Unimplemented `docker images` flags: `--filter`
 

--- a/cmd/nerdctl/images_test.go
+++ b/cmd/nerdctl/images_test.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestImagesWithNames(t *testing.T) {
+	t.Parallel()
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+
+	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	base.Cmd("images", "--names", testutil.CommonImage).AssertOutContains(testutil.CommonImage)
+}

--- a/pkg/idutil/imagewalker/imagewalker.go
+++ b/pkg/idutil/imagewalker/imagewalker.go
@@ -49,6 +49,7 @@ func (w *ImageWalker) Walk(ctx context.Context, req string) (int, error) {
 		filters = append(filters, fmt.Sprintf("name==%s", canonicalRef.String()))
 	}
 	filters = append(filters,
+		fmt.Sprintf("name==%s", req),
 		fmt.Sprintf("target.digest~=^sha256:%s.*$", regexp.QuoteMeta(req)),
 		fmt.Sprintf("target.digest~=^%s.*$", regexp.QuoteMeta(req)),
 	)


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

Fixes: https://github.com/containerd/nerdctl/issues/555

`nerdctl images` show some cri managed images in k8s.io namespace, like `sha256:5d725196c1f47e72d2bc7069776d5928b1fb1e4adf09c18997733099aa3663ac`, them can't parse out repo and tag.

Add `--names` flag to show the image name directly.

Before:
```
$ sudo CONTAINERD_NAMESPACE=k8s.io nerdctl images
REPOSITORY                            TAG                                                                 IMAGE ID        CREATED               PLATFORM       SIZE         BLOB SIZE
sha256                                5d725196c1f47e72d2bc7069776d5928b1fb1e4adf09c18997733099aa3663ac    b5bc69ac1e17    About an hour ago     linux/amd64    52.3 MiB     14.8 MiB
sha256                                a4ca41631cc7ac19ce1be3ebf0314ac5f47af7c711f17066006db82ee3b75b03    5b6ec0d6de9b    About an hour ago     linux/amd64    45.1 MiB     13.0 MiB
sha256                                a634548d10b032c2a1d704ef9a2ab04c12b0574afe67ee192b196a7f12da9536    7e75c20c0fb0    About an hour ago     linux/amd64    111.3 MiB    37.7 MiB
sha256                                aebe758cef4cd05b9f8cee39758227714d02f42ef3088023c1e3cd454f927a2b    13f53ed1d91e    About an hour ago     linux/amd64    289.3 MiB    97.4 MiB
sha256                                d3377ffb7177cc4becce8a534d8547aca9530cb30fac9ebe479b31102f1ba503    433696d8a908    About an hour ago     linux/amd64    127.4 MiB    32.2 MiB
```

After:

```
$ sudo CONTAINERD_NAMESPACE=k8s.io nerdctl images
REPOSITORY                            TAG        IMAGE ID        CREATED           PLATFORM       SIZE         BLOB SIZE
<none>                                <none>     b5bc69ac1e17    26 minutes ago    linux/amd64    52.3 MiB     14.8 MiB
<none>                                <none>     5b6ec0d6de9b    26 minutes ago    linux/amd64    45.1 MiB     13.0 MiB
<none>                                <none>     7e75c20c0fb0    26 minutes ago    linux/amd64    111.3 MiB    37.7 MiB
<none>                                <none>     13f53ed1d91e    26 minutes ago    linux/amd64    289.3 MiB    97.4 MiB
<none>                                <none>     433696d8a908    26 minutes ago    linux/amd64    127.4 MiB    32.2 MiB
```

```
$ sudo CONTAINERD_NAMESPACE=k8s.io nerdctl images --names
NAME                                                                       IMAGE ID        CREATED           PLATFORM       SIZE         BLOB SIZE
sha256:5d725196c1f47e72d2bc7069776d5928b1fb1e4adf09c18997733099aa3663ac    b5bc69ac1e17    2 hours ago       linux/amd64    52.3 MiB     14.8 MiB
sha256:a634548d10b032c2a1d704ef9a2ab04c12b0574afe67ee192b196a7f12da9536    7e75c20c0fb0    2 hours ago       linux/amd64    111.3 MiB    37.7 MiB
sha256:aebe758cef4cd05b9f8cee39758227714d02f42ef3088023c1e3cd454f927a2b    13f53ed1d91e    2 hours ago       linux/amd64    289.3 MiB    97.4 MiB
sha256:d3377ffb7177cc4becce8a534d8547aca9530cb30fac9ebe479b31102f1ba503    433696d8a908    2 hours ago       linux/amd64    127.4 MiB    32.2 MiB
```
```
$ sudo CONTAINERD_NAMESPACE=k8s.io nerdctl rmi sha256:34cdf99b1bb3b3a62c5b4226c3bc0983ab1f13e776269d1872092091b07203df
Untagged: sha256:34cdf99b1bb3b3a62c5b4226c3bc0983ab1f13e776269d1872092091b07203df@sha256:d255427f14c9236088c22cd94eb434d7c6a05f615636eac0b9681566cd142753
Deleted: sha256:0b031aac65698c8794dc6bc317a45589e07bc2db1421178f30a2c7f69a4a2cf5
Deleted: sha256:5a9b8acd98eab8ab4522da57208f4c958e33942dfb88745cad7db43c38c9a67d
Deleted: sha256:7afd3a7899f0f41b8081e457bf51be9dfe495fc6729908cb2f84ae6d86aaf45f
```