### PR TITLE
Fix: Deleting multiple networks stops at first delete fail

### DIFF
--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -69,23 +69,29 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 
 	for _, name := range args {
 		if name == "host" || name == "none" {
-			return fmt.Errorf("pseudo network %q cannot be removed", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: pseudo network %q cannot be removed\n", name)
+			continue
 		}
 		net, ok := netMap[name]
 		if !ok {
-			return fmt.Errorf("no such network: %s", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: No such network: %s\n", name)
+			continue
 		}
 		if value, ok := usedNetworkInfo[name]; ok {
-			return fmt.Errorf("network %q is in use by container %q", name, value)
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: network %q is in use by container %q\n", name, value)
+			continue
 		}
 		if net.NerdctlID == nil {
-			return fmt.Errorf("%s is managed outside nerdctl and cannot be removed", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: %s is managed outside nerdctl and cannot be removed\n", name)
+			continue
 		}
 		if net.File == "" {
-			return fmt.Errorf("%s is a pre-defined network and cannot be removed", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: %s is a pre-defined network and cannot be removed\n", name)
+			continue
 		}
 		if err := e.RemoveNetwork(net); err != nil {
-			return err
+			fmt.Fprintf(cmd.OutOrStdout(), "Error: %s\n", err.Error())
+			continue
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), name)
 	}


### PR DESCRIPTION
fixing https://github.com/containerd/nerdctl/issues/1587

```bash
 ~ nerdctl network create deleteme --gateway 10.10.11.1 --subnet 10.10.11.0/24
f9d6cec6deabf54691804bb7c1bf02ad7f461ab07f31a18398495b9de1cabf28

 ~ nerdctl network ls                                                         
NETWORK ID      NAME               FILE
                k8s-pod-network    /etc/cni/net.d/10-calico.conflist
17f29b073143    bridge             /etc/cni/net.d/nerdctl-bridge.conflist
f9d6cec6deab    deleteme           /etc/cni/net.d/nerdctl-deleteme.conflist
                host               
                none

 ~ nerdctl network rm host k8s-pod-network test deleteme
Error: pseudo network "host" cannot be removed
Error: k8s-pod-network is managed outside nerdctl and cannot be removed
Error: No such network: test
deleteme
```

Signed-off-by: yaozhenxiu <946666800@qq.com>