### PR TITLE
MAINTAINERS: add Manu Gupta (manugupt1) as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -14,3 +14,4 @@
 # GitHub ID, Name, Email address
 "jsturtevant","James Sturtevant","jstur@microsoft.com"
 "yuchanns", "Hanchin Hsieh", "me@yuchanns.xyz"
+"manugupt1", "Manu Gupta", "manugupt1@gmail.com"


### PR DESCRIPTION
Manu Gupta (@manugupt1) has been very actively contributing to the project:
https://github.com/containerd/nerdctl/pulls?q=author%3Amanugupt1+

So I'd like to invite @manugupt1 as a reviewer.

Needs explicit LGTM from @manugupt1 and 1/3 of the nerdctl Committers ( $ceil \left( 1 \times \frac{2}{3} \right) = 1$ ), according to https://github.com/containerd/project/blob/main/GOVERNANCE.md :


> After a candidate has been informally proposed in the maintainers forum, the
> existing maintainers are given seven days to discuss the candidate, raise
> objections and show their support. Formal voting takes place on a pull request
> that adds the contributor to the MAINTAINERS file. Candidates must be approved
> by 2/3 of the current committers by adding their approval or LGTM to the pull
> request. The reviewer role has the same process but only requires 1/3 of current
> committers.
> 
> If a candidate is approved, they will be invited to add their own LGTM or
> approval to the pull request to acknowledge their agreement. A committer will
> verify the numbers of votes that have been received and the allotted seven days
> have passed, then merge the pull request and invite the contributor to the
> organization.
> 
> For non-core sub-projects, only committers of the repository that the candidate
> is proposed for are given votes.


- [x] @manugupt1
- [x] @ktock (nerdctl Committer)
- [x] @fahedouch (nerdctl Committer)

I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 7 days.