### PR TITLE
Make compose help more consistent with docker and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1401,7 +1401,7 @@ Unimplemented `docker compose up` (V2) flags: `--environment`
 ### :whale: nerdctl compose logs
 Create and start containers
 
-Usage: `nerdctl compose logs [OPTIONS]`
+Usage: `nerdctl compose logs [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `--no-color`: Produce monochrome output
@@ -1414,7 +1414,7 @@ Unimplemented `docker compose logs` (V2) flags:  `--since`, `--until`
 ### :whale: nerdctl compose build
 Build or rebuild services.
 
-Usage: `nerdctl compose build [OPTIONS]`
+Usage: `nerdctl compose build [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `--build-arg`: Set build-time variables for services
@@ -1437,7 +1437,7 @@ Unimplemented `docker-compose down` (V1) flags: `--rmi`, `--remove-orphans`, `--
 ### :whale: nerdctl compose ps
 List containers of services
 
-Usage: `nerdctl compose ps`
+Usage: `nerdctl compose ps [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose ps` (V1) flags: `--quiet`, `--services`, `--filter`, `--all`
 
@@ -1446,7 +1446,7 @@ Unimplemented `docker compose ps` (V2) flags: `--format`, `--status`
 ### :whale: nerdctl compose pull
 Pull service images
 
-Usage: `nerdctl compose pull`
+Usage: `nerdctl compose pull [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `-q, --quiet`: Pull without printing progress information
@@ -1456,7 +1456,7 @@ Unimplemented `docker-compose pull` (V1) flags: `--ignore-pull-failures`, `--par
 ### :whale: nerdctl compose push
 Push service images
 
-Usage: `nerdctl compose push`
+Usage: `nerdctl compose push [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose pull` (V1) flags: `--ignore-push-failures`
 
@@ -1478,7 +1478,7 @@ Unimplemented `docker compose config` (V2) flags: `--resolve-image-digests`, `--
 ### :whale: nerdctl compose kill
 Force stop service containers
 
-Usage: `nerdctl compose kill`
+Usage: `nerdctl compose kill [OPTIONS] [SERVICE...]`
 
 Flags:
 - :whale: `-s, --signal`: SIGNAL to send to the container (default: "SIGKILL")
@@ -1486,7 +1486,7 @@ Flags:
 ### :whale: nerdctl compose run
 Run a one-off command on a service
 
-Usage: `nerdctl compose run`
+Usage: `nerdctl compose run [OPTIONS] SERVICE [COMMAND] [ARGS...]`
 
 Unimplemented `docker-compose run` (V1) flags: `--use-aliases`, `--no-TTY`
 

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -36,7 +36,7 @@ import (
 
 func newComposeCommand() *cobra.Command {
 	var composeCommand = &cobra.Command{
-		Use:              "compose",
+		Use:              "compose [flags] COMMAND",
 		Short:            "Compose",
 		RunE:             unknownSubcommandAction,
 		SilenceUsage:     true,

--- a/cmd/nerdctl/compose_kill.go
+++ b/cmd/nerdctl/compose_kill.go
@@ -23,7 +23,7 @@ import (
 
 func newComposeKillCommand() *cobra.Command {
 	var composeKillCommand = &cobra.Command{
-		Use:           "kill [SERVICE...]",
+		Use:           "kill [flags] [SERVICE...]",
 		Short:         "Force stop service containers",
 		RunE:          composeKillAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_logs.go
+++ b/cmd/nerdctl/compose_logs.go
@@ -23,8 +23,8 @@ import (
 
 func newComposeLogsCommand() *cobra.Command {
 	var composeLogsCommand = &cobra.Command{
-		Use:           "logs [SERVICE...]",
-		Short:         "Show logs of a running container",
+		Use:           "logs [flags] [SERVICE...]",
+		Short:         "Show logs of running containers",
 		RunE:          composeLogsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -28,7 +28,7 @@ import (
 
 func newComposePsCommand() *cobra.Command {
 	var composePsCommand = &cobra.Command{
-		Use:           "ps",
+		Use:           "ps [flags] [SERVICE...]",
 		Short:         "List containers of services",
 		RunE:          composePsAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_pull.go
+++ b/cmd/nerdctl/compose_pull.go
@@ -23,7 +23,7 @@ import (
 
 func newComposePullCommand() *cobra.Command {
 	var composePullCommand = &cobra.Command{
-		Use:           "pull [SERVICE...]",
+		Use:           "pull [flags] [SERVICE...]",
 		Short:         "Pull service images",
 		RunE:          composePullAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_push.go
+++ b/cmd/nerdctl/compose_push.go
@@ -23,7 +23,7 @@ import (
 
 func newComposePushCommand() *cobra.Command {
 	var composePushCommand = &cobra.Command{
-		Use:           "push [SERVICE...]",
+		Use:           "push [flags] [SERVICE...]",
 		Short:         "Push service images",
 		RunE:          composePushAction,
 		SilenceUsage:  true,

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -28,7 +28,7 @@ import (
 
 func newComposeUpCommand() *cobra.Command {
 	var composeUpCommand = &cobra.Command{
-		Use:           "up [SERVICE...]",
+		Use:           "up [flags] [SERVICE...]",
 		Short:         "Create and start containers",
 		RunE:          composeUpAction,
 		SilenceUsage:  true,


### PR DESCRIPTION
This PR updates `nerdctl compose` usage in README and in `nerdctl compose -h`, making the output more consistent.

Some inconsistencies include:

1. `[Service...]` args are supported but not shown:

```bash
$ nerdctl compose ps -h
List containers of services

Usage: nerdctl compose ps [flags]
```

2. Sometimes `[flags]` shows before `args` and sometimes after `args`:

```bash
$ nerdctl compose run -h
Run a one-off command on a service

Usage: nerdctl compose run [flags] SERVICE [COMMAND] [ARGS...]

$ nerdctl compose logs -h
Show logs of a running container

Usage: nerdctl compose logs [SERVICE...] [flags]
```

Together with #1479 , #1450 should be fixed, since the support for `[Service...]` args should be consistent with `docker compose`.

Signed-off-by: Jin Dong <jindon@amazon.com>