### PR TITLE
update golangci-lint (v1.50.1) 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3.3.1
       with:
-        version: v1.49.0
+        version: v1.50.1
         args: --verbose
 
   test-unit:


### PR DESCRIPTION
update golangci lint version to v1.50.1

Signed-off-by: Kay Yan [kay.yan@daocloud.io](mailto:kay.yan@daocloud.io)