### PR TITLE
fix network creation behavior

### DIFF
--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -130,7 +130,7 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 		Experimental:     experimental,
 	}
 
-	cniEnv, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	cniEnv, err := netutil.NewCNIEnv(cniPath, cniNetconfpath, netutil.WithDefaultNetwork())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nerdctl/run_network.go
+++ b/cmd/nerdctl/run_network.go
@@ -273,7 +273,7 @@ func verifyCNINetwork(cmd *cobra.Command, netSlice []string, macAddress string) 
 	if err != nil {
 		return err
 	}
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath, netutil.WithDefaultNetwork())
 	if err != nil {
 		return err
 	}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -138,7 +138,7 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 	case nettype.Host, nettype.None, nettype.Container:
 		// NOP
 	case nettype.CNI:
-		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath)
+		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath, netutil.WithDefaultNetwork())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Nerdctl `default network` should be considered like other networks, that means we should be able to `CRUD` the default network. 
in this PR I am eliminating the confusion during a default network CRUD by disabling automatic creation during CRUD.

The default network still be automatically created by a container runtime

fixing https://github.com/containerd/nerdctl/issues/1490

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>