### PR TITLE
container exit should terminate tail logs

### DIFF
--- a/pkg/logging/jsonfile/jsonfile.go
+++ b/pkg/logging/jsonfile/jsonfile.go
@@ -78,13 +78,12 @@ func Encode(w io.WriteCloser, stdout, stderr io.Reader) error {
 	return nil
 }
 
-func Decode(stdout, stderr io.Writer, r io.Reader, timestamps bool, since string, until string, logsEOFChan chan<- struct{}) error {
+func Decode(stdout, stderr io.Writer, r io.Reader, timestamps bool, since string, until string) error {
 	dec := json.NewDecoder(r)
 	now := time.Now()
 	for {
 		var e Entry
 		if err := dec.Decode(&e); err == io.EOF {
-			logsEOFChan <- struct{}{}
 			break
 		} else if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

Fixes: https://github.com/containerd/nerdctl/issues/1207

```
# term1
# sudo nerdctl ps -a
CONTAINER ID    IMAGE                             COMMAND                   CREATED              STATUS    PORTS    NAMES
8c234a118fc8    docker.io/library/nginx:latest    "/docker-entrypoint.…"    About an hour ago    Up                 nginx-8c234
# sudo nerdctl logs 8c23 -f

...log
```

```
# term2
# sudo nerdctl stop 8c23
```

logs command should be terminated when stopping the container.