### PR TITLE
Add support to overlaybd convert

### DIFF
--- a/docs/overlaybd.md
+++ b/docs/overlaybd.md
@@ -27,3 +27,9 @@ nerdctl run --net host -it --rm --snapshotter=overlaybd registry.hub.docker.com/
 ```
 
 For more details about how to build overlaybd image, please refer to [accelerated-container-image](https://github.com/containerd/accelerated-container-image/blob/main/docs/IMAGE_CONVERTOR.md) conversion tool.
+
+## Build OverlayBD image using `nerdctl image convert`
+
+Nerdctl supports to convert an OCI image or docker format v2 image to OverlayBD image by using the `nerdctl image convert` command.
+
+Before the conversion, you should have the `overlaybd-snapshotter` binary installed, which build from [accelerated-container-image](https://github.com/containerd/accelerated-container-image). You can run the command like `nerdctl image convert --overlaybd --oci <source_image> <target_image>` to convert the `<source_image>` to a OverlayBD image whose tag is `<target_image>`.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Microsoft/go-winio v0.6.0
 	github.com/compose-spec/compose-go v1.7.0
+	github.com/containerd/accelerated-container-image v0.5.2
 	github.com/containerd/cgroups v1.0.5-0.20220816231112-7083cd60b721
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.0-beta.0

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u9
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/compose-spec/compose-go v1.7.0 h1:70HzJ/g81pdxF1ao9L7W2fgje/9FxNKH/davgvusEKc=
 github.com/compose-spec/compose-go v1.7.0/go.mod h1:Tb5Ae2PsYN3GTqYqzl2IRbTPiJtPZZjMw8UKUvmehFk=
+github.com/containerd/accelerated-container-image v0.5.2 h1:gnPqNqmynp/SjoAvFJpWTnZfaurtY9oop6etRSmFXPM=
+github.com/containerd/accelerated-container-image v0.5.2/go.mod h1:2gtaJ7535HlImo5DGYmUyRKSGOr9JqTqw1DX5FTpY3k=
 github.com/containerd/aufs v0.0.0-20200908144142-dab0cbea06f4/go.mod h1:nukgQABAEopAHvB6j7cnP5zJ+/3aVcE7hCYqvIwAHyE=
 github.com/containerd/aufs v0.0.0-20201003224125-76a6863f2989/go.mod h1:AkGGQs9NM2vtYHaUen+NljV0/baGCAPELGm2q9ZXpWU=
 github.com/containerd/aufs v0.0.0-20210316121734-20793ff83c97/go.mod h1:kL5kd6KM5TzQjR79jljyi4olc1Vrx6XBlcyj3gNv2PU=


### PR DESCRIPTION
This PR supports using nerdctl image convert to convert docker v2 or OCI images to OverlayBD images.

Before the conversion, users should have the `overlaybd-snapshotter` binary installed, which build from [accelerated-container-image](https://github.com/containerd/accelerated-container-image). They can run the command like `nerdctl image convert --overlaybd --oci <source_image> <target_image>` to convert a docker v2 or OCI image to a OverlayBD image whose tag is `<target_image>`.

After the conversion, they can use the nerdctl image push command to push the converted OverlayBD image to their registry and then use the `nerdctl run --snapshotter overlaybd` to run the image.

Signed-off-by: Haoqi Miao <miaohaoqi.mhq@alibaba-inc.com>