### PR TITLE
Fix: Delete the used network in other namespace

### DIFF
--- a/cmd/nerdctl/container_lsutil.go
+++ b/cmd/nerdctl/container_lsutil.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
-	"github.com/containerd/containerd/namespaces"
 	"github.com/sirupsen/logrus"
 )
 
@@ -373,22 +372,4 @@ func idOrNameFilter(ctx context.Context, containers []containerd.Container, valu
 		}
 	}
 	return nil, fmt.Errorf("no such container %s", value)
-}
-
-func getContainersInAllNamespaces(ctx context.Context, client *containerd.Client) ([]containerd.Container, error) {
-	nsService := client.NamespaceService()
-	nsList, err := nsService.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	var results []containerd.Container
-	for _, ns := range nsList {
-		newCtx := namespaces.WithNamespace(ctx, ns)
-		containers, err := client.Containers(newCtx)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, containers...)
-	}
-	return results, nil
 }

--- a/cmd/nerdctl/network_prune.go
+++ b/cmd/nerdctl/network_prune.go
@@ -85,12 +85,7 @@ func networkPrune(ctx context.Context, cmd *cobra.Command, client *containerd.Cl
 		return err
 	}
 
-	containers, err := getContainersInAllNamespaces(ctx, client)
-	if err != nil {
-		return err
-	}
-
-	usedNetworks, err := netutil.UsedNetworks(ctx, containers)
+	usedNetworks, err := netutil.UsedNetworks(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -60,11 +60,8 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	containers, err := getContainersInAllNamespaces(ctx, client)
-	if err != nil {
-		return err
-	}
-	usedNetworkInfo, err := netutil.UsedNetworks(ctx, containers)
+
+	usedNetworkInfo, err := netutil.UsedNetworks(ctx, client)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_rm_linux_test.go
+++ b/cmd/nerdctl/network_rm_linux_test.go
@@ -25,6 +25,30 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+func TestNetworkRemoveInOtherNamespace(t *testing.T) {
+	if rootlessutil.IsRootless() {
+		t.Skip("test skipped for remove rootless network")
+	}
+	if testutil.GetTarget() == testutil.Docker {
+		t.Skip("test skipped for docker")
+	}
+	// --namespace=nerdctl-test
+	base := testutil.NewBase(t)
+	// --namespace=nerdctl-other
+	baseOther := testutil.NewBaseWithNamespace(t, "nerdctl-other")
+	networkName := testutil.Identifier(t)
+
+	base.Cmd("network", "create", networkName).AssertOK()
+	defer base.Cmd("network", "rm", networkName).AssertOK()
+
+	tID := testutil.Identifier(t)
+	base.Cmd("run", "-d", "--net", networkName, "--name", tID, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	defer base.Cmd("rm", "-f", tID).Run()
+
+	// delete network in namespace nerdctl-other
+	baseOther.Cmd("network", "rm", networkName).AssertFail()
+}
+
 func TestNetworkRemove(t *testing.T) {
 	if rootlessutil.IsRootless() {
 		t.Skip("test skipped for remove rootless network")

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -572,7 +572,18 @@ func RequireSystemService(t testing.TB, sv string) {
 
 const Namespace = "nerdctl-test"
 
+func NewBaseWithNamespace(t *testing.T, ns string) *Base {
+	if ns == "" || ns == "default" || ns == Namespace {
+		t.Fatalf(`the other base namespace cannot be "%s"`, ns)
+	}
+	return newBase(t, ns)
+}
+
 func NewBase(t *testing.T) *Base {
+	return newBase(t, Namespace)
+}
+
+func newBase(t *testing.T, ns string) *Base {
 	base := &Base{
 		T:                t,
 		Target:           GetTarget(),
@@ -585,7 +596,7 @@ func NewBase(t *testing.T) *Base {
 		if err != nil {
 			t.Fatal(err)
 		}
-		base.Args = []string{"--namespace=" + Namespace}
+		base.Args = []string{"--namespace=" + ns}
 		base.ComposeBinary = ""
 	case Docker:
 		base.Binary, err = exec.LookPath("docker")


### PR DESCRIPTION
fix https://github.com/containerd/nerdctl/issues/1635

**nd**: aliased to sudo nerdctl -n **nerdctl-test**
**n**: aliased to sudo nerdctl -n **default**

1.  create network `test` in namespace `nerdctl-test`
```bash
~ nd network create test --gateway 10.10.13.1 --subnet 10.10.13.0/24
9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
```

2. create container use netwrok `test` in namespace `nerdctl-test`
```bash
~ nd run -d --network test --name ndtest nginx             
b2dee527f9954e93bfa49beda122ef3f641b7bf464c02340a80d1a02462b697a
```

3. delete network `test` in namespace `nerdctl-test` , can't delete 
```bash
~ nd network rm test                                                
ERRO[0000] network "test" is in use by container ["b2dee527f9954e93bfa49beda122ef3f641b7bf464c02340a80d1a02462b697a"]
```

4.  fix bug
```bash
~ n network rm test                                                 
ERRO[0000] network "test" is in use by container ["b2dee527f9954e93bfa49beda122ef3f641b7bf464c02340a80d1a02462b697a"]
```
<br>
<br>

In addition, do we need to output the namespace of the container? like
```bash
~ n network rm test                                                 
ERRO[0000] network "test" is in use by container ["b2dee527f9954e93bfa49beda122ef3f641b7bf464c02340a80d1a02462b697a[nerdctl-test]"]
```
because when the output container is not in the current namespace, it may be confusing


<br>
<br>
Signed-off-by: yaozhenxiu <946666800@qq.com>