### PR TITLE
Support `log-path` opt for json-file logging driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,6 +501,9 @@ Logging flags:
       - The `json-file` logging driver supports the following logging options:
         - :whale: `--log-opt=max-size=<MAX-SIZE>`: The maximum size of the log before it is rolled. A positive integer plus a modifier representing the unit of measure (k, m, or g). Defaults to unlimited.
         - :whale: `--log-opt=max-file=<MAX-FILE>`: The maximum number of log files that can be present. If rolling the logs creates excess files, the oldest file is removed. Only effective when `max-size` is also set. A positive integer. Defaults to 1.
+        - :nerd_face: `--log-opt=log-path=<LOG-PATH>`: The log path where the logs are written. The path will be created if it does not exist. If the log file exists, the old file will be renamed to `<LOG-PATH>.1`.
+          - Default: `<data-root>/<containerd-socket-hash>/<namespace>/<container-id>/<container-id>-json.log`
+          - Example: `/var/lib/nerdctl/1935db59/containers/default/<container-id>/<container-id>-json.log`
     - :whale: `--log-driver=journald`: Writes log messages to `journald`. The `journald` daemon must be running on the host machine.
       - :whale: `--log-opt=tag=<TEMPLATE>`: Specify template to set `SYSLOG_IDENTIFIER` value in journald logs.
     - :whale: `--log-driver=fluentd`: Writes log messages to `fluentd`. The `fluentd` daemon must be running on the host machine.

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -32,6 +32,7 @@ import (
 const (
 	// MagicArgv1 is the magic argv1 for the containerd runtime v2 logging plugin mode.
 	MagicArgv1 = "_NERDCTL_INTERNAL_LOGGING"
+	LogPath    = "log-path"
 	MaxSize    = "max-size"
 	MaxFile    = "max-file"
 	Tag        = "tag"


### PR DESCRIPTION
Support specifying log-path when using json-file logging driver.

Signed-off-by: Bingmang <todd.g@qq.com>