### PR TITLE
Add the ability to inspect volume sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,7 @@ Usage: `nerdctl volume inspect [OPTIONS] VOLUME [VOLUME...]`
 
 Flags:
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
+- :nerd_face: `--size`: Displays disk usage of volume
 
 ### :whale: nerdctl volume rm
 Remove one or more volumes

--- a/cmd/nerdctl/volume_inspect_test.go
+++ b/cmd/nerdctl/volume_inspect_test.go
@@ -17,8 +17,13 @@
 package main
 
 import (
+	"crypto/rand"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"gotest.tools/v3/assert"
 )
@@ -28,12 +33,37 @@ func TestVolumeInspectContainsLabels(t *testing.T) {
 	testVolume := testutil.Identifier(t)
 
 	base := testutil.NewBase(t)
+	base.Cmd("volume", "create", "--label", "tag=testVolume", testVolume).AssertOK()
 	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
 
-	base.Cmd("volume", "create", "--label", "tag=testVolume", testVolume).AssertOK()
 	inspect := base.InspectVolume(testVolume)
 	inspectNerdctlLabels := (*inspect.Labels)
 	expected := make(map[string]string, 1)
 	expected["tag"] = "testVolume"
 	assert.DeepEqual(base.T, expected, inspectNerdctlLabels)
+}
+
+func TestVolumeInspectSize(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	testVolume := testutil.Identifier(t)
+	base := testutil.NewBase(t)
+	base.Cmd("volume", "create", testVolume).AssertOK()
+	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
+
+	cmdResult := base.Cmd("volume", "inspect", "--size", testVolume).Run()
+	var dc []native.Volume
+	err := json.Unmarshal([]byte(cmdResult.Stdout()), &dc)
+	assert.NilError(t, err)
+	var mountpoint = dc[0].Mountpoint
+
+	token := make([]byte, 1028)
+	rand.Read(token)
+	err = os.WriteFile(filepath.Join(mountpoint, "test-file"), token, 0644)
+	assert.NilError(t, err)
+	cmdResult = base.Cmd("volume", "inspect", "--size", testVolume).Run()
+	assert.NilError(t, err)
+	err = json.Unmarshal([]byte(cmdResult.Stdout()), &dc)
+	assert.NilError(t, err)
+	assert.Equal(t, dc[0].Size, int64(1028))
 }

--- a/pkg/inspecttypes/native/volume.go
+++ b/pkg/inspecttypes/native/volume.go
@@ -21,4 +21,5 @@ type Volume struct {
 	Name       string             `json:"Name"`
 	Mountpoint string             `json:"Mountpoint"`
 	Labels     *map[string]string `json:"Labels,omitempty"`
+	Size       int64              `json:"Size,omitempty"`
 }


### PR DESCRIPTION
Introduce a --size flag on volume inspect to inspect a volume
size. The flag is an explicit option because it can be slow and
not everyone might want it.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>