### PR TITLE
Clean up boilerplate code in test

### DIFF
--- a/cmd/nerdctl/compose_config_test.go
+++ b/cmd/nerdctl/compose_config_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -128,14 +127,6 @@ services:
 	base.Env = append(os.Environ(), "COMPOSE_FILE="+comp.YAMLFullPath()+","+filepath.Join(comp.Dir(), "docker-compose.test.yml"), "COMPOSE_PATH_SEPARATOR=,")
 
 	base.ComposeCmd("config").AssertOutContains("alpine:3.14")
-	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutWithFunc(func(out string) error {
-		if !strings.Contains(out, "hello1\n") {
-			return fmt.Errorf("expected hello1, got %s", out)
-		}
-		if !strings.Contains(out, "hello2\n") {
-			return fmt.Errorf("expected hello2, got %s", out)
-		}
-		return nil
-	})
+	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutContainsAll("hello1\n", "hello2\n")
 	base.ComposeCmd("--project-directory", comp.Dir(), "config").AssertOutContains("alpine:3.14")
 }

--- a/cmd/nerdctl/compose_images_linux_test.go
+++ b/cmd/nerdctl/compose_images_linux_test.go
@@ -64,23 +64,14 @@ volumes:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
 
-	ImageAssertHandler := func(svc string, image string, exist bool) func(stdout string) error {
-		return func(stdout string) error {
-			if strings.Contains(stdout, image) != exist {
-				return fmt.Errorf("image %s from service %s: expect in output (%t), actual (%t)", image, svc, exist, !exist)
-			}
-			return nil
-		}
-	}
-
 	wordpressImageName := strings.Split(testutil.WordpressImage, ":")[0]
 	dbImageName := strings.Split(testutil.MariaDBImage, ":")[0]
 
 	// check one service image
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "images", "db").AssertOutWithFunc(ImageAssertHandler("db", dbImageName, true))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "images", "db").AssertOutWithFunc(ImageAssertHandler("wordpress", wordpressImageName, false))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "images", "db").AssertOutContains(dbImageName)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "images", "db").AssertOutNotContains(wordpressImageName)
 
 	// check all service images
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "images").AssertOutWithFunc(ImageAssertHandler("db", dbImageName, true))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "images").AssertOutWithFunc(ImageAssertHandler("wordpress", wordpressImageName, true))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "images").AssertOutContains(dbImageName)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "images").AssertOutContains(wordpressImageName)
 }

--- a/cmd/nerdctl/compose_kill_linux_test.go
+++ b/cmd/nerdctl/compose_kill_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -69,18 +68,7 @@ volumes:
 
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "kill", "db").AssertOK()
 	time.Sleep(3 * time.Second)
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(func(stdout string) error {
-		// Docker Compose v1: "Exit 137", v2: "exited (137)"
-		if !strings.Contains(stdout, " 137") && !strings.Contains(stdout, "(137)") {
-			return fmt.Errorf("service \"db\" must have exited with code 137")
-		}
-		return nil
-	})
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(func(stdout string) error {
-		// Docker Compose v1: "Up", v2: "running"
-		if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
-			return fmt.Errorf("service \"wordpress\" must have been still running")
-		}
-		return nil
-	})
+	// Docker Compose v1: "Exit 137", v2: "exited (137)"
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutContainsAny(" 137", "(137)")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutContainsAny("Up", "running")
 }

--- a/cmd/nerdctl/compose_restart_linux_test.go
+++ b/cmd/nerdctl/compose_restart_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -64,35 +63,16 @@ volumes:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
 
