### PR TITLE
Add `nerdctl compose stop` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose logs](#whale-nerdctl-compose-logs)
     - [:whale: nerdctl compose build](#whale-nerdctl-compose-build)
     - [:whale: nerdctl compose down](#whale-nerdctl-compose-down)
+    - [:whale: nerdctl compose stop](#whale-nerdctl-compose-stop)
     - [:whale: nerdctl compose ps](#whale-nerdctl-compose-ps)
     - [:whale: nerdctl compose pull](#whale-nerdctl-compose-pull)
     - [:whale: nerdctl compose push](#whale-nerdctl-compose-push)
@@ -1434,6 +1435,16 @@ Flags:
 
 Unimplemented `docker-compose down` (V1) flags: `--rmi`, `--remove-orphans`, `--timeout`
 
+### :whale: nerdctl compose stop
+
+Stop containers in services without removing them.
+
+Usage: `nerdctl compose stop [OPTIONS] [SERVICE...]`
+
+Flags:
+
+- :whale: `-t, --timeout`: Seconds to wait for stop before killing it (default 10)
+
 ### :whale: nerdctl compose ps
 List containers of services
 
@@ -1570,7 +1581,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose create|events|exec|images|pause|port|restart|rm|scale|start|stop|top|unpause`
+- `docker-compose create|events|exec|images|pause|port|restart|rm|scale|start|top|unpause`
 
 Others:
 - `docker system df`

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -61,6 +61,7 @@ func newComposeCommand() *cobra.Command {
 		newComposeKillCommand(),
 		newComposeRunCommand(),
 		newComposeVersionCommand(),
+		newComposeStopCommand(),
 	)
 
 	return composeCommand

--- a/cmd/nerdctl/compose_stop.go
+++ b/cmd/nerdctl/compose_stop.go
@@ -1,0 +1,59 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/spf13/cobra"
+)
+
+func newComposeStopCommand() *cobra.Command {
+	var composeStopCommand = &cobra.Command{
+		Use:           "stop [flags] [SERVICE...]",
+		Short:         "Stop running containers without removing them.",
+		RunE:          composeStopAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	composeStopCommand.Flags().UintP("timeout", "t", 10, "Seconds to wait for stop before killing them")
+	return composeStopCommand
+}
+
+func composeStopAction(cmd *cobra.Command, args []string) error {
+	var opt composer.StopOptions
+
+	if cmd.Flags().Changed("timeout") {
+		timeValue, err := cmd.Flags().GetUint("timeout")
+		if err != nil {
+			return err
+		}
+		opt.TimeChanged = true
+		opt.Timeout = timeValue
+	}
+
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+	return c.Stop(ctx, opt, args)
+}

--- a/cmd/nerdctl/compose_stop_linux_test.go
+++ b/cmd/nerdctl/compose_stop_linux_test.go
@@ -1,0 +1,84 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeStop(t *testing.T) {
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+
+  wordpress:
+    image: %s
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
+    volumes:
+      - wordpress:/var/www/html
+
+  db:
+    image: %s
+    environment:
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+`, testutil.WordpressImage, testutil.MariaDBImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "db").AssertOK()
+	time.Sleep(3 * time.Second)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(func(stdout string) error {
+		// Docker Compose v1: "Exit code", v2: "exited (code)"
+		if !strings.Contains(stdout, "Exit") && !strings.Contains(stdout, "exited") {
+			return fmt.Errorf("service \"db\" must have exited")
+		}
+		return nil
+	})
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(func(stdout string) error {
+		// Docker Compose v1: "Up", v2: "running"
+		if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
+			return fmt.Errorf("service \"wordpress\" must have been still running")
+		}
+		return nil
+	})
+}

--- a/pkg/composer/stop.go
+++ b/pkg/composer/stop.go
@@ -1,0 +1,76 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/containerd/nerdctl/pkg/strutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+// StopOptions stores all option input from `nerdctl compose stop`
+type StopOptions struct {
+	TimeChanged bool
+	Timeout     uint
+}
+
+// Stop stops containers in `services` without removing them. It calls
+// `nerdctl stop CONTAINER_ID` to do the actual job.
+func (c *Composer) Stop(ctx context.Context, opt StopOptions, services []string) error {
+	serviceNames, err := c.ServiceNames(services...)
+	if err != nil {
+		return err
+	}
+	// reverse dependency order
+	for _, svc := range strutil.ReverseStrSlice(serviceNames) {
+		containers, err := c.Containers(ctx, svc)
+		if err != nil {
+			return err
+		}
+		if err := c.stopContainers(ctx, containers, opt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Composer) stopContainers(ctx context.Context, containers []containerd.Container, opt StopOptions) error {
+	var timeoutArg string
+	if opt.TimeChanged {
+		timeoutArg = fmt.Sprintf("--timeout=%d", opt.Timeout)
+	}
+
+	for _, container := range containers {
+		info, _ := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+		logrus.Infof("Stopping container %s", info.Labels[labels.Name])
+		args := []string{"stop"}
+		if opt.TimeChanged {
+			args = append(args, timeoutArg)
+		}
+		args = append(args, container.ID())
+		if err := c.runNerdctlCmd(ctx, args...); err != nil {
+			logrus.Warn(err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fix #666 

This implementation uses `nerdctl stop [flags] container` to stop all containers in given services, similar to how `compose down` works [link](https://github.com/containerd/nerdctl/blob/6bcd80643dc3acc3e5e2aaeccc4d0f7a4bbba799/pkg/composer/down.go#L113).

I didn't use a `WaitGroup` to parallelize the `nerdctl stop` calls, as in [here](https://github.com/containerd/nerdctl/blob/660680b7ddfde1d38a66ec1c7f08f8d89ab92c68/pkg/composer/run.go#L283-L297), since I'm not sure what `forcibly`/`gracefully` means. Thanks for any explanation and I can optimize (seems some refactor/dedup can be done here as well)

Also in the same place, it seems like a bug. This [line](https://github.com/containerd/nerdctl/blob/660680b7ddfde1d38a66ec1c7f08f8d89ab92c68/pkg/composer/run.go#L285) should be outside of `for` loop right?

I'll also try to add test as well.


```bash
$ cat full.yaml
version: '3.1'

services:
  service1:
    image: alpine:3.13
    command: "sleep infinity"
  service2:
    image: alpine:3.13
    command: "sleep infinity"
```

```bash
$ sudoe nerdctl compose -f full.yaml up -d
INFO[0000] Ensuring image alpine:3.13
...
$ sudoe nerdctl ps
CONTAINER ID    IMAGE                            COMMAND             CREATED           STATUS    PORTS    NAMES
6ab9f4de1c07    docker.io/library/alpine:3.13    "sleep infinity"    17 seconds ago    Up                 orphan_service2_1
e046dbf0bdf3    docker.io/library/alpine:3.13    "sleep infinity"    17 seconds ago    Up                 orphan_service1_1
$ sudoe nerdctl compose -f full.yaml stop service1
INFO[0000] Stopping container orphan_service1_1
$ sudoe nerdctl ps -a
CONTAINER ID    IMAGE                              COMMAND             CREATED               STATUS                         PORTS    NAMES
...
6ab9f4de1c07    docker.io/library/alpine:3.13      "sleep infinity"    About a minute ago    Up                                      orphan_service2_1
e046dbf0bdf3    docker.io/library/alpine:3.13      "sleep infinity"    About a minute ago    Exited (137) 13 seconds ago             orphan_service1_1
...
```

Signed-off-by: Jin Dong <jindon@amazon.com>