### PR TITLE
Add compose start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ It does not necessarily mean that the corresponding features are missing in cont
     - [:whale: nerdctl compose exec](#whale-nerdctl-compose-exec)
     - [:whale: nerdctl compose down](#whale-nerdctl-compose-down)
     - [:whale: nerdctl compose images](#whale-nerdctl-compose-images)
+    - [:whale: nerdctl compose start](#whale-nerdctl-compose-start)
     - [:whale: nerdctl compose stop](#whale-nerdctl-compose-stop)
     - [:whale: nerdctl compose port](#whale-nerdctl-compose-port)
     - [:whale: nerdctl compose ps](#whale-nerdctl-compose-ps)
@@ -1483,6 +1484,12 @@ Flags:
 
 - :whale: `-q, --quiet`: Only show numeric image IDs
 
+### :whale: nerdctl compose start
+
+Start existing containers for service(s)
+
+Usage: `nerdctl compose start [SERVICE...]`
+
 ### :whale: nerdctl compose stop
 
 Stop containers in services without removing them.
@@ -1680,7 +1687,7 @@ Registry:
 - `docker search`
 
 Compose:
-- `docker-compose create|events|scale|start`
+- `docker-compose create|events|scale`
 
 Others:
 - `docker system df`

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -70,6 +70,7 @@ func newComposeCommand() *cobra.Command {
 		newComposeRemoveCommand(),
 		newComposeRunCommand(),
 		newComposeVersionCommand(),
+		newComposeStartCommand(),
 		newComposeStopCommand(),
 		newComposePauseCommand(),
 		newComposeUnpauseCommand(),

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"fmt"
 	"text/tabwriter"
-	"time"
 
 	"github.com/containerd/containerd"
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/portutil"
@@ -178,7 +178,7 @@ func composeContainerPrintableJSON(ctx context.Context, container containerd.Con
 		state    string
 		exitCode uint32
 	)
-	status, err := containerStatus(ctx, container)
+	status, err := containerutil.ContainerStatus(ctx, container)
 	if err == nil {
 		// show exitCode only when container is exited/stopped
 		if status.Status == containerd.Stopped {
@@ -200,19 +200,6 @@ func composeContainerPrintableJSON(ctx context.Context, container containerd.Con
 		ExitCode:   exitCode,
 		Publishers: formatPublishers(info.Labels),
 	}, nil
-}
-
-func containerStatus(ctx context.Context, c containerd.Container) (containerd.Status, error) {
-	// Just in case, there is something wrong in server.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	task, err := c.Task(ctx, nil)
-	if err != nil {
-		return containerd.Status{}, err
-	}
-
-	return task.Status(ctx)
 }
 
 // PortPublisher hold status about published port

--- a/cmd/nerdctl/compose_start.go
+++ b/cmd/nerdctl/compose_start.go
@@ -1,0 +1,109 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+func newComposeStartCommand() *cobra.Command {
+	var composeRestartCommand = &cobra.Command{
+		Use:                   "start [SERVICE...]",
+		Short:                 "Start existing containers for service(s)",
+		RunE:                  composeStartAction,
+		SilenceUsage:          true,
+		SilenceErrors:         true,
+		DisableFlagsInUseLine: true,
+	}
+	return composeRestartCommand
+}
+
+func composeStartAction(cmd *cobra.Command, args []string) error {
+	client, ctx, cancel, err := newClient(cmd)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	c, err := getComposer(cmd, client)
+	if err != nil {
+		return err
+	}
+
+	// TODO(djdongjin): move to `pkg/composer` and rewrite `c.Services + for-loop`
+	// with `c.project.WithServices` after refactor (#1639) is done.
+	services, err := c.Services(ctx, args...)
+	if err != nil {
+		return err
+	}
+	for _, svc := range services {
+		svcName := svc.Unparsed.Name
+		containers, err := c.Containers(ctx, svcName)
+		if err != nil {
+			return err
+		}
+		// return error if no containers and service replica is not zero
+		if len(containers) == 0 {
+			if len(svc.Containers) == 0 {
+				continue
+			}
+			return fmt.Errorf("service %q has no container to start", svcName)
+		}
+
+		if err := startContainers(ctx, client, containers); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func startContainers(ctx context.Context, client *containerd.Client, containers []containerd.Container) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, c := range containers {
+		c := c
+		eg.Go(func() error {
+			if cStatus, err := containerutil.ContainerStatus(ctx, c); err != nil {
+				return err
+			} else if cStatus.Status == containerd.Running {
+				return nil
+			}
+
+			// in compose, always disable attach
+			if err := startContainer(ctx, c, false, client); err != nil {
+				return err
+			}
+			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
+			if err != nil {
+				return err
+			}
+
+			_, err = fmt.Fprintf(os.Stdout, "Container %s started\n", info.Labels[labels.Name])
+			return err
+		})
+	}
+
+	return eg.Wait()
+}

--- a/cmd/nerdctl/compose_start_linux_test.go
+++ b/cmd/nerdctl/compose_start_linux_test.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestComposeStart(t *testing.T) {
+	base := testutil.NewBase(t)
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+    command: "sleep infinity"
+  svc1:
+    image: %s
+    command: "sleep infinity"
+`, testutil.CommonImage, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+
+	upAssertHandler := func(svc string) func(stdout string) error {
+		return func(stdout string) error {
+			// Docker Compose v1: "Up", v2: "running"
+			if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
+				return fmt.Errorf("service \"%s\" must have been still running", svc)
+			}
+			return nil
+		}
+	}
+
+	// calling `compose start` after all services up has no effect.
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertOK()
+
+	// `compose start`` can start a stopped/killed service container
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "--timeout", "1", "svc0").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "kill", "svc1").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0").AssertOutWithFunc(upAssertHandler("svc0"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc1").AssertOutWithFunc(upAssertHandler("svc1"))
+}
+
+func TestComposeStartFailWhenServicePause(t *testing.T) {
+	// Incompatible with docker compose v1. Currently CI is using compose v1.
+	// Starting a paused container triggers an error in v2 but is ignored in v1.
+	testutil.DockerIncompatible(t)
+
+	base := testutil.NewBase(t)
+	switch base.Info().CgroupDriver {
+	case "none", "":
+		t.Skip("requires cgroup (for pausing)")
+	}
+
+	var dockerComposeYAML = fmt.Sprintf(`
+version: '3.1'
+
+services:
+  svc0:
+    image: %s
+    command: "sleep infinity"
+`, testutil.CommonImage)
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+	projectName := comp.ProjectName()
+	t.Logf("projectName=%q", projectName)
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+
+	// `compose start` cannot start a paused service container
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "pause", "svc0").AssertOK()
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertFail()
+}

--- a/cmd/nerdctl/compose_top.go
+++ b/cmd/nerdctl/compose_top.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/spf13/cobra"
 )
@@ -58,7 +59,7 @@ func composeTopAction(cmd *cobra.Command, args []string) error {
 
 	stdout := cmd.OutOrStdout()
 	for _, c := range containers {
-		cStatus, err := containerStatus(ctx, c)
+		cStatus, err := containerutil.ContainerStatus(ctx, c)
 		if err != nil {
 			return err
 		}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -132,9 +132,10 @@ func (c *Composer) runNerdctlCmd(ctx context.Context, args ...string) error {
 	return nil
 }
 
-func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, error) {
+// Services returns the parsed Service objects in dependency order.
+func (c *Composer) Services(ctx context.Context, svcs ...string) ([]*serviceparser.Service, error) {
 	var services []*serviceparser.Service
-	if err := c.project.WithServices(nil, func(svc compose.ServiceConfig) error {
+	if err := c.project.WithServices(svcs, func(svc compose.ServiceConfig) error {
 		parsed, err := serviceparser.Parse(c.project, svc)
 		if err != nil {
 			return err
@@ -147,9 +148,10 @@ func (c *Composer) Services(ctx context.Context) ([]*serviceparser.Service, erro
 	return services, nil
 }
 
-func (c *Composer) ServiceNames(services ...string) ([]string, error) {
+// ServiceNames returns service names in dependency order.
+func (c *Composer) ServiceNames(svcs ...string) ([]string, error) {
 	var names []string
-	if err := c.project.WithServices(services, func(svc compose.ServiceConfig) error {
+	if err := c.project.WithServices(svcs, func(svc compose.ServiceConfig) error {
 		names = append(names, svc.Name)
 		return nil
 	}); err != nil {

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/portutil"
@@ -52,4 +53,18 @@ func PrintHostPort(ctx context.Context, writer io.Writer, container containerd.C
 		}
 	}
 	return fmt.Errorf("no public port %d/%s published for %q", containerPort, proto, container.ID())
+}
+
+// ContainerStatus returns the container's status from its task.
+func ContainerStatus(ctx context.Context, c containerd.Container) (containerd.Status, error) {
+	// Just in case, there is something wrong in server.
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	task, err := c.Task(ctx, nil)
+	if err != nil {
+		return containerd.Status{}, err
+	}
+
+	return task.Status(ctx)
 }


### PR DESCRIPTION
https://docs.docker.com/engine/reference/commandline/compose_start/

It starts one or more services following their dependency order.
1. Running containers will be skipped.
2. Stopped/killed containers will be started. (same for `created` but we don't have `compose create` yet).
3. Paused containers will trigger error and exit command. (see below)

```shell
# docker compose (dc)
➜  dc ps
NAME                COMMAND             SERVICE             STATUS              PORTS
compstart-svc0-1    "sleep infinity"    svc0                paused
compstart-svc1-1    "sleep infinity"    svc1                running
➜  dc start svc0
[+] Running 0/0
 ⠋ Container compstart-svc0-1  Starting                                                                                                                                                                                                                                                                                                                                0.0s
Error response from daemon: cannot start a paused container, try unpause instead

# nerdctl compose (sndc)
➜  sndc ps
NAME                COMMAND             SERVICE    STATUS     PORTS
compstart_svc0_1    "sleep infinity"    svc0       Paused
compstart_svc1_1    "sleep infinity"    svc1       running
➜  sndc start svc0
FATA[0000] task 054fe64fb2c7ea44cbab05b063c504344673ccde48411f71777d602a5f0f397d: already exists
```

Signed-off-by: Jin Dong <jindon@amazon.com>