### PR TITLE
Support --pid=container:xxx for `nerdctl run` cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Basic flags:
 - :whale: `--rm`: Automatically remove the container when it exits
 - :whale: `--pull=(always|missing|never)`: Pull image before running
   - Default: "missing"
-- :whale: `--pid=(host)`: PID namespace to use
+- :whale: `--pid=(host|container:<container>)`: PID namespace to use
 - :whale: `--stop-signal`: Signal to stop a container (default "SIGTERM")
 - :whale: `--stop-timeout`: Timeout (in seconds) to stop a container
 

--- a/cmd/nerdctl/run_freebsd.go
+++ b/cmd/nerdctl/run_freebsd.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/spf13/cobra"
@@ -38,6 +39,10 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]oci.SpecOpts, error) {
+func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]oci.SpecOpts, error) {
 	return opts, nil
+}
+
+func setPlatformContainerOptions(ctx context.Context, cOpts []containerd.NewContainerOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]containerd.NewContainerOpts, error) {
+	return cOpts, nil
 }

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/bypass4netnsutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/docker/go-units"
@@ -55,7 +58,7 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	}
 }
 
-func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]oci.SpecOpts, error) {
+func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]oci.SpecOpts, error) {
 	opts = append(opts,
 		oci.WithDefaultUnixDevices,
 		WithoutRunMount(), // unmount default tmpfs on "/run": https://github.com/containerd/nerdctl/issues/157)
@@ -128,21 +131,15 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 		opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
 	}
 
-	pidNs, err := cmd.Flags().GetString("pid")
+	pid, err := cmd.Flags().GetString("pid")
 	if err != nil {
 		return nil, err
 	}
-	pidNs = strings.ToLower(pidNs)
-	if pidNs != "" {
-		if pidNs != "host" {
-			return nil, fmt.Errorf("invalid pid namespace. Set --pid=host to enable host pid namespace")
-		} else {
-			opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
-			if rootlessutil.IsRootless() {
-				opts = append(opts, withBindMountHostProcfs)
-			}
-		}
+	pidOpts, err := generatePIDOpts(ctx, client, pid)
+	if err != nil {
+		return nil, err
 	}
+	opts = append(opts, pidOpts...)
 
 	ulimitOpts, err := generateUlimitsOpts(cmd)
 	if err != nil {
@@ -192,6 +189,21 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 	return opts, nil
 }
 
+func setPlatformContainerOptions(ctx context.Context, cOpts []containerd.NewContainerOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]containerd.NewContainerOpts, error) {
+	pid, err := cmd.Flags().GetString("pid")
+	if err != nil {
+		return nil, err
+	}
+
+	pidCOpts, err := generatePIDCOpts(ctx, client, pid)
+	if err != nil {
+		return nil, err
+	}
+	cOpts = append(cOpts, pidCOpts...)
+
+	return cOpts, nil
+}
+
 func setOOMScoreAdj(opts []oci.SpecOpts, cmd *cobra.Command) ([]oci.SpecOpts, error) {
 	if !cmd.Flags().Changed("oom-score-adj") {
 		return opts, nil
@@ -216,4 +228,84 @@ func withOOMScoreAdj(score int) oci.SpecOpts {
 		s.Process.OOMScoreAdj = &score
 		return nil
 	}
+}
+
+func generatePIDOpts(ctx context.Context, client *containerd.Client, pid string) ([]oci.SpecOpts, error) {
+	opts := make([]oci.SpecOpts, 0)
+	pid = strings.ToLower(pid)
+
+	switch pid {
+	case "":
+		// do nothing
+	case "host":
+		opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
+		if rootlessutil.IsRootless() {
+			opts = append(opts, withBindMountHostProcfs)
+		}
+	default: // container:<id|name>
+		parsed := strings.Split(pid, ":")
+		if len(parsed) < 2 || parsed[0] != "container" {
+			return nil, fmt.Errorf("invalid pid namespace. Set --pid=[host|container:<name|id>")
+		}
+
+		containerName := parsed[1]
+		walker := &containerwalker.ContainerWalker{
+			Client: client,
+			OnFound: func(ctx context.Context, found containerwalker.Found) error {
+				if found.MatchCount > 1 {
+					return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+				}
+
+				o, err := generateSharingPIDOpts(ctx, found.Container)
+				if err != nil {
+					return err
+				}
+				opts = append(opts, o...)
+
+				return nil
+			},
+		}
+		matchedCount, err := walker.Walk(ctx, containerName)
+		if err != nil {
+			return nil, err
+		}
+		if matchedCount < 1 {
+			return nil, fmt.Errorf("no such container: %s", containerName)
+		}
+	}
+
+	return opts, nil
+}
+
+func generatePIDCOpts(ctx context.Context, client *containerd.Client, pid string) ([]containerd.NewContainerOpts, error) {
+	pid = strings.ToLower(pid)
+
+	cOpts := make([]containerd.NewContainerOpts, 0)
+	parsed := strings.Split(pid, ":")
+	if len(parsed) < 2 || parsed[0] != "container" {
+		// no need to save pid options
+		return cOpts, nil
+	}
+
+	containerName := parsed[1]
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			cOpts = append(cOpts, containerd.WithAdditionalContainerLabels(map[string]string{
+				labels.PIDContainer: containerName,
+			}))
+			return nil
+		},
+	}
+	matchedCount, err := walker.Walk(ctx, containerName)
+	if err != nil {
+		return nil, err
+	}
+	if matchedCount < 1 {
+		return nil, fmt.Errorf("no such container: %s", containerName)
+	}
+	return cOpts, nil
 }

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -75,6 +75,18 @@ func TestRunPidHost(t *testing.T) {
 	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
 }
 
