### PR TITLE
Add compose ps json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1476,7 +1476,7 @@ Usage: `nerdctl compose ps [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose ps` (V1) flags: `--quiet`, `--services`, `--filter`, `--all`
 
-Unimplemented `docker compose ps` (V2) flags: `--format`, `--status`
+Unimplemented `docker compose ps` (V2) flags: `--status`
 
 ### :whale: nerdctl compose pull
 Pull service images

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -17,12 +17,17 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"text/tabwriter"
+	"time"
 
 	"github.com/containerd/containerd"
+	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/containerd/nerdctl/pkg/portutil"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -34,10 +39,34 @@ func newComposePsCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+	composePsCommand.Flags().String("format", "", "Format the output. Supported values: [json]")
 	return composePsCommand
 }
 
+type composeContainerPrintable struct {
+	ID       string
+	Name     string
+	Command  string
+	Project  string
+	Service  string
+	State    string
+	Health   string // placeholder, lack containerd support.
+	ExitCode uint32
+	// `Publishers` stores docker-compatible ports and used for json output.
+	// `Ports` stores formatted ports and only used for console output.
+	Publishers []PortPublisher
+	Ports      string `json:"-"`
+}
+
 func composePsAction(cmd *cobra.Command, args []string) error {
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
+	if format != "json" && format != "" {
+		return fmt.Errorf("unsupported format %s, supported formats are: [json]", format)
+	}
+
 	client, ctx, cancel, err := newClient(cmd)
 	if err != nil {
 		return err
@@ -48,61 +77,46 @@ func composePsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	// TODO: make JSON-printable.
-	// The JSON format must correspond to `docker compose ps --json` (Docker Compose v2)
-	type containerPrintable struct {
-		Name    string
-		Command string
-		Service string
-		Status  string
-		Ports   string
-	}
-
-	containersPrintable := []containerPrintable{}
-
 	serviceNames, err := c.ServiceNames(args...)
 	if err != nil {
 		return err
 	}
-
 	containers, err := c.Containers(ctx, serviceNames...)
 	if err != nil {
 		return err
 	}
-	for _, container := range containers {
-		info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
-		if err != nil {
-			return err
-		}
 
-		spec, err := container.Spec(ctx)
+	containersPrintable := []composeContainerPrintable{}
+	var p composeContainerPrintable
+	for _, container := range containers {
+		if format == "json" {
+			p, err = composeContainerPrintableJSON(ctx, container)
+		} else {
+			p, err = composeContainerPrintableTab(ctx, container)
+		}
 		if err != nil {
 			return err
-		}
-		status := formatter.ContainerStatus(ctx, container)
-		if status == "Up" {
-			status = "running" // corresponds to Docker Compose v2.0.1
-		}
-		p := containerPrintable{
-			Name:    info.Labels[labels.Name],
-			Command: formatter.InspectContainerCommandTrunc(spec),
-			Service: info.Labels[labels.ComposeService],
-			Status:  status,
-			Ports:   formatter.FormatPorts(info.Labels),
 		}
 		containersPrintable = append(containersPrintable, p)
 	}
 
+	if format == "json" {
+		outJSON, err := formatter.ToJSON(containersPrintable, "", "")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprint(cmd.OutOrStdout(), outJSON)
+		return err
+	}
+
 	w := tabwriter.NewWriter(cmd.OutOrStdout(), 4, 8, 4, ' ', 0)
 	fmt.Fprintln(w, "NAME\tCOMMAND\tSERVICE\tSTATUS\tPORTS")
-
 	for _, p := range containersPrintable {
 		if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
 			p.Name,
 			p.Command,
 			p.Service,
-			p.Status,
+			p.State,
 			p.Ports,
 		); err != nil {
 			return err
@@ -110,4 +124,115 @@ func composePsAction(cmd *cobra.Command, args []string) error {
 	}
 
 	return w.Flush()
+}
+
+// composeContainerPrintableTab constructs composeContainerPrintable with fields
+// only for console output.
+func composeContainerPrintableTab(ctx context.Context, container containerd.Container) (composeContainerPrintable, error) {
+	info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+	if err != nil {
+		return composeContainerPrintable{}, err
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return composeContainerPrintable{}, err
+	}
+	status := formatter.ContainerStatus(ctx, container)
+	if status == "Up" {
+		status = "running" // corresponds to Docker Compose v2.0.1
+	}
+
+	return composeContainerPrintable{
+		Name:    info.Labels[labels.Name],
+		Command: formatter.InspectContainerCommandTrunc(spec),
+		Service: info.Labels[labels.ComposeService],
+		State:   status,
+		Ports:   formatter.FormatPorts(info.Labels),
+	}, nil
+}
+
+// composeContainerPrintableTab constructs composeContainerPrintable with fields
+// only for json output and compatible docker output.
+func composeContainerPrintableJSON(ctx context.Context, container containerd.Container) (composeContainerPrintable, error) {
+	info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+	if err != nil {
+		return composeContainerPrintable{}, err
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return composeContainerPrintable{}, err
+	}
+
+	var (
+		state    string
+		exitCode uint32
+	)
+	status, err := containerStatus(ctx, container)
+	if err == nil {
+		// show exitCode only when container is exited/stopped
+		if status.Status == containerd.Stopped {
+			exitCode = status.ExitStatus
+		}
+		state = string(status.Status)
+	} else {
+		state = string(containerd.Unknown)
+	}
+
+	return composeContainerPrintable{
+		ID:         container.ID(),
+		Name:       info.Labels[labels.Name],
+		Command:    formatter.InspectContainerCommand(spec, false, false),
+		Project:    info.Labels[labels.ComposeProject],
+		Service:    info.Labels[labels.ComposeService],
+		State:      state,
+		Health:     "",
+		ExitCode:   exitCode,
+		Publishers: formatPublishers(info.Labels),
+	}, nil
+}
+
+func containerStatus(ctx context.Context, c containerd.Container) (containerd.Status, error) {
+	// Just in case, there is something wrong in server.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	task, err := c.Task(ctx, nil)
+	if err != nil {
+		return containerd.Status{}, err
+	}
+
+	return task.Status(ctx)
+}
+
+// PortPublisher hold status about published port
+// Use this to match the json output with docker compose
+// FYI: https://github.com/docker/compose/blob/v2.13.0/pkg/api/api.go#L305C27-L311
+type PortPublisher struct {
+	URL           string
+	TargetPort    int
+	PublishedPort int
+	Protocol      string
+}
+
+// formatPublishers parses and returns docker-compatible []PortPublisher from
+// label map. If an error happens, an empty slice is returned.
+func formatPublishers(labelMap map[string]string) []PortPublisher {
+	mapper := func(pm gocni.PortMapping) PortPublisher {
+		return PortPublisher{
+			URL:           pm.HostIP,
+			TargetPort:    int(pm.ContainerPort),
+			PublishedPort: int(pm.HostPort),
+			Protocol:      pm.Protocol,
+		}
+	}
+
+	var dockerPorts []PortPublisher
+	if portMappings, err := portutil.ParsePortsLabel(labelMap); err == nil {
+		for _, p := range portMappings {
+			dockerPorts = append(dockerPorts, mapper(p))
+		}
+	} else {
+		logrus.Error(err.Error())
+	}
+	return dockerPorts
 }

--- a/cmd/nerdctl/compose_ps_linux_test.go
+++ b/cmd/nerdctl/compose_ps_linux_test.go
@@ -1,0 +1,109 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposePsJSON(t *testing.T) {
+	// `--format` is only supported in compose v2.
+	// Currently CI is using compose v1.
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  wordpress:
+    image: %s
+    ports:
+      - 8080:80
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: exampleuser
+      WORDPRESS_DB_PASSWORD: examplepass
+      WORDPRESS_DB_NAME: exampledb
+    volumes:
+      - wordpress:/var/www/html
+  db:
+    image: %s
+    environment:
+      MYSQL_DATABASE: exampledb
+      MYSQL_USER: exampleuser
+      MYSQL_PASSWORD: examplepass
+      MYSQL_RANDOM_ROOT_PASSWORD: '1'
+    volumes:
+      - db:/var/lib/mysql
+
+volumes:
+  wordpress:
+  db:
+`, testutil.WordpressImage, testutil.MariaDBImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
+
+	assertHandler := func(svc string, count int, fields ...string) func(stdout string) error {
+		return func(stdout string) error {
+			// 1. check json output can be unmarshalled back to printables.
+			var printables []composeContainerPrintable
+			if err := json.Unmarshal([]byte(stdout), &printables); err != nil {
+				return fmt.Errorf("[service: %s]failed to unmarshal json output from `compose ps`: %s", svc, stdout)
+			}
+			// 2. check #printables matches expected count.
+			if len(printables) != count {
+				return fmt.Errorf("[service: %s]unmarshal generates %d printables, expected %d: %s", svc, len(printables), count, stdout)
+			}
+			// 3. check marshalled json string has all expected substrings.
+			for _, field := range fields {
+				if !strings.Contains(stdout, field) {
+					return fmt.Errorf("[service: %s]marshalled json output doesn't have expected string (%s): %s", svc, field, stdout)
+				}
+			}
+			return nil
+		}
+	}
+
+	// check other formats are not supported
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--format", "yaml").AssertFail()
+	// check all services are up (can be marshalled and unmarshalled)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--format", "json").
+		AssertOutWithFunc(assertHandler("all", 2, `"Service":"wordpress"`, `"Service":"db"`))
+	// check wordpress is running
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--format", "json", "wordpress").
+		AssertOutWithFunc(assertHandler("wordpress", 1, `"Service":"wordpress"`, `"State":"running"`, `"TargetPort":80`, `"PublishedPort":8080`))
+	// check wordpress is stopped
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "wordpress").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--format", "json", "wordpress").
+		AssertOutWithFunc(assertHandler("wordpress", 1, `"Service":"wordpress"`, `"State":"stopped"`))
+	// check wordpress is removed
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "rm", "-f", "wordpress").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--format", "json", "wordpress").
+		AssertOutWithFunc(assertHandler("wordpress", 0))
+}

--- a/cmd/nerdctl/ps.go
+++ b/cmd/nerdctl/ps.go
@@ -219,7 +219,7 @@ func printContainers(ctx context.Context, client *containerd.Client, cmd *cobra.
 		}
 
 		p := containerPrintable{
-			Command:   formatter.InspectContainerCommand(spec, trunc),
+			Command:   formatter.InspectContainerCommand(spec, trunc, true),
 			CreatedAt: info.CreatedAt.Round(time.Second).Local().String(), // format like "2021-08-07 02:19:45 +0900 JST"
 			ID:        id,
 			Image:     imageName,


### PR DESCRIPTION
Fix #1564. This seems require more changes than I thought to match docker output :)

Below is a comparision:

(The format of json output including keys matches. Some values might miss/mismatch (maybe because how nerdctl/docker runs differently. Notice the `Publishers` in service `wordpress`)

```shell
$ docker compose ps --format json | jq
[
  {
    "ID": "aba85f638641033254a353baf0f73ac2bce302d46d843c0037849005171a4238",
    "Name": "compose-ps-json-db-1",
    "Command": "docker-entrypoint.sh mysqld",
    "Project": "compose-ps-json",
    "Service": "db",
    "State": "running",
    "Health": "",
    "ExitCode": 0,
    "Publishers": [
      {
        "URL": "",
        "TargetPort": 3306,
        "PublishedPort": 0,
        "Protocol": "tcp"
      }
    ]
  },
  {
    "ID": "001f54b33d9bd481bda12d98821a93e11f40b92e2e557186c2b66e20c9279196",
    "Name": "compose-ps-json-wordpress-1",
    "Command": "docker-entrypoint.sh apache2-foreground",
    "Project": "compose-ps-json",
    "Service": "wordpress",
    "State": "running",
    "Health": "",
    "ExitCode": 0,
    "Publishers": [
      {
        "URL": "0.0.0.0",
        "TargetPort": 80,
        "PublishedPort": 8080,
        "Protocol": "tcp"
      },
      {
        "URL": "::",
        "TargetPort": 80,
        "PublishedPort": 8080,
        "Protocol": "tcp"
      }
    ]
  }
]
```

```shell
$ sudo nerdctl compose ps --format json | jq
[
  {
    "ID": "73a5c6cb8b2cf0a8c55fb571b9b6c2a4f84f2fc70f6706b76c208e370e18ea00",
    "Name": "compose-ps-json_wordpress_1",
    "Command": "docker-entrypoint.sh apache2-foreground",
    "Project": "compose-ps-json",
    "Service": "wordpress",
    "State": "running",
    "Health": "",
    "ExitCode": 0,
    "Publishers": [
      {
        "URL": "0.0.0.0",
        "TargetPort": 80,
        "PublishedPort": 8080,
        "Protocol": "tcp"
      }
    ]
  },
  {
    "ID": "a5330ffb76808ab679202a2c834c1c0270bdf4536a13c7347332029a1942780c",
    "Name": "compose-ps-json_db_1",
    "Command": "docker-entrypoint.sh mysqld",
    "Project": "compose-ps-json",
    "Service": "db",
    "State": "running",
    "Health": "",
    "ExitCode": 0,
    "Publishers": null
  }
]
```
```shell
$ cat docker-compose.yml
version: '3.1'

services:
  wordpress:
    image: wordpress:5.7
    ports:
      - 8080:80
    environment:
      WORDPRESS_DB_HOST: db
      WORDPRESS_DB_USER: exampleuser
      WORDPRESS_DB_PASSWORD: examplepass
      WORDPRESS_DB_NAME: exampledb
    volumes:
      - wordpress:/var/www/html
  db:
    image: mariadb:10.5
    environment:
      MYSQL_DATABASE: exampledb
      MYSQL_USER: exampleuser
      MYSQL_PASSWORD: examplepass
      MYSQL_RANDOM_ROOT_PASSWORD: '1'
    volumes:
      - db:/var/lib/mysql

volumes:
  wordpress:
  db:
```

----
A question is do we need to keep the json output identical as `docker compose ps --format json`?

The current implmenetation has several differences compared to docker:

1. No `Health`: not sure how to add it in nerdctl/containerd. (somehow I remember containerd doesn't support health check)
2. No `ExitCode`: has a function similar to [`ContainerStatus`](https://github.com/djdongjin/nerdctl/blob/950db8cefca281cb13bc8759d8aa45d7e1eac4bd/pkg/formatter/formatter.go#L41) that returns `ExitCode` (or split `ContainerStatus` into 2 funcs (e.g., `GetContainerStatus` and `ParseContainerStatus`))
3. `Status(nerdctl)` v.s. `State(docker)`: `running, Exited (0) 7 hours ago` v.s. `running, exited`.
4. `Ports(nerdctl)` v.s. `Publishers(docker)`: docker uses [this struct](https://github.com/docker/compose/blob/v2/pkg/api/api.go#L306) for port output in json. `nerdctl` uses `gocni.PortMapping`. (So even we output a slide than a string, the keys are still different)

```go
type PortMapping struct {
	HostPort      int32
	ContainerPort int32
	Protocol      string
	HostIP        string
}
```

Signed-off-by: Jin Dong <jindon@amazon.com>