### PR TITLE
go-ipfs (0.13.1) -> Kubo (0.14.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG BYPASS4NETNS_VERSION=v0.2.2
 ARG FUSE_OVERLAYFS_VERSION=v1.9
 ARG CONTAINERD_FUSE_OVERLAYFS_VERSION=v1.0.4
 # Extra deps: IPFS
-ARG IPFS_VERSION=v0.13.1
+ARG KUBO_VERSION=v0.14.0
 # Extra deps: Init
 ARG TINI_VERSION=v0.19.0
 # Extra deps: Debug
@@ -191,14 +191,14 @@ RUN fname="containerd-fuse-overlayfs-${CONTAINERD_FUSE_OVERLAYFS_VERSION/v}-${TA
   tar xzf "${fname}" -C /out/bin && \
   rm -f "${fname}" && \
   echo "- containerd-fuse-overlayfs: ${CONTAINERD_FUSE_OVERLAYFS_VERSION}" >> /out/share/doc/nerdctl-full/README.md
-ARG IPFS_VERSION
-RUN fname="go-ipfs_${IPFS_VERSION}_${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz" && \
-  curl -o "${fname}" -fSL "https://github.com/ipfs/go-ipfs/releases/download/${IPFS_VERSION}/${fname}" && \
-  grep "${fname}" "/SHA256SUMS.d/go-ipfs-${IPFS_VERSION}" | sha256sum -c && \
+ARG KUBO_VERSION
+RUN fname="kubo_${KUBO_VERSION}_${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz" && \
+  curl -o "${fname}" -fSL "https://github.com/ipfs/kubo/releases/download/${KUBO_VERSION}/${fname}" && \
+  grep "${fname}" "/SHA256SUMS.d/kubo-${KUBO_VERSION}" | sha256sum -c && \
   tmpout=$(mktemp -d) && \
-  tar -C ${tmpout} -xzf "${fname}" go-ipfs/ipfs && \
-  mv ${tmpout}/go-ipfs/ipfs /out/bin/ && \
-  echo "- IPFS: ${IPFS_VERSION}" >> /out/share/doc/nerdctl-full/README.md
+  tar -C ${tmpout} -xzf "${fname}" kubo/ipfs && \
+  mv ${tmpout}/kubo/ipfs /out/bin/ && \
+  echo "- Kubo (IPFS): ${KUBO_VERSION}" >> /out/share/doc/nerdctl-full/README.md
 ARG TINI_VERSION
 RUN fname="tini-static-${TARGETARCH:-amd64}" && \
   curl -o "${fname}" -fSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${fname}" && \
@@ -217,7 +217,7 @@ RUN echo "" >> /out/share/doc/nerdctl-full/README.md && \
   echo "## License" >> /out/share/doc/nerdctl-full/README.md && \
   echo "- bin/slirp4netns:    [GNU GENERAL PUBLIC LICENSE, Version 2](https://github.com/rootless-containers/slirp4netns/blob/${SLIRP4NETNS_VERSION}/COPYING)" >> /out/share/doc/nerdctl-full/README.md && \
   echo "- bin/fuse-overlayfs: [GNU GENERAL PUBLIC LICENSE, Version 3](https://github.com/containers/fuse-overlayfs/blob/${FUSE_OVERLAYFS_VERSION}/COPYING)" >> /out/share/doc/nerdctl-full/README.md && \
-  echo "- bin/ipfs: [Combination of MIT-only license and dual MIT/Apache-2.0 license](https://github.com/ipfs/go-ipfs/blob/${IPFS_VERSION}/LICENSE)" >> /out/share/doc/nerdctl-full/README.md && \
+  echo "- bin/ipfs: [Combination of MIT-only license and dual MIT/Apache-2.0 license](https://github.com/ipfs/kubo/blob/${KUBO_VERSION}/LICENSE)" >> /out/share/doc/nerdctl-full/README.md && \
   echo "- bin/{runc,bypass4netns,bypass4netnsd}: Apache License 2.0, statically linked with libseccomp ([LGPL 2.1](https://github.com/seccomp/libseccomp/blob/main/LICENSE), source code available at https://github.com/seccomp/libseccomp/)" >> /out/share/doc/nerdctl-full/README.md && \
   echo "- bin/tini: [MIT License](https://github.com/krallin/tini/blob/${TINI_VERSION}/LICENSE)" >> /out/share/doc/nerdctl-full/README.md && \
   echo "- Other files: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)" >> /out/share/doc/nerdctl-full/README.md && \

--- a/Dockerfile.d/SHA256SUMS.d/go-ipfs-v0.13.1
+++ b/Dockerfile.d/SHA256SUMS.d/go-ipfs-v0.13.1
@@ -1,3 +1,0 @@
-# From https://github.com/ipfs/go-ipfs/releases
-0506a4bd0edc8c6c80cd6403b20e76fc9241a41b32ebeb8e58618d660ddf4361  go-ipfs_v0.13.1_linux-amd64.tar.gz
-1f69b183714a2d392fc6aee098b0df11f03160d1d0b165837b125e399b19acff  go-ipfs_v0.13.1_linux-arm64.tar.gz

--- a/Dockerfile.d/SHA256SUMS.d/kubo-v0.14.0
+++ b/Dockerfile.d/SHA256SUMS.d/kubo-v0.14.0
@@ -1,0 +1,3 @@
+# From https://github.com/ipfs/kubo/releases
+edaace86c6019cfe0e3125f944f69a94fd91040cf6812988a23a61fcfe9fe54d  kubo_v0.14.0_linux-amd64.tar.gz
+5720cb956e1d5ab59f0ad68743818a5c238fbf4c604f1b10e44aa78cad592a87  kubo_v0.14.0_linux-arm64.tar.gz

--- a/docs/ipfs.md
+++ b/docs/ipfs.md
@@ -9,8 +9,8 @@ IPFS support is completely optional. Your host is NOT connected to any P2P netwo
 
 ## Prerequisites
 
-To use this feature, make sure `ipfs daemon` is running on your host.
-For example, you can run an IPFS daemon using the following command.
+To use this feature, make sure an IPFS daemon such as [Kubo](https://github.com/ipfs/kubo) (former go-ipfs) is running on your host.
+For example, you can run Kubo using the following command.
 
 ```
 ipfs daemon

--- a/examples/nerdctl-ipfs-registry-kubernetes/README.md
+++ b/examples/nerdctl-ipfs-registry-kubernetes/README.md
@@ -2,7 +2,7 @@
 
 Usage:
 - Generate `bootstrap.yaml` by executing `bootstrap.yaml.sh` (e.g. `./bootstrap.yaml.sh > ${DIR_LOCATION}/bootstrap.yaml`)
-  - [`ipfs-swarm-key-gen`](https://github.com/Kubuxu/go-ipfs-swarm-key-gen) is required (see https://github.com/ipfs/go-ipfs/blob/v0.10.0/docs/experimental-features.md#private-networks)
+  - [`ipfs-swarm-key-gen`](https://github.com/Kubuxu/go-ipfs-swarm-key-gen) is required (see https://github.com/ipfs/kubo/blob/v0.14.0/docs/experimental-features.md#private-networks)
 - Deploy `bootstrap.yaml` and `nerdctl-ipfs-registry.yaml` (e.g. using `kubectl apply`)
 - Make sure nodes contain containerd >= v1.5.8
 


### PR DESCRIPTION
go-ipfs was renamed to Kubo
https://github.com/ipfs/kubo/releases/tag/v0.14.0

The file name of the `ipfs` binary is unchanged

```
$ tar tf kubo_v0.14.0_linux-amd64.tar.gz
kubo/LICENSE
kubo/LICENSE-APACHE
kubo/LICENSE-MIT
kubo/README.md
kubo/install.sh
kubo/ipfs
```
- - -

Planning to release nerdctl  v0.22.1 soon with this