### PR TITLE
Add a prefix to apparmor command options to avoid conflict

### DIFF
--- a/cmd/nerdctl/apparmor_inspect_linux.go
+++ b/cmd/nerdctl/apparmor_inspect_linux.go
@@ -38,7 +38,7 @@ func newApparmorInspectCommand() *cobra.Command {
 }
 
 func apparmorInspectAction(cmd *cobra.Command, args []string) error {
-	options := &types.InspectCommandOptions{}
+	options := &types.ApparmorInspectCommandOptions{}
 	options.Writer = cmd.OutOrStdout()
 	return apparmor.Inspect(options)
 }

--- a/cmd/nerdctl/apparmor_ls_linux.go
+++ b/cmd/nerdctl/apparmor_ls_linux.go
@@ -42,7 +42,7 @@ func newApparmorLsCommand() *cobra.Command {
 }
 
 func apparmorLsAction(cmd *cobra.Command, args []string) error {
-	options := &types.LsCommandOptions{}
+	options := &types.ApparmorLsCommandOptions{}
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/apparmor_unload_linux.go
+++ b/cmd/nerdctl/apparmor_unload_linux.go
@@ -43,7 +43,7 @@ func apparmorUnloadAction(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		target = args[0]
 	}
-	options := &types.UnloadCommandOptions{}
+	options := &types.ApparmorUnloadCommandOptions{}
 	options.Target = target
 	return apparmor.Unload(options)
 }

--- a/pkg/api/types/apparmor_types.go
+++ b/pkg/api/types/apparmor_types.go
@@ -18,17 +18,17 @@ package types
 
 import "io"
 
-type InspectCommandOptions struct {
+type ApparmorInspectCommandOptions struct {
 	// Writer is the output writer
 	Writer io.Writer
 }
 
-type UnloadCommandOptions struct {
+type ApparmorUnloadCommandOptions struct {
 	// Target is the profile name
 	Target string
 }
 
-type LsCommandOptions struct {
+type ApparmorLsCommandOptions struct {
 	// Only display profile names
 	Quiet bool
 	// Format the output using the given go template

--- a/pkg/cmd/apparmor/inspect_linux.go
+++ b/pkg/cmd/apparmor/inspect_linux.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/defaults"
 )
 
-func Inspect(options *types.InspectCommandOptions) error {
+func Inspect(options *types.ApparmorInspectCommandOptions) error {
 	b, err := apparmor.DumpDefaultProfile(defaults.AppArmorProfileName)
 	if err != nil {
 		return err

--- a/pkg/cmd/apparmor/ls_linux.go
+++ b/pkg/cmd/apparmor/ls_linux.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/formatter"
 )
 
-func Ls(options *types.LsCommandOptions) error {
+func Ls(options *types.ApparmorLsCommandOptions) error {
 	quiet := options.Quiet
 	w := options.Writer
 	var tmpl *template.Template

--- a/pkg/cmd/apparmor/unload_linux.go
+++ b/pkg/cmd/apparmor/unload_linux.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Unload(options *types.UnloadCommandOptions) error {
+func Unload(options *types.ApparmorUnloadCommandOptions) error {
 	logrus.Infof("Unloading profile %q", options.Target)
 	return apparmorutil.Unload(options.Target)
 }


### PR DESCRIPTION
See https://github.com/containerd/nerdctl/pull/1773#issuecomment-1368783993

Add a prefix to the apparmor command options to avoid struct name conflicts.