### PR TITLE
Add '--mode' to 'network inspect' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,6 +1100,7 @@ Usage: `nerdctl network inspect [OPTIONS] NETWORK [NETWORK...]`
 
 Flags:
 - :whale: `--format`: Format the output using the given Go template, e.g, `{{json .}}`
+- :nerd_face: `--mode=(dockercompat|native)`: Inspection mode. "native" produces more information.
 
 Unimplemented `docker network inspect` flags: `--verbose`
 


### PR DESCRIPTION
`--mode` is supported by `network inspect`:

```sh
➜  nerdctl git:(network-inspect-doc) lima nerdctl network inspect --help
Display detailed information on one or more networks

Usage: nerdctl network inspect [flags] NETWORK [NETWORK, ...]

Flags:
  -f, --format string   Format the output using the given Go template, e.g, '{{json .}}'
  -h, --help            help for inspect
      --mode string     Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output (default "dockercompat")

See also 'nerdctl --help' for the global flags such as '--namespace', '--snapshotter', and '--cgroup-manager'.
```

The added line is copied from the doc of [`image inspect`](https://github.com/containerd/nerdctl/blob/6fdce2313e336e6c83b9c3d2953f20d033dc2fdb/README.md?plain=1#L942).