### PR TITLE
Prevent double-creation of nerdctl default network.

### DIFF
--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -109,9 +109,13 @@ func shellCompleteNetworkNames(cmd *cobra.Command, exclude []string) ([]string, 
 		return nil, cobra.ShellCompDirectiveError
 	}
 	candidates := []string{}
-	for _, n := range e.Networks {
-		if _, ok := excludeMap[n.Name]; !ok {
-			candidates = append(candidates, n.Name)
+	netConfigs, err := e.NetworkMap()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	for netName := range netConfigs {
+		if _, ok := excludeMap[netName]; !ok {
+			candidates = append(candidates, netName)
 		}
 	}
 	for _, s := range []string{"host", "none"} {

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -136,9 +136,13 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 	if err != nil {
 		return nil, err
 	}
+	networkConfigs, err := cniEnv.NetworkList()
+	if err != nil {
+		return nil, err
+	}
 
 	o.NetworkExists = func(netName string) (bool, error) {
-		for _, f := range cniEnv.Networks {
+		for _, f := range networkConfigs {
 			if f.Name == netName {
 				return true, nil
 			}

--- a/cmd/nerdctl/network_inspect.go
+++ b/cmd/nerdctl/network_inspect.go
@@ -62,7 +62,10 @@ func networkInspectAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	netMap := e.NetworkMap()
+	netMap, err := e.NetworkMap()
+	if err != nil {
+		return err
+	}
 
 	result := make([]interface{}, len(args))
 	for i, name := range args {

--- a/cmd/nerdctl/network_ls.go
+++ b/cmd/nerdctl/network_ls.go
@@ -97,8 +97,12 @@ func networkLsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	pp := make([]networkPrintable, len(e.Networks))
-	for i, n := range e.Networks {
+	netConfigs, err := e.NetworkList()
+	if err != nil {
+		return err
+	}
+	pp := make([]networkPrintable, len(netConfigs))
+	for i, n := range netConfigs {
 		p := networkPrintable{
 			Name: n.Name,
 			file: n.File,

--- a/cmd/nerdctl/network_prune.go
+++ b/cmd/nerdctl/network_prune.go
@@ -95,8 +95,13 @@ func networkPrune(ctx context.Context, cmd *cobra.Command, client *containerd.Cl
 		return err
 	}
 
+	networkConfigs, err := e.NetworkList()
+	if err != nil {
+		return err
+	}
+
 	var removedNetworks []string // nolint: prealloc
-	for _, net := range e.Networks {
+	for _, net := range networkConfigs {
 		if strutil.InStringSlice(networkDriversToKeep, net.Name) {
 			continue
 		}

--- a/cmd/nerdctl/run_network.go
+++ b/cmd/nerdctl/run_network.go
@@ -278,7 +278,10 @@ func verifyCNINetwork(cmd *cobra.Command, netSlice []string, macAddress string) 
 		return err
 	}
 	macValidNetworks := []string{"bridge", "macvlan"}
-	netMap := e.NetworkMap()
+	netMap, err := e.NetworkMap()
+	if err != nil {
+		return err
+	}
 	for _, netstr := range netSlice {
 		netConfig, ok := netMap[netstr]
 		if !ok {

--- a/pkg/idutil/netwalker/netwalker.go
+++ b/pkg/idutil/netwalker/netwalker.go
@@ -52,11 +52,12 @@ func (w *NetworkWalker) Walk(ctx context.Context, req string) (int, error) {
 		return 0, err
 	}
 
-	networks := []*netutil.NetworkConfig{}
-	for _, n := range w.Client.Networks {
-		if n.Name == req || longIDExp.Match([]byte(*n.NerdctlID)) || shortIDExp.Match([]byte(*n.NerdctlID)) {
-			networks = append(networks, n)
-		}
+	idFilterF := func(n *netutil.NetworkConfig) bool {
+		return n.Name == req || longIDExp.Match([]byte(*n.NerdctlID)) || shortIDExp.Match([]byte(*n.NerdctlID))
+	}
+	networks, err := w.Client.FilterNetworks(idFilterF)
+	if err != nil {
+		return 0, err
 	}
 
 	matchCount := len(networks)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -89,6 +89,12 @@ const (
 
 	// PIDContainer is the `nerdctl run --pid` for restarting
 	PIDContainer = Prefix + "pid-container"
+
+	// NerdctlDefaultNetwork indicates whether a network is the default network
+	// created and owned by Nerdctl.
+	// Boolean value which can be parsed with strconv.ParseBool() is required.
+	// (like "nerdctl/default-network=true" or "nerdctl/default-network=false")
+	NerdctlDefaultNetwork = Prefix + "default-network"
 )
 
 var ShellCompletions = []string{

--- a/pkg/netutil/netutil_linux_test.go
+++ b/pkg/netutil/netutil_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package netutil
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/rootlessutil"
+)
+
+// Tests whether nerdctl properly creates the default network when required.
+// On Linux, the default driver used will be "bridge". (netutil.DefaultNetworkName)
+func TestDefaultNetworkCreation(t *testing.T) {
+	if rootlessutil.IsRootless() {
+		t.Skip("must be superuser to create default network for this test")
+	}
+
+	testDefaultNetworkCreation(t)
+}

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -17,11 +17,42 @@
 package netutil
 
 import (
+	"bytes"
+	"fmt"
 	"net"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
+	"text/template"
+
+	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/containerd/nerdctl/pkg/testutil"
 
 	"gotest.tools/v3/assert"
 )
+
+const preExistingNetworkConfigTemplate = `
+{
+    "cniVersion": "0.2.0",
+    "name": "{{ .network_name }}",
+    "type": "nat",
+    "master": "Ethernet",
+    "ipam": {
+        "subnet": "{{ .subnet }}",
+        "routes": [
+            {
+                "GW": "{{ .gateway }}"
+            }
+        ]
+    },
+    "capabilities": {
+        "portMappings": true,
+        "dns": true
+    }
+}
+`
 
 func TestParseIPAMRange(t *testing.T) {
 	t.Parallel()
@@ -96,4 +127,138 @@ func TestParseIPAMRange(t *testing.T) {
 			assert.Equal(t, *tc.expected, *got)
 		}
 	}
+}
+
+// Tests whether nerdctl properly creates the default network when required.
+// Note that this test will require a CNI driver bearing the same name as
+// the type of the default network. (denoted by netutil.DefaultNetworkName,
+// which is used as both the name of the default network and its Driver)
+func testDefaultNetworkCreation(t *testing.T) {
+	// To prevent subnet collisions when attempting to recreate the default network
+	// in the isolated CNI config dir we'll be using, we must first delete
+	// the network in the default CNI config dir.
+	defaultCniEnv := CNIEnv{
+		Path:        ncdefaults.CNIPath(),
+		NetconfPath: ncdefaults.CNINetConfPath(),
+	}
+	defaultNet, err := defaultCniEnv.GetDefaultNetworkConfig()
+	assert.NilError(t, err)
+	if defaultNet != nil {
+		assert.NilError(t, defaultCniEnv.RemoveNetwork(defaultNet))
+	}
+
+	// We create a tempdir for the CNI conf path to ensure an empty env for this test.
+	cniConfTestDir := t.TempDir()
+	cniEnv := CNIEnv{
+		Path:        ncdefaults.CNIPath(),
+		NetconfPath: cniConfTestDir,
+	}
+	// Ensure no default network config is not present.
+	defaultNetConf, err := cniEnv.GetDefaultNetworkConfig()
+	assert.NilError(t, err)
+	assert.Assert(t, defaultNetConf == nil)
+
+	// Attempt to create the default network.
+	err = cniEnv.ensureDefaultNetworkConfig()
+	assert.NilError(t, err)
+
+	// Ensure no default network config is present now.
+	defaultNetConf, err = cniEnv.GetDefaultNetworkConfig()
+	assert.NilError(t, err)
+	assert.Assert(t, defaultNetConf != nil)
+
+	// Check network config file present.
+	stat, err := os.Stat(defaultNetConf.File)
+	assert.NilError(t, err)
+	firstConfigModTime := stat.ModTime()
+
+	// Check default network label present.
+	assert.Assert(t, defaultNetConf.NerdctlLabels != nil)
+	lstr, ok := (*defaultNetConf.NerdctlLabels)[labels.NerdctlDefaultNetwork]
+	assert.Assert(t, ok)
+	boolv, err := strconv.ParseBool(lstr)
+	assert.NilError(t, err)
+	assert.Assert(t, boolv)
+
+	// Ensure network isn't created twice or accidentally re-created.
+	err = cniEnv.ensureDefaultNetworkConfig()
+	assert.NilError(t, err)
+
+	// Check for any other network config files.
+	files := []os.FileInfo{}
+	walkF := func(p string, info os.FileInfo, err error) error {
+		files = append(files, info)
+		return nil
+	}
+	err = filepath.Walk(cniConfTestDir, walkF)
+	assert.NilError(t, err)
+	assert.Assert(t, len(files) == 2) // files[0] is the entry for '.'
+	assert.Assert(t, filepath.Join(cniConfTestDir, files[1].Name()) == defaultNetConf.File)
+	assert.Assert(t, firstConfigModTime == files[1].ModTime())
+}
+
+// Tests whether nerdctl skips the creation of the default network if a
+// network bearing the default network name already exists in a
+// non-nerdctl-managed network config file.
+func TestNetworkWithDefaultNameAlreadyExists(t *testing.T) {
+	// We create a tempdir for the CNI conf path to ensure an empty env for this test.
+	cniConfTestDir := t.TempDir()
+	cniEnv := CNIEnv{
+		Path:        t.TempDir(), // irrelevant for this test
+		NetconfPath: cniConfTestDir,
+	}
+
+	// Ensure no default network config is not present.
+	defaultNetConf, err := cniEnv.GetDefaultNetworkConfig()
+	assert.NilError(t, err)
+	assert.Assert(t, defaultNetConf == nil)
+
+	// Manually define and write a network config file.
+	values := map[string]string{
+		"network_name": DefaultNetworkName,
+		"subnet":       "10.7.1.1/24",
+		"gateway":      "10.7.1.1",
+	}
+	tpl, err := template.New("test").Parse(preExistingNetworkConfigTemplate)
+	assert.NilError(t, err)
+	buf := &bytes.Buffer{}
+	assert.NilError(t, tpl.ExecuteTemplate(buf, "test", values))
+
+	// Filename is irrelevant as long as it's not nerdctl's.
+	testConfFile := filepath.Join(cniConfTestDir, fmt.Sprintf("%s.conf", testutil.Identifier(t)))
+	err = os.WriteFile(testConfFile, buf.Bytes(), 0600)
+	assert.NilError(t, err)
+
+	// Check network is detected.
+	netConfs, err := cniEnv.NetworkList()
+	assert.NilError(t, err)
+	assert.Assert(t, len(netConfs) > 0)
+
+	var listedDefaultNetConf *NetworkConfig
+	for _, netConf := range netConfs {
+		if netConf.Name == DefaultNetworkName {
+			listedDefaultNetConf = netConf
+			break
+		}
+	}
+	assert.Assert(t, listedDefaultNetConf != nil)
+
+	defaultNetConf, err = cniEnv.GetDefaultNetworkConfig()
+	assert.NilError(t, err)
+	assert.Assert(t, defaultNetConf != nil)
+	assert.Assert(t, defaultNetConf.File == testConfFile)
+
+	err = cniEnv.ensureDefaultNetworkConfig()
+	assert.NilError(t, err)
+
+	netConfs, err = cniEnv.NetworkList()
+	assert.NilError(t, err)
+	defaultNamedNetworksFileDefinitions := []string{}
+	for _, netConf := range netConfs {
+		if netConf.Name == DefaultNetworkName {
+			defaultNamedNetworksFileDefinitions = append(defaultNamedNetworksFileDefinitions, netConf.File)
+		}
+	}
+	assert.Assert(t, len(defaultNamedNetworksFileDefinitions) == 1)
+	assert.Assert(t, defaultNamedNetworksFileDefinitions[0] == testConfFile)
 }

--- a/pkg/netutil/netutil_windows_test.go
+++ b/pkg/netutil/netutil_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package netutil
+
+import "testing"
+
+// Tests whether nerdctl properly creates the default network when required.
+// On Windows, the default driver used will be "nat". (netutil.DefaultNetworkName)
+func TestDefaultNetworkCreation(t *testing.T) {
+	testDefaultNetworkCreation(t)
+}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -145,7 +145,10 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 		cniOpts := []gocni.Opt{
 			gocni.WithPluginDir([]string{cniPath}),
 		}
-		netMap := e.NetworkMap()
+		netMap, err := e.NetworkMap()
+		if err != nil {
+			return nil, err
+		}
 		for _, netstr := range networks {
 			net, ok := netMap[netstr]
 			if !ok {


### PR DESCRIPTION
This patch adds logic to pkg/netutil to prevent nerdctl from accidentally creating a second default network if a non-nerdctl-created network with the same default name already happens to exist.

Additionally, a new `nerdctl/default-network` label definition has been added to indicate whether a network was created by nerdctl with the express purpose of being used as a default network.

Signed-off-by: Nashwan Azhari <nazhari@cloudbasesolutions.com>