### PR TITLE
Resolve flaky TestRunWithLogBinary

### DIFF
--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -440,7 +440,7 @@ COPY --from=builder /go/src/logger/logger /
 	base.Cmd("container", "rm", "-f", containerName).AssertOK()
 	base.Cmd("run", "-d", "--log-driver", fmt.Sprintf("binary://%s/logger", tmpDir), "--name", containerName, testutil.CommonImage,
 		"sh", "-euxc", "echo foo; echo bar").AssertOK()
-	defer base.Cmd("container", "rm", "-f", containerName)
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
 
 	inspectedContainer := base.InspectContainer(containerName)
 	bytes, err := os.ReadFile(filepath.Join(os.TempDir(), fmt.Sprintf("%s_%s.log", inspectedContainer.ID, "stdout")))


### PR DESCRIPTION
This should fix #1549 (if my suspection is correct :) ).

Both error examples in #1549 points to container service in containerd ([1](https://github.com/containerd/containerd/blob/v1.6.8/metadata/containers.go#L60), [2](https://github.com/containerd/containerd/blob/v1.6.8/container.go#L201)).

Error 1 seems saying `container not exists` while error 2 seems saying `container exists (Get call from (1) is returned) but image not exist`.

Both errors' entry point in `nerdctl` is in `nerdctm container rm -f` command (so the command is called in the test via the `defer`, although no `Run()`/`AssertOK()` is followed).

I suspect the issue is because there is no `AssertOK()` for this `defer` (thus no explicit call of `Run()`), which causing `defer container rm` executed after the `defer image rm`, although it's deferred after `defer image rm`.

Signed-off-by: Jin Dong <jindon@amazon.com>