### PR TITLE
Refactor stop/rm containers in compose

### DIFF
--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -281,20 +281,7 @@ func (c *Composer) runServices(ctx context.Context, parsedServices []*servicepar
 	}
 
 	logrus.Infof("Stopping containers (forcibly)") // TODO: support gracefully stopping
-	for id, container := range containers {
-		var stopWG sync.WaitGroup
-		id := id
-		container := container
-		stopWG.Add(1)
-		go func() {
-			defer stopWG.Done()
-			logrus.Infof("Stopping container %s", container.Name)
-			if err := c.runNerdctlCmd(ctx, "stop", id); err != nil {
-				logrus.Warn(err)
-			}
-		}()
-		stopWG.Wait()
-	}
+	c.stopContainersFromParsedServices(ctx, containers)
 
 	if ro.Rm {
 		var rmWG sync.WaitGroup

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -86,20 +86,7 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 	}
 
 	logrus.Infof("Stopping containers (forcibly)") // TODO: support gracefully stopping
-	var rmWG sync.WaitGroup
-	for id, container := range containers {
-		id := id
-		container := container
-		rmWG.Add(1)
-		go func() {
-			defer rmWG.Done()
-			logrus.Infof("Stopping container %s", container.Name)
-			if err := c.runNerdctlCmd(ctx, "rm", "-f", id); err != nil {
-				logrus.Warn(err)
-			}
-		}()
-	}
-	rmWG.Wait()
+	c.stopContainersFromParsedServices(ctx, containers)
 	return nil
 }
 


### PR DESCRIPTION
See #1502 for more details.

This PR made the following changes:

1. Parallelize `stop containers` in `compose stop`.
2. Refactor `stop containers` in `compose run` and `compose up`.
    1. Fix a bug in `compose run` when stopping containers.
    2. Change `rm containers` in `compose up` to `stop containers`, as its log said.

Signed-off-by: Jin Dong <jindon@amazon.com>