### PR TITLE
Improve compose test logging

### DIFF
--- a/cmd/nerdctl/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose_build_linux_test.go
@@ -50,6 +50,8 @@ services:
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
 	comp.WriteFile("Dockerfile", dockerfile)
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	defer base.Cmd("rmi", imageSvc0).Run()
 	defer base.Cmd("rmi", imageSvc1).Run()

--- a/cmd/nerdctl/compose_kill_linux_test.go
+++ b/cmd/nerdctl/compose_kill_linux_test.go
@@ -61,6 +61,8 @@ volumes:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()

--- a/cmd/nerdctl/compose_pull_linux_test.go
+++ b/cmd/nerdctl/compose_pull_linux_test.go
@@ -59,6 +59,8 @@ volumes:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "pull", "db").AssertNoOut("wordpress")
 }

--- a/cmd/nerdctl/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose_run_linux_test.go
@@ -137,8 +137,8 @@ services:
 		if err != nil {
 			return err
 		}
-		t.Logf("respBody=%q", respBody)
 		if !strings.Contains(string(respBody), testutil.NginxAlpineIndexHTMLSnippet) {
+			t.Logf("respBody=%q", respBody)
 			return fmt.Errorf("respBody does not contain %q", testutil.NginxAlpineIndexHTMLSnippet)
 		}
 		return nil
@@ -196,8 +196,8 @@ services:
 		if err != nil {
 			return err
 		}
-		t.Logf("respBody=%q", respBody)
 		if !strings.Contains(string(respBody), testutil.NginxAlpineIndexHTMLSnippet) {
+			t.Logf("respBody=%q", respBody)
 			return fmt.Errorf("respBody does not contain %q", testutil.NginxAlpineIndexHTMLSnippet)
 		}
 		return nil

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -92,8 +92,8 @@ func testComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string) 
 		if err != nil {
 			return err
 		}
-		t.Logf("respBody=%q", respBody)
 		if !strings.Contains(string(respBody), testutil.WordpressIndexHTMLSnippet) {
+			t.Logf("respBody=%q", respBody)
 			return fmt.Errorf("respBody does not contain %q", testutil.WordpressIndexHTMLSnippet)
 		}
 		return nil
@@ -141,6 +141,8 @@ COPY index.html /usr/share/nginx/html/index.html
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	comp.WriteFile("Dockerfile", dockerfile)
 	comp.WriteFile("index.html", indexHTML)
@@ -262,6 +264,8 @@ services:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	base.Env = append(os.Environ(), "ADDRESS=0.0.0.0")
 
@@ -290,6 +294,8 @@ services:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	envFile := `TAG=1.19-alpine-org`
 	comp.WriteFile(".env", envFile)
@@ -311,6 +317,8 @@ services:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
 
 	envFile := `TAG=1.19-alpine-org`
 	comp.WriteFile("envFile", envFile)
@@ -334,7 +342,6 @@ services:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
-
 	projectName := comp.ProjectName()
 	t.Logf("projectName=%q", projectName)
 
@@ -364,7 +371,6 @@ networks:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
-
 	projectName := comp.ProjectName()
 	t.Logf("projectName=%q", projectName)
 
@@ -427,7 +433,6 @@ services:
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
-
 	projectName := comp.ProjectName()
 	t.Logf("projectName=%q", projectName)
 
@@ -435,7 +440,6 @@ services:
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "down").AssertOK()
-
 }
 
 func TestComposeUpWithExternalNetwork(t *testing.T) {


### PR DESCRIPTION
This PR adds `projectName` log to compose tests without it. 

Compose tests create resources like images(compose build/pull) and network(compose up/run). Sometimes resources are left due to bugs/test errors/forgot clean up/etc, and it's difficult to find which testcase causes it. (e.g. #1586, #1535).

It also moves some response body log to only when error occurs. Those logs are quite long and I think it's sufficient to only log them when error occurs. This makes test output more clean and short. 

Signed-off-by: Jin Dong <jindon@amazon.com>