### PR TITLE
follow-up TestLoadStdinFromPipe

### DIFF
--- a/cmd/nerdctl/load_linux_test.go
+++ b/cmd/nerdctl/load_linux_test.go
@@ -29,13 +29,12 @@ import (
 )
 
 func TestLoadStdinFromPipe(t *testing.T) {
-	t.Parallel()
 	base := testutil.NewBase(t)
 
 	tmp := t.TempDir()
 	base.Cmd("pull", testutil.CommonImage).AssertOK()
 	base.Cmd("save", testutil.CommonImage, "-o", filepath.Join(tmp, "common.tar")).AssertOK()
-
+	base.Cmd("rmi", testutil.CommonImage).AssertOK()
 	loadCmd := strings.Join(base.Cmd("load").Command, " ")
 	output := filepath.Join(tmp, "output")
 


### PR DESCRIPTION
follow-up https://github.com/containerd/nerdctl/pull/1405

For the consistency of the `TestLoadStdinFromPipe` test,  the image should be removed after saving it.

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>