### PR TITLE
Makefile: Set VERSION & REVISION only if unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ endif
 PACKAGE := github.com/containerd/nerdctl
 BINDIR ?= /usr/local/bin
 
-VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)
-REVISION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
 export GO_BUILD=GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -ldflags "-s -w -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.Revision=$(REVISION)"
 


### PR DESCRIPTION
This is useful while building nerdctl from git tag. For example, while building rpm from a tagged source tarball.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>