### PR TITLE
Add compose pause and unpause commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,8 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose ps](#whale-nerdctl-compose-ps)
     - [:whale: nerdctl compose pull](#whale-nerdctl-compose-pull)
     - [:whale: nerdctl compose push](#whale-nerdctl-compose-push)
+    - [:whale: nerdctl compose pause](#whale-nerdctl-compose-pause)
+    - [:whale: nerdctl compose unpause](#whale-nerdctl-compose-unpause)
     - [:whale: nerdctl compose config](#whale-nerdctl-compose-config)
     - [:whale: nerdctl compose kill](#whale-nerdctl-compose-kill)
     - [:whale: nerdctl compose restart](#whale-nerdctl-compose-restart)
@@ -1515,6 +1517,18 @@ Usage: `nerdctl compose push [OPTIONS] [SERVICE...]`
 
 Unimplemented `docker-compose pull` (V1) flags: `--ignore-push-failures`
 
+### :whale: nerdctl compose pause
+
+Pause all processes within containers of service(s). They can be unpaused with `nerdctl compose unpause`
+
+Usage: `nerdctl compose pause [SERVICE...]`
+
+### :whale: nerdctl compose unpause
+
+Unpause all processes within containers of service(s)
+
+Usage: `nerdctl compose unpause [SERVICE...]`
+
 ### :whale: nerdctl compose config
 Validate and view the Compose file
 
@@ -1647,7 +1661,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose create|events|pause|port|scale|start|top|unpause`
+- `docker-compose create|events|port|scale|start|top`
 
 Others:
 - `docker system df`

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -70,6 +70,8 @@ func newComposeCommand() *cobra.Command {
 		newComposeRunCommand(),
 		newComposeVersionCommand(),
 		newComposeStopCommand(),
+		newComposePauseCommand(),
+		newComposeUnpauseCommand(),
 	)
 
 	return composeCommand

--- a/cmd/nerdctl/compose_pause.go
+++ b/cmd/nerdctl/compose_pause.go
@@ -1,0 +1,143 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+func newComposePauseCommand() *cobra.Command {
+	var composePauseCommand = &cobra.Command{
+		Use:                   "pause [SERVICE...]",
+		Short:                 "Pause all processes within containers of service(s). They can be unpaused with nerdctl compose unpause",
+		RunE:                  composePauseAction,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+	}
+	return composePauseCommand
+}
+
+func composePauseAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+	serviceNames, err := c.ServiceNames(args...)
+	if err != nil {
+		return err
+	}
+	containers, err := c.Containers(ctx, serviceNames...)
+	if err != nil {
+		return err
+	}
+
+	stdout := cmd.OutOrStdout()
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, c := range containers {
+		c := c
+		eg.Go(func() error {
+			if err := pauseContainer(ctx, client, c.ID()); err != nil {
+				return err
+			}
+			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			_, err = fmt.Fprintf(stdout, "%s\n", info.Labels[labels.Name])
+
+			return err
+		})
+	}
+
+	return eg.Wait()
+}
+
+func newComposeUnpauseCommand() *cobra.Command {
+	var composeUnpauseCommand = &cobra.Command{
+		Use:                   "unpause [SERVICE...]",
+		Short:                 "Unpause all processes within containers of service(s).",
+		RunE:                  composeUnpauseAction,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+	}
+	return composeUnpauseCommand
+}
+
+func composeUnpauseAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+	serviceNames, err := c.ServiceNames(args...)
+	if err != nil {
+		return err
+	}
+	containers, err := c.Containers(ctx, serviceNames...)
+	if err != nil {
+		return err
+	}
+
+	stdout := cmd.OutOrStdout()
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, c := range containers {
+		c := c
+		eg.Go(func() error {
+			if err := unpauseContainer(ctx, client, c.ID()); err != nil {
+				return err
+			}
+			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			_, err = fmt.Fprintf(stdout, "%s\n", info.Labels[labels.Name])
+
+			return err
+		})
+	}
+
+	return eg.Wait()
+}

--- a/cmd/nerdctl/compose_pause_linux_test.go
+++ b/cmd/nerdctl/compose_pause_linux_test.go
@@ -1,0 +1,81 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposePauseAndUnpause(t *testing.T) {
+	base := testutil.NewBase(t)
+	switch base.Info().CgroupDriver {
+	case "none", "":
+		t.Skip("requires cgroup (for pausing)")
+	}
+
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+    command: "sleep infinity"
+  svc1:
+    image: %s
+    command: "sleep infinity"
+`, testutil.CommonImage, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+
+	pausedAssertHandler := func(svc string) func(stdout string) error {
+		return func(stdout string) error {
+			// Docker Compose v1: "Paused", v2: "paused"
+			if !strings.Contains(stdout, "Paused") && !strings.Contains(stdout, "paused") {
+				return fmt.Errorf("service \"%s\" must have paused", svc)
+			}
+			return nil
+		}
+	}
+	upAssertHandler := func(svc string) func(stdout string) error {
+		return func(stdout string) error {
+			// Docker Compose v1: "Up", v2: "running"
+			if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
+				return fmt.Errorf("service \"%s\" must have been still running", svc)
+			}
+			return nil
+		}
+	}
+
+	// pause a service should (only) pause its own container
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "pause", "svc0").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0").AssertOutWithFunc(pausedAssertHandler("svc0"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc1").AssertOutWithFunc(upAssertHandler("svc1"))
+
+	// unpause should be able to recover the paused service container
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "unpause", "svc0").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0").AssertOutWithFunc(upAssertHandler("svc0"))
+}


### PR DESCRIPTION
I put the two commands in the same file and all logic on the `cmd/nerdctl` side (no logic in `pkg/composer`) because:

1. They rely on `pauseContainer` and `unpauseContainer` which are in `cmd` and we don't want `pkg` to rely on `cmd`. (Or maybe we can move all to their related `pkg`s).
2. The two commands have straightforward and almost same logic (only difference on `(un)pause`) and they're usually used together.
3. We test them together (pause and then unpause)

The current implementation follows docker compose behavior, which _parallelizes `(un)pause services` and stops whenever there is an error, causing the result in an intermediate state_ (some services are paused and some are not, depending on the parallelization). As an example:

```shell
$ nerdctl compose pause svc0 # pause 1 svc
compose-test_svc0_1
$ nerdctl compose ps
NAME                     COMMAND             SERVICE    STATUS     PORTS
...
compose-test_svcc6_1     "sleep infinity"    svcc6      running
compose-test_svc0_1      "sleep infinity"    svc0       Paused
compose-test_svccc4_1    "sleep infinity"    svccc4     running
...
$ nerdctl compose pause # pause all svc
FATA[0000] container add38a31feb35a125d4433ec69be845aff356080a137c5768fb851a54ab7d61a is already paused
$ nerdctl compose ps # some are paused and some are not
NAME                     COMMAND             SERVICE    STATUS     PORTS
compose-test_svcc2_1     "sleep infinity"    svcc2      Paused
compose-test_svcc3_1     "sleep infinity"    svcc3      running
compose-test_svccc0_1    "sleep infinity"    svccc0     Paused
compose-test_svc3_1      "sleep infinity"    svc3       Paused
compose-test_svccc2_1    "sleep infinity"    svccc2     Paused
compose-test_svcc4_1     "sleep infinity"    svcc4      Paused
compose-test_svccc1_1    "sleep infinity"    svccc1     running
compose-test_svc7_1      "sleep infinity"    svc7       Paused
compose-test_svc5_1      "sleep infinity"    svc5       running
compose-test_svc6_1      "sleep infinity"    svc6       Paused
compose-test_svcc0_1     "sleep infinity"    svcc0      Paused
compose-test_svcc6_1     "sleep infinity"    svcc6      running
compose-test_svc0_1      "sleep infinity"    svc0       Paused
compose-test_svccc4_1    "sleep infinity"    svccc4     Paused
compose-test_svcc7_1     "sleep infinity"    svcc7      running
compose-test_svc2_1      "sleep infinity"    svc2       Paused
compose-test_svc1_1      "sleep infinity"    svc1       Paused
compose-test_svccc6_1    "sleep infinity"    svccc6     running
compose-test_svccc3_1    "sleep infinity"    svccc3     running
compose-test_svcc1_1     "sleep infinity"    svcc1      running
compose-test_svc4_1      "sleep infinity"    svc4       running
compose-test_svccc7_1    "sleep infinity"    svccc7     running
compose-test_svcc5_1     "sleep infinity"    svcc5      Paused
compose-test_svccc5_1    "sleep infinity"    svccc5     Paused
```

Signed-off-by: Jin Dong <jindon@amazon.com>