### PR TITLE
Add RequireExecutable to testutil

### DIFF
--- a/cmd/nerdctl/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose_run_linux_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -412,9 +411,7 @@ services:
 }
 
 func TestComposePushAndPullWithCosignVerify(t *testing.T) {
-	if _, err := exec.LookPath("cosign"); err != nil {
-		t.Skip()
-	}
+	testutil.RequireExecutable(t, "cosign")
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)

--- a/cmd/nerdctl/image_convert_linux_test.go
+++ b/cmd/nerdctl/image_convert_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"runtime"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestImageConvertNydus(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no windows support yet")
 	}
-
+	testutil.RequireExecutable(t, "nydus-image")
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
 	convertedImage := testutil.Identifier(t) + ":nydus"
@@ -50,9 +49,7 @@ func TestImageConvertNydus(t *testing.T) {
 	}
 
 	// skip if nydusify is not installed
-	if _, err := exec.LookPath("nydusify"); err != nil {
-		t.Skip("Nydusify is not installed")
-	}
+	testutil.RequireExecutable(t, "nydusify")
 
 	// setup local docker registry
 	registryPort := 15000

--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -36,9 +36,7 @@ type jweKeyPair struct {
 }
 
 func newJWEKeyPair(t testing.TB) *jweKeyPair {
-	if _, err := exec.LookPath("openssl"); err != nil {
-		t.Skip(err)
-	}
+	testutil.RequireExecutable(t, "openssl")
 	td, err := os.MkdirTemp(t.TempDir(), "jwe-key-pair")
 	assert.NilError(t, err)
 	prv := filepath.Join(td, "mykey.pem")

--- a/cmd/nerdctl/logs_test.go
+++ b/cmd/nerdctl/logs_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -104,10 +103,7 @@ func TestLogsWithInheritedFlags(t *testing.T) {
 
 func TestLogsOfJournaldDriver(t *testing.T) {
 	t.Parallel()
-	_, err := exec.LookPath("journalctl")
-	if err != nil {
-		t.Skipf("`journalctl` executable is required for this test: %s", err)
-	}
+	testutil.RequireExecutable(t, "journalctl")
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
 

--- a/cmd/nerdctl/pull_linux_test.go
+++ b/cmd/nerdctl/pull_linux_test.go
@@ -58,9 +58,7 @@ func newCosignKeyPair(t testing.TB, path string) *cosignKeyPair {
 }
 
 func TestImageVerifyWithCosign(t *testing.T) {
-	if _, err := exec.LookPath("cosign"); err != nil {
-		t.Skip()
-	}
+	testutil.RequireExecutable(t, "cosign")
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	t.Setenv("COSIGN_PASSWORD", "1")
@@ -114,9 +112,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 }
 
 func TestImageVerifyWithCosignShouldFailWhenKeyIsNotCorrect(t *testing.T) {
-	if _, err := exec.LookPath("cosign"); err != nil {
-		t.Skip()
-	}
+	testutil.RequireExecutable(t, "cosign")
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	t.Setenv("COSIGN_PASSWORD", "1")

--- a/cmd/nerdctl/run_verify_linux_test.go
+++ b/cmd/nerdctl/run_verify_linux_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -28,9 +27,7 @@ import (
 )
 
 func TestRunVerifyCosign(t *testing.T) {
-	if _, err := exec.LookPath("cosign"); err != nil {
-		t.Skip()
-	}
+	testutil.RequireExecutable(t, "cosign")
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)
 	t.Setenv("COSIGN_PASSWORD", "1")

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -570,6 +570,13 @@ func RequireSystemService(t testing.TB, sv string) {
 	}
 }
 
+// RequireExecutable skips tests when executable `name` is not present in PATH.
+func RequireExecutable(t testing.TB, name string) {
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("required executable doesn't exist in PATH: %s", name)
+	}
+}
+
 const Namespace = "nerdctl-test"
 
 func NewBaseWithNamespace(t *testing.T, ns string) *Base {


### PR DESCRIPTION
`nydus-image` is required for nydus image convert ([link](https://github.com/containerd/nerdctl/blob/main/docs/nydus.md#build-nydus-image-using-nerdctl-image-convert)).

This PR skips nydus convert test when binary is not there, otherwise the test fails. Also simplify other similar checks (cosign, journalctl) in tests.

Signed-off-by: Jin Dong <jindon@amazon.com>