+func TestRunPidContainer(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+
+	sharedContainerResult := base.Cmd("run", "-d", testutil.AlpineImage, "sleep", "infinity").Run()
+	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
+	defer base.Cmd("rm", "-f", baseContainerID).Run()
+
+	base.Cmd("run", "--rm", fmt.Sprintf("--pid=container:%s", baseContainerID),
+		testutil.AlpineImage, "ps", "ax").AssertOutContains("sleep infinity")
+}
+
 func TestRunIpcHost(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)

--- a/cmd/nerdctl/run_windows.go
+++ b/cmd/nerdctl/run_windows.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/docker/go-units"
@@ -40,7 +41,7 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]oci.SpecOpts, error) {
+func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]oci.SpecOpts, error) {
 	cpus, err := cmd.Flags().GetFloat64("cpus")
 	if err != nil {
 		return nil, err
@@ -66,4 +67,8 @@ func setPlatformOptions(opts []oci.SpecOpts, cmd *cobra.Command, id string) ([]o
 		oci.WithWindowsIgnoreFlushesDuringBoot())
 
 	return opts, nil
+}
+
+func setPlatformContainerOptions(ctx context.Context, cOpts []containerd.NewContainerOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]containerd.NewContainerOpts, error) {
+	return cOpts, nil
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -86,6 +86,9 @@ const (
 	StopTimout = Prefix + "stop-timeout"
 
 	MACAddress = Prefix + "mac-address"
+
+	// PIDContainer is the `nerdctl run --pid` for restarting
+	PIDContainer = Prefix + "pid-container"
 )
 
 var ShellCompletions = []string{


### PR DESCRIPTION
#1293 
Signed-off-by: Min Uk Lee <minuk.dev@gmail.com>

### Changes
- support `--pid=container:xxx` for `nerdctl run` command
- extract `generatePIDOpts()` function for pid
- (Updated) update `setPlatformOptions()`
- (Updated) add `setPlatformContainerOptions()` - Details 1
- (Updated) add `PIDContainer` label - Details 2

### Details
#### 1. add `setPlatformContainerOptions()`
- Some functions only works on a specific platform (mostly linux). For persistency, they need to save information into container's labels.
- Previously, it was processed on runtime. (e.g. [hostname](https://github.com/containerd/nerdctl/blob/b4c01094b5815e7616c43151086c708ddd57bc37/cmd/nerdctl/run.go#L569), [logURI](https://github.com/containerd/nerdctl/blob/b4c01094b5815e7616c43151086c708ddd57bc37/cmd/nerdctl/run.go#L529)). It caused [too many number of `withInternalLabels()`'s parameters](https://github.com/containerd/nerdctl/blob/b4c01094b5815e7616c43151086c708ddd57bc37/cmd/nerdctl/run.go#L660)
- In my opinion, to keep up with it, if the number of retrun values ​​of `setPlatformOptions()` increase, it would be difficult to maintain the code quality.
- Therefore, I suggest adding `addPlatformContainerOptions()`.

#### 2. add `PIDContainer` label

> Thanks, but we need to deal with shared container restarts, it will change pid namesapce.

- For `--pid` flag's persistency, save the based container's id into the shared container's label.
- When the container restart, `reconfigPIDContainer()` will recover it in `startContainer()`

---
### a difference with docker
- Because docker supports to isolate a container with a user namespace, it should share user namespace between containers when containers share their pid namespace.
  - [docker docs](https://docs.docker.com/engine/security/userns-remap/)
  - [moby/moby/daemon/oci_linux.go#L231-L240](https://github.com/moby/moby/blob/6c1df4f9c53b604866526e0f2aa4d34614c5f7ab/daemon/oci_linux.go#L231-L240)
- But, nerdctl does not support the user ns isolation.

### references
- [moby/moby/daemon/oci_linux.go#L294-L321](https://github.com/moby/moby/blob/6c1df4f9c53b604866526e0f2aa4d34614c5f7ab/daemon/oci_linux.go#L294-L321)
- [man pages - pid_namespaces](https://man7.org/linux/man-pages/man7/pid_namespaces.7.html)