### PR TITLE
terminal output connected to stdout

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -337,7 +337,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 	}
 	logURI := lab[labels.LogURI]
 
-	task, err := taskutil.NewTask(ctx, client, container, false, flagI, flagT, flagD, con, logURI)
+	task, err := taskutil.NewTask(ctx, client, container, false, flagI, flagT, flagD, logURI)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -135,7 +135,7 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 			logrus.WithError(err).Debug("failed to delete old task")
 		}
 	}
-	task, err := taskutil.NewTask(ctx, client, container, flagA, false, flagT, true, nil, logURI)
+	task, err := taskutil.NewTask(ctx, client, container, flagA, false, flagT, true, logURI)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixing https://github.com/containerd/nerdctl/issues/1685

When `nerdctl run`, I changed the output from `con` to `os.Stdout`.
Executing the `nerdctl run -t --rm alpine sh -c 'echo foo; echo bar' | grep foo` command locally can get the correct result,
but this makes a lot of tests fail

Signed-off-by: yaozhenxiu <946666800@qq.com>