### PR TITLE
support --network=container:<contaienr> for sharing network namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,8 +382,9 @@ Init process flags:
   - Default: `tini`
 
 Network flags:
-- :whale: `--net, --network=(bridge|host|none|<CNI>)`: Connect a container to a network
+- :whale: `--net, --network=(bridge|host|none|container:<container>|<CNI>)`: Connect a container to a network.
   - Default: "bridge"
+  - 'container:<name|id>': reuse another container's network stack, container has to be precreated.
   - :nerd_face: Unlike Docker, this flag can be specified multiple times (`--net foo --net bar`)
 - :whale: `-p, --publish`: Publish a container's port(s) to the host
 - :whale: `--dns`: Set custom DNS servers

--- a/cmd/nerdctl/restart.go
+++ b/cmd/nerdctl/restart.go
@@ -66,7 +66,7 @@ func restartAction(cmd *cobra.Command, args []string) error {
 			if err := stopContainer(ctx, found.Container, timeout); err != nil {
 				return err
 			}
-			if err := startContainer(ctx, found.Container, false); err != nil {
+			if err := startContainer(ctx, found.Container, false, client); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", found.Req)
@@ -81,5 +81,6 @@ func restartAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("no such container %s", req)
 		}
 	}
+
 	return nil
 }

--- a/pkg/netutil/nettype/nettype.go
+++ b/pkg/netutil/nettype/nettype.go
@@ -16,7 +16,10 @@
 
 package nettype
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type Type int
 
@@ -25,13 +28,15 @@ const (
 	None
 	Host
 	CNI
+	Container
 )
 
 var netTypeToName = map[interface{}]string{
-	Invalid: "invalid",
-	None:    "none",
-	Host:    "host",
-	CNI:     "cni",
+	Invalid:   "invalid",
+	None:      "none",
+	Host:      "host",
+	CNI:       "cni",
+	Container: "container",
 }
 
 func Detect(names []string) (Type, error) {
@@ -39,11 +44,16 @@ func Detect(names []string) (Type, error) {
 
 	for _, name := range names {
 		var tmp Type
-		switch name {
+
+		// In case of using --network=container:<container> to share the network namespace
+		networkName := strings.SplitN(name, ":", 2)[0]
+		switch networkName {
 		case "none":
 			tmp = None
 		case "host":
 			tmp = Host
+		case "container":
+			tmp = Container
 		default:
 			tmp = CNI
 		}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -135,7 +135,7 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 	}
 
 	switch netType {
-	case nettype.Host, nettype.None:
+	case nettype.Host, nettype.None, nettype.Container:
 		// NOP
 	case nettype.CNI:
 		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath)


### PR DESCRIPTION
implement: https://github.com/containerd/nerdctl/issues/421

Signed-off-by: tianyang ni <tianzong48@gmail.com>

```
sudo ls /proc/76239/ns -alh |grep net
lrwxrwxrwx 1 root root 0 Jul 11 23:50 net -> net:[4026532895]
```

```
sudo ls /proc/65159/ns -alh |grep net
lrwxrwxrwx 1 lxd tianyang 0 Jul 11 22:55 net -> net:[4026532895]
```