### PR TITLE
allow container network_mode in compose

### DIFF
--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -372,7 +372,9 @@ func getNetworks(project *types.Project, svc types.ServiceConfig) ([]networkName
 			return nil, errors.New("net and network_mode must not be set together")
 		}
 		if strings.Contains(svc.NetworkMode, ":") {
-			return nil, fmt.Errorf("unsupported network_mode: %q", svc.NetworkMode)
+			if !strings.HasPrefix(svc.NetworkMode, "container:") {
+				return nil, fmt.Errorf("unsupported network_mode: %q", svc.NetworkMode)
+			}
 		}
 		fullNames = append(fullNames, networkNamePair{
 			fullName:         svc.NetworkMode,


### PR DESCRIPTION
Allow `container:name` network_mode in compose, it's already supported in nerdctl run.