### PR TITLE
Update images usage to contain positional arguments

### DIFF
--- a/cmd/nerdctl/images.go
+++ b/cmd/nerdctl/images.go
@@ -59,14 +59,15 @@ Properties:
 - BLOB SIZE:  Size of the blobs (such as layer tarballs) in the content store
 `
 	var imagesCommand = &cobra.Command{
-		Use:               "images",
-		Short:             shortHelp,
-		Long:              longHelp,
-		Args:              cobra.MaximumNArgs(1),
-		RunE:              imagesAction,
-		ValidArgsFunction: imagesShellComplete,
-		SilenceUsage:      true,
-		SilenceErrors:     true,
+		Use:                   "images [flags] [REPOSITORY[:TAG]]",
+		Short:                 shortHelp,
+		Long:                  longHelp,
+		Args:                  cobra.MaximumNArgs(1),
+		RunE:                  imagesAction,
+		ValidArgsFunction:     imagesShellComplete,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
 	}
 
 	imagesCommand.Flags().BoolP("quiet", "q", false, "Only show numeric IDs")


### PR DESCRIPTION
PR updates the `images` usage line to be consistent with that in [README](https://github.com/containerd/nerdctl#whale-blue_square-nerdctl-images). Changed `OPTIONS` to `flags` because the latter is the term that's displayed in `--help`, and it's also used in other commands like `start`, `stop`, etc.

Before PR:

```
Usage: nerdctl images [flags]
```

After PR:

```
Usage: nerdctl images [flags] [REPOSITORY[:TAG]]
```

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>