### PR TITLE
MAINTAINERS: promote Zheao Li from a REVIEWER to a COMMITTER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -7,9 +7,9 @@
 # GitHub ID, Name, Email address
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com"
 "fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com"
+"Zheaoli", "Zheao Li", "me@manjusaka.me"
 
 # REVIEWERS
 # GitHub ID, Name, Email address
 "jsturtevant","James Sturtevant","jstur@microsoft.com"
 "Junnplus","Ye Sijun","junnplus@gmail.com"
-"Zheaoli", "Zheao Li", "me@manjusaka.me"


### PR DESCRIPTION
@Zheaoli has been a reviewer since June (https://github.com/containerd/nerdctl/pull/1121), and he has been very actively contributing to the project:
https://github.com/containerd/nerdctl/pulls?q=author%3AZheaoli+

So I'd like to promote @Zheaoli to a committer.

Needs explicit LGTM from @Zheaoli and 2/3 of the nerdctl Committers ( $ceil \left( 2 \times \frac{2}{3} \right) = 2$ ), according to https://github.com/containerd/project/blob/main/GOVERNANCE.md :


> After a candidate has been informally proposed in the maintainers forum, the
> existing maintainers are given seven days to discuss the candidate, raise
> objections and show their support. Formal voting takes place on a pull request
> that adds the contributor to the MAINTAINERS file. Candidates must be approved
> by 2/3 of the current committers by adding their approval or LGTM to the pull
> request. The reviewer role has the same process but only requires 1/3 of current
> committers.
> 
> If a candidate is approved, they will be invited to add their own LGTM or
> approval to the pull request to acknowledge their agreement. A committer will
> verify the numbers of votes that have been received and the allotted seven days
> have passed, then merge the pull request and invite the contributor to the
> organization.
> 
> For non-core sub-projects, only committers of the repository that the candidate
> is proposed for are given votes.


- [x] @Zheaoli
- [x] @ktock (nerdctl Committer)
- [x] @fahedouch (nerdctl Committer)

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 7 days.