### PR TITLE
setPlatformOptions: Change signature

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -436,10 +436,11 @@ func createContainer(ctx context.Context, cmd *cobra.Command, client *containerd
 		oci.WithDefaultSpec(),
 	)
 
-	opts, internalLabels, err = setPlatformOptions(ctx, opts, cmd, client, id, internalLabels)
+	platformOpts, err := setPlatformOptions(ctx, cmd, client, id, &internalLabels)
 	if err != nil {
 		return nil, nil, err
 	}
+	opts = append(opts, platformOpts...)
 
 	rootfsOpts, rootfsCOpts, ensuredImage, err := generateRootfsOpts(ctx, client, platform, cmd, args, id)
 	if err != nil {

--- a/cmd/nerdctl/run_freebsd.go
+++ b/cmd/nerdctl/run_freebsd.go
@@ -39,6 +39,12 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string, internalLabels internalLabels) ([]oci.SpecOpts, internalLabels, error) {
-	return opts, internalLabels, nil
+func setPlatformOptions(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client *containerd.Client,
+	id string,
+	internalLabels *internalLabels,
+) ([]oci.SpecOpts, error) {
+	return []oci.SpecOpts{}, nil
 }

--- a/cmd/nerdctl/run_windows.go
+++ b/cmd/nerdctl/run_windows.go
@@ -41,10 +41,17 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Command, client *containerd.Client, id string, internalLabels internalLabels) ([]oci.SpecOpts, internalLabels, error) {
+func setPlatformOptions(
+	ctx context.Context,
+	cmd *cobra.Command,
+	client *containerd.Client,
+	id string,
+	internalLabels *internalLabels,
+) ([]oci.SpecOpts, error) {
+	var opts []oci.SpecOpts
 	cpus, err := cmd.Flags().GetFloat64("cpus")
 	if err != nil {
-		return nil, internalLabels, err
+		return nil, err
 	}
 	if cpus > 0.0 {
 		opts = append(opts, oci.WithWindowsCPUCount(uint64(cpus)))
@@ -52,12 +59,12 @@ func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Com
 
 	memStr, err := cmd.Flags().GetString("memory")
 	if err != nil {
-		return nil, internalLabels, err
+		return nil, err
 	}
 	if memStr != "" {
 		mem64, err := units.RAMInBytes(memStr)
 		if err != nil {
-			return nil, internalLabels, fmt.Errorf("failed to parse memory bytes %q: %w", memStr, err)
+			return nil, fmt.Errorf("failed to parse memory bytes %q: %w", memStr, err)
 		}
 		opts = append(opts, oci.WithMemoryLimit(uint64(mem64)))
 	}
@@ -66,5 +73,5 @@ func setPlatformOptions(ctx context.Context, opts []oci.SpecOpts, cmd *cobra.Com
 		oci.WithWindowNetworksAllowUnqualifiedDNSQuery(),
 		oci.WithWindowsIgnoreFlushesDuringBoot())
 
-	return opts, internalLabels, nil
+	return opts, nil
 }


### PR DESCRIPTION
This changes `setPlatformOptions`' signature to avoid passing back a fresh copy of an internalLabels structure when we could just pass in a pointer and have the function set whats needed. This additionally removes the opts parameter as the naming is a bit odd for this. To me, reading the function name it'd seem as if we're going to make use of the opts in the body (e.g. actually apply/set them) but we just append to the slice internally. I've changed to returning a new slice that makes it more obvious that all we're doing internally is tallying up each platforms specific options and returning them.