### PR TITLE
remove invalid debug

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -643,7 +643,6 @@ func createContainer(cmd *cobra.Command, ctx context.Context, client *containerd
 	spec := containerd.WithSpec(&s, opts...)
 	cOpts = append(cOpts, spec)
 
-	logrus.Debugf("final cOpts is %v", cOpts)
 	container, err := client.NewContainer(ctx, id, cOpts...)
 	if err != nil {
 		return nil, "", nil, err


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

```
$ nerdctl --debug run xxx
DEBU[0000] final cOpts is [0xb3d5a0 0xf94840 0xb3dba0 0xb3d900 0xb3d420 0xb3d6c0 0xb3d6c0 0xb3e0e0]
````