### PR TITLE
Enable service args for `compose build`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,7 +1401,7 @@ Unimplemented `docker compose up` (V2) flags: `--environment`
 ### :whale: nerdctl compose logs
 Create and start containers
 
-Usage: `nerdctl compose logs [OPTIONS]`
+Usage: `nerdctl compose logs [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `--no-color`: Produce monochrome output
@@ -1414,7 +1414,7 @@ Unimplemented `docker compose logs` (V2) flags:  `--since`, `--until`
 ### :whale: nerdctl compose build
 Build or rebuild services.
 
-Usage: `nerdctl compose build [OPTIONS]`
+Usage: `nerdctl compose build [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `--build-arg`: Set build-time variables for services
@@ -1437,7 +1437,7 @@ Unimplemented `docker-compose down` (V1) flags: `--rmi`, `--remove-orphans`, `--
 ### :whale: nerdctl compose ps
 List containers of services
 
-Usage: `nerdctl compose ps`
+Usage: `nerdctl compose ps [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose ps` (V1) flags: `--quiet`, `--services`, `--filter`, `--all`
 
@@ -1446,7 +1446,7 @@ Unimplemented `docker compose ps` (V2) flags: `--format`, `--status`
 ### :whale: nerdctl compose pull
 Pull service images
 
-Usage: `nerdctl compose pull`
+Usage: `nerdctl compose pull [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `-q, --quiet`: Pull without printing progress information
@@ -1456,7 +1456,7 @@ Unimplemented `docker-compose pull` (V1) flags: `--ignore-pull-failures`, `--par
 ### :whale: nerdctl compose push
 Push service images
 
-Usage: `nerdctl compose push`
+Usage: `nerdctl compose push [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose pull` (V1) flags: `--ignore-push-failures`
 
@@ -1478,7 +1478,7 @@ Unimplemented `docker compose config` (V2) flags: `--resolve-image-digests`, `--
 ### :whale: nerdctl compose kill
 Force stop service containers
 
-Usage: `nerdctl compose kill`
+Usage: `nerdctl compose kill [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `-s, --signal`: SIGNAL to send to the container (default: "SIGKILL")
@@ -1486,7 +1486,7 @@ Flags:
 ### :whale: nerdctl compose run
 Run a one-off command on a service
 
-Usage: `nerdctl compose run`
+Usage: `nerdctl compose run [OPTIONS] SERVICE [COMMAND] [ARGS...]`
 
 Unimplemented `docker-compose run` (V1) flags: `--use-aliases`, `--no-TTY`
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -36,7 +36,7 @@ import (
 
 func newComposeCommand() *cobra.Command {
 	var composeCommand = &cobra.Command{
-		Use:              "compose",
+		Use:              "compose [flags] COMMAND",
 		Short:            "Compose",
 		RunE:             unknownSubcommandAction,
 		SilenceUsage:     true,

--- a/cmd/nerdctl/compose_build.go
+++ b/cmd/nerdctl/compose_build.go
@@ -17,15 +17,13 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/containerd/nerdctl/pkg/composer"
 	"github.com/spf13/cobra"
 )
 
 func newComposeBuildCommand() *cobra.Command {
 	var composeBuildCommand = &cobra.Command{
-		Use:           "build",
+		Use:           "build [flags] [SERVICE...]",
 		Short:         "Build or rebuild services",
 		RunE:          composeBuildAction,
 		SilenceUsage:  true,
@@ -41,10 +39,6 @@ func newComposeBuildCommand() *cobra.Command {
 }
 
 func composeBuildAction(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		// TODO: support specifying service names as args
-		return fmt.Errorf("arguments %v not supported", args)
-	}
 	buildArg, err := cmd.Flags().GetStringArray("build-arg")
 	if err != nil {
 		return err
@@ -78,5 +72,5 @@ func composeBuildAction(cmd *cobra.Command, args []string) error {
 		Progress: progress,
 		IPFS:     enableIPFS,
 	}
-	return c.Build(ctx, bo)
+	return c.Build(ctx, bo, args)
 }

--- a/cmd/nerdctl/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose_build_linux_test.go
@@ -1,0 +1,69 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeBuild(t *testing.T) {
+	const imageSvc0 = "composebuild_svc0"
+	const imageSvc1 = "composebuild_svc1"
+
+	dockerComposeYAML := fmt.Sprintf(`
+services:
+  svc0:
+    build: .
+    image: %s
+    ports:
+    - 8080:80
+  svc1:
+    build: .
+    image: %s
+    ports:
+    - 8081:80
+`, imageSvc0, imageSvc1)
+
+	dockerfile := fmt.Sprintf(`FROM %s`, testutil.AlpineImage)
+
+	testutil.RequiresBuild(t)
+	base := testutil.NewBase(t)
+	defer base.Cmd("builder", "prune").Run()
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	comp.WriteFile("Dockerfile", dockerfile)
+
+	defer base.Cmd("rmi", imageSvc0).Run()
+	defer base.Cmd("rmi", imageSvc1).Run()
+
+	// 1. build only 1 service
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0").AssertOK()
+	base.Cmd("images").AssertOutContains(imageSvc0)
+	base.Cmd("images").AssertOutNotContains(imageSvc1)
+	// 2. build multiple services
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0", "svc1").AssertOK()
+	base.Cmd("images").AssertOutContains(imageSvc0)
+	base.Cmd("images").AssertOutContains(imageSvc1)
+	// 3. build all if no args are given
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "build").AssertOK()
+	// 4. fail if some services args not exist in compose.yml
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0", "svc100").AssertFail()
+}

--- a/cmd/nerdctl/compose_kill.go
+++ b/cmd/nerdctl/compose_kill.go
@@ -23,7 +23,7 @@ import (
 
 func newComposeKillCommand() *cobra.Command {
 	var composeKillCommand = &cobra.Command{
-		Use:           "kill [SERVICE...]",
+		Use:           "kill [flags] [SERVICE...]",
 		Short:         "Force stop service containers",
 		RunE:          composeKillAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_logs.go
+++ b/cmd/nerdctl/compose_logs.go
@@ -23,8 +23,8 @@ import (
 
 func newComposeLogsCommand() *cobra.Command {
 	var composeLogsCommand = &cobra.Command{
-		Use:           "logs [SERVICE...]",
-		Short:         "Show logs of a running container",
+		Use:           "logs [flags] [SERVICE...]",
+		Short:         "Show logs of running containers",
 		RunE:          composeLogsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -28,7 +28,7 @@ import (
 
 func newComposePsCommand() *cobra.Command {
 	var composePsCommand = &cobra.Command{
-		Use:           "ps",
+		Use:           "ps [flags] [SERVICE...]",
 		Short:         "List containers of services",
 		RunE:          composePsAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_pull.go
+++ b/cmd/nerdctl/compose_pull.go
@@ -23,7 +23,7 @@ import (
 
 func newComposePullCommand() *cobra.Command {
 	var composePullCommand = &cobra.Command{
-		Use:           "pull [SERVICE...]",
+		Use:           "pull [flags] [SERVICE...]",
 		Short:         "Pull service images",
 		RunE:          composePullAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_push.go
+++ b/cmd/nerdctl/compose_push.go
@@ -23,7 +23,7 @@ import (
 
 func newComposePushCommand() *cobra.Command {
 	var composePushCommand = &cobra.Command{
-		Use:           "push [SERVICE...]",
+		Use:           "push [flags] [SERVICE...]",
 		Short:         "Push service images",
 		RunE:          composePushAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -28,7 +28,7 @@ import (
 
 func newComposeUpCommand() *cobra.Command {
 	var composeUpCommand = &cobra.Command{
-		Use:           "up [SERVICE...]",
+		Use:           "up [flags] [SERVICE...]",
 		Short:         "Create and start containers",
 		RunE:          composeUpAction,
 		SilenceUsage:  true,

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -34,8 +34,8 @@ type BuildOptions struct {
 	IPFS     bool
 }
 
-func (c *Composer) Build(ctx context.Context, bo BuildOptions) error {
-	return c.project.WithServices(nil, func(svc types.ServiceConfig) error {
+func (c *Composer) Build(ctx context.Context, bo BuildOptions, services []string) error {
+	return c.project.WithServices(services, func(svc types.ServiceConfig) error {
 		ps, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix #1450 

The `[Service]...` args are passed down to `compose` pkg and all validation are done via docker's own compose lib. The output (succeed or fail message) is identical to `docker compose build`.

Signed-off-by: Jin Dong [jindon@amazon.com](mailto:jindon@amazon.com)