### PR TITLE
Add zstd compress level support

### DIFF
--- a/cmd/nerdctl/image_convert_test.go
+++ b/cmd/nerdctl/image_convert_test.go
@@ -48,6 +48,6 @@ func TestImageConvertZstdChunked(t *testing.T) {
 	base.Cmd("rmi", convertedImage).Run()
 	defer base.Cmd("rmi", convertedImage).Run()
 	base.Cmd("pull", testutil.CommonImage).AssertOK()
-	base.Cmd("image", "convert", "--zstdchunked", "--oci",
+	base.Cmd("image", "convert", "--zstdchunked", "--oci", "--zstdchunked-compression-level", "3",
 		testutil.CommonImage, convertedImage).AssertOK()
 }

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -6,6 +6,8 @@ The following features are experimental and subject to change:
 - [FreeBSD containers](./freebsd.md)
 - Importing an external eStargz record JSON file with `nerdctl image convert --estargz-record-in=FILE` .
   eStargz itself is out of experimental.
+- Importing an external zstd record JSON file with `nerdctl image convert --zstdchunked-record-in=FILE` .
+  zstd itself is out of experimental.
 - [Image Distribution on IPFS](./ipfs.md)
 - [Image Sign and Verify (cosign)](./cosign.md)
 - [Rootless container networking acceleration with bypass4netns](./rootless.md#bypass4netns)

--- a/go.mod
+++ b/go.mod
@@ -104,7 +104,7 @@ require (
 	github.com/ipld/go-codec-dagpb v1.3.2 // indirect
 	github.com/ipld/go-ipld-prime v0.11.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
-	github.com/klauspost/compress v1.15.12 // indirect
+	github.com/klauspost/compress v1.15.12
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	// NOTE: P2P image distribution (IPFS) is completely optional. Your host is NOT connected to any P2P network, unless you opt in to install and run IPFS daemon.
 	github.com/libp2p/go-buffer-pool v0.0.2 // indirect


### PR DESCRIPTION
Fix #1367

This [PR](https://github.com/containerd/stargz-snapshotter/pull/984) in `stargz` adds support for customizing zstd compression level in `ctr-remote`. This PR does a similar thing to add the support in nerdctl.

I tested the change locally using the `stargz` main branch. After the new version of `stargz` is released (with the change in that PR), it should work.

```sh
$ nerdctl image convert --oci --zstdchunked ghcr.io/stargz-containers/python:3.7-esgz level-default
sha256:d649464e45963ead9c0a2ec4b1a124eb7f55a924c3eb687c2975012a7a4f397c
$ nerdctl image convert --oci --zstdchunked --zstdchunked-compression-level=9 ghcr.io/stargz-containers/python:3.7-esgz level-9
sha256:c19da79809fc2e2853cb231f8f62dbd7eaa3a0d49a57d0a86d301acfa03ad902
$ nerdctl images
REPOSITORY                          TAG         IMAGE ID        CREATED           PLATFORM       SIZE         BLOB SIZE
alpine                              3.13        100448e45467    34 hours ago      linux/amd64    5.6 MiB      2.7 MiB
level-9                             latest      c19da79809fc    39 seconds ago    linux/amd64    0.0 B        328.4 MiB
level-default                       latest      d649464e4596    3 minutes ago     linux/amd64    0.0 B        334.3 MiB
ghcr.io/stargz-containers/python    3.7-esgz    6a421075162f    4 minutes ago     linux/amd64    903.7 MiB    333.1 MiB
```

Signed-off-by: Jin Dong <jindon@amazon.com>