### PR TITLE
add label display support in ps subcommand

### DIFF
--- a/cmd/nerdctl/ps.go
+++ b/cmd/nerdctl/ps.go
@@ -115,7 +115,8 @@ type containerPrintable struct {
 	Status    string
 	Runtime   string // nerdctl extension
 	Size      string
-	// TODO: "Labels", "LocalVolumes", "Mounts", "Networks", "RunningFor",  "State"
+	Labels    string
+	// TODO: "LocalVolumes", "Mounts", "Networks", "RunningFor", "State"
 }
 
 func printContainers(ctx context.Context, client *containerd.Client, cmd *cobra.Command, containers []containerd.Container, all bool) error {
@@ -216,6 +217,7 @@ func printContainers(ctx context.Context, client *containerd.Client, cmd *cobra.
 			Ports:     formatter.FormatPorts(info.Labels),
 			Status:    cStatus,
 			Runtime:   info.Runtime.Name,
+			Labels:    formatter.FormatLabels(info.Labels),
 		}
 
 		if size || wide {

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -135,3 +135,13 @@ func FormatPorts(labelMap map[string]string) string {
 func TimeSinceInHuman(since time.Time) string {
 	return fmt.Sprintf("%s ago", units.HumanDuration(time.Since(since)))
 }
+
+func FormatLabels(labelMap map[string]string) string {
+	strs := make([]string, len(labelMap))
+	idx := 0
+	for i := range labelMap {
+		strs[idx] = fmt.Sprintf("%s=%s", i, labelMap[i])
+		idx++
+	}
+	return strings.Join(strs, ",")
+}

--- a/pkg/strutil/strutil.go
+++ b/pkg/strutil/strutil.go
@@ -84,6 +84,8 @@ func DedupeStrSlice(in []string) []string {
 // ParseCSVMap parses a string like "foo=x,bar=y" into a map
 func ParseCSVMap(s string) (map[string]string, error) {
 	csvR := csv.NewReader(strings.NewReader(s))
+	// s can contains quotes, but the csv reader needs LazyQuotes to recognize quotes as values.
+	csvR.LazyQuotes = true
 	ra, err := csvR.ReadAll()
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse %q: %w", s, err)

--- a/pkg/strutil/strutil_test.go
+++ b/pkg/strutil/strutil_test.go
@@ -252,6 +252,19 @@ func TestParseCSVMap(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "normal-2",
+			args: args{
+				s: "foo=\"x,bar=y,baz=\"z\",qux",
+			},
+			want: map[string]string{
+				"foo": "\"x",
+				"bar": "y",
+				"baz": "\"z\"",
+				"qux": "",
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid",
 			args: args{
 				s: "sssssss\nsss",


### PR DESCRIPTION
Signed-off-by: Min Uk Lee <minuk.dev@gmail.com>

Some projects like [kind](https://github.com/kubernetes-sigs/kind) uses labels to distinguish containers.
(e.g. https://github.com/kubernetes-sigs/kind/blob/982df26f902085469d18e109a245965aa81b7f32/pkg/cluster/internal/providers/docker/provision.go#L139,
https://github.com/kubernetes-sigs/kind/blob/982df26f902085469d18e109a245965aa81b7f32/pkg/cluster/internal/providers/docker/provider.go#L105)
Therefore, need to display labels.

Example usage

```bash
$ nerdctl run --label key1=value1,key2=value2 hello-world
# skip output
$ nerdctl ps -a --format=json
# {"Command":"\"/hello\"","CreatedAt":"2022-07-23 18:56:54 +0000 UTC","ID":"bf6dda95ce71","Image":"docker.io/library/hello-world:latest","Platform":"linux/arm64/v8","Names":"hello-world-bf6dd","Ports":"","Status":"Exited (0) 35 seconds ago","Runtime":"io.containerd.runc.v2","Size":"","Labels":"key1=value1,key2=value2,io.containerd.image.config.stop-signal=SIGTERM"}
```