### PR TITLE
Fix: error message

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -87,7 +87,7 @@ func (e *CNIEnv) GenerateNetworkConfig(labels []string, id int, name string, plu
 	for _, f := range plugins {
 		p := filepath.Join(e.Path, f.GetPluginType())
 		if _, err := exec.LookPath(p); err != nil {
-			return nil, fmt.Errorf("needs CNI plugin %q to be installed in CNI_PATH (%q), see https://github.com/containernetworking/plugins/releases: %w", f, e.Path, err)
+			return nil, fmt.Errorf("needs CNI plugin %q to be installed in CNI_PATH (%q), see https://github.com/containernetworking/plugins/releases: %w", f.GetPluginType(), e.Path, err)
 		}
 	}
 	labelsMap := strutil.ConvertKVStringsToMap(labels)


### PR DESCRIPTION
error messasge:
```
FATA[0026] needs CNI plugin &{"bridge" "nerdctl0" %!q(bool=true) %!q(bool=false) %!q(bool=false) %!q(bool=true) '\x00' %!q(bool=true) %!q(bool=false) '\x00' map["ranges":[[map["gateway":"10.4.0.1" "subnet":"10.4.0.0/24"]]] "routes":[map["dst":"0.0.0.0/0"]] "type":"host-local"]} to be installed in CNI_PATH ("/opt/cni/bin"), see https://github.com/containernetworking/plugins/releases: exec: "/opt/cni/bin/bridge": stat /opt/cni/bin/bridge: no such file or directory
```

Signed-off-by: tianyang ni <tianzong48@gmail.com>