### PR TITLE
Bump up buildg to v0.4.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG KUBO_VERSION=v0.15.0
 # Extra deps: Init
 ARG TINI_VERSION=v0.19.0
 # Extra deps: Debug
-ARG BUILDG_VERSION=v0.3.0
+ARG BUILDG_VERSION=v0.4.1
 
 # Test deps
 ARG GO_VERSION=1.19

--- a/Dockerfile.d/SHA256SUMS.d/buildg-v0.3.0
+++ b/Dockerfile.d/SHA256SUMS.d/buildg-v0.3.0
@@ -1,2 +1,0 @@
-c57faadd382ae19a48fb6f3e46aa440b6fdb71bc0eaac49080216e9a23371302  buildg-v0.3.0-linux-amd64.tar.gz
-c8b6c18924fbf774351e74a882274bf90048a553b876c4e364cbdc00fa4fecce  buildg-v0.3.0-linux-arm64.tar.gz

--- a/Dockerfile.d/SHA256SUMS.d/buildg-v0.4.1
+++ b/Dockerfile.d/SHA256SUMS.d/buildg-v0.4.1
@@ -1,0 +1,2 @@
+87d047c4742b904e9f0f48427aec5cd157dc96ea97cd89e3ff5b1db171c6eb5e  buildg-v0.4.1-linux-amd64.tar.gz
+44ab3251cef95f0e79e94f54113be962dacf197ad8d5c5b455aa4a6b8d566111  buildg-v0.4.1-linux-arm64.tar.gz


### PR DESCRIPTION
Release note: https://github.com/ktock/buildg/releases/tag/v0.4.1