### PR TITLE
Fix: Deleting multiple networks stops at first delete fail

### DIFF
--- a/pkg/idutil/netwalker/netwalker.go
+++ b/pkg/idutil/netwalker/netwalker.go
@@ -55,7 +55,7 @@ func (w *NetworkWalker) Walk(ctx context.Context, req string) (int, error) {
 	idFilterF := func(n *netutil.NetworkConfig) bool {
 		if n.NerdctlID == nil {
 			// External network
-			return false
+			return n.Name == req
 		}
 		return n.Name == req || longIDExp.Match([]byte(*n.NerdctlID)) || shortIDExp.Match([]byte(*n.NerdctlID))
 	}


### PR DESCRIPTION
fixing https://github.com/containerd/nerdctl/issues/1587

```bash
 ~ nerdctl network create deleteme --gateway 10.10.11.1 --subnet 10.10.11.0/24

f9d6cec6deabf54691804bb7c1bf02ad7f461ab07f31a18398495b9de1cabf28

 ~ nerdctl  network ls                                                         
NETWORK ID      NAME               FILE
                k8s-pod-network    /etc/cni/net.d/10-calico.conflist
17f29b073143    bridge             /etc/cni/net.d/nerdctl-bridge.conflist
f9d6cec6deab    deleteme           /etc/cni/net.d/nerdctl-deleteme.conflist
                host               
                none

 ~ nerdctl network rm host k8s-pod-network test deleteme
ERRO[0000] pseudo network "host" cannot be removed      
ERRO[0000] k8s-pod-network is managed outside nerdctl and cannot be removed 
ERRO[0000] No such network: test                        
f9d6cec6deab
```


Signed-off-by: yaozhenxiu <946666800@qq.com>