### PR TITLE
Add Gitpod configuration for quick setup of development environments

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+tasks:
+  - name: Configure nerdctl
+    command: mkdir -p /home/gitpod/.config/nerdctl && echo 'snapshotter = "native"' > /home/gitpod/.config/nerdctl/nerdctl.toml
+  - name: Run containerd
+    command: bash -c "curl https://raw.githubusercontent.com/containerd/containerd/main/script/setup/install-cni | bash" && sudo containerd
+  - name: Watch nerdctl
+    before: npm install --global nodemon
+    command: nodemon --watch './**/*.go' --ext go --signal SIGTERM --exec 'make binaries && make install && sudo chown root $BINDIR/nerdctl && sudo chmod +s $BINDIR/nerdctl'
+    env:
+      BINDIR: /home/gitpod/.local/bin
+
+vscode:
+  extensions:
+    - golang.go

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,8 @@ tasks:
   - name: Configure nerdctl
     command: mkdir -p /home/gitpod/.config/nerdctl && echo 'snapshotter = "native"' > /home/gitpod/.config/nerdctl/nerdctl.toml
   - name: Run containerd
-    command: bash -c "curl https://raw.githubusercontent.com/containerd/containerd/main/script/setup/install-cni | bash" && sudo containerd
+    init: mkdir -p /workspace/containerd/root
+    command: bash -c "curl https://raw.githubusercontent.com/containerd/containerd/main/script/setup/install-cni | bash" && sudo containerd --root /workspace/containerd/root
   - name: Watch nerdctl
     before: npm install --global nodemon
     command: nodemon --watch './**/*.go' --ext go --signal SIGTERM --exec 'make binaries && make install && sudo chown root $BINDIR/nerdctl && sudo chmod +s $BINDIR/nerdctl'

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ As a containerd non-core sub-project, you will find the:
 
 information in our [`containerd/project`](https://github.com/containerd/project) repository.
 
+### Quickly getting a development environment setup
+
+To get a quick working development environment you could use Gitpod.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/containerd/nerdctl)
+
 ### Compiling nerdctl from source
 
 **Tips: You should make your Go toolchain newer than 1.17.**


### PR DESCRIPTION
With this change, any developer can simply open a development environment in Gitpod. The environment has containerd running and a new nerdctl binary being built (and installed) on every code change.

Also included the vscode extension for Go.

Try it here:
[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/containerd/nerdctl/pull/1469)

Signed-off-by: Yarden Shoham <hrsi88@gmail.com>