### PR TITLE
add --pid=container in run command

### DIFF
--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -75,6 +75,18 @@ func TestRunPidHost(t *testing.T) {
 	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
 }
 
+func TestRunPidContainer(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+
+	sharedContainerResult := base.Cmd("run", "-d", testutil.AlpineImage, "sleep", "30").Run()
+	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
+	defer base.Cmd("rm", "-f", baseContainerID).Run()
+
+	base.Cmd("run", "--rm", fmt.Sprintf("--pid=container:%s", baseContainerID),
+		testutil.AlpineImage, "ps", "ax").AssertOutContains("sleep 30")
+}
+
 func TestRunIpcHost(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)


### PR DESCRIPTION
Signed-off-by: Min Uk Lee <minuk.dev@gmail.com>

#1293 
references:
- [github moby/moby/daemon/oci_linux.go#L297-L314](https://github.com/moby/moby/blob/500c026818e5f571a64273c155a0f3bc38a7ebe2/daemon/oci_linux.go#L297-L314)

---
### Why this pr is draft pr?

- For getting container's pid, this function needs  a `containerd.Client` instance. It preallocated in `createContainer()` cmd/nerdctl/run.go#L385.
- But, should all `setPlatformOptions()` be changed to pass this variable? I'm not sure about it.
  - Does anyone have any idea?