### PR TITLE
Fix compose dependency order

### DIFF
--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -70,8 +70,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 	var parsedServices []*serviceparser.Service
 	// use WithServices to sort the services in dependency order
 	if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
-		replicas, ok := uo.Scale[svc.Name]
-		if ok {
+		if replicas, ok := uo.Scale[svc.Name]; ok {
 			if svc.Deploy == nil {
 				svc.Deploy = &types.DeployConfig{}
 			}

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -48,10 +48,10 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 		containers   = make(map[string]serviceparser.Container) // key: container ID
 		services     = []string{}
 		containersMu sync.Mutex
-		runEG        errgroup.Group
 	)
 	for _, ps := range parsedServices {
 		ps := ps
+		var runEG errgroup.Group
 		services = append(services, ps.Unparsed.Name)
 		for _, container := range ps.Containers {
 			container := container
@@ -66,9 +66,9 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 				return nil
 			})
 		}
-	}
-	if err := runEG.Wait(); err != nil {
-		return err
+		if err := runEG.Wait(); err != nil {
+			return err
+		}
 	}
 
 	if uo.Detach {


### PR DESCRIPTION
Fix #1658

In restart, the order is in-dependency instead of reverse dependency order.

In up, we should use `errorgroup` _per service_ so the service dependency is ensured.

```shell
# in dependency order: svc2 -> svc1 -> svc0
$ cat docker-compose.yaml
version: '3.1'

services:
  svc0:
    image: alpine
    command: "sleep infinity"
    depends_on:
    - "svc1"
    - "svc2"
  svc1:
    image: alpine
    command: "sleep infinity"
    depends_on:
    - "svc2"
  svc2:
    image: alpine
    command: "sleep infinity"

$ nerdctl compose up -d
INFO[0000] Creating network compdep_default
INFO[0000] Ensuring image alpine
INFO[0000] Ensuring image alpine
INFO[0000] Ensuring image alpine
INFO[0000] Creating container compdep_svc2_1
INFO[0000] Creating container compdep_svc1_1
INFO[0000] Creating container compdep_svc0_1

$ nerdctl compose restart
INFO[0000] Restarting container compdep_svc2_1
INFO[0010] Restarting container compdep_svc1_1
INFO[0020] Restarting container compdep_svc0_1
```


Signed-off-by: Jin Dong <jindon@amazon.com>