### PR TITLE
Fix bugs in compose stop and restart

### DIFF
--- a/cmd/nerdctl/compose_restart_linux_test.go
+++ b/cmd/nerdctl/compose_restart_linux_test.go
@@ -89,10 +89,10 @@ volumes:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "restart", "db").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
 
-	// stop one service and restart all
+	// stop one service and restart all (also check `--timeout` arg).
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "db").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(exitAssertHandler("db"))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "restart").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "restart", "--timeout", "5").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(upAssertHandler("wordpress"))
 }

--- a/pkg/composer/restart.go
+++ b/pkg/composer/restart.go
@@ -56,7 +56,8 @@ func (c *Composer) Restart(ctx context.Context, opt RestartOptions, services []s
 func (c *Composer) restartContainers(ctx context.Context, containers []containerd.Container, opt RestartOptions) error {
 	var timeoutArg string
 	if opt.Timeout != nil {
-		timeoutArg = fmt.Sprintf("--timeout=%d", *opt.Timeout)
+		// `nerdctl restart` uses `--time` instead of `--timeout`
+		timeoutArg = fmt.Sprintf("--time=%d", *opt.Timeout)
 	}
 
 	var rsWG sync.WaitGroup

--- a/pkg/composer/stop.go
+++ b/pkg/composer/stop.go
@@ -57,7 +57,8 @@ func (c *Composer) Stop(ctx context.Context, opt StopOptions, services []string)
 func (c *Composer) stopContainers(ctx context.Context, containers []containerd.Container, opt StopOptions) error {
 	var timeoutArg string
 	if opt.Timeout != nil {
-		timeoutArg = fmt.Sprintf("--timeout=%d", opt.Timeout)
+		// `nerdctl stop` uses `--time` instead of `--timeout`
+		timeoutArg = fmt.Sprintf("--time=%d", *opt.Timeout)
 	}
 
 	var rmWG sync.WaitGroup


### PR DESCRIPTION
In both command the timeout arg is `--timeout, -t` while the underlying command (`nerdctl restart/stop`) uses `--time, -t`. Change to use `-t` when constructing the underlying command. Also fix a pointer deference bug.

Fix them and add testcases.

Signed-off-by: Jin Dong <jindon@amazon.com>