### PR TITLE
run: Add --uts flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Basic flags:
 - :whale: `--pull=(always|missing|never)`: Pull image before running
   - Default: "missing"
 - :whale: `--pid=(host|container:<container>)`: PID namespace to use
+- :whale: `--uts=(host)` : UTS namespace to use
 - :whale: `--stop-signal`: Signal to stop a container (default "SIGTERM")
 - :whale: `--stop-timeout`: Timeout (in seconds) to stop a container
 
@@ -577,7 +578,7 @@ Unimplemented `docker run` flags:
     `--attach`, `--blkio-weight-device`, `--cgroup-parent`, `--cpu-rt-*`, `--detach-keys`, `--device-*`,
     `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--ip6`, `--isolation`, `--no-healthcheck`,
     `--link*`, `--mac-address`, `--publish-all`, `--sig-proxy`, `--storage-opt`,
-    `--userns`, `--uts`, `--volume-driver`, `--volumes-from`
+    `--userns`, `--volume-driver`, `--volumes-from`
 
 ### :whale: :blue_square: nerdctl exec
 Run a command in a running container.

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -164,6 +164,30 @@ func setPlatformOptions(
 		opts = append(opts, oci.WithRdt(rdtClass, "", ""))
 	}
 
+	nsOpts, err := generateNamespaceOpts(ctx, cmd, client, internalLabels)
+	if err != nil {
+		return nil, err
+	}
+	opts = append(opts, nsOpts...)
+
+	opts, err = setOOMScoreAdj(opts, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	return opts, nil
+}
+
+// Helper to validate the namespace options exposed via run and return the correct
+// opts.
+func generateNamespaceOpts(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client *containerd.Client,
+	internalLabels *internalLabels,
+) ([]oci.SpecOpts, error) {
+	var opts []oci.SpecOpts
+
 	// UTS
 	uts, err := cmd.Flags().GetString("uts")
 	if err != nil {
@@ -206,11 +230,6 @@ func setPlatformOptions(
 	}
 	internalLabels.pidContainer = pidLabel
 	opts = append(opts, pidOpts...)
-
-	opts, err = setOOMScoreAdj(opts, cmd)
-	if err != nil {
-		return nil, err
-	}
 
 	return opts, nil
 }

--- a/cmd/nerdctl/run_linux_test.go
+++ b/cmd/nerdctl/run_linux_test.go
@@ -75,6 +75,21 @@ func TestRunPidHost(t *testing.T) {
 	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
 }
 
+func TestRunUtsHost(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+
+	// Was thinking of os.ReadLink("/proc/1/ns/uts")
+	// but you'd get EPERM for rootless. Just validate the
+	// hostname is the same.
+	hostName, err := os.Hostname()
+	assert.NilError(base.T, err)
+
+	base.Cmd("run", "--rm", "--uts=host", testutil.AlpineImage, "hostname").AssertOutContains(hostName)
+	// Validate we can't provide a hostname with uts=host
+	base.Cmd("run", "--rm", "--uts=host", "--hostname=foobar", testutil.AlpineImage, "hostname").AssertFail()
+}
+
 func TestRunPidContainer(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)


### PR DESCRIPTION
Adds support for specifying the host UTS namespace (the only thing
docker supported). This also consolidates the namespace options
checks for linux on run into a single function.