### PR TITLE
Support IPv6 for nerdctl network

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,6 +104,50 @@ jobs:
       - name: "Run integration tests"
         run: docker run -t --rm --privileged test-integration
 
+  test-integration-ipv6:
+    runs-on: "ubuntu-${{ matrix.ubuntu }}"
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-20.04: cgroup v1, ubuntu-22.04: cgroup v2
+        include:
+          - ubuntu: 22.04
+            containerd: v1.7.7
+    env:
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
+      CONTAINERD_VERSION: "${{ matrix.containerd }}"
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 1
+      - name: Enable ipv4 and ipv6 forwarding
+        run: |
+          sudo sysctl -w net.ipv6.conf.all.forwarding=1
+          sudo sysctl -w net.ipv4.ip_forward=1
+      - name: Enable IPv6 for Docker
+        run: |
+          sudo mkdir -p /etc/docker
+          echo '{"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+      - name: "Prepare integration test environment"
+        run: DOCKER_BUILDKIT=1 docker build -t test-integration-ipv6 --target test-integration-ipv6 --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+      - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
+        run: |
+          sudo systemctl disable --now snapd.service snapd.socket
+          sudo apt-get purge -y snapd
+          sudo losetup -Dv
+          sudo losetup -lv
+      - name: "Register QEMU (tonistiigi/binfmt)"
+        run: docker run --privileged --rm tonistiigi/binfmt --install all
+      - name: "Run integration tests"
+        # The nested IPv6 network inside docker and qemu is complex and needs a bunch of sysctl config.
+        # Therefore it's hard to debug why the IPv6 tests fail in such an isolation layer.
+        # On the other side, using the host network is easier at configuration.
+        # Besides, each job is running on a different instance, which means using host network here
+        # is safe and has no side effects on others.
+        run: docker run --network host -t --rm --privileged test-integration-ipv6
+
   test-integration-rootless:
     runs-on: "ubuntu-${{ matrix.ubuntu }}"
     timeout-minutes: 60
@@ -200,6 +244,8 @@ jobs:
           sudo apt-get install -y expect
       - name: "Ensure that the integration test suite is compatible with Docker"
         run: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon
+      - name: "Ensure that the IPv6 integration test suite is compatible with Docker"
+        run: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon -test.ipv6
 
   test-integration-windows:
     # A "larger" runner is used for enabling Hyper-V containers

--- a/Dockerfile
+++ b/Dockerfile
@@ -341,4 +341,8 @@ FROM test-integration-rootless AS test-integration-rootless-port-slirp4netns
 COPY ./Dockerfile.d/home_rootless_.config_systemd_user_containerd.service.d_port-slirp4netns.conf /home/rootless/.config/systemd/user/containerd.service.d/port-slirp4netns.conf
 RUN chown -R rootless:rootless /home/rootless/.config
 
+FROM test-integration AS test-integration-ipv6
+CMD ["gotestsum", "--format=testname", "--rerun-fails=2", "--packages=github.com/containerd/nerdctl/cmd/nerdctl/...", \
+  "--", "-timeout=30m", "-args", "-test.kill-daemon", "-test.ipv6"]
+
 FROM base AS demo

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -120,8 +120,8 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("dns-option", nil, "Set DNS options")
 	// publish is defined as StringSlice, not StringArray, to allow specifying "--publish=80:80,443:443" (compatible with Podman)
 	cmd.Flags().StringSliceP("publish", "p", nil, "Publish a container's port(s) to the host")
-	// FIXME: not support IPV6 yet
 	cmd.Flags().String("ip", "", "IPv4 address to assign to the container")
+	cmd.Flags().String("ip6", "", "IPv6 address to assign to the container")
 	cmd.Flags().StringP("hostname", "h", "", "Container host name")
 	cmd.Flags().String("mac-address", "", "MAC address to assign to the container")
 	// #endregion

--- a/cmd/nerdctl/container_run_network.go
+++ b/cmd/nerdctl/container_run_network.go
@@ -77,6 +77,13 @@ func loadNetworkFlags(cmd *cobra.Command) (types.NetworkOptions, error) {
 	}
 	netOpts.IPAddress = ipAddress
 
