### PR TITLE
Refactor remove containers in compose

### DIFF
--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/strutil"
 
 	"github.com/sirupsen/logrus"
@@ -42,7 +40,7 @@ func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
 		if err != nil {
 			return err
 		}
-		if err := c.downContainers(ctx, containers, downOptions.RemoveVolumes); err != nil {
+		if err := c.removeContainers(ctx, containers, RemoveOptions{Stop: true, Volumes: downOptions.RemoveVolumes}); err != nil {
 			return err
 		}
 	}
@@ -104,22 +102,6 @@ func (c *Composer) downVolume(ctx context.Context, shortName string) error {
 	} else if volExists {
 		logrus.Infof("Removing volume %s", fullName)
 		if err := c.runNerdctlCmd(ctx, "volume", "rm", "-f", fullName); err != nil {
-			logrus.Warn(err)
-		}
-	}
-	return nil
-}
-
-func (c *Composer) downContainers(ctx context.Context, containers []containerd.Container, removeAnonVolumes bool) error {
-	for _, container := range containers {
-		info, _ := container.Info(ctx, containerd.WithoutRefreshedMetadata)
-		logrus.Infof("Removing container %s", info.Labels[labels.Name])
-		args := []string{"rm", "-f"}
-		if removeAnonVolumes {
-			args = append(args, "-v")
-		}
-		args = append(args, container.ID())
-		if err := c.runNerdctlCmd(ctx, args...); err != nil {
 			logrus.Warn(err)
 		}
 	}

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -95,7 +95,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 	}
 	if len(orphans) > 0 {
 		if uo.RemoveOrphans {
-			if err := c.downContainers(ctx, orphans, true); err != nil {
+			if err := c.removeContainers(ctx, orphans, RemoveOptions{Stop: true, Volumes: true}); err != nil {
 				return fmt.Errorf("error removing orphaned containers: %s", err)
 			}
 		} else {


### PR DESCRIPTION
Fix #1502.

`remove compose containers` are used in several compose commands:

1. `compose down`: force remove (`-f`) containers and their volumes (`-v`)
2. `compose rm`: remove non-running containers. `-v` is passed based on user input. If `-s` is passed, `stop` containers before `rm`.
3. `compose run`: force remove (`-f`) containers when exit (if `--rm` is passed). Don't remove volumes (no `-v`).
4. `remove orphans` (in `up` and `run`): force remove orphans (`-f`) and volumes (`-v`).

What this PR changes:

1. Move all `remove` related functions/code to `compose/rm.go`.
2. Remove `downContainers` func/calls and change to use `removeContainers`.

Signed-off-by: Jin Dong <jindon@amazon.com>