### PR TITLE
removes the obsolete //+build lines with go1.18

### DIFF
--- a/cmd/nerdctl/login_unix.go
+++ b/cmd/nerdctl/login_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/nerdctl/main_unix.go
+++ b/cmd/nerdctl/main_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/cmd/nerdctl/network_create_unix.go
+++ b/cmd/nerdctl/network_create_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/infoutil/infoutil_unix.go
+++ b/pkg/infoutil/infoutil_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/infoutil/infoutil_unix_test.go
+++ b/pkg/infoutil/infoutil_unix_test.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/netutil/cni_plugin_unix.go
+++ b/pkg/netutil/cni_plugin_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/netutil/netutil_unix_test.go
+++ b/pkg/netutil/netutil_unix_test.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/portutil/port_allocate_others.go
+++ b/pkg/portutil/port_allocate_others.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 /*
    Copyright The containerd Authors.

--- a/pkg/systemutil/socket_unix.go
+++ b/pkg/systemutil/socket_unix.go
@@ -1,5 +1,4 @@
 //go:build freebsd || linux
-// +build freebsd linux
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
Extract from https://tip.golang.org/doc/go1.18, section `//go:build lines`
> In Go 1.18, go fix now removes the now-obsolete // +build lines in modules declaring go 1.18 or later in their go.mod files.

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>