### PR TITLE
Support `nerdctl build` custom outputs alias of type local

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -290,6 +290,11 @@ func generateBuildctlArgs(cmd *cobra.Command, buildkitHost string, platform, arg
 			needsLoading = true
 		}
 	} else {
+		if !strings.Contains(output, "type=") {
+			// should accept --output <DIR> as an alias of --output
+			// type=local,dest=<DIR>
+			output = fmt.Sprintf("type=local,dest=%s", output)
+		}
 		if strings.Contains(output, "type=docker") || strings.Contains(output, "type=oci") {
 			needsLoading = true
 		}


### PR DESCRIPTION
Fix #1422 

* Also remove call of `testutil.DockerIncompatible` in `TestBuildLocal`

Signed-off-by: Hanchin Hsieh <me@yuchanns.xyz>