### PR TITLE
run: add a new `privileged-without-host-devices` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Security flags:
 - :whale: `--security-opt seccomp=<PROFILE_JSON_FILE>`: specify custom seccomp profile
 - :whale: `--security-opt apparmor=<PROFILE>`: specify custom AppArmor profile
 - :whale: `--security-opt no-new-privileges`: disallow privilege escalation, e.g., setuid and file capabilities
+- :nerd_face: `--security-opt privileged-without-host-devices`: Don't pass host devices to privileged containers
 - :whale: `--cap-add=<CAP>`: Add Linux capabilities
 - :whale: `--cap-drop=<CAP>`: Drop Linux capabilities
 - :whale: `--privileged`: Give extended privileges to this container

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -188,7 +188,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	// #region security flags
 	cmd.Flags().StringArray("security-opt", []string{}, "Security options")
 	cmd.RegisterFlagCompletionFunc("security-opt", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"seccomp=", "seccomp=unconfined", "apparmor=", "apparmor=" + defaults.AppArmorProfileName, "apparmor=unconfined", "no-new-privileges"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"seccomp=", "seccomp=unconfined", "apparmor=", "apparmor=" + defaults.AppArmorProfileName, "apparmor=unconfined", "no-new-privileges", "privileged-without-host-devices"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	// cap-add and cap-drop are defined as StringSlice, not StringArray, to allow specifying "--cap-add=CAP_SYS_ADMIN,CAP_NET_ADMIN" (compatible with Podman)
 	cmd.Flags().StringSlice("cap-add", []string{}, "Add Linux capabilities")

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -93,23 +93,20 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 		opts = append(opts, capOpts...)
 	}
 
+	privileged, err := cmd.Flags().GetBool("privileged")
+	if err != nil {
+		return nil, err
+	}
+
 	securityOpt, err := cmd.Flags().GetStringArray("security-opt")
 	if err != nil {
 		return nil, err
 	}
 	securityOptsMaps := strutil.ConvertKVStringsToMap(strutil.DedupeStrSlice(securityOpt))
-	if secOpts, err := generateSecurityOpts(securityOptsMaps); err != nil {
+	if secOpts, err := generateSecurityOpts(privileged, securityOptsMaps); err != nil {
 		return nil, err
 	} else {
 		opts = append(opts, secOpts...)
-	}
-
-	privileged, err := cmd.Flags().GetBool("privileged")
-	if err != nil {
-		return nil, err
-	}
-	if privileged {
-		opts = append(opts, privilegedOpts...)
 	}
 
 	b4nnOpts, err := bypass4netnsutil.GenerateBypass4netnsOpts(securityOptsMaps, labelsMap, id)

--- a/pkg/maputil/maputil.go
+++ b/pkg/maputil/maputil.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package maputil
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// MapBoolValueAsOpt will parse key as a command-line option.
+// If only key is specified will be treated as true,
+// otherwise, the value will be parsed and returned.
+// This is useful when command line flags have options.
+// Following examples illustrate this:
+// --security-opt xxx returns true
+// --security-opt xxx=true returns true
+// --security-opt xxx=false returns false
+// --security-opt xxx=invalid returns false and error
+func MapBoolValueAsOpt(m map[string]string, key string) (bool, error) {
+	if str, ok := m[key]; ok {
+		if str == "" {
+			return true, nil
+		} else {
+			b, err := strconv.ParseBool(str)
+			if err != nil {
+				return false, fmt.Errorf("invalid \"%s\" value: %q: %w", key, str, err)
+			}
+			return b, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/maputil/maputil_test.go
+++ b/pkg/maputil/maputil_test.go
@@ -1,0 +1,77 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package maputil
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestMapBoolValueAsOpt(t *testing.T) {
+	tests := []struct {
+		m       map[string]string
+		key     string
+		want    bool
+		wantErr bool
+	}{
+		// cases that key does not exist
+		{
+			m:       map[string]string{},
+			key:     "key",
+			want:    false,
+			wantErr: false,
+		},
+		// key exist, but has no value
+		{
+			m:       map[string]string{"key": ""},
+			key:     "key",
+			want:    true,
+			wantErr: false,
+		},
+		// key exist, and set to true
+		{
+			m:       map[string]string{"key": "true"},
+			key:     "key",
+			want:    true,
+			wantErr: false,
+		},
+		// key exist, and set to false
+		{
+			m:       map[string]string{"key": "false"},
+			key:     "key",
+			want:    false,
+			wantErr: false,
+		},
+		// cases with error
+		{
+			m:       map[string]string{"key": "abc"},
+			key:     "key",
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for i, tt := range tests {
+		got, err := MapBoolValueAsOpt(tt.m, tt.key)
+		assert.Equal(t, got, tt.want, fmt.Sprintf("case %d", (i+1)))
+		if (err != nil) != tt.wantErr {
+			t.Errorf("MapBoolValueAsOpt() case %d error = %v, wantErr %v", (i + 1), err, tt.wantErr)
+		}
+	}
+}


### PR DESCRIPTION
Containers with  --privileged enabled will default pass all
devices on the host side to containers, but for runtimes
like Kata Containers, this action will bring up some issues,
for example permission or naming conflict, add a new command
line option `--privileged-without-host-devices` will not pass
all host devices to containers, if needed, users can pass
devices by `--device` option.

Fixes: #1290

Signed-off-by: bin liu <liubin0329@gmail.com>