### PR TITLE
binfmt: support /proc/sys/fs/binfmt_misc/rosetta

### DIFF
--- a/pkg/platformutil/binfmt.go
+++ b/pkg/platformutil/binfmt.go
@@ -60,6 +60,11 @@ func canExecProbably(s string) (bool, error) {
 			"/proc/sys/fs/binfmt_misc/qemu-" + qemuArch,
 			"/proc/sys/fs/binfmt_misc/buildkit-qemu-" + qemuArch,
 		}
+		// Rosetta 2 for Linux on ARM Mac
+		// https://developer.apple.com/documentation/virtualization/running_intel_binaries_in_linux_vms_with_rosetta
+		if runtime.GOARCH == "arm64" && p.Architecture == "amd64" {
+			candidates = append(candidates, "/proc/sys/fs/binfmt_misc/rosetta")
+		}
 		for _, cand := range candidates {
 			if _, err := os.Stat(cand); err == nil {
 				return true, nil


### PR DESCRIPTION
For silencing the `Platform "linux/amd64" seems incompatible with the host platform "linux/arm64/v8"` warning on Lima
https://github.com/lima-vm/lima/blob/v0.14.0-beta.1/pkg/cidata/cidata.TEMPLATE.d/boot/05-rosetta-volume.sh
