### PR TITLE
Change login and logout msg from Docker registry to container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -993,7 +993,7 @@ Flags:
 
 ## Registry
 ### :whale: nerdctl login
-Log in to a Docker registry.
+Log in to a container registry.
 
 Usage: `nerdctl login [OPTIONS] [SERVER]`
 
@@ -1003,7 +1003,7 @@ Flags:
 - :whale: `--password-stdin`: Take the password from stdin
 
 ### :whale: nerdctl logout
-Log out from a Docker registry
+Log out from a container registry
 
 Usage: `nerdctl logout [SERVER]`
 

--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -62,7 +62,7 @@ func newLoginCommand() *cobra.Command {
 	var loginCommand = &cobra.Command{
 		Use:           "login [flags] [SERVER]",
 		Args:          cobra.MaximumNArgs(1),
-		Short:         "Log in to a Docker registry",
+		Short:         "Log in to a container registry",
 		RunE:          loginAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/nerdctl/logout.go
+++ b/cmd/nerdctl/logout.go
@@ -28,7 +28,7 @@ func newLogoutCommand() *cobra.Command {
 	var logoutCommand = &cobra.Command{
 		Use:               "logout [flags] [SERVER]",
 		Args:              cobra.MaximumNArgs(1),
-		Short:             "Log out from a Docker registry",
+		Short:             "Log out from a container registry",
 		RunE:              logoutAction,
 		ValidArgsFunction: logoutShellComplete,
 		SilenceUsage:      true,


### PR DESCRIPTION
Changing the message of login/logout from “Docker registry” to “container registry” to make the words more generic and more focused on OCI images and artifacts.

Signed-off-by: Ziwen Ning <ningziwe@amazon.com>