### PR TITLE
Fix stats values

### DIFF
--- a/cmd/nerdctl/stats_freebsd.go
+++ b/cmd/nerdctl/stats_freebsd.go
@@ -21,8 +21,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/statsutil"
 )
 
-func renderStatsEntry(previousStats map[string]uint64, anydata interface{}, pid int, interfaces []native.NetInterface) (statsutil.StatsEntry, error) {
-
+func setContainerStatsAndRenderStatsEntry(previousStats *statsutil.ContainerStats, firstSet bool, anydata interface{}, pid int, interfaces []native.NetInterface) (statsutil.StatsEntry, error) {
 	return statsutil.StatsEntry{}, nil
-
 }

--- a/cmd/nerdctl/stats_windows.go
+++ b/cmd/nerdctl/stats_windows.go
@@ -21,8 +21,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/statsutil"
 )
 
-func renderStatsEntry(previousStats map[string]uint64, anydata interface{}, pid int, interfaces []native.NetInterface) (statsutil.StatsEntry, error) {
-
+func setContainerStatsAndRenderStatsEntry(previousStats *statsutil.ContainerStats, firstSet bool, anydata interface{}, pid int, interfaces []native.NetInterface) (statsutil.StatsEntry, error) {
 	return statsutil.StatsEntry{}, nil
-
 }

--- a/pkg/statsutil/stats.go
+++ b/pkg/statsutil/stats.go
@@ -19,6 +19,7 @@ package statsutil
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	units "github.com/docker/go-units"
 )
@@ -57,6 +58,13 @@ type Stats struct {
 	mutex sync.RWMutex
 	StatsEntry
 	err error
+}
+
+// ContainerStats represents the runtime container stats
+type ContainerStats struct {
+	Time                        time.Time
+	CgroupCPU, Cgroup2CPU       uint64
+	CgroupSystem, Cgroup2System uint64
 }
 
 //NewStats is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L113-L116


### PR DESCRIPTION
````
# nerdctl run -d --name alpine sleep infinity
3601cbfea60f9f78a3b82df87ac710b69ee5f2100ee11b0957ce95eb61af81a5

# nerdctl stats
CONTAINER ID   NAME           CPU %     MEM USAGE / LIMIT   MEM %     NET I/O          BLOCK I/O         PIDS
3601cbfea60f   alpine-c532b   183.65%    1.848MiB / 16EiB    0.00%     2.6kB / 1.17kB   1.45MB / 8.19kB   8

````
After 
````
# nerdctl run -d --name alpine sleep infinity
e201b14489a5f2cf0e50e72203d5fcef19a78f118f138039fac642675e1fb6f6

# nerdctl stats
CONTAINER ID   NAME           CPU %     MEM USAGE / LIMIT   MEM %     NET I/O          BLOCK I/O         PIDS
e201b14489a5   alpine-c532b   99.74%    1.848MiB / 16EiB    0.00%     2.6kB / 1.17kB   1.45MB / 8.19kB   8
````
We are close to docker stats

fixing https://github.com/containerd/nerdctl/issues/1240
refacto stats && Fix stats values