### PR TITLE
fix `nerdctl exec` init console size 0 0 problem

### DIFF
--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -230,6 +230,14 @@ func generateExecProcessSpec(ctx context.Context, cmd *cobra.Command, args []str
 		return nil, err
 	}
 	pspec.Terminal = flagT
+	if flagT {
+		con := console.Current()
+		if size, err := con.Size(); err != nil {
+			return nil, err
+		} else {
+			pspec.ConsoleSize = &specs.Box{Height: uint(size.Height), Width: uint(size.Width)}
+		}
+	}
 	pspec.Args = args[1:]
 
 	workdir, err := cmd.Flags().GetString("workdir")


### PR DESCRIPTION
when execute `nerdctl exec -it <containerID> bash`,  initial tty size is `0,0`,  fix this bug by initialize terminal size when create execute spec