-	exitAssertHandler := func(svc string) func(stdout string) error {
-		return func(stdout string) error {
-			// Docker Compose v1: "Exit code", v2: "exited (code)"
-			if !strings.Contains(stdout, "Exit") && !strings.Contains(stdout, "exited") {
-				return fmt.Errorf("service \"%s\" must have exited", svc)
-			}
-			return nil
-		}
-	}
-	upAssertHandler := func(svc string) func(stdout string) error {
-		return func(stdout string) error {
-			// Docker Compose v1: "Up", v2: "running"
-			if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
-				return fmt.Errorf("service \"%s\" must have been still running", svc)
-			}
-			return nil
-		}
-	}
-
 	// stop and restart a single service.
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "db").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(exitAssertHandler("db"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutContainsAny("Exit", "exited")
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "restart", "db").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutContainsAny("Up", "running")
 
 	// stop one service and restart all (also check `--timeout` arg).
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "db").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(exitAssertHandler("db"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutContainsAny("Exit", "exited")
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "restart", "--timeout", "5").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(upAssertHandler("db"))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(upAssertHandler("wordpress"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutContainsAny("Up", "running")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutContainsAny("Up", "running")
 }

--- a/cmd/nerdctl/compose_start_linux_test.go
+++ b/cmd/nerdctl/compose_start_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -46,16 +45,6 @@ services:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
 
-	upAssertHandler := func(svc string) func(stdout string) error {
-		return func(stdout string) error {
-			// Docker Compose v1: "Up", v2: "running"
-			if !strings.Contains(stdout, "Up") && !strings.Contains(stdout, "running") {
-				return fmt.Errorf("service \"%s\" must have been still running", svc)
-			}
-			return nil
-		}
-	}
-
 	// calling `compose start` after all services up has no effect.
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertOK()
 
@@ -63,8 +52,8 @@ services:
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "stop", "--timeout", "1", "svc0").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "kill", "svc1").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0").AssertOutWithFunc(upAssertHandler("svc0"))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc1").AssertOutWithFunc(upAssertHandler("svc1"))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0").AssertOutContainsAny("Up", "running")
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc1").AssertOutContainsAny("Up", "running")
 }
 
 func TestComposeStartFailWhenServicePause(t *testing.T) {

--- a/cmd/nerdctl/run_test.go
+++ b/cmd/nerdctl/run_test.go
@@ -51,13 +51,7 @@ CMD ["echo", "bar"]
 	defer os.RemoveAll(buildCtx)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
-	base.Cmd("run", "--rm", imageName).AssertOutWithFunc(func(stdout string) error {
-		expected := "foo echo bar\n"
-		if stdout != expected {
-			return fmt.Errorf("expected %q, got %q", expected, stdout)
-		}
-		return nil
-	})
+	base.Cmd("run", "--rm", imageName).AssertOutExactly("foo echo bar\n")
 	base.Cmd("run", "--rm", "--entrypoint", "", imageName).AssertFail()
 	base.Cmd("run", "--rm", "--entrypoint", "", imageName, "echo", "blah").AssertOutWithFunc(func(stdout string) error {
 		if !strings.Contains(stdout, "blah") {

--- a/cmd/nerdctl/run_user_linux_test.go
+++ b/cmd/nerdctl/run_user_linux_test.go
@@ -104,6 +104,7 @@ func TestRunAddGroup(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		testCase := testCase
 		t.Run(testCase.user, func(t *testing.T) {
 			t.Parallel()
 			cmd := []string{"run", "--rm"}

--- a/cmd/nerdctl/start_test.go
+++ b/cmd/nerdctl/start_test.go
@@ -17,9 +17,7 @@
 package main
 
 import (
-	"errors"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
@@ -32,13 +30,7 @@ func TestStart(t *testing.T) {
 
 	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	base.Cmd("run", "--name", containerName, testutil.CommonImage).AssertOK()
-	base.Cmd("start", containerName).AssertOutWithFunc(func(stdout string) error {
-		if !strings.Contains(stdout, containerName) {
-			t.Log(stdout)
-			return errors.New("got bad container name output on start")
-		}
-		return nil
-	})
+	base.Cmd("start", containerName).AssertOutContains(containerName)
 }
 
 func TestStartAttach(t *testing.T) {
@@ -51,10 +43,5 @@ func TestStartAttach(t *testing.T) {
 
 	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	base.Cmd("run", "--name", containerName, testutil.CommonImage, "sh", "-euxc", "echo foo").AssertOK()
-	base.Cmd("start", "-a", containerName).AssertOutWithFunc(func(stdout string) error {
-		if !strings.Contains(stdout, "foo") {
-			return errors.New("got bad attached output on start")
-		}
-		return nil
-	})
+	base.Cmd("start", "-a", containerName).AssertOutContains("foo")
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -359,13 +359,40 @@ func (c *Cmd) AssertCombinedOutContains(s string) {
 	assert.Assert(c.Base.T, strings.Contains(res.Combined(), s))
 }
 
+// AssertOutContainsAll checks if command output contains All strings in `strs`.
+func (c *Cmd) AssertOutContainsAll(strs ...string) {
+	c.Base.T.Helper()
+	fn := func(stdout string) error {
+		for _, s := range strs {
+			if !strings.Contains(stdout, s) {
+				return fmt.Errorf("expected stdout to contain %q", s)
+			}
+		}
+		return nil
+	}
+	c.AssertOutWithFunc(fn)
+}
+
+// AssertOutContainsAny checks if command output contains Any string in `strs`.
+func (c *Cmd) AssertOutContainsAny(strs ...string) {
+	c.Base.T.Helper()
+	fn := func(stdout string) error {
+		for _, s := range strs {
+			if strings.Contains(stdout, s) {
+				return nil
+			}
+		}
+		return fmt.Errorf("expected stdout to contain any of %q", strings.Join(strs, "|"))
+	}
+	c.AssertOutWithFunc(fn)
+}
+
 func (c *Cmd) AssertOutNotContains(s string) {
 	c.AssertOutWithFunc(func(stdout string) error {
 		if strings.Contains(stdout, s) {
 			return fmt.Errorf("expected stdout to not contain %q", s)
 		}
 		return nil
-
 	})
 }
 


### PR DESCRIPTION
Some tests have duplicated handler functions to check if a test command output contains (any|all of) strings.

Maybe we can do some cleanup to avoid those duplications. If a test fails, the whole output (and what is the expected strings) will be printed. I think these should be sufficient as logs/debug info in the case of test failure?