### PR TITLE
Format command usage output

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -41,7 +41,7 @@ import (
 
 func newBuildCommand() *cobra.Command {
 	var buildCommand = &cobra.Command{
-		Use:   "build",
+		Use:   "build [flags] PATH",
 		Short: "Build an image from a Dockerfile. Needs buildkitd to be running.",
 		Long: `Build an image from a Dockerfile. Needs buildkitd to be running.
 If Dockerfile is not present and -f is not specified, it will look for Containerfile and build with it. `,

--- a/cmd/nerdctl/cp_linux.go
+++ b/cmd/nerdctl/cp_linux.go
@@ -48,8 +48,8 @@ WARNING: 'nerdctl cp' is designed only for use with trusted, cooperating contain
 Using 'nerdctl cp' with untrusted or malicious containers is unsupported and may not provide protection against unexpected behavior.
 `
 
-	usage := `cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-
-  nerdctl cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH`
+	usage := `cp [flags] CONTAINER:SRC_PATH DEST_PATH|-
+  nerdctl cp [flags] SRC_PATH|- CONTAINER:DEST_PATH`
 	var cpCommand = &cobra.Command{
 		Use:               usage,
 		Args:              cobra.ExactArgs(2),

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -40,7 +40,7 @@ import (
 
 func newExecCommand() *cobra.Command {
 	var execCommand = &cobra.Command{
-		Use:               "exec [OPTIONS] CONTAINER COMMAND [ARG...]",
+		Use:               "exec [flags] CONTAINER COMMAND [ARG...]",
 		Args:              cobra.MinimumNArgs(2),
 		Short:             "Run a command in a running container",
 		RunE:              execAction,

--- a/cmd/nerdctl/history.go
+++ b/cmd/nerdctl/history.go
@@ -39,7 +39,7 @@ import (
 
 func newHistoryCommand() *cobra.Command {
 	var historyCommand = &cobra.Command{
-		Use:               "history [OPTIONS] IMAGE",
+		Use:               "history [flags] IMAGE",
 		Short:             "Show the history of an image",
 		Args:              cobra.ExactArgs(1),
 		RunE:              historyAction,

--- a/cmd/nerdctl/image_inspect.go
+++ b/cmd/nerdctl/image_inspect.go
@@ -32,7 +32,7 @@ import (
 
 func newImageInspectCommand() *cobra.Command {
 	var imageInspectCommand = &cobra.Command{
-		Use:               "inspect [OPTIONS] IMAGE [IMAGE...]",
+		Use:               "inspect [flags] IMAGE [IMAGE...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Display detailed information on one or more images.",
 		Long:              "Hint: set `--mode=native` for showing the full output",

--- a/cmd/nerdctl/namespace_rm.go
+++ b/cmd/nerdctl/namespace_rm.go
@@ -26,7 +26,7 @@ import (
 
 func newNamespaceRmCommand() *cobra.Command {
 	namespaceRmCommand := &cobra.Command{
-		Use:           "remove [OPTIONS] NAMESPACE [NAMESPACE...]",
+		Use:           "remove [flags] NAMESPACE [NAMESPACE...]",
 		Aliases:       []string{"rm"},
 		Args:          cobra.MinimumNArgs(1),
 		Short:         "Remove one or more namespaces",

--- a/cmd/nerdctl/namespace_update.go
+++ b/cmd/nerdctl/namespace_update.go
@@ -22,7 +22,7 @@ import (
 
 func newNamespacelabelUpdateCommand() *cobra.Command {
 	namespaceLableCommand := &cobra.Command{
-		Use:           "update NAMESPACE",
+		Use:           "update [flags] NAMESPACE",
 		Short:         "Update labels for a namespace",
 		RunE:          labelUpdateAction,
 		Args:          cobra.MinimumNArgs(1),

--- a/cmd/nerdctl/port.go
+++ b/cmd/nerdctl/port.go
@@ -33,7 +33,7 @@ import (
 
 func newPortCommand() *cobra.Command {
 	var portCommand = &cobra.Command{
-		Use:               "port CONTAINER [PRIVATE_PORT[/PROTO]]",
+		Use:               "port [flags] CONTAINER [PRIVATE_PORT[/PROTO]]",
 		Args:              cobra.RangeArgs(1, 2),
 		Short:             "List port mappings or a specific mapping for the container",
 		RunE:              portAction,

--- a/cmd/nerdctl/pull.go
+++ b/cmd/nerdctl/pull.go
@@ -37,7 +37,7 @@ import (
 
 func newPullCommand() *cobra.Command {
 	var pullCommand = &cobra.Command{
-		Use:           "pull",
+		Use:           "pull [flags] NAME[:TAG]",
 		Short:         "Pull an image from a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS.",
 		Args:          cobra.ExactArgs(1),
 		RunE:          pullAction,

--- a/cmd/nerdctl/push.go
+++ b/cmd/nerdctl/push.go
@@ -50,7 +50,7 @@ const (
 
 func newPushCommand() *cobra.Command {
 	var pushCommand = &cobra.Command{
-		Use:               "push NAME[:TAG]",
+		Use:               "push [flags] NAME[:TAG]",
 		Short:             "Push an image or a repository to a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to push image to IPFS.",
 		Args:              cobra.ExactArgs(1),
 		RunE:              pushAction,

--- a/cmd/nerdctl/rename.go
+++ b/cmd/nerdctl/rename.go
@@ -30,7 +30,7 @@ import (
 
 func newRenameCommand() *cobra.Command {
 	var renameCommand = &cobra.Command{
-		Use:               "rename CONTAINER NEW_NAME",
+		Use:               "rename [flags] CONTAINER NEW_NAME",
 		Args:              cobra.ExactArgs(2),
 		Short:             "rename a container",
 		RunE:              renameAction,

--- a/cmd/nerdctl/tag.go
+++ b/cmd/nerdctl/tag.go
@@ -29,7 +29,7 @@ import (
 
 func newTagCommand() *cobra.Command {
 	var tagCommand = &cobra.Command{
-		Use:               "tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
+		Use:               "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
 		Short:             "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
 		Args:              cobra.ExactArgs(2),
 		RunE:              tagAction,


### PR DESCRIPTION
The usage output for some commands are not consistent and sometime confusing:

1. Some use `[OPTIONS]` instead of `[flags]`, causing `cobra` will append another `[flags]` at the end of usage output.

```shell
➜  nerdctl git:(doc-flag) sudo nerdctl exec -h
Run a command in a running container

Usage: nerdctl exec [OPTIONS] CONTAINER COMMAND [ARG...] [flags]
```

2. When a command accepts args, _appending `[flags]` at the end_ isn't consistent with the general format of `nerdctl COMMAND [flags] ARGS`. 

```shell
➜  nerdctl git:(doc-flag) sudo nerdctl tag -h
Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE

Usage: nerdctl tag SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG] [flags]
```

Signed-off-by: Jin Dong <jindon@amazon.com>