### PR TITLE
fix: multi-image files load output

### DIFF
--- a/cmd/nerdctl/load.go
+++ b/cmd/nerdctl/load.go
@@ -132,7 +132,7 @@ func loadImage(in io.Reader, cmd *cobra.Command, platMC platforms.MatchComparer,
 		if quiet {
 			fmt.Fprintln(cmd.OutOrStdout(), img.Target.Digest)
 		} else {
-			fmt.Fprintf(cmd.OutOrStdout(), "Loaded image: %s", img.Name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Loaded image: %s\n", img.Name)
 		}
 	}
 


### PR DESCRIPTION
# Description:

Now the output is formatted as:

```bash
unpacking docker.io/lib/my-app1:1.2.3 (sha256:xxxx)... 
Loaded image: docker.io/lib/my-app1:1.2.3unpacking docker.io/lib/my-app2:2.3.4 (sha256:yyyy)...$
```

There is a missing Line Feed("\n") before next order.

# Issue

#1596 

# Test

- I have bundle some images to a tar file
- use `nerdctl load -i image-name` to load the images

# Testing Example

```bash
$ nerdctl load -i ./docker-app/nginx.tar
unpacking docker.io/library/nginx:1.21 (sha256:56edf1dcb8a68cfafa096182f56e9e1c700806fc60662df9118a32638f66fb8f)...
Loaded image: docker.io/library/nginx:1.21
$
```

Signed-off-by: Airmelt [4irmelt@gmail.com](mailto:4irmelt@gmail.com)