### PR TITLE
Fix env handling in 2 exec commands

### DIFF
--- a/cmd/nerdctl/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose_exec_linux_test.go
@@ -17,7 +17,11 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -46,9 +50,57 @@ services:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "run", "-d", "-i=false", "svc0", "sleep", "1h").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
 
+	// test basic functionality and `--workdir` flag
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "svc0", "echo", "success").AssertOutExactly("success\n")
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "--workdir", "/tmp", "svc0", "pwd").AssertOutExactly("/tmp\n")
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false", "svc1", "echo", "success").AssertFail()
+
+	// test `--env` flag
+	// FYI: https://github.com/containerd/nerdctl/blob/e4b2b6da56555dc29ed66d0fd8e7094ff2bc002d/cmd/nerdctl/run_test.go#L177
+	base.Env = append(os.Environ(), "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "-t=false",
+		"--env", "FOO=foo1,foo2",
+		"--env", "BAR=bar1 bar2",
+		"--env", "BAZ=",
+		"--env", "QUX", // not exported in OS
+		"--env", "QUUX=quux1",
+		"--env", "QUUX=quux2",
+		"--env", "CORGE", // OS exported
+		"--env", "GRAULT=grault_key=grault_value", // value contains `=` char
+		"--env", "GARPLY=", // OS exported
+		"--env", "WALDO=", // not exported in OS
+
+		"svc0", "env").AssertOutWithFunc(func(stdout string) error {
+		if !strings.Contains(stdout, "\nFOO=foo1,foo2\n") {
+			return errors.New("got bad FOO")
+		}
+		if !strings.Contains(stdout, "\nBAR=bar1 bar2\n") {
+			return errors.New("got bad BAR")
+		}
+		if !strings.Contains(stdout, "\nBAZ=\n") && runtime.GOOS != "windows" {
+			return errors.New("got bad BAZ")
+		}
+		if strings.Contains(stdout, "QUX") {
+			return errors.New("got bad QUX (should not be set)")
+		}
+		if !strings.Contains(stdout, "\nQUUX=quux2\n") {
+			return errors.New("got bad QUUX")
+		}
+		if !strings.Contains(stdout, "\nCORGE=corge-value-in-host\n") {
+			return errors.New("got bad CORGE")
+		}
+		if !strings.Contains(stdout, "\nGRAULT=grault_key=grault_value\n") {
+			return errors.New("got bad GRAULT")
+		}
+		if !strings.Contains(stdout, "\nGARPLY=\n") && runtime.GOOS != "windows" {
+			return errors.New("got bad GARPLY")
+		}
+		if !strings.Contains(stdout, "\nWALDO=\n") && runtime.GOOS != "windows" {
+			return errors.New("got bad WALDO")
+		}
+
+		return nil
+	})
 }
 
 func TestComposeExecWithUser(t *testing.T) {

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -28,9 +28,9 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/cmd/ctr/commands"
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
+	"github.com/containerd/nerdctl/pkg/flagutil"
 	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
-	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containerd/nerdctl/pkg/taskutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
@@ -243,18 +243,15 @@ func generateExecProcessSpec(ctx context.Context, cmd *cobra.Command, args []str
 	if err != nil {
 		return nil, err
 	}
-	if envFiles := strutil.DedupeStrSlice(envFile); len(envFiles) > 0 {
-		env, err := parseEnvVars(envFiles)
-		if err != nil {
-			return nil, err
-		}
-		pspec.Env = append(pspec.Env, env...)
-	}
 	env, err := cmd.Flags().GetStringArray("env")
 	if err != nil {
 		return nil, err
 	}
-	pspec.Env = append(pspec.Env, strutil.DedupeStrSlice(env)...)
+	envs, err := generateEnvs(envFile, env)
+	if err != nil {
+		return nil, err
+	}
+	pspec.Env = flagutil.ReplaceOrAppendEnvValues(pspec.Env, envs)
 
 	privileged, err := cmd.Flags().GetBool("privileged")
 	if err != nil {

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -74,8 +74,8 @@ func (c *Composer) exec(ctx context.Context, container containerd.Container, eo 
 	if eo.WorkDir != "" {
 		args = append(args, "--workdir", eo.WorkDir)
 	}
-	if len(eo.Env) > 0 {
-		args = append(append(args, "--env"), eo.Env...)
+	for _, e := range eo.Env {
+		args = append(args, "--env", e)
 	}
 	args = append(args, container.ID())
 	args = append(args, eo.Args...)

--- a/pkg/flagutil/flagutil.go
+++ b/pkg/flagutil/flagutil.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package flagutil
+
+import "strings"
+
+// ReplaceOrAppendEnvValues returns the defaults with the overrides either
+// replaced by env key or appended to the list
+// FYI: https://github.com/containerd/containerd/blob/698622b89a053294593b9b5a363efff7715e9394/oci/spec_opts.go#L186-L222
+// defaults should have valid `k=v` strings.
+// overrides may have the following formats: `k=v` (override k), `k=` (emptify k), `k` (remove k).
+func ReplaceOrAppendEnvValues(defaults, overrides []string) []string {
+	cache := make(map[string]int, len(defaults))
+	results := make([]string, 0, len(defaults))
+	for i, e := range defaults {
+		k, _, _ := strings.Cut(e, "=")
+		results = append(results, e)
+		cache[k] = i
+	}
+
+	for _, value := range overrides {
+		// Values w/o = means they want this env to be removed/unset.
+		k, _, ok := strings.Cut(value, "=")
+		if !ok {
+			if i, exists := cache[k]; exists {
+				results[i] = "" // Used to indicate it should be removed
+			}
+			continue
+		}
+
+		// Just do a normal set/update
+		if i, exists := cache[k]; exists {
+			results[i] = value
+		} else {
+			results = append(results, value)
+		}
+	}
+
+	// Now remove all entries that we want to "unset"
+	for i := 0; i < len(results); i++ {
+		if results[i] == "" {
+			results = append(results[:i], results[i+1:]...)
+			i--
+		}
+	}
+
+	return results
+}

--- a/pkg/flagutil/flagutil_test.go
+++ b/pkg/flagutil/flagutil_test.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestReplaceOrAppendEnvValues(t *testing.T) {
+
+	tests := []struct {
+		defaults  []string
+		overrides []string
+		expected  []string
+	}{
+		// override defaults
+		{
+			defaults:  []string{"A=default", "B=default"},
+			overrides: []string{"A=override", "C=override"},
+			expected:  []string{"A=override", "B=default", "C=override"},
+		},
+		// empty defaults
+		{
+			defaults:  []string{"A=default", "B=default"},
+			overrides: []string{"A=override", "B="},
+			expected:  []string{"A=override", "B="},
+		},
+		// remove defaults
+		{
+			defaults:  []string{"A=default", "B=default"},
+			overrides: []string{"A=override", "B"},
+			expected:  []string{"A=override"},
+		},
+	}
+
+	comparator := func(s1, s2 []string) bool {
+		if len(s1) != len(s2) {
+			return false
+		}
+		sort.Slice(s1, func(i, j int) bool {
+			return s1[i] < s1[j]
+		})
+		sort.Slice(s2, func(i, j int) bool {
+			return s2[i] < s2[j]
+		})
+		for i, v := range s1 {
+			if v != s2[i] {
+				return false
+			}
+		}
+		return true
+	}
+	for _, tt := range tests {
+		actual := ReplaceOrAppendEnvValues(tt.defaults, tt.overrides)
+		assert.Assert(t, comparator(actual, tt.expected), fmt.Sprintf("expected: %s, actual: %s", tt.expected, actual))
+	}
+}


### PR DESCRIPTION
This PR fixes env handling (`--env-file` and `--env`) in `compose exec` (https://github.com/containerd/nerdctl/pull/1598#discussion_r1040579720) and underlying `exec`.

Changes include:

1. Refactor `--env` and `--env-flie` in `run.go` to a func so it can be reused by `exec`.
2. Fix the below issue in `nerdctl exec` by copying the (unexported) func from containerd that handles env overwrite.
3. Fix the `--env` handling in `compose exec` and add test.

More details:

I notice a bug/behavior of the above args in `nerdctl exec` that incompatible with `docker exec` or `nerdctl run` (the specific flag behavior).

I think the bahavior of `--env-file`/`--env` is (in both `exec` and `run`):
1. if the format is `k=v`, pass the env variable to process/container and overwrite any existing `k`.
4. if the format is `k` and `k` exists in local env, format it as `k=local_v` and continue as 1.
5. if the format is `k=`, emptify `k` in process/container (`k=empty string`).
6. if the format is `k` and `k` doesn't exist in local, ignore.

docker exec:
```shell
$ d exec 939f0ae12fe1 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=939f0ae12fe1
NGINX_VERSION=1.19.10
NJS_VERSION=0.5.3
PKG_RELEASE=1
HOME=/root

$ d exec -e AAA=aaa (1) -e PKG_RELEASE= (3) -e HOME (2) -e FOOBAR (4) 939f0ae12fe1 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=939f0ae12fe1
NGINX_VERSION=1.19.10
NJS_VERSION=0.5.3
PKG_RELEASE=
AAA=aaa
HOME=/home/ec2-user
```

nerdctl exec:
```shell
$  snd exec 33f3f0e7adfc env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
NGINX_VERSION=1.19.10
NJS_VERSION=0.5.3
PKG_RELEASE=1
HOME=/root
# before fix
$ snd exec -e AAA=aaa -e PKG_RELEASE= -e HOME -e FOOBAR 33f3f0e7adfc env
FATA[0000] OCI runtime exec failed: exec failed: unable to start container process: invalid environment variable: "HOME": unknown
# after fix
$ snd exec -e AAA=aaa (1) -e PKG_RELEASE= (3) -e HOME (2) -e FOOBAR (4) 33f3f0e7adfc env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
NGINX_VERSION=1.19.10
NJS_VERSION=0.5.3
PKG_RELEASE=
AAA=aaa
HOME=/root
```
