### PR TITLE
wait for detached container running before exec

### DIFF
--- a/cmd/nerdctl/commit_test.go
+++ b/cmd/nerdctl/commit_test.go
@@ -40,6 +40,7 @@ func TestCommit(t *testing.T) {
 		"false",
 	} {
 		base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "infinity").AssertOK()
+		base.EnsureContainerStarted(testContainer)
 		base.Cmd("exec", testContainer, "sh", "-euxc", `echo hello-test-commit > /foo`).AssertOK()
 		base.Cmd(
 			"commit",

--- a/cmd/nerdctl/exec_linux_test.go
+++ b/cmd/nerdctl/exec_linux_test.go
@@ -26,9 +26,10 @@ func TestExecWithUser(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 	testContainer := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", testContainer).Run()
 
+	defer base.Cmd("rm", "-f", testContainer).Run()
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.EnsureContainerStarted(testContainer)
 
 	testCases := map[string]string{
 		"":             "uid=0(root) gid=0(root)",

--- a/cmd/nerdctl/exec_test.go
+++ b/cmd/nerdctl/exec_test.go
@@ -30,6 +30,7 @@ func TestExec(t *testing.T) {
 	defer base.Cmd("rm", "-f", testContainer).Run()
 
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "1h").AssertOK()
+	base.EnsureContainerStarted(testContainer)
 
 	base.Cmd("exec", testContainer, "echo", "success").AssertOutExactly("success\n")
 }
@@ -42,6 +43,7 @@ func TestExecWithDoubleDash(t *testing.T) {
 	defer base.Cmd("rm", "-f", testContainer).Run()
 
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "1h").AssertOK()
+	base.EnsureContainerStarted(testContainer)
 
 	base.Cmd("exec", testContainer, "--", "echo", "success").AssertOutExactly("success\n")
 }
@@ -56,6 +58,7 @@ func TestExecStdin(t *testing.T) {
 	testContainer := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", testContainer).Run()
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "1h").AssertOK()
+	base.EnsureContainerStarted(testContainer)
 
 	const testStr = "test-exec-stdin"
 	opts := []func(*testutil.Cmd){

--- a/cmd/nerdctl/ps_linux_test.go
+++ b/cmd/nerdctl/ps_linux_test.go
@@ -44,6 +44,7 @@ func prepareTest(t *testing.T) (*testutil.Base, string) {
 		testutil.CommonImage,
 		"top",
 	}...).AssertOK()
+	base.EnsureContainerStarted(testContainerName)
 
 	// dd if=/dev/zero of=test_file bs=1M count=25
 	// let the container occupy 25MiB space.

--- a/cmd/nerdctl/rename_linux_test.go
+++ b/cmd/nerdctl/rename_linux_test.go
@@ -45,9 +45,11 @@ func TestRenameUpdateHosts(t *testing.T) {
 
 	defer base.Cmd("rm", "-f", testContainerName).Run()
 	base.Cmd("run", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.EnsureContainerStarted(testContainerName)
 
 	defer base.Cmd("rm", "-f", testContainerName+"_1").Run()
 	base.Cmd("run", "-d", "--name", testContainerName+"_1", testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.EnsureContainerStarted(testContainerName + "_1")
 
 	defer base.Cmd("rm", "-f", testContainerName+"_new").Run()
 	base.Cmd("exec", testContainerName, "cat", "/etc/hosts").AssertOutContains(testContainerName + "_1")

--- a/cmd/nerdctl/run_cgroup_linux_test.go
+++ b/cmd/nerdctl/run_cgroup_linux_test.go
@@ -109,9 +109,11 @@ func TestRunCgroupV2(t *testing.T) {
 		"cat", "cpu.max", "memory.max", "memory.swap.max",
 		"pids.max", "cpu.weight", "cpuset.cpus", "cpuset.mems").AssertOutExactly(expected1)
 
+	defer base.Cmd("rm", "-f", testutil.Identifier(t)+"-testUpdate2").Run()
 	base.Cmd("run", "--name", testutil.Identifier(t)+"-testUpdate2", "-w", "/sys/fs/cgroup", "-d",
 		testutil.AlpineImage, "sleep", "infinity").AssertOK()
-	defer base.Cmd("rm", "-f", testutil.Identifier(t)+"-testUpdate2").Run()
+	base.EnsureContainerStarted(testutil.Identifier(t) + "-testUpdate2")
+
 	base.Cmd("update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000",
 		"--memory", "42m", "--memory-reservation", "6m", "--memory-swap", "100m",
 		"--pids-limit", "42", "--cpu-shares", "2000", "--cpuset-cpus", "0-1",

--- a/cmd/nerdctl/run_mount_linux_test.go
+++ b/cmd/nerdctl/run_mount_linux_test.go
@@ -223,10 +223,12 @@ RUN echo -n "rev0" > /mnt/file
 		base.Cmd("run", "-d", "--name", containerName, "-v", volumeName+":/mnt", imageName, "sleep", "infinity").AssertOK()
 	}
 	runContainer()
+	base.EnsureContainerStarted(containerName)
 	base.Cmd("exec", containerName, "cat", "/mnt/file").AssertOutExactly("rev0")
 	base.Cmd("exec", containerName, "sh", "-euc", "echo -n \"rev1\" >/mnt/file").AssertOK()
 	base.Cmd("rm", "-f", containerName).AssertOK()
 	runContainer()
+	base.EnsureContainerStarted(containerName)
 	base.Cmd("exec", containerName, "cat", "/mnt/file").AssertOutExactly("rev1")
 }
 

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -255,6 +255,23 @@ func (b *Base) InfoNative() native.Info {
 	}
 	return info
 }
+func (b *Base) EnsureContainerStarted(con string) {
+	b.T.Helper()
+
+	const (
+		maxRetry = 5
+		sleep    = time.Second
+	)
+	for i := 0; i < maxRetry; i++ {
+		if b.InspectContainer(con).State.Running {
+			b.T.Logf("container %s is now running", con)
+			return
+		}
+		b.T.Logf("(retry=%d)", i+1)
+		time.Sleep(sleep)
+	}
+	b.T.Fatalf("conainer %s not running", con)
+}
 
 type Cmd struct {
 	icmd.Cmd


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/1018

seems a lot of flaky cases happen when `exec` on a run `-d` container, the reason might be exec before the container process start( runc spawns the container process)


Signed-off-by: tianyang ni <tianzong48@gmail.com>

