### PR TITLE
Support for ephemeral ports

### DIFF
--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -698,9 +698,6 @@ func servicePortConfigToFlagP(c types.ServicePortConfig) (string, error) {
 	default:
 		return "", fmt.Errorf("unsupported port mode: %s", c.Mode)
 	}
-	if c.Published == "" {
-		return "", fmt.Errorf("unsupported port number: %q", c.Published)
-	}
 	if c.Target <= 0 {
 		return "", fmt.Errorf("unsupported port number: %d", c.Target)
 	}

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -53,6 +53,13 @@ func TestServicePortConfigToFlagP(t *testing.T) {
 			},
 			expected: "127.0.0.1:8080:80",
 		},
+		{
+			ServicePortConfig: types.ServicePortConfig{
+				HostIP: "127.0.0.1",
+				Target: 80,
+			},
+			expected: "127.0.0.1::80",
+		},
 	}
 	for i, tc := range testCases {
 		got, err := servicePortConfigToFlagP(tc.ServicePortConfig)


### PR DESCRIPTION
Signed-off-by: Jack Zhang <jack4zhang@gmail.com>

Related to #351

How I tested

```shell
$ cat docker-compose.yaml
version: '3.1'

services:
  nginx:
    image: nginx
    restart: always
    ports:
      - 80

$ sudo ~/src/github/nerdctl/_output/nerdctl --cni-path=/opt/cni/bin compose up
$ sudo nerdctl port 02
80/tcp -> 0.0.0.0:49153
  ```

```shell
$ sudo nerdctl run --cni-path=/opt/cni/bin --rm -p :80 nginx
```