+	// --ip6=<container static IP6>
+	ip6Address, err := cmd.Flags().GetString("ip6")
+	if err != nil {
+		return netOpts, err
+	}
+	netOpts.IP6Address = ip6Address
+
 	// -h/--hostname=<container hostname>
 	hostName, err := cmd.Flags().GetString("hostname")
 	if err != nil {

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -183,6 +183,7 @@ Network flags:
 - :whale: `--add-host`: Add a custom host-to-IP mapping (host:ip). `ip` could be a special string `host-gateway`,
 - which will be resolved to the `host-gateway-ip` in nerdctl.toml or global flag.
 - :whale: `--ip`: Specific static IP address(es) to use
+- :whale: `--ip6`: Specific static IP6 address(es) to use. Should be used with user networks
 - :whale: `--mac-address`: Specific MAC address to use. Be aware that it does not
   check if manually specified MAC addresses are unique. Supports network
   type `bridge` and `macvlan`
@@ -375,7 +376,7 @@ IPFS flags:
 
 Unimplemented `docker run` flags:
     `--attach`, `--blkio-weight-device`, `--cpu-rt-*`, `--device-*`,
-    `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--ip6`, `--isolation`, `--no-healthcheck`,
+    `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
     `--link*`, `--mac-address`, `--publish-all`, `--sig-proxy`, `--storage-opt`,
     `--userns`, `--volume-driver`
 
@@ -992,8 +993,9 @@ Flags:
 - :whale: `--gateway`: Gateway for the master subnet
 - :whale: `--ip-range`: Allocate container ip from a sub-range
 - :whale: `--label`: Set metadata on a network
+- :whale: `--ipv6`: Enable IPv6. Should be used with a valid subnet.
 
-Unimplemented `docker network create` flags: `--attachable`, `--aux-address`, `--config-from`, `--config-only`, `--ingress`, `--internal`, `--ipv6`, `--scope`
+Unimplemented `docker network create` flags: `--attachable`, `--aux-address`, `--config-from`, `--config-only`, `--ingress`, `--internal`, `--scope`
 
 ### :whale: nerdctl network ls
 

--- a/pkg/api/types/container_network_types.go
+++ b/pkg/api/types/container_network_types.go
@@ -28,6 +28,8 @@ type NetworkOptions struct {
 	MACAddress string
 	// IPAddress set specific static IP address(es) to use
 	IPAddress string
+	// IP6Address set specific static IP6 address(es) to use
+	IP6Address string
 	// Hostname set container host name
 	Hostname string
 	// DNSServers set custom DNS servers

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -193,6 +193,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	internalLabels.hostname = netLabelOpts.Hostname
 	internalLabels.ports = netLabelOpts.PortMappings
 	internalLabels.ipAddress = netLabelOpts.IPAddress
+	internalLabels.ip6Address = netLabelOpts.IP6Address
 	internalLabels.networks = netLabelOpts.NetworkSlice
 	internalLabels.macAddress = netLabelOpts.MACAddress
 
@@ -505,6 +506,7 @@ type internalLabels struct {
 	// network
 	networks   []string
 	ipAddress  string
+	ip6Address string
 	ports      []gocni.PortMapping
 	macAddress string
 	// volume
@@ -559,6 +561,10 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 
 	if internalLabels.ipAddress != "" {
 		m[labels.IPAddress] = internalLabels.ipAddress
+	}
+
+	if internalLabels.ip6Address != "" {
+		m[labels.IP6Address] = internalLabels.ip6Address
 	}
 
 	m[labels.Platform], err = platformutil.NormalizeString(internalLabels.platform)

--- a/pkg/cmd/network/create.go
+++ b/pkg/cmd/network/create.go
@@ -26,10 +26,11 @@ import (
 )
 
 func Create(options types.NetworkCreateOptions, stdout io.Writer) error {
-	if options.CreateOptions.Subnet == "" {
+	if len(options.CreateOptions.Subnets) == 0 {
 		if options.CreateOptions.Gateway != "" || options.CreateOptions.IPRange != "" {
 			return fmt.Errorf("cannot set gateway or ip-range without subnet, specify --subnet manually")
 		}
+		options.CreateOptions.Subnets = []string{""}
 	}
 
 	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -60,6 +60,9 @@ const (
 	// IPAddress is the static IP address of the container assigned by the user
 	IPAddress = Prefix + "ip"
 
+	// IP6Address is the static IP6 address of the container assigned by the user
+	IP6Address = Prefix + "ip6"
+
 	// LogURI is the log URI
 	LogURI = Prefix + "log-uri"
 

--- a/pkg/netutil/cni_plugin_unix.go
+++ b/pkg/netutil/cni_plugin_unix.go
@@ -31,12 +31,14 @@ type bridgeConfig struct {
 	PromiscMode  bool                   `json:"promiscMode,omitempty"`
 	Vlan         int                    `json:"vlan,omitempty"`
 	IPAM         map[string]interface{} `json:"ipam"`
+	Capabilities map[string]bool        `json:"capabilities,omitempty"`
 }
 
 func newBridgePlugin(bridgeName string) *bridgeConfig {
 	return &bridgeConfig{
-		PluginType: "bridge",
-		BrName:     bridgeName,
+		PluginType:   "bridge",
+		BrName:       bridgeName,
+		Capabilities: map[string]bool{},
 	}
 }
 
@@ -46,16 +48,18 @@ func (*bridgeConfig) GetPluginType() string {
 
 // vlanConfig describes the macvlan/ipvlan config
 type vlanConfig struct {
-	PluginType string                 `json:"type"`
-	Master     string                 `json:"master"`
-	Mode       string                 `json:"mode,omitempty"`
-	MTU        int                    `json:"mtu,omitempty"`
-	IPAM       map[string]interface{} `json:"ipam"`
+	PluginType   string                 `json:"type"`
+	Master       string                 `json:"master"`
+	Mode         string                 `json:"mode,omitempty"`
+	MTU          int                    `json:"mtu,omitempty"`
+	IPAM         map[string]interface{} `json:"ipam"`
+	Capabilities map[string]bool        `json:"capabilities,omitempty"`
 }
 
 func newVLANPlugin(pluginType string) *vlanConfig {
 	return &vlanConfig{
-		PluginType: pluginType,
+		PluginType:   pluginType,
+		Capabilities: map[string]bool{},
 	}
 }
 

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -231,10 +231,11 @@ type CreateOptions struct {
 	Options     map[string]string
 	IPAMDriver  string
 	IPAMOptions map[string]string
-	Subnet      string
+	Subnets     []string
 	Gateway     string
 	IPRange     string
 	Labels      []string
+	IPv6        bool
 }
 
 func (e *CNIEnv) CreateNetwork(opts CreateOptions) (*NetworkConfig, error) { //nolint:revive
@@ -249,11 +250,11 @@ func (e *CNIEnv) CreateNetwork(opts CreateOptions) (*NetworkConfig, error) { //n
 	}
 
 	fn := func() error {
-		ipam, err := e.generateIPAM(opts.IPAMDriver, opts.Subnet, opts.Gateway, opts.IPRange, opts.IPAMOptions)
+		ipam, err := e.generateIPAM(opts.IPAMDriver, opts.Subnets, opts.Gateway, opts.IPRange, opts.IPAMOptions, opts.IPv6)
 		if err != nil {
 			return err
 		}
-		plugins, err := e.generateCNIPlugins(opts.Driver, opts.Name, ipam, opts.Options)
+		plugins, err := e.generateCNIPlugins(opts.Driver, opts.Name, ipam, opts.Options, opts.IPv6)
 		if err != nil {
 			return err
 		}
@@ -352,7 +353,7 @@ func (e *CNIEnv) createDefaultNetworkConfig() error {
 	opts := CreateOptions{
 		Name:       DefaultNetworkName,
 		Driver:     DefaultNetworkName,
-		Subnet:     DefaultCIDR,
+		Subnets:    []string{DefaultCIDR},
 		IPAMDriver: "default",
 		Labels:     []string{fmt.Sprintf("%s=true", labels.NerdctlDefaultNetwork)},
 	}


### PR DESCRIPTION
Fix #1547 

FYI: [cni-ipam](https://www.cni.dev/plugins/current/ipam/host-local/)

Tasks:
- [x] Support in the `network create` command.
- [x] Support `--ip6` argument for the `container run` command.
- [x] Integration tests.
- [x] Documentation.
- [ ] ...

Signed-off-by: Hanchin Hsieh me@yuchanns.xyz
Co-authored-by: Zheao Li <me@manjusaka.me>