### PR TITLE
deflake network tests

### DIFF
--- a/cmd/nerdctl/network_create_linux_test.go
+++ b/cmd/nerdctl/network_create_linux_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestNetworkCreateWithMTU(t *testing.T) {
-	t.Parallel()
 	testNetwork := testutil.Identifier(t)
 	base := testutil.NewBase(t)
 
@@ -39,7 +38,6 @@ func TestNetworkCreateWithMTU(t *testing.T) {
 }
 
 func TestNetworkCreate(t *testing.T) {
-	t.Parallel()
 	base := testutil.NewBase(t)
 	testNetwork := testutil.Identifier(t)
 

--- a/cmd/nerdctl/network_rm_linux_test.go
+++ b/cmd/nerdctl/network_rm_linux_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestNetworkRemove(t *testing.T) {
-	t.Parallel()
 	if rootlessutil.IsRootless() {
 		t.Skip("test skipped for remove rootless network")
 	}
@@ -51,7 +50,6 @@ func TestNetworkRemove(t *testing.T) {
 }
 
 func TestNetworkRemoveWhenLinkWithContainer(t *testing.T) {
-	t.Parallel()
 	if rootlessutil.IsRootless() {
 		t.Skip("test skipped for remove rootless network")
 	}


### PR DESCRIPTION
`nerdctl network rm`  is [scanning containers in All namespaces](https://github.com/containerd/nerdctl/blob/main/cmd/nerdctl/network_rm.go#L64) . So to avoid flaky network rm behavior, the test shouldn't be run in parallel with other parallel tests  

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>