### PR TITLE
Validate formats before ticking 

### DIFF
--- a/cmd/nerdctl/stats.go
+++ b/cmd/nerdctl/stats.go
@@ -125,6 +125,16 @@ func statsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	var w = cmd.OutOrStdout()
+	var tmpl *template.Template
+	switch format {
+	case "", "table":
+		w = tabwriter.NewWriter(cmd.OutOrStdout(), 10, 1, 3, ' ', 0)
+	case "raw":
+		return errors.New("unsupported format: \"raw\"")
+	default:
+		tmpl, err = parseTemplate(format)
+	}
 
 	noTrunc, err := cmd.Flags().GetBool("no-trunc")
 	if err != nil {
@@ -302,17 +312,9 @@ func statsAction(cmd *cobra.Command, args []string) error {
 		}
 		cStats.mu.Unlock()
 
-		w := cmd.OutOrStdout()
-		var tmpl *template.Template
-
-		switch format {
-		case "", "table":
-			w = tabwriter.NewWriter(cmd.OutOrStdout(), 10, 1, 3, ' ', 0)
+		// print header for every tab
+		if format == "" || format == "table" {
 			fmt.Fprintln(w, "CONTAINER ID\tNAME\tCPU %\tMEM USAGE / LIMIT\tMEM %\tNET I/O\tBLOCK I/O\tPIDS")
-		case "raw":
-			return errors.New("unsupported format: \"raw\"")
-		default:
-			tmpl, err = parseTemplate(format)
 		}
 
 		for _, c := range ccstats {


### PR DESCRIPTION
Follow up on:
https://github.com/containerd/nerdctl/pull/1179#discussion_r912340899


Testing details

```
CONTAINER ID   NAME           CPU %     MEM USAGE / LIMIT   MEM %     NET I/O         BLOCK I/O     PIDS
d8da42cafb9e   busybox-d8da   0.00%     1.094MiB / 16EiB    0.00%     1.38kB / 752B   1.18MB / 0B   2
```

on every tick after moving the writer outside. 