### PR TITLE
Add SOCI snapshotter guideline in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Also, `nerdctl` might be potentially useful for debugging Kubernetes clusters, b
 
 ## Features present in `nerdctl` but not present in Docker
 Major:
-- On-demand image pulling (lazy-pulling) using [Stargz](./docs/stargz.md)/[Nydus](./docs/nydus.md)/[OverlayBD](./docs/overlaybd.md) Snapshotter: `nerdctl --snapshotter=stargz|nydus|overlaybd run IMAGE` .
+- On-demand image pulling (lazy-pulling) using [Stargz](./docs/stargz.md)/[Nydus](./docs/nydus.md)/[OverlayBD](./docs/overlaybd.md)/[SOCI](./docs/soci.md) Snapshotter: `nerdctl --snapshotter=stargz|nydus|overlaybd|soci run IMAGE` .
 - [Image encryption and decryption using ocicrypt (imgcrypt)](./docs/ocicrypt.md): `nerdctl image (encrypt|decrypt) SRC DST`
 - [P2P image distribution using IPFS](./docs/ipfs.md): `nerdctl run ipfs://CID` .
   P2P image distribution (IPFS) is completely optional. Your host is NOT connected to any P2P network, unless you opt in to [install and run IPFS daemon](https://docs.ipfs.io/install/).

--- a/docs/soci.md
+++ b/docs/soci.md
@@ -1,0 +1,29 @@
+# Lazy-pulling using SOCI Snapshotter
+
+| :zap: Requirement | nerdctl >= 1.1.1 |
+| ----------------- |------------------|
+
+SOCI Snapshotter is a containerd snapshotter plugin. It enables standard OCI images to be lazily loaded without requiring a build-time conversion step. "SOCI" is short for "Seekable OCI", and is pronounced "so-CHEE".
+
+See https://github.com/awslabs/soci-snapshotter to learn further information.
+
+## Enable SOCI for `nerdctl run`
+
+- Install containerd remote snapshotter plugin (`soci`) from https://github.com/awslabs/soci-snapshotter/blob/main/docs/GETTING_STARTED.md#prerequisites
+
+- Add the following to `/etc/containerd/config.toml`:
+```toml
+[proxy_plugins]
+  [proxy_plugins.soci]
+    type = "snapshot"
+    address = "/run/soci-snapshotter-grpc/soci-snapshotter-grpc.sock"
+```
+
+- Launch `containerd` and `soci-snapshotter`
+
+- Run `nerdctl` with `--snapshotter=soci`
+```console
+nerdctl run --it --rm --snapshotter=soci docker.io/library/alpine:3.14.2
+```
+
+For more details about how to build soci image, please refer to [soci-snapshotter](https://github.com/awslabs/soci-snapshotter/blob/main/docs/GETTING_STARTED.md#create-and-push-a-soci-index)


### PR DESCRIPTION
For now, I think the nerdctl project can support the SOCI as others snapshotter in containerd directly. We need to add a guideline to describe how to use this snapshotter.

And the SOCI-snapshotter doesn't have an implementation for `converter.ConvertFunc`, so I think we can't support the `nerdctl image convert` command for the SOCI snapshotter right now.

Signed-off-by: Zheao.Li <me@manjusaka.me>