### PR TITLE
Add `compose rm` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose config](#whale-nerdctl-compose-config)
     - [:whale: nerdctl compose kill](#whale-nerdctl-compose-kill)
     - [:whale: nerdctl compose restart](#whale-nerdctl-compose-restart)
+    - [:whale: nerdctl compose rm](#whale-nerdctl-compose-rm)
     - [:whale: nerdctl compose run](#whale-nerdctl-compose-run)
     - [:whale: nerdctl compose version](#whale-nerdctl-compose-version)
   - [IPFS management](#ipfs-management)
@@ -1514,6 +1515,18 @@ Flags:
 
 - :whale: `-t, --timeout`: Seconds to wait before restarting it (default 10)
 
+### :whale: nerdctl compose rm
+
+Remove stopped service containers
+
+Usage: `nerdctl compose rm [OPTIONS] [SERVICE...]`
+
+Flags:
+
+- :whale: `-f, --force`: Don't prompt for confirmation (different with `-f` in `nerdctl rm` which means force deletion).
+- :whale: `-s, --stop`: Stop containers before removing.
+- :whale: `-v, --volumes`: Remove anonymous volumes associated with the container.
+
 ### :whale: nerdctl compose run
 Run a one-off command on a service
 
@@ -1601,7 +1614,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose create|events|exec|images|pause|port|rm|scale|start|top|unpause`
+- `docker-compose create|events|exec|images|pause|port|scale|start|top|unpause`
 
 Others:
 - `docker system df`

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -64,6 +64,7 @@ func newComposeCommand() *cobra.Command {
 		newComposePsCommand(),
 		newComposeKillCommand(),
 		newComposeRestartCommand(),
+		newComposeRemoveCommand(),
 		newComposeRunCommand(),
 		newComposeVersionCommand(),
 		newComposeStopCommand(),

--- a/cmd/nerdctl/compose_rm.go
+++ b/cmd/nerdctl/compose_rm.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/spf13/cobra"
+)
+
+func newComposeRemoveCommand() *cobra.Command {
+	var composeRemoveCommand = &cobra.Command{
+		Use:           "rm [flags] [SERVICE...]",
+		Short:         "Remove stopped service containers",
+		RunE:          composeRemoveAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	composeRemoveCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	composeRemoveCommand.Flags().BoolP("stop", "s", false, "Stop containers before removing")
+	composeRemoveCommand.Flags().BoolP("volumes", "v", false, "Remove anonymous volumes associated with containers")
+	return composeRemoveCommand
+}
+
+func composeRemoveAction(cmd *cobra.Command, args []string) error {
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return err
+	}
+	if !force {
+		var confirm string
+		services := "all"
+		if len(args) != 0 {
+			services = strings.Join(args, ",")
+		}
+		msg := fmt.Sprintf("This will remove all stopped containers from services: %s.", services)
+		msg += "\nAre you sure you want to continue? [y/N] "
+		fmt.Fprintf(cmd.OutOrStdout(), "WARNING! %s", msg)
+		fmt.Fscanf(cmd.InOrStdin(), "%s", &confirm)
+
+		if strings.ToLower(confirm) != "y" {
+			return nil
+		}
+	}
+
+	stop, err := cmd.Flags().GetBool("stop")
+	if err != nil {
+		return err
+	}
+	volumes, err := cmd.Flags().GetBool("volumes")
+	if err != nil {
+		return err
+	}
+
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+
+	rmOpts := composer.RemoveOptions{
+		Stop:    stop,
+		Volumes: volumes,
+	}
+	return c.Remove(ctx, rmOpts, args)
+}

--- a/cmd/nerdctl/compose_rm_linux_test.go
+++ b/cmd/nerdctl/compose_rm_linux_test.go
@@ -1,0 +1,103 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeRemove(t *testing.T) {
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+
+  wordpress:
+    image: %s
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
+    volumes:
+      - wordpress:/var/www/html
+
+  db:
+    image: %s
+    environment:
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+`, testutil.WordpressImage, testutil.MariaDBImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
+
+	rmAssertHandler := func(svc string) func(stdout string) error {
+		return func(stdout string) error {
+			if strings.Contains(stdout, svc) {
+				return fmt.Errorf("service \"%s\" still has remaining containers", svc)
+			}
+			return nil
+		}
+	}
+	upAssertHandler := func(svc string) func(stdout string) error {
+		return func(stdout string) error {
+			// Docker Compose v1: "Up", v2: "running"
+			if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
+				return fmt.Errorf("service \"%s\" must have been still running", svc)
+			}
+			return nil
+		}
+	}
+
+	// no stopped containers
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "rm", "-f").AssertOK()
+	time.Sleep(3 * time.Second)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(upAssertHandler("wordpress"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
+	// remove one stopped service
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "wordpress").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "rm", "-f", "wordpress").AssertOK()
+	time.Sleep(3 * time.Second)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(rmAssertHandler("wordpress"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
+	// remove all services with `--stop`
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "rm", "-f", "-s").AssertOK()
+	time.Sleep(3 * time.Second)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(rmAssertHandler("db"))
+}

--- a/pkg/composer/rm.go
+++ b/pkg/composer/rm.go
@@ -1,0 +1,94 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/formatter"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/containerd/nerdctl/pkg/strutil"
+
+	"github.com/sirupsen/logrus"
+)
+
+// RemoveOptions stores all option input from `nerdctl compose rm`
+type RemoveOptions struct {
+	Stop    bool
+	Volumes bool
+}
+
+// Remove removes stopped containers in `services`.
+func (c *Composer) Remove(ctx context.Context, opt RemoveOptions, services []string) error {
+	serviceNames, err := c.ServiceNames(services...)
+	if err != nil {
+		return err
+	}
+	// reverse dependency order
+	for _, svc := range strutil.ReverseStrSlice(serviceNames) {
+		containers, err := c.Containers(ctx, svc)
+		if err != nil {
+			return err
+		}
+		if opt.Stop {
+			// use default Options to stop service containers.
+			if err := c.stopContainers(ctx, containers, StopOptions{}); err != nil {
+				return err
+			}
+		}
+		if err := c.removeContainers(ctx, containers, opt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Composer) removeContainers(ctx context.Context, containers []containerd.Container, opt RemoveOptions) error {
+	args := []string{"rm", "-f"}
+	if opt.Volumes {
+		args = append(args, "-v")
+	}
+
+	var rmWG sync.WaitGroup
+	for _, container := range containers {
+		container := container
+		rmWG.Add(1)
+		go func() {
+			defer rmWG.Done()
+			info, _ := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+			// if no `--stop` is passed, check status and skip running container
+			if !opt.Stop {
+				cStatus := formatter.ContainerStatus(ctx, container)
+				if strings.HasPrefix(cStatus, "Up") {
+					logrus.Warnf("Removing container %s failed: container still running.", info.Labels[labels.Name])
+					return
+				}
+			}
+
+			logrus.Infof("Removing container %s", info.Labels[labels.Name])
+			if err := c.runNerdctlCmd(ctx, append(args, container.ID())...); err != nil {
+				logrus.Warn(err)
+			}
+		}()
+	}
+	rmWG.Wait()
+
+	return nil
+}


### PR DESCRIPTION
Add `compose rm` command and related args ([docker doc](https://docs.docker.com/engine/reference/commandline/compose_rm/)).

High level logic:

```shell
for each given service:
    if `stop` is passed:
        `stop` all containers in the service (use `c.stopContainers(containers, ...)`)
    for each container in the service:
        if `status` == `Up`:
            continue
        `rm` the container using `nerdctl rm -f` (and `-v` if it's passed)
```

Signed-off-by: Jin Dong <jindon@amazon.com>