### PR TITLE
Add cosign in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Major:
   P2P image distribution (IPFS) is completely optional. Your host is NOT connected to any P2P network, unless you opt in to [install and run IPFS daemon](https://docs.ipfs.io/install/).
 - Recursive read-only (RRO) bind-mount: `nerdctl run -v /mnt:/mnt:rro` (make children such as `/mnt/usb` to be read-only, too).
   Requires kernel >= 5.12, and crun >= 1.4 or runc >= 1.1 (PR [#3272](https://github.com/opencontainers/runc/pull/3272)).
-- [Cosign integration](./docs/cosign.md): `nerdctl pull --verify=cosign` and `nerdctl push --sign=cosign`
+- [Cosign integration](./docs/cosign.md): `nerdctl pull --verify=cosign` and `nerdctl push --sign=cosign`, and [in Compose](./docs/cosign.md#cosign-in-compose)
 - [Accelerated rootless containers using bypass4netns](./docs/rootless.md): `nerdctl run --label nerdctl/bypass4netns=true`
 
 Minor:

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -201,12 +201,14 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 				if !o.Experimental {
 					return fmt.Errorf("cosign only work with enable experimental feature")
 				}
-				keyRef, ok := ps.Unparsed.Extensions[serviceparser.ComposeCosignPublicKey]
-				if !ok {
-					return fmt.Errorf("no cosign public key, service: %s", ps.Unparsed.Name)
+
+				// if key is given, use key mode, otherwise use keyless mode.
+				keyRef := ""
+				if keyVal, ok := ps.Unparsed.Extensions[serviceparser.ComposeCosignPublicKey]; ok {
+					keyRef = keyVal.(string)
 				}
 
-				ref, err = cosignutil.VerifyCosign(ctx, ref, keyRef.(string), hostsDirs)
+				ref, err = cosignutil.VerifyCosign(ctx, ref, keyRef, hostsDirs)
 				if err != nil {
 					return err
 				}

--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -17,18 +17,16 @@
 package main
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"os/exec"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/nerdctl/pkg/cosignutil"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/pkg/imgutil/push"
@@ -254,7 +252,7 @@ func pushAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = signCosign(rawRef, keyRef)
+		err = cosignutil.SignCosign(rawRef, keyRef)
 		if err != nil {
 			return err
 		}
@@ -312,48 +310,4 @@ func isReusableESGZ(ctx context.Context, cs content.Store, desc ocispec.Descript
 		return false
 	}
 	return true
-}
-
-func signCosign(rawRef string, keyRef string) error {
-	cosignExecutable, err := exec.LookPath("cosign")
-	if err != nil {
-		logrus.WithError(err).Error("cosign executable not found in path $PATH")
-		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
-		return err
-	}
-
-	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
-	cosignCmd.Env = os.Environ()
-
-	if keyRef != "" {
-		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
-	} else {
-		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
-	}
-
-	cosignCmd.Args = append(cosignCmd.Args, rawRef)
-
-	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
-
-	stdout, _ := cosignCmd.StdoutPipe()
-	stderr, _ := cosignCmd.StderrPipe()
-	if err := cosignCmd.Start(); err != nil {
-		return err
-	}
-
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() {
-		logrus.Info("cosign: " + scanner.Text())
-	}
-
-	errScanner := bufio.NewScanner(stderr)
-	for errScanner.Scan() {
-		logrus.Info("cosign: " + errScanner.Text())
-	}
-
-	if err := cosignCmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -75,3 +75,106 @@ INFO[0003] cosign: failed to verify signature
 INFO[0003] cosign: main.go:46: error during command execution: no matching signatures:
 INFO[0003] cosign: failed to verify signature
 ```
+
+## Cosign in Compose
+
+> Cosign support in Compose is also experimental and implemented based on Compose's [extension](https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension) capibility.
+
+cosign is supported in `nerdctl compose up|run|push|pull`. You can use cosign in Compose by adding the following fields in your compose yaml. These fields are _per service_, and you can enable only `verify` or only `sign` (or both).
+
+```yaml
+# only put cosign related fields under the service you want to sign/verify.
+services:
+  svc0:
+    build: .
+    image: ${REGISTRY}/svc0_image # replace with your registry
+    # `x-nerdctl-verify` and `x-nerdctl-cosign-public-key` are for verify
+    # required for `nerdctl compose up|run|pull`
+    x-nerdctl-verify: cosign
+    x-nerdctl-cosign-public-key: /path/to/cosign.pub
+    # `x-nerdctl-sign` and `x-nerdctl-cosign-private-key` are for sign
+    # required for `nerdctl compose push`
+    x-nerdctl-sign: cosign
+    x-nerdctl-cosign-private-key: /path/to/cosign.key
+    ports:
+    - 8080:80
+  svc1:
+    build: .
+    image: ${REGISTRY}/svc1_image # replace with your registry
+    ports:
+    - 8081:80
+```
+
+Following the cosign tutorial above, first set up environment and prepare cosign key pair:
+
+```shell
+# Generate a key-pair: cosign.key and cosign.pub
+$ cosign generate-key-pair
+
+# Export your COSIGN_PASSWORD to prevent CLI prompting
+$ export COSIGN_PASSWORD=$COSIGN_PASSWORD
+```
+
+We'll use the following `Dockerfile` and `docker-compose.yaml`:
+
+```shell
+$ cat Dockerfile
+FROM nginx:1.19-alpine
+RUN uname -m > /usr/share/nginx/html/index.html
+
+$ cat docker-compose.yml
+services:
+  svc0:
+    build: .
+    image: ${REGISTRY}/svc1_image # replace with your registry
+    x-nerdctl-verify: cosign
+    x-nerdctl-cosign-public-key: ./cosign.pub
+    x-nerdctl-sign: cosign
+    x-nerdctl-cosign-private-key: ./cosign.key
+    ports:
+    - 8080:80
+  svc1:
+    build: .
+    image: ${REGISTRY}/svc1_image # replace with your registry
+    ports:
+    - 8081:80
+```
+
+> The `env "COSIGN_PASSWORD="$COSIGN_PASSWORD""` part in the below commands is a walkaround to use rootful nerdctl and make the env variable visible to root (in sudo). You don't need this part if (1) you're using rootless, or (2) your `COSIGN_PASSWORD` is visible in root.
+
+First let's `build` and `push` the two services:
+
+```shell
+$ sudo nerdctl compose build
+INFO[0000] Building image xxxxx/svc0_image
+...
+INFO[0000] Building image xxxxx/svc1_image
+[+] Building 0.2s (6/6) FINISHED
+
+$ sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose --experimental=true push
+INFO[0000] Pushing image xxxxx/svc1_image
+...
+INFO[0000] Pushing image xxxxx/svc0_image
+INFO[0000] pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.v2+json, sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9)
+INFO[0000] cosign: WARNING: Image reference xxxxx/svc0_image uses a tag, not a digest, to identify the image to sign.
+INFO[0000] cosign:
+INFO[0000] cosign: This can lead you to sign a different image than the intended one. Please use a
+INFO[0000] cosign: digest (example.com/ubuntu@sha256:abc123...) rather than tag
+INFO[0000] cosign: (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
+INFO[0000] cosign: images by tag will be removed in a future release.
+INFO[0000] cosign: Pushing signature to: xxxxx/svc0_image
+```
+
+Then we can `pull` and `up` services (`run` is similar to up):
+
+```shell
+# ensure built images are removed and pull is performed.
+$ sudo nerdctl compose down
+$ sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose --experimental=true pull
+$ sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose --experimental=true up
+$ sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose --experimental=true run svc0 -- echo "hello"
+# clean up compose resources.
+$ sudo nerdctl compose down
+```
+
+Check your logs to confirm that svc0 is verified by cosign (have cosign logs) and svc1 is not. You can also change the public key in `docker-compose.yaml` to a random value to see verify failure will stop the container being `pull|up|run`.

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -44,8 +44,9 @@ type Options struct {
 	NetworkExists    func(string) (bool, error)
 	VolumeExists     func(string) (bool, error)
 	ImageExists      func(ctx context.Context, imageName string) (bool, error)
-	EnsureImage      func(ctx context.Context, imageName, pullMode, platform string, quiet bool) error
+	EnsureImage      func(ctx context.Context, imageName, pullMode, platform string, ps *serviceparser.Service, quiet bool) error
 	DebugPrintFull   bool // full debug print, may leak secret env var to logs
+	Experimental     bool // enable experimental features
 }
 
 func New(o Options, client *containerd.Client) (*Composer, error) {

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -34,6 +34,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// ComposeExtensionKey defines fields used to implement extension features.
+const (
+	ComposeVerify           = "x-nerdctl-verify"
+	ComposeCosignPublicKey  = "x-nerdctl-cosign-public-key"
+	ComposeSign             = "x-nerdctl-sign"
+	ComposeCosignPrivateKey = "x-nerdctl-cosign-private-key"
+)
+
 func warnUnknownFields(svc types.ServiceConfig) {
 	if unknown := reflectutil.UnknownNonEmptyFields(&svc,
 		"Name",
@@ -57,6 +65,7 @@ func warnUnknownFields(svc types.ServiceConfig) {
 		"Entrypoint",
 		"Environment",
 		"Extends", // handled by the loader
+		"Extensions",
 		"ExtraHosts",
 		"Hostname",
 		"Image",

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -97,17 +97,16 @@ func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Ser
 		}
 		if ok, err := c.ImageExists(ctx, ps.Image); err != nil {
 			return err
-		} else if ok {
-			logrus.Debugf("Image %s already exists, not building", ps.Image)
-		} else {
+		} else if !ok {
 			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
+		// even when c.ImageExists returns true, we need to call c.EnsureImage
+		// because ps.PullMode can be "always". So no return here.
+		logrus.Debugf("Image %s already exists, not building", ps.Image)
 	}
 
-	// even when c.ImageExists returns true, we need to call c.EnsureImage
-	// because ps.PullMode can be "always".
 	logrus.Infof("Ensuring image %s", ps.Image)
-	if err := c.EnsureImage(ctx, ps.Image, ps.PullMode, ps.Unparsed.Platform, quiet); err != nil {
+	if err := c.EnsureImage(ctx, ps.Image, ps.PullMode, ps.Unparsed.Platform, ps, quiet); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cosignutil/cosignutil.go
+++ b/pkg/cosignutil/cosignutil.go
@@ -1,0 +1,143 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cosignutil
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/imgutil"
+	"github.com/sirupsen/logrus"
+)
+
+// SignCosign signs an image(`rawRef`) using a cosign private key (`keyRef`)
+func SignCosign(rawRef string, keyRef string) error {
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		logrus.WithError(err).Error("cosign executable not found in path $PATH")
+		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
+		return err
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"sign"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode(experimental)
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, rawRef)
+
+	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
+
+	err = processCosignIO(cosignCmd)
+	if err != nil {
+		return err
+	}
+
+	if err := cosignCmd.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// VerifyCosign verifies an image(`rawRef`) with a cosign public key(`keyRef`)
+// `hostsDirs` are used to resolve image `rawRef`
+func VerifyCosign(ctx context.Context, rawRef string, keyRef string, hostsDirs []string) (string, error) {
+	digest, err := imgutil.ResolveDigest(ctx, rawRef, false, hostsDirs)
+	if err != nil {
+		logrus.WithError(err).Errorf("unable to resolve digest for an image %s: %v", rawRef, err)
+		return rawRef, err
+	}
+	ref := rawRef
+	if !strings.Contains(ref, "@") {
+		ref += "@" + digest
+	}
+
+	logrus.Debugf("verifying image: %s", ref)
+
+	cosignExecutable, err := exec.LookPath("cosign")
+	if err != nil {
+		logrus.WithError(err).Error("cosign executable not found in path $PATH")
+		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
+		return ref, err
+	}
+
+	cosignCmd := exec.Command(cosignExecutable, []string{"verify"}...)
+	cosignCmd.Env = os.Environ()
+
+	// if key is empty, use keyless mode(experimental)
+	if keyRef != "" {
+		cosignCmd.Args = append(cosignCmd.Args, "--key", keyRef)
+	} else {
+		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
+	}
+
+	cosignCmd.Args = append(cosignCmd.Args, ref)
+
+	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
+
+	err = processCosignIO(cosignCmd)
+	if err != nil {
+		return ref, err
+	}
+	if err := cosignCmd.Wait(); err != nil {
+		return ref, err
+	}
+
+	return ref, nil
+}
+
+func processCosignIO(cosignCmd *exec.Cmd) error {
+	stdout, err := cosignCmd.StdoutPipe()
+	if err != nil {
+		logrus.Warn("cosign: " + err.Error())
+	}
+	stderr, err := cosignCmd.StderrPipe()
+	if err != nil {
+		logrus.Warn("cosign: " + err.Error())
+	}
+	if err := cosignCmd.Start(); err != nil {
+		// only return err if it's critical (cosign start failed.)
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		logrus.Info("cosign: " + scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		logrus.Warn("cosign: " + err.Error())
+	}
+
+	errScanner := bufio.NewScanner(stderr)
+	for errScanner.Scan() {
+		logrus.Info("cosign: " + errScanner.Text())
+	}
+	if err := errScanner.Err(); err != nil {
+		logrus.Warn("cosign: " + err.Error())
+	}
+
+	return nil
+}


### PR DESCRIPTION
Fix #607.

Similar to ##556, #606, #628, this PR adds cosign support to compose:

- [x] Support cosign in `compose run`, `compose up`, `compose push`, `compose pull`.
- [x] Refactor cosign related functions to its own package, so they can be used by both `nerdctl` and `nerdctl compose`.
- [x] Add tests.
- [x] Update doc.
- [x] Figure how to add `--experimental` for cosign support in `compose` commands.
- [x] Rebase.

I'm more towards the below method from #607 discussion, since it's less error-prone than cli args and more flexibile (my understanding is we should provide the capability to sign/verify individual images per services and cannot assume user will use the same pair for all images in a compose yaml).

```yaml
services:
  foo:
    image: bar
    x-nerdctl-verify: cosign
    x-nerdctl-cosign-public-key: /path/to/cosign.pub
    x-nerdctl-sign: cosign
    x-nerdctl-cosign-private-key: /path/to/cosign.key
```

A running example:

```shell
➜  compose-cosign cat docker-compose.yml
services:
  svc0:
    build: .
    image: docker.io/djdongjin95/svc0_image
    x-nerdctl-verify: cosign
    x-nerdctl-cosign-public-key: ./cosign.pub
    x-nerdctl-sign: cosign
    x-nerdctl-cosign-private-key: ./cosign.key
    ports:
    - 8080:80
  svc1:
    build: .
    image: docker.io/djdongjin95/svc1_image
    ports:
    - 8081:80

# compose push
➜  compose-cosign sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose push
WARN[0000] build.config should be relative path, got "/home/ec2-user/tmp/compose-cosign"
...
elapsed: 0.2 s                                                                    total:  9.3 Ki (46.2 KiB/s)
INFO[0001] cosign: WARNING: Image reference docker.io/djdongjin95/svc0_image uses a tag, not a digest, to identify the image to sign.
INFO[0001] cosign:
INFO[0001] cosign: This can lead you to sign a different image than the intended one. Please use a
INFO[0001] cosign: digest (example.com/ubuntu@sha256:abc123...) rather than tag
INFO[0001] cosign: (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
INFO[0001] cosign: images by tag will be removed in a future release.
INFO[0001] cosign: Pushing signature to: index.docker.io/djdongjin95/svc0_image
WARN[0001] build.config should be relative path, got "/home/ec2-user/tmp/compose-cosign"
INFO[0001] Pushing image docker.io/djdongjin95/svc1_image
...
elapsed: 0.2 s                                                                    total:  9.3 Ki (46.3 KiB/s)

# compose pull
➜  compose-cosign sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose pull
WARN[0000] build.config should be relative path, got "/home/ec2-user/tmp/compose-cosign"
INFO[0000] Pulling image docker.io/djdongjin95/svc0_image
INFO[0000] cosign:
INFO[0000] cosign: [{"critical":{"identity":{"docker-reference":"index.docker.io/djdongjin95/svc0_image"},"image":{"docker-manifest-digest":"sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9"},"type":"cosign container image signature"},"optional":null}]
INFO[0000] cosign:
INFO[0000] cosign: Verification for index.docker.io/djdongjin95/svc0_image@sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9 --
INFO[0000] cosign: The following checks were performed on each of these signatures:
INFO[0000] cosign:   - The cosign claims were validated
INFO[0000] cosign:   - The signatures were verified against the specified public key
docker.io/djdongjin95/svc0_image@sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9: resolved       |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9:                         done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:abcd9b97b24c8f2f763d937a726a62e39c1ef39574a6c24cc779bea8e08c2519:                           done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 0.3 s                                                                                            total:  1.7 Ki (5.8 KiB/s)
WARN[0000] build.config should be relative path, got "/home/ec2-user/tmp/compose-cosign"
...
elapsed: 0.2 s                                                                    total:   0.0 B (0.0 B/s)

# pulled images
➜  compose-cosign sudo nerdctl images
REPOSITORY                TAG       IMAGE ID        CREATED           PLATFORM       SIZE        BLOB SIZE
djdongjin95/svc0_image    <none>    4329abc3143b    15 seconds ago    linux/amd64    24.5 MiB    9.4 MiB
djdongjin95/svc1_image    latest    4329abc3143b    15 seconds ago    linux/amd64    24.5 MiB    9.4 MiB

# compose up
➜  compose-cosign sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose up
...
INFO[0000] Ensuring image docker.io/djdongjin95/svc0_image
INFO[0000] cosign:
INFO[0000] cosign: [{"critical":{"identity":{"docker-reference":"index.docker.io/djdongjin95/svc0_image"},"image":{"docker-manifest-digest":"sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9"},"type":"cosign container image signature"},"optional":null}]
INFO[0000] cosign:
INFO[0000] cosign: Verification for index.docker.io/djdongjin95/svc0_image@sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9 --
INFO[0000] cosign: The following checks were performed on each of these signatures:
INFO[0000] cosign:   - The cosign claims were validated
INFO[0000] cosign:   - The signatures were verified against the specified public key
INFO[0000] Ensuring image docker.io/djdongjin95/svc1_image
INFO[0000] Creating container compose-cosign_svc1_1
INFO[0000] Creating container compose-cosign_svc0_1
INFO[0001] Attaching to logs

# compose run
➜  compose-cosign sudo env "COSIGN_PASSWORD="$COSIGN_PASSWORD"" nerdctl compose run svc0 -- echo "hello"
...
INFO[0000] Ensuring image docker.io/djdongjin95/svc0_image
INFO[0000] cosign:
INFO[0000] cosign: [{"critical":{"identity":{"docker-reference":"index.docker.io/djdongjin95/svc0_image"},"image":{"docker-manifest-digest":"sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9"},"type":"cosign container image signature"},"optional":null}]
INFO[0000] cosign:
INFO[0000] cosign: Verification for index.docker.io/djdongjin95/svc0_image@sha256:4329abc3143b1545835de17e1302c8313a9417798b836022f4c8c8dc8b10a3e9 --
INFO[0000] cosign: The following checks were performed on each of these signatures:
INFO[0000] cosign:   - The cosign claims were validated
INFO[0000] cosign:   - The signatures were verified against the specified public key
INFO[0000] Creating container compose-cosign_svc0_run_a516dddd5769
hello
INFO[0000] Stopping containers (forcibly)
INFO[0000] Stopping container compose-cosign_svc0_run_a516dddd5769
```

Signed-off-by: Jin Dong <jindon@amazon.com>