### PR TITLE
Support argument `--mac-address` for nerdctl run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,9 @@ Network flags:
 - :whale: `-h, --hostname`: Container host name
 - :whale: `--add-host`: Add a custom host-to-IP mapping (host:ip)
 - :whale: `--ip`: Specific static IP address(es) to use
+- :whale: `--mac-address`: Specific MAC address to use. Be aware that it does not
+  check if manually specified MAC addresses are unique. Supports network
+  type `bridge` and `macvlan`
 
 Resource flags:
 - :whale: `--cpus`: Number of CPUs

--- a/cmd/nerdctl/create_linux_test.go
+++ b/cmd/nerdctl/create_linux_test.go
@@ -17,9 +17,11 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
+	"github.com/containerd/nerdctl/pkg/testutil/nettestutil"
 )
 
 func TestCreate(t *testing.T) {
@@ -32,4 +34,75 @@ func TestCreate(t *testing.T) {
 	base.Cmd("ps", "-a").AssertOutContains("Created")
 	base.Cmd("start", tID).AssertOK()
 	base.Cmd("logs", tID).AssertOutContains("foo")
+}
+
+func TestCreateWithMACAddress(t *testing.T) {
+	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+	networkBridge := "testNetworkBridge" + tID
+	networkMACvlan := "testNetworkMACvlan" + tID
+	networkIPvlan := "testNetworkIPvlan" + tID
+	base.Cmd("network", "create", networkBridge, "--driver", "bridge").AssertOK()
+	base.Cmd("network", "create", networkMACvlan, "--driver", "macvlan").AssertOK()
+	base.Cmd("network", "create", networkIPvlan, "--driver", "ipvlan").AssertOK()
+	t.Cleanup(func() {
+		base.Cmd("network", "rm", networkBridge).Run()
+		base.Cmd("network", "rm", networkMACvlan).Run()
+		base.Cmd("network", "rm", networkIPvlan).Run()
+	})
+	tests := []struct {
+		Network string
+		WantErr bool
+		Expect  string
+	}{
+		{"host", true, "conflicting options"},
+		{"none", true, "can't open '/sys/class/net/eth0/address'"},
+		{"container:whatever" + tID, true, "conflicting options"},
+		{"bridge", false, ""},
+		{networkBridge, false, ""},
+		{networkMACvlan, false, ""},
+		{networkIPvlan, true, "not support"},
+	}
+	for i, test := range tests {
+		containerName := fmt.Sprintf("%s_%d", tID, i)
+		macAddress, err := nettestutil.GenerateMACAddress()
+		if err != nil {
+			t.Errorf("failed to generate MAC address: %s", err)
+		}
+		if test.Expect == "" && !test.WantErr {
+			test.Expect = macAddress
+		}
+		t.Cleanup(func() {
+			base.Cmd("rm", "-f", containerName).Run()
+		})
+		cmd := base.Cmd("create", "--network", test.Network, "--mac-address", macAddress, "--name", containerName, testutil.CommonImage, "cat", "/sys/class/net/eth0/address")
+		if !test.WantErr {
+			cmd.AssertOK()
+			base.Cmd("start", containerName).AssertOK()
+			cmd = base.Cmd("logs", containerName)
+			cmd.AssertOK()
+			cmd.AssertOutContains(test.Expect)
+		} else {
+			if (testutil.GetTarget() == testutil.Docker && test.Network == networkIPvlan) || test.Network == "none" {
+				// 1. unlike nerdctl
+				// when using network ipvlan in Docker
+				// it delays fail on executing start command
+				// 2. start on network none will success in both
+				// nerdctl and Docker
+				cmd.AssertOK()
+				cmd = base.Cmd("start", containerName)
+				if test.Network == "none" {
+					// we check the result on logs command
+					cmd.AssertOK()
+					cmd = base.Cmd("logs", containerName)
+				}
+			}
+			cmd.AssertCombinedOutContains(test.Expect)
+			if test.Network == "none" {
+				cmd.AssertOK()
+			} else {
+				cmd.AssertFail()
+			}
+		}
+	}
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -84,6 +84,8 @@ const (
 
 	// StopTimeout is seconds to wait for stop a container.
 	StopTimout = Prefix + "stop-timeout"
+
+	MACAddress = Prefix + "mac-address"
 )
 
 var ShellCompletions = []string{

--- a/pkg/testutil/nettestutil/nettestutil.go
+++ b/pkg/testutil/nettestutil/nettestutil.go
@@ -17,6 +17,7 @@
 package nettestutil
 
 import (
+	"crypto/rand"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -72,4 +73,15 @@ func NonLoopbackIPv4() (net.IP, error) {
 		return ipv4, nil
 	}
 	return nil, fmt.Errorf("non-loopback IPv4 address not found, attempted=%+v: %w", addrs, errdefs.ErrNotFound)
+}
+
+func GenerateMACAddress() (string, error) {
+	buf := make([]byte, 6)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	// make sure byte 0 (broadcast) of the first byte is not set
+	// and byte 1 (local) is set
+	buf[0] = buf[0]&254 | 2
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", buf[0], buf[1], buf[2], buf[3], buf[4], buf[5]), nil
 }


### PR DESCRIPTION
Fix #1382 

* Support for both `nerdctl run` and `nerdctl create` commands.
* Support for `--network=bridge`.
* Partial support for `--network=<network>` (when actual network types are one of bridge and macvlan).

- [x] Code implementation
- [x] Add integration tests
- [x] Add document

Signed-off-by: Hanchin Hsieh <me@yuchanns.xyz>