### PR TITLE
[Refactor] Move the Config Struct from cmd/main.go to pkg/config

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -25,9 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/defaults"
-	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/nerdctl/pkg/config"
 	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/logging"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
@@ -134,44 +132,8 @@ func xmain() error {
 	return app.Execute()
 }
 
-// Config corresponds to nerdctl.toml .
-// See docs/config.md .
-type Config struct {
-	Debug            bool     `toml:"debug"`
-	DebugFull        bool     `toml:"debug_full"`
-	Address          string   `toml:"address"`
-	Namespace        string   `toml:"namespace"`
-	Snapshotter      string   `toml:"snapshotter"`
-	CNIPath          string   `toml:"cni_path"`
-	CNINetConfPath   string   `toml:"cni_netconfpath"`
-	DataRoot         string   `toml:"data_root"`
-	CgroupManager    string   `toml:"cgroup_manager"`
-	InsecureRegistry bool     `toml:"insecure_registry"`
-	HostsDir         []string `toml:"hosts_dir"`
-	Experimental     bool     `toml:"experimental"`
-}
-
-// NewConfig creates a default Config object statically,
-// without interpolating CLI flags, env vars, and toml.
-func NewConfig() *Config {
-	return &Config{
-		Debug:            false,
-		DebugFull:        false,
-		Address:          defaults.DefaultAddress,
-		Namespace:        namespaces.Default,
-		Snapshotter:      containerd.DefaultSnapshotter,
-		CNIPath:          ncdefaults.CNIPath(),
-		CNINetConfPath:   ncdefaults.CNINetConfPath(),
-		DataRoot:         ncdefaults.DataRoot(),
-		CgroupManager:    ncdefaults.CgroupManager(),
-		InsecureRegistry: false,
-		HostsDir:         ncdefaults.HostsDirs(),
-		Experimental:     true,
-	}
-}
-
 func initRootCmdFlags(rootCmd *cobra.Command, tomlPath string) (*pflag.FlagSet, error) {
-	cfg := NewConfig()
+	cfg := config.New()
 	if r, err := os.Open(tomlPath); err == nil {
 		logrus.Debugf("Loading config from %q", tomlPath)
 		defer r.Close()

--- a/pkg/api/types/global.go
+++ b/pkg/api/types/global.go
@@ -1,0 +1,21 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package types
+
+import "github.com/containerd/nerdctl/pkg/config"
+
+type GlobalCommandOptions config.Config

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,60 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package config
+
+import (
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/defaults"
+	"github.com/containerd/containerd/namespaces"
+	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
+)
+
+// Config corresponds to nerdctl.toml .
+// See docs/config.md .
+type Config struct {
+	Debug            bool     `toml:"debug"`
+	DebugFull        bool     `toml:"debug_full"`
+	Address          string   `toml:"address"`
+	Namespace        string   `toml:"namespace"`
+	Snapshotter      string   `toml:"snapshotter"`
+	CNIPath          string   `toml:"cni_path"`
+	CNINetConfPath   string   `toml:"cni_netconfpath"`
+	DataRoot         string   `toml:"data_root"`
+	CgroupManager    string   `toml:"cgroup_manager"`
+	InsecureRegistry bool     `toml:"insecure_registry"`
+	HostsDir         []string `toml:"hosts_dir"`
+	Experimental     bool     `toml:"experimental"`
+}
+
+// New creates a default Config object statically,
+// without interpolating CLI flags, env vars, and toml.
+func New() *Config {
+	return &Config{
+		Debug:            false,
+		DebugFull:        false,
+		Address:          defaults.DefaultAddress,
+		Namespace:        namespaces.Default,
+		Snapshotter:      containerd.DefaultSnapshotter,
+		CNIPath:          ncdefaults.CNIPath(),
+		CNINetConfPath:   ncdefaults.CNINetConfPath(),
+		DataRoot:         ncdefaults.DataRoot(),
+		CgroupManager:    ncdefaults.CgroupManager(),
+		InsecureRegistry: false,
+		HostsDir:         ncdefaults.HostsDirs(),
+		Experimental:     true,
+	}
+}


### PR DESCRIPTION
Most of the subcommand is related to this Config struct and global flags. like #1792

So I split it from the cmd package to let us can reuse the definition.


Signed-off-by: Zheao.Li <me@manjusaka.me>