### PR TITLE
golangci: add unconvert check

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters:
     - stylecheck
     # - testpackage
     # - tparallel
-    # - unconvert
+    - unconvert
     # - unparam
     - unused
     # - whitespace

--- a/cmd/nerdctl/cp_linux.go
+++ b/cmd/nerdctl/cp_linux.go
@@ -233,7 +233,7 @@ func kopy(ctx context.Context, container2host bool, pid int, dst, src string, fo
 	}
 	tarX = append(tarX, "-f", "-")
 	if rootlessutil.IsRootless() {
-		nsenter := []string{"nsenter", "-t", strconv.Itoa(int(pid)), "-U", "--preserve-credentials", "--"}
+		nsenter := []string{"nsenter", "-t", strconv.Itoa(pid), "-U", "--preserve-credentials", "--"}
 		if container2host {
 			tarC = append(nsenter, tarC...)
 		} else {

--- a/cmd/nerdctl/cp_linux_test.go
+++ b/cmd/nerdctl/cp_linux_test.go
@@ -136,7 +136,7 @@ func TestCopyFromContainer(t *testing.T) {
 		assert.NilError(t, err)
 		stSys := st.Sys().(*syscall.Stat_t)
 		// stSys.Uid matches euid, not srcUID
-		assert.DeepEqual(t, uint32(euid), uint32(stSys.Uid))
+		assert.DeepEqual(t, uint32(euid), stSys.Uid)
 	}
 
 	td := t.TempDir()

--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -26,7 +26,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"syscall"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes/docker"
@@ -361,7 +360,7 @@ func ConfigureAuthentication(authConfig *types.AuthConfig, options *loginOptions
 
 func readUsername() (string, error) {
 	var fd *os.File
-	if term.IsTerminal(int(syscall.Stdin)) {
+	if term.IsTerminal(int(os.Stdin.Fd())) {
 		fd = os.Stdin
 	} else {
 		return "", fmt.Errorf("stdin is not a terminal (Hint: use `nerdctl login --username=USERNAME --password-stdin`)")

--- a/pkg/buildkitutil/buildkitutil.go
+++ b/pkg/buildkitutil/buildkitutil.go
@@ -136,7 +136,7 @@ func getHint() string {
 func PingBKDaemon(buildkitHost string) error {
 	if out, err := pingBKDaemon(buildkitHost); err != nil {
 		if out != "" {
-			logrus.Error(string(out))
+			logrus.Error(out)
 		}
 		return fmt.Errorf(getHint()+": %w", err)
 	}


### PR DESCRIPTION
Enhance the static-analysis workflow with add some golangci checks.

Signed-off-by: Kay Yan [kay.yan@daocloud.io](mailto:kay.yan@daocloud.io)