### PR TITLE
Improve the documenation of 'compose build --progress'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1419,7 +1419,7 @@ Usage: `nerdctl compose build [OPTIONS] [SERVICE...]`
 Flags:
 - :whale: `--build-arg`: Set build-time variables for services
 - :whale: `--no-cache`: Do not use cache when building the image
-- :whale: `--progress`: Set type of progress output (auto, plain, tty)
+- :whale: `--progress`: Set type of progress output (auto, plain, tty). Use plain to show container output
 - :nerd_face: `--ipfs`: Build images with pulling base images from IPFS. See [`./docs/ipfs.md`](./docs/ipfs.md) for details.
 
 Unimplemented `docker-compose build` (V1) flags:  `--compress`, `--force-rm`, `--memory`, `--no-rm`, `--parallel`, `--pull`, `--quiet`

--- a/cmd/nerdctl/compose_build.go
+++ b/cmd/nerdctl/compose_build.go
@@ -31,7 +31,7 @@ func newComposeBuildCommand() *cobra.Command {
 	}
 	composeBuildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables for services.")
 	composeBuildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image.")
-	composeBuildCommand.Flags().String("progress", "", "Set type of progress output")
+	composeBuildCommand.Flags().String("progress", "", "Set type of progress output (auto, plain, tty). Use plain to show container output")
 
 	composeBuildCommand.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
 


### PR DESCRIPTION
The added content comes from [the documentation of `nerdctl build --progress`](https://github.com/containerd/nerdctl/blob/fe371ea36bba4932ae5752ec72696aa1c86f3038/cmd/nerdctl/build.go#L59).

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>