### PR TITLE
Add `nerdctl compose version` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose config](#whale-nerdctl-compose-config)
     - [:whale: nerdctl compose kill](#whale-nerdctl-compose-kill)
     - [:whale: nerdctl compose run](#whale-nerdctl-compose-run)
+    - [:whale: nerdctl compose version](#whale-nerdctl-compose-version)
   - [IPFS management](#ipfs-management)
     - [:nerd_face: nerdctl ipfs registry up](#nerd_face-nerdctl-ipfs-registry-up)
     - [:nerd_face: nerdctl ipfs registry down](#nerd_face-nerdctl-ipfs-registry-down)
@@ -1452,6 +1453,15 @@ Usage: `nerdctl compose run`
 Unimplemented `docker-compose run` (V1) flags: `--use-aliases`, `--no-TTY`
 
 Unimplemented `docker compose run` (V2) flags: `--use-aliases`, `--no-TTY`, `--tty`
+
+### :whale: nerdctl compose version
+Show the Compose version information (which is the nerdctl version)
+
+Usage: `nerdctl compose version`
+
+Flags:
+- :whale: `-f, --format`: Format the output. Values: [pretty | json] (default "pretty")
+- :whale: `--short`: Shows only Compose's version number
 
 ## IPFS management
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -60,6 +60,7 @@ func newComposeCommand() *cobra.Command {
 		newComposePsCommand(),
 		newComposeKillCommand(),
 		newComposeRunCommand(),
+		newComposeVersionCommand(),
 	)
 
 	return composeCommand

--- a/cmd/nerdctl/compose_version.go
+++ b/cmd/nerdctl/compose_version.go
@@ -1,0 +1,68 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/version"
+	"github.com/spf13/cobra"
+)
+
+func newComposeVersionCommand() *cobra.Command {
+	var composeVersionCommand = &cobra.Command{
+		Use:           "version",
+		Short:         "Show the Compose version information",
+		Args:          cobra.NoArgs,
+		RunE:          composeVersionAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	composeVersionCommand.Flags().StringP("format", "f", "pretty", "Format the output. Values: [pretty | json]")
+	composeVersionCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"json", "pretty"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	composeVersionCommand.Flags().Bool("short", false, "Shows only Compose's version number")
+	return composeVersionCommand
+}
+
+func composeVersionAction(cmd *cobra.Command, args []string) error {
+	short, err := cmd.Flags().GetBool("short")
+	if err != nil {
+		return err
+	}
+	if short {
+		fmt.Fprintln(cmd.OutOrStdout(), strings.TrimPrefix(version.Version, "v"))
+		return nil
+	}
+
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	switch format {
+	case "pretty":
+		fmt.Fprintln(cmd.OutOrStdout(), "nerdctl Compose version "+version.Version)
+	case "json":
+		fmt.Fprintf(cmd.OutOrStdout(), "{\"version\":\"%v\"}\n", version.Version)
+	default:
+		return fmt.Errorf("format can be either pretty or json, not %v", format)
+	}
+
+	return nil
+}

--- a/cmd/nerdctl/compose_version_test.go
+++ b/cmd/nerdctl/compose_version_test.go
@@ -1,0 +1,40 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeVersion(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.ComposeBinary = "" // test with docker compose version, not docker-compose version
+	base.ComposeCmd("version").AssertOutContains("Compose version ")
+}
+
+func TestComposeVersionShort(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.ComposeCmd("version", "--short").AssertOK()
+}
+
+func TestComposeVersionJson(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.ComposeBinary = "" // test with docker compose version, not docker-compose version
+	base.ComposeCmd("version", "--format", "json").AssertOutContains("{\"version\":\"")
+}


### PR DESCRIPTION
Made it exactly like the Docker compose version. For the actual version, I just used the nerdctl version

Closes #1368 