### PR TITLE
Implements logURI to support 3rd party ctrd shim logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,8 @@ Logging flags:
         - :whale: `--log-opt=fluentd-sub-second-precision=<true|false>`: Enable sub-second precision for fluentd. The default value is false.
         - :nerd_face: `--log-opt=fluentd-async-reconnect-interval=<1s|1ms>`: The time to wait before retrying to reconnect to fluentd. The default value is 0s.
         - :nerd_face: `--log-opt=fluentd-request-ack=<true|false>`: Enable request ack for fluentd. The default value is false.
+    - :nerd_face: Accepts a LogURI which is a containerd shim logger. A scheme must be specified for the URI. Example: `nerdctl run -d --log-driver binary:///usr/bin/ctr-journald-shim docker.io/library/hello-world:latest`. An implementation of shim logger can be found at (https://github.com/containerd/containerd/tree/dbef1d56d7ebc05bc4553d72c419ed5ce025b05d/runtime/v2#logging)
+
 
 Shared memory flags:
 - :whale: `--ipc`: IPC namespace to use


### PR DESCRIPTION
Testing details

Custom built the journld shim logger

```
nerdctl run -d --log-driver binary:/home/manu/go/src/github.com/manugupt1/ctr-journald-shim/ctr-journald-shim docker.io/library/hello-world:latest
```

Journalctl logs
```
ep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: Hello from Docker!
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: This message shows that your installation appears to be working correctly.
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: To generate this message, Docker took the following steps:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  1. The Docker client contacted the Docker daemon.
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  2. The Docker daemon pulled the "hello-world" image from the Docker Hub.
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:     (amd64)
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  3. The Docker daemon created a new container from that image which runs the
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:     executable that produces the output you are currently reading.
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  4. The Docker daemon streamed that output to the Docker client, which sent it
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:     to your terminal.
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: To try something more ambitious, you can run an Ubuntu container with:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  $ docker run -it ubuntu bash
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: Share images, automate workflows, and more with a free Docker ID:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  https://hub.docker.com/
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]: For more examples and ideas, visit:
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:  https://docs.docker.com/get-started/
Sep 05 15:36:24 fedora default:10585b461231fb19106451008cc013f14bfd0fc0fc6bfaa11c3dd81a8f962674[189472]:
Sep 05 15:36:24 fedora containerd-rootless.sh[3083]: time="2022-09-05T15:36:24.411080375-07:00" level=warning msg="error from *cgroupsv2.Manager.EventChan" error="failed to add inotify watch for \"/sys/fs/cgroup/user
```