### PR TITLE
refactor container restart command

### DIFF
--- a/cmd/nerdctl/restart_linux_test.go
+++ b/cmd/nerdctl/restart_linux_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+func TestRestart(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+
+	base.Cmd("run", "-d", "--name", tID, testutil.NginxAlpineImage).AssertOK()
+	defer base.Cmd("rm", "-f", tID).AssertOK()
+	base.EnsureContainerStarted(tID)
+
+	inspect := base.InspectContainer(tID)
+	pid := inspect.State.Pid
+
+	base.Cmd("restart", tID).AssertOK()
+	base.EnsureContainerStarted(tID)
+
+	newInspect := base.InspectContainer(tID)
+	newPid := newInspect.State.Pid
+	assert.Assert(t, pid != newPid)
+}


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

https://github.com/containerd/nerdctl/pull/1108 introduce attach flag cause restart command failed.
```
$ sudo nerdctl restart test
test
FATA[0000] flag accessed but not defined: attach
```