### PR TITLE
docs: add nydus snapshotter description

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
  ✅ [Optional] Supports [rootless mode, without slirp overhead (bypass4netns)](./docs/rootless.md)
 
- ✅ [Optional] Supports [lazy-pulling (Stargz)](./docs/stargz.md)
+ ✅ [Optional] Supports lazy-pulling ([Stargz](./docs/stargz.md), [Nydus](./docs/nydus.md))
 
  ✅ [Optional] Supports [encrypted images (ocicrypt)](./docs/ocicrypt.md)
 
@@ -145,7 +145,7 @@ docker run -it --rm --privileged nerdctl
 
 The goal of `nerdctl` is to facilitate experimenting the cutting-edge features of containerd that are not present in Docker.
 
-Such features include, but not limited to, [on-demand image pulling (lazy-pulling)](./docs/stargz.md) and [image encryption/decryption](./docs/ocicrypt.md).
+Such features include, but not limited to, on-demand image pulling (lazy-pulling) [Stargz](./docs/stargz.md), [Nydus](./docs/nydus.md) and [image encryption/decryption](./docs/ocicrypt.md).
 
 Note that competing with Docker is _not_ the goal of `nerdctl`. Those cutting-edge features are expected to be eventually available in Docker as well.
 
@@ -153,7 +153,7 @@ Also, `nerdctl` might be potentially useful for debugging Kubernetes clusters, b
 
 ## Features present in `nerdctl` but not present in Docker
 Major:
-- [On-demand image pulling (lazy-pulling) using Stargz Snapshotter](./docs/stargz.md): `nerdctl --snapshotter=stargz run IMAGE` .
+- On-demand image pulling (lazy-pulling) using [Stargz](./docs/stargz.md)/[Nydus](./docs/nydus.md) Snapshotter: `nerdctl --snapshotter=stargz|nydus run IMAGE` .
 - [Image encryption and decryption using ocicrypt (imgcrypt)](./docs/ocicrypt.md): `nerdctl image (encrypt|decrypt) SRC DST`
 - [P2P image distribution using IPFS](./docs/ipfs.md): `nerdctl run ipfs://CID` .
   P2P image distribution (IPFS) is completely optional. Your host is NOT connected to any P2P network, unless you opt in to [install and run IPFS daemon](https://docs.ipfs.io/install/).
@@ -1552,6 +1552,7 @@ Basic features:
 
 Advanced features:
 - [`./docs/stargz.md`](./docs/stargz.md):     Lazy-pulling using Stargz Snapshotter
+- [`./docs/nydus.md`](./docs/nydus.md):       Lazy-pulling using Nydus Snapshotter
 - [`./docs/ocicrypt.md`](./docs/ocicrypt.md): Running encrypted images
 - [`./docs/gpu.md`](./docs/gpu.md):           Using GPUs inside containers
 - [`./docs/multi-platform.md`](./docs/multi-platform.md):  Multi-platform mode

--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -1,0 +1,29 @@
+# Lazy-pulling using Nydus Snapshotter
+
+| :zap: Requirement | nerdctl >= 0.22 |
+| ----------------- | --------------- |
+
+Nydus snapshotter is a remote snapshotter plugin of containerd for [Nydus](https://github.com/dragonflyoss/image-service) image service which implements a chunk-based content-addressable filesystem that improves the current OCI image specification, in terms of container launching speed, image space, and network bandwidth efficiency, as well as data integrity with several runtime backends: FUSE, virtiofs and in-kernel EROFS (Linux kernel 5.19+).
+
+## Enable lazy-pulling for `nerdctl run`
+
+- Install containerd remote snapshotter plugin (`containerd-nydus-grpc`) from https://github.com/containerd/nydus-snapshotter
+
+- Add the following to `/etc/containerd/config.toml`:
+```toml
+[proxy_plugins]
+  [proxy_plugins.nydus]
+    type = "snapshot"
+    address = "/run/containerd-nydus-grpc/containerd-nydus-grpc.sock"
+```
+
+- Launch `containerd` and `containerd-nydus-grpc`
+
+- Run `nerdctl` with `--snapshotter=nydus`
+```console
+# nerdctl --snapshotter=nydus run -it --rm ghcr.io/dragonflyoss/image-service/ubuntu:nydus-nightly-v5
+```
+
+For the list of pre-converted Nydus images, see https://github.com/orgs/dragonflyoss/packages?page=1&repo_name=image-service
+
+For more details about how to build Nydus image, please refer to [nydusify](https://github.com/dragonflyoss/image-service/blob/master/docs/nydusify.md) conversion tool and [acceld](https://github.com/goharbor/acceleration-service).


### PR DESCRIPTION
At present, `nerdctl run` has supported nydus snapshotter, this PR adds description in doc.

Signed-off-by: Yan Song <yansong.ys@antfin.com>