### PR TITLE
Enable `rmi -f` to remove multiple images with the same digest

### DIFF
--- a/cmd/nerdctl/rmi.go
+++ b/cmd/nerdctl/rmi.go
@@ -78,7 +78,9 @@ func rmiAction(cmd *cobra.Command, args []string) error {
 	walker := &imagewalker.ImageWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found imagewalker.Found) error {
-			if found.MatchCount > 1 {
+			// if found multiple images, return error unless in force-mode and
+			// there is only 1 unique image.
+			if found.MatchCount > 1 && !(force && found.UniqueImages == 1) {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
 			if _, ok := usedImages[found.Image.Name]; ok && !force {


### PR DESCRIPTION
Another try to resolve #1272 (and #1273 if merged)

This change adds a new field (`Identical`) to `Found` indicating if all `found` images have the same image digest. If yes, `rmi -f` can delete and if not, `rmi -f` fails.

In the example below, `alpine:3.14` and `alpine-rename` are 2 identical images, and `ubuntu` has the same short prefix (`4`) with `alpine`. So `nerdctl rmi 4` will fail regardless `-f`. `nerdctl rmi 4c869a63e1b7` succeeds with `-f` and fails without `-f`.

```sh
$ nerdctl images
REPOSITORY                          TAG                  IMAGE ID        CREATED          PLATFORM       SIZE        BLOB SIZE
alpine-rename                       latest               4c869a63e1b7    2 minutes ago    linux/amd64    5.6 MiB     2.7 MiB
alpine                              3.14                 4c869a63e1b7    5 minutes ago    linux/amd64    5.6 MiB     2.7 MiB
ubuntu                              latest               4b1d0c4a2d2a    5 minutes ago    linux/amd64    80.8 MiB    29.0 MiB
ghcr.io/stargz-containers/ubuntu    22.04-zstdchunked    526c1588142b    24 hours ago     linux/amd64    80.9 MiB    31.3 MiB
$ nerdctl rmi 4
FATA[0000] multiple IDs found with provided prefix: 4
$ nerdctl rmi -f 4
ERRO[0000] multiple IDs found with provided prefix: 4
$ nerdctl rmi 4c869a63e1b7
FATA[0000] multiple IDs found with provided prefix: 4c869a63e1b7
$ nerdctl rmi -f 4c869a63e1b7
Untagged: docker.io/library/alpine-rename:latest@sha256:4c869a63e1b7c0722fed1e402a6466610327c3b83bdddb94bd94fb71da7f638a
Deleted: sha256:63493a9ab2d41e319e25dd7474e184d875e28cb267f7e6856ca91dccdd90ee28
Untagged: docker.io/library/alpine:3.14@sha256:4c869a63e1b7c0722fed1e402a6466610327c3b83bdddb94bd94fb71da7f638a
Deleted: sha256:63493a9ab2d41e319e25dd7474e184d875e28cb267f7e6856ca91dccdd90ee28
$ nerdctl images
REPOSITORY                          TAG                  IMAGE ID        CREATED          PLATFORM       SIZE        BLOB SIZE
ubuntu                              latest               4b1d0c4a2d2a    5 minutes ago    linux/amd64    80.8 MiB    29.0 MiB
ghcr.io/stargz-containers/ubuntu    22.04-zstdchunked    526c1588142b    24 hours ago     linux/amd64    80.9 MiB    31.3 MiB
```
Signed-off-by: Jin Dong <jindon@amazon.com>