### PR TITLE
Add more flags for image conversion (`--estargz-min-chunk-size`, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,7 +982,13 @@ Flags:
 -  `--estargz-record-in=<FILE>`         : read `ctr-remote optimize --record-out=<FILE>` record file. :warning: This flag is experimental and subject to change.
 -  `--estargz-compression-level=<LEVEL>`: eStargz compression level (default: 9)
 -  `--estargz-chunk-size=<SIZE>`        : eStargz chunk size
+-  `--estargz-min-chunk-size=<SIZE>` : The minimal number of bytes of data must be written in one gzip stream (requires stargz-snapshotter >= v0.13.0). Useful for creating a smaller eStargz image (refer to [`./docs/stargz.md`](./docs/stargz.md) for details).
+-  `--estargz-external-toc` : Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. (requires stargz-snapshotter >= v0.13.0) Useful for creating a smaller eStargz image (refer to [`./docs/stargz.md`](./docs/stargz.md) for details). :warning: This flag is experimental and subject to change.
+-  `--estargz-keep-diff-id`: Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')
 -  `--zstdchunked`                      : Use zstd compression instead of gzip (a.k.a zstd:chunked). Should be used in conjunction with '--oci'
+-  `--zstdchunked-record-in=<FILE>` : read `ctr-remote optimize --record-out=<FILE>` record file. :warning: This flag is experimental and subject to change.
+-  `--zstdchunked-compression-level=<LEVEL>`: zstd:chunked compression level (default: 3)
+-  `--zstdchunked-chunk-size=<SIZE>`: zstd:chunked chunk size
 -  `--uncompress`                       : convert tar.gz layers to uncompressed tar layers
 -  `--oci`                              : convert Docker media types to OCI media types
 -  `--platform=<PLATFORM>`              : convert content for a specific platform

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,13 +1,12 @@
 # Experimental features of nerdctl
 
-The following features are experimental and subject to change:
+The following features are experimental and subject to change.
+See [`./config.md`](config.md) about how to enable these features.
 
 - [Windows containers](https://github.com/containerd/nerdctl/issues/28)
 - [FreeBSD containers](./freebsd.md)
-- Importing an external eStargz record JSON file with `nerdctl image convert --estargz-record-in=FILE` .
-  eStargz itself is out of experimental.
-- Importing an external zstd record JSON file with `nerdctl image convert --zstdchunked-record-in=FILE` .
-  zstd itself is out of experimental.
+- Flags of `nerdctl image convert`: `--estargz-record-in=FILE` and `--zstdchunked-record-in=FILE` (Importing an external eStargz record JSON file), `--estargz-external-toc` (Separating TOC JSON to another image).
+  eStargz and zstd themselves are out of experimental.
 - [Image Distribution on IPFS](./ipfs.md)
 - [Image Sign and Verify (cosign)](./cosign.md)
 - [Rootless container networking acceleration with bypass4netns](./rootless.md#bypass4netns)

--- a/pkg/imgutil/converter/info.go
+++ b/pkg/imgutil/converter/info.go
@@ -1,0 +1,28 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package converter
+
+// ConvertedImageInfo is information of the images created by a conversion.
+type ConvertedImageInfo struct {
+	// Image is the reference of the converted image.
+	// The reference is the image's name and digest concatenated with "@" (i.e. `<name>@<digest>`).
+	Image string `json:"Image"`
+
+	// ExtraImages is a set of converter-specific additional images (e.g. external TOC image of eStargz).
+	// The reference format is the same as the "Image" field.
+	ExtraImages []string `json:"ExtraImages"`
+}


### PR DESCRIPTION
Fixes  #1367

This adds the following flags and docs about the usage.

-  `--estargz-min-chunk-size=<SIZE>` : The minimal number of bytes of data must be written in one gzip stream (requires stargz-snapshotter >= v0.13.0). Useful for creating a smaller eStargz image (refer to [`./docs/stargz.md`](./docs/stargz.md) for details).
-  `--estargz-external-toc` : Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. (requires stargz-snapshotter >= v0.13.0) Useful for creating a smaller eStargz image (refer to [`./docs/stargz.md`](./docs/stargz.md) for details). :warning: This flag is experimental and subject to change.
-  `--estargz-keep-diff-id`: Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')
