### PR TITLE
Add support for filtering images by labels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -854,13 +854,13 @@ Flags:
 - :whale: `-f, --filter`: Filter the images. For now, only 'before=<image:tag>' and 'since=<image:tag>' is supported.
   - :whale: `--filter=before=<image:tag>`: Images created before given image (exclusive)
   - :whale: `--filter=since=<image:tag>`: Images created after given image (exclusive)
+  - :whale: `--filter=label<key>=<value>`: Matches images based on the presence of a label alone or a label and a value
 - :nerd_face: `--names`: Show image names
 
 Following arguments for `--filter` are not supported yet:
 
-1. `--filter=label=<key>=<value>`: Filter images by label
-2. `--filter=reference=<image:tag>`: Filter images by reference
-3. `--filter=dangling=true`: Filter images by dangling
+1. `--filter=reference=<image:tag>`: Filter images by reference
+2. `--filter=dangling=true`: Filter images by dangling
 
 ### :whale: :blue_square: nerdctl pull
 Pull an image from a registry.

--- a/cmd/nerdctl/images_test.go
+++ b/cmd/nerdctl/images_test.go
@@ -84,7 +84,9 @@ func TestImagesFilter(t *testing.T) {
 	base.Cmd("pull", testutil.CommonImage).AssertOK()
 
 	dockerfile := fmt.Sprintf(`FROM %s
-CMD ["echo", "nerdctl-build-test-string"]`, testutil.CommonImage)
+CMD ["echo", "nerdctl-build-test-string"] \n
+LABEL foo=bar
+LABEL version=0.1`, testutil.CommonImage)
 
 	buildCtx, err := createBuildContext(dockerfile)
 	assert.NilError(t, err)
@@ -96,4 +98,9 @@ CMD ["echo", "nerdctl-build-test-string"]`, testutil.CommonImage)
 	base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage)).AssertOutNotContains(strings.Split(testutil.CommonImage, ":")[0])
 	base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage), testutil.CommonImage).AssertOutNotContains(strings.Split(testutil.CommonImage, ":")[0])
 	base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage), testutil.CommonImage).AssertOutNotContains(tempName)
+	base.Cmd("images", "--filter", "label=foo=bar").AssertOutContains(tempName)
+	base.Cmd("images", "--filter", "label=foo=bar1").AssertOutNotContains(tempName)
+	base.Cmd("images", "--filter", "label=foo=bar", "--filter", "label=version=0.1").AssertOutContains(tempName)
+	base.Cmd("images", "--filter", "label=foo=bar", "--filter", "label=version=0.2").AssertOutNotContains(tempName)
+	base.Cmd("images", "--filter", "label=version").AssertOutContains(tempName)
 }


### PR DESCRIPTION
OCI config labels are separate from containerd image labels. Adds support for filtering oci config labels just like docker.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>