### PR TITLE
unique hostname inside /etc/hosts

### DIFF
--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -157,7 +157,7 @@ func (u *updater) phase2() error {
 		// TODO: cut off entries for the containers in other networks
 		for ip, nwName := range u.nwNameByIPStr {
 			meta := u.metaByIPStr[ip]
-			if line := createLine(nwName, meta, myNetworks); len(line) != 0 {
+			if line := createLine(nwName, meta, myMeta.ID, myNetworks); len(line) != 0 {
 				serviceHosts[strings.Join(line, " ")] = ip
 			}
 		}
@@ -186,13 +186,17 @@ func (u *updater) phase2() error {
 // for `nerdctl --name=foo --hostname=bar --network=n0`.
 //
 // May return an empty string slice
-func createLine(thatNetwork string, meta *Meta, myNetworks map[string]struct{}) []string {
+func createLine(thatNetwork string, meta *Meta, myID string, myNetworks map[string]struct{}) []string {
 	line := []string{}
 	if _, ok := myNetworks[thatNetwork]; !ok {
 		// Do not add lines for other networks
 		return line
 	}
-	baseHostnames := []string{meta.Hostname}
+	var baseHostnames []string
+	// hostname is a unique name for a container in a network.
+	if myID == meta.ID {
+		baseHostnames = append(baseHostnames, meta.Hostname)
+	}
 	if meta.Name != "" {
 		baseHostnames = append(baseHostnames, meta.Name)
 	}

--- a/pkg/dnsutil/hostsstore/updater_test.go
+++ b/pkg/dnsutil/hostsstore/updater_test.go
@@ -32,6 +32,7 @@ func TestCreateLine(t *testing.T) {
 		thatHostname string // nerdctl run --hostname
 		thatName     string // nerdctl run --name
 		myNetwork    string
+		myID         string
 		expected     string
 	}
 	testCases := []testCase{
@@ -41,13 +42,23 @@ func TestCreateLine(t *testing.T) {
 			thatHostname: "bar",
 			thatName:     "foo",
 			myNetwork:    "n1",
+			myID:         "984d63ce45ae",
 			expected:     "bar bar.n1 foo foo.n1",
+		},
+		{
+			thatIP:       "10.4.2.2",
+			thatNetwork:  "n1",
+			thatHostname: "bar",
+			thatName:     "foo",
+			myNetwork:    "n1",
+			expected:     "foo foo.n1",
 		},
 		{
 			thatIP:       "10.4.2.3",
 			thatNetwork:  "n1",
 			thatHostname: "bar",
 			myNetwork:    "n1",
+			myID:         "984d63ce45ae",
 			expected:     "bar bar.n1",
 		},
 		{
@@ -97,7 +108,7 @@ func TestCreateLine(t *testing.T) {
 		myNetworks := map[string]struct{}{
 			tc.myNetwork: {},
 		}
-		lines := createLine(tc.thatNetwork, thatMeta, myNetworks)
+		lines := createLine(tc.thatNetwork, thatMeta, tc.myID, myNetworks)
 		line := strings.Join(lines, " ")
 		t.Logf("tc=%+v, line=%q", tc, line)
 		assert.Equal(t, tc.expected, line)


### PR DESCRIPTION
```
bare-metal-srv14:~# nerdctl ps -a
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
bare-metal-srv14:~# nerdctl   run  --hostname etcd-0 -it alpine cat /etc/hosts 
# <nerdctl>
127.0.0.1	localhost localhost.localdomain
::1		localhost localhost.localdomain
10.4.0.138      etcd-0 alpine-4d8a2
# </nerdctl>
bare-metal-srv14:~# nerdctl   run  --hostname etcd-0 -it alpine cat /etc/hosts 
# <nerdctl>
127.0.0.1	localhost localhost.localdomain
::1		localhost localhost.localdomain
10.4.0.139      etcd-0 alpine-21cc4
10.4.0.138      etcd-0 alpine-4d8a2
# </nerdctl>
bare-metal-srv14:~# nerdctl   run  --hostname etcd-0 -it alpine cat /etc/hosts 
# <nerdctl>
127.0.0.1	localhost localhost.localdomain
::1		localhost localhost.localdomain
10.4.0.139      etcd-0 alpine-21cc4
10.4.0.138      etcd-0 alpine-4d8a2
10.4.0.140      etcd-0 alpine-a1579
# </nerdctl>
bare-metal-srv14:~# nerdctl   run  --hostname etcd-0 -it alpine hostname -i
10.4.0.138 10.4.0.141 10.4.0.140 10.4.0.139
bare-metal-srv14:~# nerdctl_org   run  --hostname etcd-0 -it alpine ping etcd-0
PING etcd-0 (10.4.0.139): 56 data bytes
```
mapping the same hostname to multiple IP addresses in a container context  causes network issues in that context. This fix enforce unique hostname, within nerdctl generated hosts `<nerdctl> </nerdctl>`, per IP addresse and per container context. 

[for more details about the issue I am resolving  ](https://github.com/containerd/nerdctl/issues/1674)
Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>