### PR TITLE
tests: Use AssertOK for deferred cleanup

### DIFF
--- a/cmd/nerdctl/run_cgroup_linux_test.go
+++ b/cmd/nerdctl/run_cgroup_linux_test.go
@@ -186,7 +186,7 @@ func TestRunDevice(t *testing.T) {
 
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	// lo0 is readable but not writable.
 	// lo1 is readable and writable
 	// lo2 is not accessible.
@@ -298,7 +298,7 @@ func TestRunBlkioWeightCgroupV2(t *testing.T) {
 		t.Skip("test requires cgroup driver")
 	}
 	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	// when bfq io scheduler is used, the io.weight knob is exposed as io.bfq.weight
 	base.Cmd("run", "--name", containerName, "--blkio-weight", "300", "-w", "/sys/fs/cgroup", testutil.AlpineImage, "sleep", "infinity").AssertOK()
 	base.Cmd("exec", containerName, "cat", "io.bfq.weight").AssertOutExactly("default 300\n")

--- a/cmd/nerdctl/run_mount_linux_test.go
+++ b/cmd/nerdctl/run_mount_linux_test.go
@@ -50,7 +50,7 @@ func TestRunVolume(t *testing.T) {
 	}
 
 	containerName := tID
-	defer base.Cmd("rm", "-f", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	base.Cmd("run",
 		"-d",
 		"--name", containerName,
@@ -302,7 +302,7 @@ func TestRunBindMountBind(t *testing.T) {
 	}
 
 	containerName := tID
-	defer base.Cmd("rm", "-f", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	base.Cmd("run",
 		"-d",
 		"--name", containerName,


### PR DESCRIPTION
The standard here seems to be to use `AssertOK` to validate that `nerdctl rm -f` exited successfully for a given test, however there was some stragglers, namely in the cgroup and mount tests. Now these should fail properly if `rm -f` exits with != 0