### PR TITLE
optimize tests of stop the sleep container 

### DIFF
--- a/cmd/nerdctl/container_prune_linux_test.go
+++ b/cmd/nerdctl/container_prune_linux_test.go
@@ -36,7 +36,7 @@ func TestPruneContainer(t *testing.T) {
 	base.Cmd("inspect", tID+"-1").AssertOK()
 	base.Cmd("inspect", tID+"-2").AssertFail()
 
-	base.Cmd("stop", tID+"-1").AssertOK()
+	base.Cmd("kill", tID+"-1").AssertOK()
 	base.Cmd("container", "prune", "-f").AssertOK()
 	base.Cmd("inspect", tID+"-1").AssertFail()
 }

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -77,7 +77,7 @@ func TestIPFSCommit(t *testing.T) {
 	newContainer, newImg := tID, tID+":v1"
 	base.Cmd("run", "--name", newContainer, "-d", ipfsCID, "/bin/sh", "-c", "echo hello > /hello ; sleep 10000").AssertOK()
 	base.Cmd("commit", newContainer, newImg).AssertOK()
-	base.Cmd("stop", newContainer).AssertOK()
+	base.Cmd("kill", newContainer).AssertOK()
 	base.Cmd("rm", newContainer).AssertOK()
 	ipfsCID2 := cidOf(t, base.Cmd("push", "ipfs://"+newImg).OutLines())
 	rmiAll(base)
@@ -115,7 +115,7 @@ func TestIPFSWithLazyPullingCommit(t *testing.T) {
 	newContainer, newImg := tID, tID+":v1"
 	base.Cmd("run", "--name", newContainer, "-d", ipfsCID, "/bin/sh", "-c", "echo hello > /hello ; sleep 10000").AssertOK()
 	base.Cmd("commit", newContainer, newImg).AssertOK()
-	base.Cmd("stop", newContainer).AssertOK()
+	base.Cmd("kill", newContainer).AssertOK()
 	base.Cmd("rm", newContainer).AssertOK()
 	ipfsCID2 := cidOf(t, base.Cmd("push", "--estargz", "ipfs://"+newImg).OutLines())
 	rmiAll(base)

--- a/cmd/nerdctl/run_network.go
+++ b/cmd/nerdctl/run_network.go
@@ -272,6 +272,7 @@ func verifyCNINetwork(cmd *cobra.Command, netSlice []string) error {
 	}
 	return nil
 }
+
 func verifyContainerNetwork(cmd *cobra.Command, netSlice []string) error {
 	if cmd.Flags().Changed("publish") {
 		return fmt.Errorf("conflicting options: port publishing and the container type network mode")

--- a/cmd/nerdctl/run_network_linux_test.go
+++ b/cmd/nerdctl/run_network_linux_test.go
@@ -511,28 +511,21 @@ func TestSharedNetworkStack(t *testing.T) {
 		testutil.NginxAlpineImage).AssertOK()
 	base.EnsureContainerStarted(containerName)
 
-	containerNameJoin := testutil.Identifier(t) + "-nework"
+	containerNameJoin := testutil.Identifier(t) + "-network"
 	defer base.Cmd("rm", "-f", containerNameJoin).AssertOK()
-	cmd := base.Cmd("run",
+	base.Cmd("run",
 		"-d",
 		"--name", containerNameJoin,
 		"--network=container:"+containerName,
 		testutil.CommonImage,
-		"sleep", "infinity")
-	cmd.AssertOK()
+		"sleep", "infinity").AssertOK()
 
 	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
 		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
 
 	base.Cmd("restart", containerName).AssertOK()
-	base.Cmd("restart", containerNameJoin).AssertOK()
-	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
-		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
-
-	base.Cmd("restart", containerName).AssertOK()
-	base.Cmd("stop", containerNameJoin).AssertOK()
+	base.Cmd("stop", "--time=1", containerNameJoin).AssertOK()
 	base.Cmd("start", containerNameJoin).AssertOK()
 	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
 		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
-
 }


### PR DESCRIPTION
Signed-off-by: Ye Sijun <junnplus@gmail.com>

Stop a sleep container always need to wait for 10s, it's so slow.

Before:
```sh
$ go test -v ./cmd/nerdctl/... -exec sudo -run TestSharedNetworkStack
test target: "nerdctl"
=== RUN   TestSharedNetworkStack
    run_network_linux_test.go:512: container nerdctl-testsharednetworkstack is now running
--- PASS: TestSharedNetworkStack (22.34s)
PASS
ok      github.com/containerd/nerdctl/cmd/nerdctl       22.369s
```

After: 
```sh
$ go test -v ./cmd/nerdctl/... -exec sudo -run TestSharedNetworkStack
test target: "nerdctl"
=== RUN   TestSharedNetworkStack
    run_network_linux_test.go:512: container nerdctl-testsharednetworkstack is now running
--- PASS: TestSharedNetworkStack (2.62s)
PASS
ok      github.com/containerd/nerdctl/cmd/nerdctl       2.656s
```