### PR TITLE
Log matches of log paths to understand TestRunWithJsonFileLogDriver flakiness

### DIFF
--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -234,7 +234,7 @@ func TestRunWithJsonFileLogDriver(t *testing.T) {
 	matches, err := filepath.Glob(filepath.Join(logJSONPath, inspectedContainer.ID+"*"))
 	assert.NilError(t, err)
 	if len(matches) != 2 {
-		t.Fatal("the maximum number of old log files to retain exceeded 2 files")
+		t.Fatalf("the maximum number of old log files to retain exceeded 2 files, got: %s", matches)
 	}
 	for _, file := range matches {
 		fInfo, err := os.Stat(file)


### PR DESCRIPTION
TestRunWithJsonFileLogDriver failed with error
```
    run_test.go:237: the maximum number of old log files to retain exceeded 2 files
```

Since we can't inspect the container directly, knowing the
contents of the container will help us understand flakiness.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>