### PR TITLE
replace use of deprecated sys.RunningInUserNS

### DIFF
--- a/cmd/nerdctl/run_cgroup_linux_test.go
+++ b/cmd/nerdctl/run_cgroup_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/containerd/cgroups"
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/testutil/loopback"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"gotest.tools/v3/assert"
@@ -74,7 +74,7 @@ func TestRunCgroupV2(t *testing.T) {
 0
 `
 
-	//In CgroupV2 CPUWeight replace CPUShares => weight := 1 + ((shares-2)*9999)/262142
+	// In CgroupV2 CPUWeight replace CPUShares => weight := 1 + ((shares-2)*9999)/262142
 	base.Cmd("run", "--rm",
 		"--cpus", "0.42", "--cpuset-mems", "0",
 		"--memory", "42m",
@@ -166,7 +166,7 @@ func TestRunCgroupV1(t *testing.T) {
 }
 
 func TestRunDevice(t *testing.T) {
-	if os.Geteuid() != 0 || sys.RunningInUserNS() {
+	if os.Geteuid() != 0 || userns.RunningInUserNS() {
 		t.Skip("test requires the root in the initial user namespace")
 	}
 

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/pkg/strutil"
@@ -142,7 +142,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		Destination: dst,
 		Options:     options,
 	}
-	if sys.RunningInUserNS() {
+	if userns.RunningInUserNS() {
 		unpriv, err := getUnprivilegedMountFlags(src)
 		if err != nil {
 			return nil, err

--- a/pkg/rootlessutil/child.go
+++ b/pkg/rootlessutil/child.go
@@ -19,9 +19,9 @@ package rootlessutil
 import (
 	"os"
 
-	"github.com/containerd/containerd/sys"
+	"github.com/containerd/containerd/pkg/userns"
 )
 
 func IsRootlessChild() bool {
-	return !IsRootlessParent() && sys.RunningInUserNS() && os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
+	return !IsRootlessParent() && userns.RunningInUserNS() && os.Getenv("ROOTLESSKIT_STATE_DIR") != ""
 }


### PR DESCRIPTION
Noticed this while looking for external consumers of functions in containerd's `sys` package 😄