### PR TITLE
Add oom-score-adj option while running

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Network flags:
 - :whale: `--add-host`: Add a custom host-to-IP mapping (host:ip)
 - :whale: `--ip`: Specific static IP address(es) to use
 
-Cgroup flags:
+Resource flags:
 - :whale: `--cpus`: Number of CPUs
 - :whale: `--cpu-quota`: Limit the CPU CFS (Completely Fair Scheduler) quota
 - :whale: `--cpu-period`: Limit the CPU CFS (Completely Fair Scheduler) period
@@ -407,6 +407,7 @@ Cgroup flags:
 - :whale: `--memory-swappiness`: Tune container memory swappiness (0 to 100) (default -1)
 - :whale: `--kernel-memory`: Kernel memory limit (deprecated)
 - :whale: `--oom-kill-disable`: Disable OOM Killer
+- :whale: `--oom-score-adj`: Tune container’s OOM preferences (-1000 to 1000)
 - :whale: `--pids-limit`: Tune container pids limit
 - :nerd_face: `--cgroup-conf`: Configure cgroup v2 (key=value)
 - :whale: `--blkio-weight`: Block IO (relative weight), between 10 and 1000, or 0 to disable (default 0)
@@ -522,7 +523,7 @@ Verify flags:
 Unimplemented `docker run` flags:
     `--attach`, `--blkio-weight-device`, `--cgroup-parent`, `--cpu-rt-*`, `--detach-keys`, `--device-*`,
     `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--ip6`, `--isolation`, `--no-healthcheck`,
-    `--oom-score-adj`, `--link*`, `--mac-address`, `--publish-all`, `--sig-proxy`, `--storage-opt`,
+    `--link*`, `--mac-address`, `--publish-all`, `--sig-proxy`, `--storage-opt`,
     `--userns`, `--uts`, `--volume-driver`, `--volumes-from`
 
 ### :whale: :blue_square: nerdctl exec

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -156,6 +156,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().Int64("memory-swappiness", -1, "Tune container memory swappiness (0 to 100) (default -1)")
 	cmd.Flags().String("kernel-memory", "", "Kernel memory limit (deprecated)")
 	cmd.Flags().Bool("oom-kill-disable", false, "Disable OOM Killer")
+	cmd.Flags().Int("oom-score-adj", 0, "Tune container’s OOM preferences (-1000 to 1000)")
 	cmd.Flags().String("pid", "", "PID namespace to use")
 	cmd.RegisterFlagCompletionFunc("pid", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"host"}, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containerd/nerdctl/pkg/testutil"
 
@@ -330,4 +331,15 @@ func TestRunWithFluentdLogDriverWithLogOpt(t *testing.T) {
 	logData := string(data)
 	assert.Equal(t, true, strings.Contains(logData, "test2"))
 	assert.Equal(t, true, strings.Contains(logData, inspectedContainer.ID))
+}
+
+func TestRunWithOOMScoreAdj(t *testing.T) {
+	if rootlessutil.IsRootless() {
+		t.Skip("test skipped for rootless containers.")
+	}
+	t.Parallel()
+	base := testutil.NewBase(t)
+	var score = "-42"
+
+	base.Cmd("run", "--rm", "--oom-score-adj", score, testutil.AlpineImage, "cat", "/proc/self/oom_score_adj").AssertOutContains(score)
 }


### PR DESCRIPTION
This PR adds support for --oom-score-adj on
root mode only.

Testing details

```
➜  nerdctl git:(oom-score-adj) ✗ make && sudo make install && go test -v ./cmd/... -exec sudo -run TestRunWithOOMScoreAdj
GO111MODULE=on CGO_ENABLED=0 GOOS=linux go build -ldflags "-s -w -X github.com/containerd/nerdctl/pkg/version.Version=v0.21.0-143-g825e6f1 -X github.com/containerd/nerdctl/pkg/version.Revision=825e6f13da817e7c706eb0a52aa1ac5173186d19"  -o /home/manu/go/src/github.com/containerd/nerdctl/_output/nerdctl github.com/containerd/nerdctl/cmd/nerdctl
[sudo] password for manu: 
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/_output/nerdctl /usr/local/bin/nerdctl
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/extras/rootless/containerd-rootless.sh /usr/local/bin/containerd-rootless.sh
install -D -m 755 /home/manu/go/src/github.com/containerd/nerdctl/extras/rootless/containerd-rootless-setuptool.sh /usr/local/bin/containerd-rootless-setuptool.sh
test target: "nerdctl"
=== RUN   TestRunWithOOMScoreAdj
=== PAUSE TestRunWithOOMScoreAdj
=== CONT  TestRunWithOOMScoreAdj
--- PASS: TestRunWithOOMScoreAdj (0.33s)
PASS
ok      github.com/containerd/nerdctl/cmd/nerdctl       0.351s
➜  nerdctl git:(oom-score-adj) ✗ 
```

Signed-off-by: Manu Gupta <manugupt1@gmail.com>