### PR TITLE
Add `compose exec` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose up](#whale-nerdctl-compose-up)
     - [:whale: nerdctl compose logs](#whale-nerdctl-compose-logs)
     - [:whale: nerdctl compose build](#whale-nerdctl-compose-build)
+    - [:whale: nerdctl compose exec](#whale-nerdctl-compose-exec)
     - [:whale: nerdctl compose down](#whale-nerdctl-compose-down)
     - [:whale: nerdctl compose images](#whale-nerdctl-compose-images)
     - [:whale: nerdctl compose stop](#whale-nerdctl-compose-stop)
@@ -1439,6 +1440,25 @@ Flags:
 
 Unimplemented `docker-compose build` (V1) flags:  `--compress`, `--force-rm`, `--memory`, `--no-rm`, `--parallel`, `--pull`, `--quiet`
 
+### :whale: nerdctl compose exec
+
+Execute a command on a running container of the service.
+
+Usage: `nerdctl compose exec [OPTIONS] SERVICE COMMAND [ARGS...]`
+
+Flags:
+
+- :whale: `-d, --detach`: Detached mode: Run the command in background
+- :whale: `-e, --env`: Set environment variables
+- :whale: `--index`: Set index of the container if the service has multiple instances. (default 1)
+- :whale: `-i, --interactive`: Keep STDIN open even if not attached (default true)
+- :whale: `--privileged`: Give extended privileges to the command
+- :whale: `-t, --tty`: Allocate a pseudo-TTY
+- :whale: `-u, --user`: Username or UID (format: `<name|uid>[:<group|gid>]`)
+- :whale: `-w, --workdir`: Working directory inside the container
+
+Unimplemented `docker-compose exec` (V2) flags:  `-T, --no-TTY`
+
 ### :whale: nerdctl compose down
 Remove containers and associated resources
 
@@ -1627,7 +1647,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose create|events|exec|pause|port|scale|start|top|unpause`
+- `docker-compose create|events|pause|port|scale|start|top|unpause`
 
 Others:
 - `docker system df`

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -58,6 +58,7 @@ func newComposeCommand() *cobra.Command {
 		newComposeLogsCommand(),
 		newComposeConfigCommand(),
 		newComposeBuildCommand(),
+		newComposeExecCommand(),
 		newComposeImagesCommand(),
 		newComposePushCommand(),
 		newComposePullCommand(),

--- a/cmd/nerdctl/compose_exec.go
+++ b/cmd/nerdctl/compose_exec.go
@@ -1,0 +1,123 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+
+	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/spf13/cobra"
+)
+
+func newComposeExecCommand() *cobra.Command {
+	var composeExecCommand = &cobra.Command{
+		Use:           "exec [flags] SERVICE COMMAND [ARGS...]",
+		Short:         "Execute a command in a running container of the service",
+		Args:          cobra.MinimumNArgs(2),
+		RunE:          composeExecAction,
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	composeExecCommand.Flags().SetInterspersed(false)
+
+	composeExecCommand.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY")
+	composeExecCommand.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached")
+	composeExecCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
+	composeExecCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
+	// env needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}
+	composeExecCommand.Flags().StringArrayP("env", "e", nil, "Set environment variables")
+	// TODO: no-TTY flag
+	composeExecCommand.Flags().Bool("privileged", false, "Give extended privileges to the command")
+	composeExecCommand.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	composeExecCommand.Flags().Int("index", 1, "index of the container if the service has multiple instances.")
+
+	return composeExecCommand
+}
+
+func composeExecAction(cmd *cobra.Command, args []string) error {
+	interactive, err := cmd.Flags().GetBool("interactive")
+	if err != nil {
+		return err
+	}
+	tty, err := cmd.Flags().GetBool("tty")
+	if err != nil {
+		return err
+	}
+	detach, err := cmd.Flags().GetBool("detach")
+	if err != nil {
+		return err
+	}
+	workdir, err := cmd.Flags().GetString("workdir")
+	if err != nil {
+		return err
+	}
+	env, err := cmd.Flags().GetStringArray("env")
+	if err != nil {
+		return err
+	}
+	privileged, err := cmd.Flags().GetBool("privileged")
+	if err != nil {
+		return err
+	}
+	user, err := cmd.Flags().GetString("user")
+	if err != nil {
+		return err
+	}
+	index, err := cmd.Flags().GetInt("index")
+	if err != nil {
+		return err
+	}
+
+	if index < 1 {
+		return errors.New("index starts from 1 and should be equal or greater than 1")
+	}
+	// https://github.com/containerd/nerdctl/blob/v1.0.0/cmd/nerdctl/exec.go#L116
+	if interactive && detach {
+		return errors.New("currently flag -i and -d cannot be specified together (FIXME)")
+	}
+	// https://github.com/containerd/nerdctl/blob/v1.0.0/cmd/nerdctl/exec.go#L122
+	if tty && detach {
+		return errors.New("currently flag -t and -d cannot be specified together (FIXME)")
+	}
+
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+
+	eo := composer.ExecOptions{
+		ServiceName: args[0],
+		Index:       index,
+
+		Interactive: interactive,
+		Tty:         tty,
+		Detach:      detach,
+		WorkDir:     workdir,
+		Env:         env,
+		Privileged:  privileged,
+		User:        user,
+		Args:        args[1:],
+	}
+
+	return c.Exec(ctx, eo)
+}

--- a/cmd/nerdctl/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose_exec_linux_test.go
@@ -1,0 +1,135 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeExec(t *testing.T) {
+	// `-i` in `compose run & exec` is only supported in compose v2.
+	// Currently CI is using compose v1.
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+  svc1:
+    image: %s
+`, testutil.CommonImage, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "run", "-d", "-i=false", "svc0", "sleep", "1h").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "svc0", "echo", "success").AssertOutExactly("success\n")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "--workdir", "/tmp", "svc0", "pwd").AssertOutExactly("/tmp\n")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "svc1", "echo", "success").AssertFail()
+}
+
+func TestComposeExecWithUser(t *testing.T) {
+	// `-i` in `compose run & exec` is only supported in compose v2.
+	// Currently CI is using compose v1.
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+  svc1:
+    image: %s
+`, testutil.CommonImage, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	testContainer := testutil.Identifier(t)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "run", "-d", "-i=false", "--name", testContainer, "svc0", "sleep", "1h").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+	base.EnsureContainerStarted(testContainer)
+
+	testCases := map[string]string{
+		"":             "uid=0(root) gid=0(root)",
+		"1000":         "uid=1000 gid=0(root)",
+		"1000:users":   "uid=1000 gid=100(users)",
+		"guest":        "uid=405(guest) gid=100(users)",
+		"nobody":       "uid=65534(nobody) gid=65534(nobody)",
+		"nobody:users": "uid=65534(nobody) gid=100(users)",
+	}
+
+	for userStr, expected := range testCases {
+		args := []string{"-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false"}
+		if userStr != "" {
+			args = append(args, "--user", userStr)
+		}
+		args = append(args, "svc0", "id")
+		base.ComposeCmd(args...).AssertOutContains(expected)
+	}
+}
+
+func TestComposeExecTTY(t *testing.T) {
+	// `-i` in `compose run & exec` is only supported in compose v2.
+	// Currently CI is using compose v1.
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	if testutil.GetTarget() == testutil.Nerdctl {
+		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
+	}
+
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+  svc1:
+    image: %s
+`, testutil.CommonImage, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	testContainer := testutil.Identifier(t)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "run", "-d", "-i=false", "--name", testContainer, "svc0", "sleep", "1h").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+	base.EnsureContainerStarted(testContainer)
+
+	const sttyPartialOutput = "speed 38400 baud"
+	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
+	// unbuffer(1) can be installed with `apt-get install expect`.
+	unbuffer := []string{"unbuffer"}
+	base.ComposeCmdWithHelper(unbuffer, "-f", comp.YAMLFullPath(), "exec", "svc0", "stty").AssertOutContains(sttyPartialOutput)             // `-it`
+	base.ComposeCmdWithHelper(unbuffer, "-f", comp.YAMLFullPath(), "exec", "-i=false", "svc0", "stty").AssertOutContains(sttyPartialOutput) // `-t`
+	base.ComposeCmdWithHelper(unbuffer, "-f", comp.YAMLFullPath(), "exec", "-t=false", "svc0", "stty").AssertFail()                         // `-i`
+	base.ComposeCmdWithHelper(unbuffer, "-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "svc0", "stty").AssertFail()
+}

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -50,7 +50,7 @@ func newExecCommand() *cobra.Command {
 	}
 	execCommand.Flags().SetInterspersed(false)
 
-	execCommand.Flags().BoolP("tty", "t", false, "(Currently -t needs to correspond to -i)")
+	execCommand.Flags().BoolP("tty", "t", false, "Allocate a pseudo-TTY")
 	execCommand.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
 	execCommand.Flags().BoolP("detach", "d", false, "Detached mode: run command in the background")
 	execCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -1,0 +1,96 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/sirupsen/logrus"
+)
+
+// ExecOptions stores options passed from users as flags and args.
+type ExecOptions struct {
+	ServiceName string
+	Index       int
+	// params to be passed to `nerdctl exec`
+	Detach      bool
+	Interactive bool
+	Tty         bool
+	Privileged  bool
+	User        string
+	WorkDir     string
+	Env         []string
+	Args        []string
+}
+
+// Exec executes a given command on a running container specified by
+// `ServiceName` (and `Index` if it has multiple instances).
+func (c *Composer) Exec(ctx context.Context, eo ExecOptions) error {
+	containers, err := c.Containers(ctx, eo.ServiceName)
+	if err != nil {
+		return fmt.Errorf("fail to get containers for service %s: %s", eo.ServiceName, err)
+	}
+	if len(containers) == 0 {
+		return fmt.Errorf("no running containers from service %s", eo.ServiceName)
+	}
+	if eo.Index > len(containers) {
+		return fmt.Errorf("index (%d) out of range: only %d running instances from service %s",
+			eo.Index, len(containers), eo.ServiceName)
+	}
+	container := containers[eo.Index-1]
+
+	return c.exec(ctx, container, eo)
+}
+
+// exec constructs/executes the `nerdctl exec` command to be executed on the given container.
+func (c *Composer) exec(ctx context.Context, container containerd.Container, eo ExecOptions) error {
+	args := []string{
+		"exec",
+		fmt.Sprintf("--detach=%t", eo.Detach),
+		fmt.Sprintf("--interactive=%t", eo.Interactive),
+		fmt.Sprintf("--tty=%t", eo.Tty),
+		fmt.Sprintf("--privileged=%t", eo.Privileged),
+	}
+	if eo.User != "" {
+		args = append(args, "--user", eo.User)
+	}
+	if eo.WorkDir != "" {
+		args = append(args, "--workdir", eo.WorkDir)
+	}
+	if len(eo.Env) > 0 {
+		args = append(append(args, "--env"), eo.Env...)
+	}
+	args = append(args, container.ID())
+	args = append(args, eo.Args...)
+	cmd := c.createNerdctlCmd(ctx, args...)
+
+	if eo.Interactive {
+		cmd.Stdin = os.Stdin
+	}
+	if !eo.Detach {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	if c.DebugPrintFull {
+		logrus.Debugf("Executing %v", cmd.Args)
+	}
+	return cmd.Run()
+}


### PR DESCRIPTION
Implement `compose exec` command. docker doc: https://docs.docker.com/engine/reference/commandline/compose_exec/

Also help feature request from downstream community that relies on nerdctl (finch: https://github.com/runfinch/finch/issues/79)

Signed-off-by: Jin Dong <jindon@amazon.com>