### PR TITLE
[Carry 623] Fix can't save image by image id

### DIFF
--- a/cmd/nerdctl/save_linux_test.go
+++ b/cmd/nerdctl/save_linux_test.go
@@ -48,23 +48,6 @@ func TestSave(t *testing.T) {
 	assert.Assert(t, strings.Contains(etcOSRelease, "Alpine"))
 }
 
-func TestSaveById(t *testing.T) {
-	base := testutil.NewBase(t)
-	base.Cmd("pull", testutil.AlpineImage).AssertOK()
-	inspect := base.InspectImage(testutil.AlpineImage)
-	var id string
-	if testutil.GetTarget() == testutil.Docker {
-		id = inspect.ID
-	} else {
-		id = strings.Split(inspect.RepoDigests[0], ":")[1]
-	}
-	archiveTarPath := filepath.Join(t.TempDir(), "id.tar")
-	base.Cmd("save", "-o", archiveTarPath, id).AssertOK()
-	base.Cmd("rmi", "-f", testutil.AlpineImage).AssertOK()
-	base.Cmd("load", "-i", archiveTarPath).AssertOK()
-	base.Cmd("run", "--rm", id, "date").AssertOK()
-}
-
 func extractDockerArchive(archiveTarPath, rootfsPath string) error {
 	if err := os.MkdirAll(rootfsPath, 0755); err != nil {
 		return err

--- a/cmd/nerdctl/save_linux_test.go
+++ b/cmd/nerdctl/save_linux_test.go
@@ -48,6 +48,23 @@ func TestSave(t *testing.T) {
 	assert.Assert(t, strings.Contains(etcOSRelease, "Alpine"))
 }
 
+func TestSaveById(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.Cmd("pull", testutil.AlpineImage).AssertOK()
+	inspect := base.InspectImage(testutil.AlpineImage)
+	var id string
+	if testutil.GetTarget() == testutil.Docker {
+		id = inspect.ID
+	} else {
+		id = strings.Split(inspect.RepoDigests[0], ":")[1]
+	}
+	archiveTarPath := filepath.Join(t.TempDir(), "id.tar")
+	base.Cmd("save", "-o", archiveTarPath, id).AssertOK()
+	base.Cmd("rmi", "-f", testutil.AlpineImage).AssertOK()
+	base.Cmd("load", "-i", archiveTarPath).AssertOK()
+	base.Cmd("run", "--rm", id, "date").AssertOK()
+}
+
 func extractDockerArchive(archiveTarPath, rootfsPath string) error {
 	if err := os.MkdirAll(rootfsPath, 0755); err != nil {
 		return err

--- a/cmd/nerdctl/save_test.go
+++ b/cmd/nerdctl/save_test.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+)
+
+func TestSaveById(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	inspect := base.InspectImage(testutil.CommonImage)
+	var id string
+	if testutil.GetTarget() == testutil.Docker {
+		id = inspect.ID
+	} else {
+		id = strings.Split(inspect.RepoDigests[0], ":")[1]
+	}
+	archiveTarPath := filepath.Join(t.TempDir(), "id.tar")
+	base.Cmd("save", "-o", archiveTarPath, id).AssertOK()
+	base.Cmd("rmi", "-f", testutil.CommonImage).AssertOK()
+	base.Cmd("load", "-i", archiveTarPath).AssertOK()
+	base.Cmd("run", "--rm", id, "sh", "-euxc", "echo foo").AssertOK()
+}
+
+func TestSaveByIdWithDifferentNames(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	inspect := base.InspectImage(testutil.CommonImage)
+	var id string
+	if testutil.GetTarget() == testutil.Docker {
+		id = inspect.ID
+	} else {
+		id = strings.Split(inspect.RepoDigests[0], ":")[1]
+	}
+
+	base.Cmd("tag", testutil.CommonImage, "foobar").AssertOK()
+
+	archiveTarPath := filepath.Join(t.TempDir(), "id.tar")
+	base.Cmd("save", "-o", archiveTarPath, id).AssertOK()
+	base.Cmd("rmi", "-f", testutil.CommonImage).AssertOK()
+	base.Cmd("load", "-i", archiveTarPath).AssertOK()
+	base.Cmd("run", "--rm", id, "sh", "-euxc", "echo foo").AssertOK()
+}


### PR DESCRIPTION
Carry changes from #623 and also make some refactor to `nerdctl save`.

1. Make `nerdctl save` work when image ids are given; also works if the same image has multiple names (only one copy is saved); return error if an id prefix corresponds to multiple different images.
2. Refactor `nerdctl save`: make `saveImages` not depend on cobra.