### PR TITLE
Use current console when attaching a tty container

### DIFF
--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -24,8 +24,10 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/containerd/console"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cmd/ctr/commands"
+	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
@@ -119,6 +121,14 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 		return err
 	}
 	flagT := process.Process.Terminal
+	var con console.Console
+	if flagA && flagT {
+		con = console.Current()
+		defer con.Reset()
+		if err := con.SetRaw(); err != nil {
+			return err
+		}
+	}
 
 	logURI := lab[labels.LogURI]
 
@@ -135,7 +145,7 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 			logrus.WithError(err).Debug("failed to delete old task")
 		}
 	}
-	task, err := taskutil.NewTask(ctx, client, container, flagA, false, flagT, true, nil, logURI)
+	task, err := taskutil.NewTask(ctx, client, container, flagA, false, flagT, true, con, logURI)
 	if err != nil {
 		return err
 	}
@@ -154,6 +164,11 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 
 	if !flagA {
 		return nil
+	}
+	if flagA && flagT {
+		if err := tasks.HandleConsoleResize(ctx, task, con); err != nil {
+			logrus.WithError(err).Error("console resize")
+		}
 	}
 
 	sigc := commands.ForwardAllSignals(ctx, task)

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -42,9 +42,9 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 	if flagA {
 		logrus.Debug("attaching output instead of using the log-uri")
 		if flagT {
-			ioCreator = cio.NewCreator(cio.WithStreams(os.Stdin, os.Stdout, os.Stderr), cio.WithTerminal)
+			ioCreator = cio.NewCreator(cio.WithStreams(con, con, nil), cio.WithTerminal)
 		} else {
-			ioCreator = cio.NewCreator(cio.WithStreams(os.Stdin, os.Stdout, os.Stderr))
+			ioCreator = cio.NewCreator(cio.WithStdio)
 		}
 
 	} else if flagT && flagD {


### PR DESCRIPTION
n: aliased to sudo nerdctl

before update:
Can't get terminal window size correctly, like this:
![image](https://user-images.githubusercontent.com/13790023/209776709-eb3eb314-023f-45d9-beb0-6b0cc11d0945.png)



after update:
Can get terminal window size correctly, like this:
![image](https://user-images.githubusercontent.com/13790023/209777118-b3a4aab0-ead4-4d0c-be0b-b1f243713fe4.png)



Signed-off-by: yaozhenxiu <946666800@qq.com>