### PR TITLE
golangci-lint: remove deprecated linters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.2.0
       with:
-        version: v1.48.0
+        version: v1.49.0
         args: --verbose
 
   test-unit:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,6 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - depguard
     - gofmt
     - goimports
@@ -14,9 +13,7 @@ linters:
     - misspell
     - nakedret
     - prealloc
-    - structcheck
     - typecheck
-    - varcheck
     # - asciicheck
     # - bodyclose
     # - dogsled
@@ -61,7 +58,7 @@ linters:
     # - tparallel
     # - unconvert
     # - unparam
-    # - unused
+    - unused
     # - whitespace
     # - wrapcheck
     # - wsl


### PR DESCRIPTION
golangci-lint 1.49 deprecated the `varcheck`, `deadcode`, and `structcheck` linters in favor of the `unused` linter.

- golangci/golangci-lint#3125
