### PR TITLE
Refactor internalLabels

### DIFF
--- a/cmd/nerdctl/run_freebsd.go
+++ b/cmd/nerdctl/run_freebsd.go
@@ -39,10 +39,6 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]oci.SpecOpts, error) {
-	return opts, nil
-}
-
-func setPlatformContainerOptions(ctx context.Context, cOpts []containerd.NewContainerOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]containerd.NewContainerOpts, error) {
-	return cOpts, nil
+func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string, internalLabels internalLabels) ([]oci.SpecOpts, internalLabels, error) {
+	return opts, internalLabels, nil
 }

--- a/cmd/nerdctl/run_windows.go
+++ b/cmd/nerdctl/run_windows.go
@@ -41,10 +41,10 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]oci.SpecOpts, error) {
+func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string, internalLabels internalLabels) ([]oci.SpecOpts, internalLabels, error) {
 	cpus, err := cmd.Flags().GetFloat64("cpus")
 	if err != nil {
-		return nil, err
+		return nil, internalLabels, err
 	}
 	if cpus > 0.0 {
 		opts = append(opts, oci.WithWindowsCPUCount(uint64(cpus)))
@@ -52,12 +52,12 @@ func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Com
 
 	memStr, err := cmd.Flags().GetString("memory")
 	if err != nil {
-		return nil, err
+		return nil, internalLabels, err
 	}
 	if memStr != "" {
 		mem64, err := units.RAMInBytes(memStr)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse memory bytes %q: %w", memStr, err)
+			return nil, internalLabels, fmt.Errorf("failed to parse memory bytes %q: %w", memStr, err)
 		}
 		opts = append(opts, oci.WithMemoryLimit(uint64(mem64)))
 	}
@@ -66,9 +66,5 @@ func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Com
 		oci.WithWindowNetworksAllowUnqualifiedDNSQuery(),
 		oci.WithWindowsIgnoreFlushesDuringBoot())
 
-	return opts, nil
-}
-
-func setPlatformContainerOptions(ctx context.Context, cOpts []containerd.NewContainerOpts, cmd *cobra.Command, client *containerd.Client, id string) ([]containerd.NewContainerOpts, error) {
-	return cOpts, nil
+	return opts, internalLabels, nil
 }


### PR DESCRIPTION
related https://github.com/containerd/nerdctl/pull/1411 especially, https://github.com/containerd/nerdctl/pull/1411#discussion_r991911815, https://github.com/containerd/nerdctl/pull/1411#pullrequestreview-1145374299

## Changes
- Simplify `withInternalLabels()` in `cmd/nerdctl/run.go`
- Delete `setPlatformContainerOptions()`

## Details
### Simplify `withInternalLabels()` in `cmd/nerdctl/run.go`
  - Problem : As the features of nerdctl expands in the future, the number of internalLabel will continue to increase, but processing by increasing the parameter creates resistance to writing code that increases internalLabel.
  - Solution : Abstract and unite internalLabels as a structure.

### Delete `setPlatformContainerOptions()`:
  - Problem:
    - `setPlatformContainerOptions()` be created by processing an internalLabel (PIDContainer supporting `--pid=container:<name or id>`) for linux. But as the structure for internalLabel is created, it is not needed. 
    - Due to a structural problem in the code, `setPlatformContainerOptions()` and `setPlatformOptions()` query the container twice.
  - Solution : Delete `setPlatformContainerOptions()` and pass a new parameter into `setPlatformOptions()` for platform specific labels.
