### PR TITLE
Deflake TestCompletion

### DIFF
--- a/cmd/nerdctl/completion_linux_test.go
+++ b/cmd/nerdctl/completion_linux_test.go
@@ -33,14 +33,11 @@ func TestCompletion(t *testing.T) {
 	base.Cmd(gsc, "run", "-").AssertOutContains("--network\t")
 	base.Cmd(gsc, "run", "--n").AssertOutContains("--network\t")
 	base.Cmd(gsc, "run", "--ne").AssertOutContains("--network\t")
-	base.Cmd(gsc, "run", "--net", "").AssertOutContains("bridge\n")
 	base.Cmd(gsc, "run", "--net", "").AssertOutContains("host\n")
-	base.Cmd(gsc, "run", "-it", "--net", "").AssertOutContains("bridge\n")
-	base.Cmd(gsc, "run", "-it", "--rm", "--net", "").AssertOutContains("bridge\n")
+	base.Cmd(gsc, "run", "-it", "--net", "").AssertOutContains("host\n")
+	base.Cmd(gsc, "run", "-it", "--rm", "--net", "").AssertOutContains("host\n")
 	base.Cmd(gsc, "run", "--restart", "").AssertOutContains("always\n")
-	base.Cmd(gsc, "network", "inspect", "").AssertOutContains("bridge\n")
-	base.Cmd(gsc, "network", "rm", "").AssertNoOut("bridge\n") // bridge is unremovable
-	base.Cmd(gsc, "network", "rm", "").AssertNoOut("host\n")   // host is unremovable
+	base.Cmd(gsc, "network", "rm", "").AssertNoOut("host\n") // host is unremovable
 	base.Cmd(gsc, "run", "--cap-add", "").AssertOutContains("sys_admin\n")
 	base.Cmd(gsc, "run", "--cap-add", "").AssertNoOut("CAP_SYS_ADMIN\n") // invalid form
 


### PR DESCRIPTION
Remove the `Expected stdout to contain "bridge\n"` assertion, as the "bridge" network is no longer created until it is actually needed, since commit 85236638f09033e63314ca5c7347120fd3b6b9ab (PR #1554).

Fix #1579
