### PR TITLE
Refactor the apparmor flagging process

### DIFF
--- a/cmd/nerdctl/apparmor_inspect_linux.go
+++ b/cmd/nerdctl/apparmor_inspect_linux.go
@@ -19,7 +19,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
 	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/spf13/cobra"
 )
@@ -37,10 +38,7 @@ func newApparmorInspectCommand() *cobra.Command {
 }
 
 func apparmorInspectAction(cmd *cobra.Command, args []string) error {
-	b, err := apparmor.DumpDefaultProfile(defaults.AppArmorProfileName)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprint(cmd.OutOrStdout(), b)
-	return err
+	options := &types.InspectCommandOptions{}
+	options.Writer = cmd.OutOrStdout()
+	return apparmor.Inspect(options)
 }

--- a/cmd/nerdctl/apparmor_unload_linux.go
+++ b/cmd/nerdctl/apparmor_unload_linux.go
@@ -19,9 +19,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/containerd/nerdctl/pkg/apparmorutil"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
 	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -43,8 +43,9 @@ func apparmorUnloadAction(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		target = args[0]
 	}
-	logrus.Infof("Unloading profile %q", target)
-	return apparmorutil.Unload(target)
+	options := &types.UnloadCommandOptions{}
+	options.Target = target
+	return apparmor.Unload(options)
 }
 
 func apparmorUnloadShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/info.go
+++ b/cmd/nerdctl/info.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/containerd/nerdctl/pkg/formatter"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
 	"github.com/containerd/containerd/api/services/introspection/v1"
+	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/infoutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"

--- a/pkg/api/types/apparmor_types.go
+++ b/pkg/api/types/apparmor_types.go
@@ -14,28 +14,25 @@
    limitations under the License.
 */
 
-package main
+package types
 
-import (
-	"fmt"
+import "io"
 
-	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
-	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/spf13/cobra"
-)
-
-func newApparmorLoadCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:           "load",
-		Short:         fmt.Sprintf("Load the default AppArmor profile %q. Requires root.", defaults.AppArmorProfileName),
-		Args:          cobra.NoArgs,
-		RunE:          apparmorLoadAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-	return cmd
+type InspectCommandOptions struct {
+	// Writer is the output writer
+	Writer io.Writer
 }
 
-func apparmorLoadAction(cmd *cobra.Command, args []string) error {
-	return apparmor.Load()
+type UnloadCommandOptions struct {
+	// Target is the profile name
+	Target string
+}
+
+type LsCommandOptions struct {
+	// Only display profile names
+	Quiet bool
+	// Format the output using the given go template
+	Format string
+	// Writer is the output writer
+	Writer io.Writer
 }

--- a/pkg/cmd/apparmor/inspect_linux.go
+++ b/pkg/cmd/apparmor/inspect_linux.go
@@ -14,28 +14,21 @@
    limitations under the License.
 */
 
-package main
+package apparmor
 
 import (
 	"fmt"
 
-	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
+	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/spf13/cobra"
 )
 
-func newApparmorLoadCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:           "load",
-		Short:         fmt.Sprintf("Load the default AppArmor profile %q. Requires root.", defaults.AppArmorProfileName),
-		Args:          cobra.NoArgs,
-		RunE:          apparmorLoadAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+func Inspect(options *types.InspectCommandOptions) error {
+	b, err := apparmor.DumpDefaultProfile(defaults.AppArmorProfileName)
+	if err != nil {
+		return err
 	}
-	return cmd
-}
-
-func apparmorLoadAction(cmd *cobra.Command, args []string) error {
-	return apparmor.Load()
+	_, err = fmt.Fprint(options.Writer, b)
+	return err
 }

--- a/pkg/cmd/apparmor/load_linux.go
+++ b/pkg/cmd/apparmor/load_linux.go
@@ -14,28 +14,15 @@
    limitations under the License.
 */
 
-package main
+package apparmor
 
 import (
-	"fmt"
-
-	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
+	"github.com/containerd/containerd/contrib/apparmor"
 	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/spf13/cobra"
+	"github.com/sirupsen/logrus"
 )
 
-func newApparmorLoadCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:           "load",
-		Short:         fmt.Sprintf("Load the default AppArmor profile %q. Requires root.", defaults.AppArmorProfileName),
-		Args:          cobra.NoArgs,
-		RunE:          apparmorLoadAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-	return cmd
-}
-
-func apparmorLoadAction(cmd *cobra.Command, args []string) error {
-	return apparmor.Load()
+func Load() error {
+	logrus.Infof("Loading profile %q", defaults.AppArmorProfileName)
+	return apparmor.LoadDefaultProfile(defaults.AppArmorProfileName)
 }

--- a/pkg/cmd/apparmor/ls_linux.go
+++ b/pkg/cmd/apparmor/ls_linux.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package apparmor
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/apparmorutil"
+	"github.com/containerd/nerdctl/pkg/formatter"
+)
+
+func Ls(options *types.LsCommandOptions) error {
+	quiet := options.Quiet
+	w := options.Writer
+	var tmpl *template.Template
+	format := options.Format
+	switch format {
+	case "", "table", "wide":
+		w = tabwriter.NewWriter(options.Writer, 4, 8, 4, ' ', 0)
+		if !quiet {
+			fmt.Fprintln(w, "NAME\tMODE")
+		}
+	case "raw":
+		return errors.New("unsupported format: \"raw\"")
+	default:
+		if quiet {
+			return errors.New("format and quiet must not be specified together")
+		}
+		var err error
+		tmpl, err = formatter.ParseTemplate(format)
+		if err != nil {
+			return err
+		}
+	}
+
+	profiles, err := apparmorutil.Profiles()
+	if err != nil {
+		return err
+	}
+
+	for _, f := range profiles {
+		if tmpl != nil {
+			var b bytes.Buffer
+			if err := tmpl.Execute(&b, f); err != nil {
+				return err
+			}
+			if _, err = fmt.Fprintf(w, b.String()+"\n"); err != nil {
+				return err
+			}
+		} else if quiet {
+			fmt.Fprintln(w, f.Name)
+		} else {
+			fmt.Fprintf(w, "%s\t%s\n", f.Name, f.Mode)
+		}
+	}
+	if f, ok := w.(formatter.Flusher); ok {
+		return f.Flush()
+	}
+	return nil
+}

--- a/pkg/cmd/apparmor/unload_linux.go
+++ b/pkg/cmd/apparmor/unload_linux.go
@@ -14,28 +14,15 @@
    limitations under the License.
 */
 
-package main
+package apparmor
 
 import (
-	"fmt"
-
-	"github.com/containerd/nerdctl/pkg/cmd/apparmor"
-	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/spf13/cobra"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/apparmorutil"
+	"github.com/sirupsen/logrus"
 )
 
-func newApparmorLoadCommand() *cobra.Command {
-	cmd := &cobra.Command{
-		Use:           "load",
-		Short:         fmt.Sprintf("Load the default AppArmor profile %q. Requires root.", defaults.AppArmorProfileName),
-		Args:          cobra.NoArgs,
-		RunE:          apparmorLoadAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-	return cmd
-}
-
-func apparmorLoadAction(cmd *cobra.Command, args []string) error {
-	return apparmor.Load()
+func Unload(options *types.UnloadCommandOptions) error {
+	logrus.Infof("Unloading profile %q", options.Target)
+	return apparmorutil.Unload(options.Target)
 }


### PR DESCRIPTION
CheckList:

- [x] Create a file in `pkg/api/types/${cmd}.go`, and define the CommandOption for this command
- [x] Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

Signed-off-by: Zheao.Li <me@manjusaka.me>