### PR TITLE
Display buildkit and runc version in nerdctl

### DIFF
--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -74,6 +74,13 @@ func versionAction(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(w, " Version:\t%s\n", v.Client.Version)
 		fmt.Fprintf(w, " OS/Arch:\t%s/%s\n", v.Client.Os, v.Client.Arch)
 		fmt.Fprintf(w, " Git commit:\t%s\n", v.Client.GitCommit)
+		for _, compo := range v.Client.Components {
+			fmt.Fprintf(w, " %s:\n", compo.Name)
+			fmt.Fprintf(w, "  Version:\t%s\n", compo.Version)
+			for detailK, detailV := range compo.Details {
+				fmt.Fprintf(w, "  %s:\t%s\n", detailK, detailV)
+			}
+		}
 		if v.Server != nil {
 			fmt.Fprintf(w, "\n")
 			fmt.Fprintf(w, "Server:\n")

--- a/pkg/inspecttypes/dockercompat/info.go
+++ b/pkg/inspecttypes/dockercompat/info.go
@@ -76,11 +76,12 @@ type VersionInfo struct {
 
 // ClientVersion is from https://github.com/docker/cli/blob/v20.10.8/cli/command/system/version.go#L74-L87
 type ClientVersion struct {
-	Version   string
-	GitCommit string
-	GoVersion string
-	Os        string // GOOS
-	Arch      string // GOARCH
+	Version    string
+	GitCommit  string
+	GoVersion  string
+	Os         string             // GOOS
+	Arch       string             // GOARCH
+	Components []ComponentVersion // nerdctl extension
 }
 
 // ComponentVersion describes the version information for a specific component.


### PR DESCRIPTION
Fixes#1082 https://github.com/containerd/nerdctl/issues/1082

Signed-off-by: Manu Gupta <manugupt1@gmail.com>

Testing details

```
➜  nerdctl git:(support-container-file) ✗ make && sudo make install && nerdctl version
GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -X github.com/containerd/nerdctl/pkg/version.Version=v0.21.0-95-g733285c -X github.com/containerd/nerdctl/pkg/version.Revision=733285c464aa0e68810977a4b2c68848079e0280"  -o /home/manu/go/src/github.com/containerd/nerdctl/_output/nerdctl github.com/containerd/nerdctl/cmd/nerdctl
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/_output/nerdctl /usr/local/bin/nerdctl
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/extras/rootless/containerd-rootless.sh /usr/local/bin/containerd-rootless.sh
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/extras/rootless/containerd-rootless-setuptool.sh /usr/local/bin/containerd-rootless-setuptool.sh
Client:
 Version:       v0.21.0-95-g733285c
 OS/Arch:       linux/amd64
 Git commit:    733285c464aa0e68810977a4b2c68848079e0280
 buildctl:
  Version:      v0.10.3
  GitCommit:    c8d25d9a103b70dc300a4fd55e7e576472284e31

Server:
 containerd:
  Version:      1.6.6
  GitCommit:    10c12954828e7c7c9b6e0ea9b0c02b01407d3ae1
 runc:
  Version:      1.1.2
  commit:       v1.1.2-0-ga916309
  spec: 1.0.2-dev
  go:   go1.17.11
  libseccomp:   2.5.3
```