### PR TITLE
[refactor] Add global flag process helper function

### DIFF
--- a/cmd/nerdctl/builder.go
+++ b/cmd/nerdctl/builder.go
@@ -60,7 +60,11 @@ func newBuilderPruneCommand() *cobra.Command {
 }
 
 func builderPruneAction(cmd *cobra.Command, _ []string) error {
-	buildkitHost, err := getBuildkitHost(cmd)
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+	buildkitHost, err := getBuildkitHost(cmd, globalOptions.Namespace)
 	if err != nil {
 		return err
 	}
@@ -97,6 +101,10 @@ func newBuilderDebugCommand() *cobra.Command {
 }
 
 func builderDebugAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	if len(args) < 1 {
 		return fmt.Errorf("context needs to be specified")
 	}
@@ -106,10 +114,9 @@ func builderDebugAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	buildgArgs := []string{"debug"}
-	debugLog, err := cmd.Flags().GetBool("debug")
 	if err != nil {
 		return err
-	} else if debugLog {
+	} else if globalOptions.Debug {
 		buildgArgs = append([]string{"--debug"}, buildgArgs...)
 	}
 

--- a/cmd/nerdctl/commit.go
+++ b/cmd/nerdctl/commit.go
@@ -48,23 +48,15 @@ func newCommitCommand() *cobra.Command {
 }
 
 func commitAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	opts, err := newCommitOpts(cmd, args)
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
-
-	if err != nil {
-		return err
-	}
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -28,15 +28,11 @@ import (
 )
 
 func shellCompleteImageNames(cmd *cobra.Command) ([]string, cobra.ShellCompDirective) {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -55,15 +51,11 @@ func shellCompleteImageNames(cmd *cobra.Command) ([]string, cobra.ShellCompDirec
 }
 
 func shellCompleteContainerNames(cmd *cobra.Command, filterFunc func(containerd.ProcessStatus) bool) ([]string, cobra.ShellCompDirective) {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -108,20 +100,16 @@ func shellCompleteContainerNames(cmd *cobra.Command, filterFunc func(containerd.
 
 // shellCompleteNetworkNames includes {"bridge","host","none"}
 func shellCompleteNetworkNames(cmd *cobra.Command, exclude []string) ([]string, cobra.ShellCompDirective) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
 	excludeMap := make(map[string]struct{}, len(exclude))
 	for _, ex := range exclude {
 		excludeMap[ex] = struct{}{}
 	}
 
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveError
-	}
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -144,7 +132,11 @@ func shellCompleteNetworkNames(cmd *cobra.Command, exclude []string) ([]string, 
 }
 
 func shellCompleteVolumeNames(cmd *cobra.Command) ([]string, cobra.ShellCompDirective) {
-	vols, err := getVolumes(cmd)
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	vols, err := getVolumes(cmd, globalOptions)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/composer"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/cosignutil"
@@ -80,7 +81,7 @@ func newComposeCommand() *cobra.Command {
 	return composeCommand
 }
 
-func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Composer, error) {
+func getComposer(cmd *cobra.Command, client *containerd.Client, globalOptions *types.GlobalCommandOptions) (*composer.Composer, error) {
 	nerdctlCmd, nerdctlArgs := globalFlags(cmd)
 	projectDirectory, err := cmd.Flags().GetString("project-directory")
 	if err != nil {
@@ -94,38 +95,17 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 	if err != nil {
 		return nil, err
 	}
-	debugFull, err := cmd.Flags().GetBool("debug-full")
-	if err != nil {
-		return nil, err
-	}
+	debugFull := globalOptions.DebugFull
+	snapshotter := globalOptions.Snapshotter
 	files, err := cmd.Flags().GetStringArray("file")
 	if err != nil {
 		return nil, err
 	}
-	insecure, err := cmd.Flags().GetBool("insecure-registry")
-	if err != nil {
-		return nil, err
-	}
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return nil, err
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return nil, err
-	}
-	snapshotter, err := cmd.Flags().GetString("snapshotter")
-	if err != nil {
-		return nil, err
-	}
-	hostsDirs, err := cmd.Flags().GetStringSlice("hosts-dir")
-	if err != nil {
-		return nil, err
-	}
-	experimental, err := cmd.Flags().GetBool("experimental")
-	if err != nil {
-		return nil, err
-	}
+	insecure := globalOptions.InsecureRegistry
+	cniPath := globalOptions.CNIPath
+	cniNetconfpath := globalOptions.CNINetConfPath
+	hostsDirs := globalOptions.HostsDir
+	experimental := globalOptions.Experimental
 
 	o := composer.Options{
 		Project:          projectName,
@@ -156,7 +136,7 @@ func getComposer(cmd *cobra.Command, client *containerd.Client) (*composer.Compo
 		return false, nil
 	}
 
-	volStore, err := getVolumeStore(cmd)
+	volStore, err := getVolumeStore(globalOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nerdctl/compose_build.go
+++ b/cmd/nerdctl/compose_build.go
@@ -38,6 +38,10 @@ func newComposeBuildCommand() *cobra.Command {
 }
 
 func composeBuildAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	buildArg, err := cmd.Flags().GetStringArray("build-arg")
 	if err != nil {
 		return err
@@ -50,22 +54,14 @@ func composeBuildAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
 
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_config.go
+++ b/cmd/nerdctl/compose_config.go
@@ -43,6 +43,10 @@ func newComposeConfigCommand() *cobra.Command {
 }
 
 func composeConfigAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	if len(args) != 0 {
 		// TODO: support specifying service names as args
 		return fmt.Errorf("arguments %v not supported", args)
@@ -63,22 +67,14 @@ func composeConfigAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
 
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_create.go
+++ b/cmd/nerdctl/compose_create.go
@@ -41,6 +41,10 @@ func newComposeCreateCommand() *cobra.Command {
 }
 
 func composeCreateAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	build, err := cmd.Flags().GetBool("build")
 	if err != nil {
 		return err
@@ -64,21 +68,13 @@ func composeCreateAction(cmd *cobra.Command, args []string) error {
 		return errors.New("flag --force-recreate and --no-recreate cannot be specified together")
 	}
 
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_down.go
+++ b/cmd/nerdctl/compose_down.go
@@ -37,19 +37,15 @@ func newComposeDownCommand() *cobra.Command {
 }
 
 func composeDownAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	volumes, err := cmd.Flags().GetBool("volumes")
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
@@ -60,7 +56,7 @@ func composeDownAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_exec.go
+++ b/cmd/nerdctl/compose_exec.go
@@ -50,6 +50,10 @@ func newComposeExecCommand() *cobra.Command {
 }
 
 func composeExecAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	interactive, err := cmd.Flags().GetBool("interactive")
 	if err != nil {
 		return err
@@ -95,21 +99,13 @@ func composeExecAction(cmd *cobra.Command, args []string) error {
 		return errors.New("currently flag -t and -d cannot be specified together (FIXME)")
 	}
 
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_images.go
+++ b/cmd/nerdctl/compose_images.go
@@ -47,25 +47,22 @@ func newComposeImagesCommand() *cobra.Command {
 }
 
 func composeImagesAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}
@@ -84,11 +81,7 @@ func composeImagesAction(cmd *cobra.Command, args []string) error {
 		return printComposeImageIDs(ctx, containers)
 	}
 
-	snapshotter, err := cmd.Flags().GetString("snapshotter")
-	if err != nil {
-		return err
-	}
-	sn := client.SnapshotService(snapshotter)
+	sn := client.SnapshotService(globalOptions.Snapshotter)
 
 	return printComposeImages(ctx, cmd, containers, sn)
 }

--- a/cmd/nerdctl/compose_kill.go
+++ b/cmd/nerdctl/compose_kill.go
@@ -35,24 +35,20 @@ func newComposeKillCommand() *cobra.Command {
 }
 
 func composeKillAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	signal, err := cmd.Flags().GetString("signal")
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_logs.go
+++ b/cmd/nerdctl/compose_logs.go
@@ -39,6 +39,10 @@ func newComposeLogsCommand() *cobra.Command {
 }
 
 func composeLogsAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	follow, err := cmd.Flags().GetBool("follow")
 	if err != nil {
 		return err
@@ -59,22 +63,13 @@ func composeLogsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_pause.go
+++ b/cmd/nerdctl/compose_pause.go
@@ -40,21 +40,17 @@ func newComposePauseCommand() *cobra.Command {
 }
 
 func composePauseAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}
@@ -106,21 +102,17 @@ func newComposeUnpauseCommand() *cobra.Command {
 }
 
 func composeUnpauseAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_port.go
+++ b/cmd/nerdctl/compose_port.go
@@ -41,6 +41,10 @@ func newComposePortCommand() *cobra.Command {
 }
 
 func composePortAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	index, err := cmd.Flags().GetInt("index")
 	if err != nil {
 		return err
@@ -66,21 +70,13 @@ func composePortAction(cmd *cobra.Command, args []string) error {
 	if port <= 0 {
 		return fmt.Errorf("unexpected port: %d", port)
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -61,6 +61,10 @@ type composeContainerPrintable struct {
 }
 
 func composePsAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
 		return err
@@ -68,21 +72,13 @@ func composePsAction(cmd *cobra.Command, args []string) error {
 	if format != "json" && format != "" {
 		return fmt.Errorf("unsupported format %s, supported formats are: [json]", format)
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_pull.go
+++ b/cmd/nerdctl/compose_pull.go
@@ -35,21 +35,17 @@ func newComposePullCommand() *cobra.Command {
 }
 
 func composePullAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_push.go
+++ b/cmd/nerdctl/compose_push.go
@@ -34,21 +34,17 @@ func newComposePushCommand() *cobra.Command {
 }
 
 func composePushAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_restart.go
+++ b/cmd/nerdctl/compose_restart.go
@@ -35,6 +35,10 @@ func newComposeRestartCommand() *cobra.Command {
 }
 
 func composeRestartAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	var opt composer.RestartOptions
 
 	if cmd.Flags().Changed("timeout") {
@@ -44,22 +48,13 @@ func composeRestartAction(cmd *cobra.Command, args []string) error {
 		}
 		opt.Timeout = &timeValue
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_rm.go
+++ b/cmd/nerdctl/compose_rm.go
@@ -40,6 +40,10 @@ func newComposeRemoveCommand() *cobra.Command {
 }
 
 func composeRemoveAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err
@@ -68,20 +72,12 @@ func composeRemoveAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_run.go
+++ b/cmd/nerdctl/compose_run.go
@@ -67,6 +67,10 @@ func newComposeRunCommand() *cobra.Command {
 }
 
 func composeRunAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	detach, err := cmd.Flags().GetBool("detach")
 	if err != nil {
 		return err
@@ -163,21 +167,13 @@ func composeRunAction(cmd *cobra.Command, args []string) error {
 	if tty && detach {
 		return errors.New("currently flag -t and -d cannot be specified together (FIXME)")
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_start.go
+++ b/cmd/nerdctl/compose_start.go
@@ -43,21 +43,17 @@ func newComposeStartCommand() *cobra.Command {
 }
 
 func composeStartAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_stop.go
+++ b/cmd/nerdctl/compose_stop.go
@@ -35,6 +35,10 @@ func newComposeStopCommand() *cobra.Command {
 }
 
 func composeStopAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	var opt composer.StopOptions
 
 	if cmd.Flags().Changed("timeout") {
@@ -44,21 +48,13 @@ func composeStopAction(cmd *cobra.Command, args []string) error {
 		}
 		opt.Timeout = &timeValue
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_top.go
+++ b/cmd/nerdctl/compose_top.go
@@ -39,21 +39,18 @@ func newComposeTopCommand() *cobra.Command {
 }
 
 func composeTopAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -48,6 +48,10 @@ func newComposeUpCommand() *cobra.Command {
 }
 
 func composeUpAction(cmd *cobra.Command, services []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	detach, err := cmd.Flags().GetBool("detach")
 	if err != nil {
 		return err
@@ -99,22 +103,14 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 		}
 		scale[parts[0]] = uint64(replicas)
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
 
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	c, err := getComposer(cmd, client)
+	c, err := getComposer(cmd, client, globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container_inspect.go
+++ b/cmd/nerdctl/container_inspect.go
@@ -53,15 +53,11 @@ func newContainerInspectCommand() *cobra.Command {
 }
 
 func containerInspectAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/create.go
+++ b/cmd/nerdctl/create.go
@@ -51,28 +51,18 @@ func newCreateCommand() *cobra.Command {
 }
 
 func createAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	platform, err := cmd.Flags().GetString("platform")
 	if err != nil {
 		return err
 	}
-
-	experimental, err := cmd.Flags().GetBool("experimental")
-	if err != nil {
-		return err
-	}
-
-	if (platform == "windows" || platform == "freebsd") && !experimental {
+	if (platform == "windows" || platform == "freebsd") && !globalOptions.Experimental {
 		return fmt.Errorf("%s requires experimental mode to be enabled", platform)
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), namespace, address, platform)
+	client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), globalOptions.Namespace, globalOptions.Address, platform)
 	if err != nil {
 		return err
 	}
@@ -83,7 +73,7 @@ func createAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	container, gc, err := createContainer(ctx, cmd, client, args, platform, false, flagT, true)
+	container, gc, err := createContainer(ctx, cmd, globalOptions, client, args, platform, false, flagT, true)
 	if err != nil {
 		if gc != nil {
 			gc()

--- a/cmd/nerdctl/events.go
+++ b/cmd/nerdctl/events.go
@@ -64,15 +64,11 @@ type Out struct {
 
 // eventsActions is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go
 func eventsAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/exec.go
+++ b/cmd/nerdctl/exec.go
@@ -65,6 +65,10 @@ func newExecCommand() *cobra.Command {
 }
 
 func execAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	// simulate the behavior of double dash
 	newArg := []string{}
 	if len(args) >= 2 && args[1] == "--" {
@@ -72,15 +76,7 @@ func execAction(cmd *cobra.Command, args []string) error {
 		newArg = append(newArg, args[2:]...)
 		args = newArg
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/flagutil.go
+++ b/cmd/nerdctl/flagutil.go
@@ -1,0 +1,87 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/spf13/cobra"
+)
+
+func processRootCmdFlags(cmd *cobra.Command) (*types.GlobalCommandOptions, error) {
+	debug, err := cmd.Flags().GetBool("debug")
+	if err != nil {
+		return nil, err
+	}
+	debugFull, err := cmd.Flags().GetBool("debug-full")
+	if err != nil {
+		return nil, err
+	}
+	address, err := cmd.Flags().GetString("address")
+	if err != nil {
+		return nil, err
+	}
+	namespace, err := cmd.Flags().GetString("namespace")
+	if err != nil {
+		return nil, err
+	}
+	snapshotter, err := cmd.Flags().GetString("snapshotter")
+	if err != nil {
+		return nil, err
+	}
+	cniPath, err := cmd.Flags().GetString("cni-path")
+	if err != nil {
+		return nil, err
+	}
+	cniConfigPath, err := cmd.Flags().GetString("cni-netconfpath")
+	if err != nil {
+		return nil, err
+	}
+	dataRoot, err := cmd.Flags().GetString("data-root")
+	if err != nil {
+		return nil, err
+	}
+	cgroupManager, err := cmd.Flags().GetString("cgroup-manager")
+	if err != nil {
+		return nil, err
+	}
+	insecureRegistry, err := cmd.Flags().GetBool("insecure-registry")
+	if err != nil {
+		return nil, err
+	}
+	hostsDir, err := cmd.Flags().GetStringSlice("hosts-dir")
+	if err != nil {
+		return nil, err
+	}
+	experimental, err := cmd.Flags().GetBool("experimental")
+	if err != nil {
+		return nil, err
+	}
+	return &types.GlobalCommandOptions{
+		Debug:            debug,
+		DebugFull:        debugFull,
+		Address:          address,
+		Namespace:        namespace,
+		Snapshotter:      snapshotter,
+		CNIPath:          cniPath,
+		CNINetConfPath:   cniConfigPath,
+		DataRoot:         dataRoot,
+		CgroupManager:    cgroupManager,
+		InsecureRegistry: insecureRegistry,
+		HostsDir:         hostsDir,
+		Experimental:     experimental,
+	}, nil
+}

--- a/cmd/nerdctl/history.go
+++ b/cmd/nerdctl/history.go
@@ -70,24 +70,15 @@ type historyPrintable struct {
 }
 
 func historyAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-
-	snapshotter, err := cmd.Flags().GetString("snapshotter")
-	if err != nil {
-		return err
-	}
 
 	walker := &imagewalker.ImageWalker{
 		Client: client,
@@ -119,7 +110,7 @@ func historyAction(cmd *cobra.Command, args []string) error {
 					diffIDs := diffIDs[0 : layerCounter+1]
 					chainID := identity.ChainID(diffIDs).String()
 
-					s := client.SnapshotService(snapshotter)
+					s := client.SnapshotService(globalOptions.Snapshotter)
 					stat, err := s.Stat(ctx, chainID)
 					if err != nil {
 						return fmt.Errorf("failed to get stat: %w", err)

--- a/cmd/nerdctl/image_cryptutil.go
+++ b/cmd/nerdctl/image_cryptutil.go
@@ -99,6 +99,10 @@ func parseImgcryptFlags(cmd *cobra.Command, encrypt bool) (parsehelpers.EncArgs,
 
 func getImgcryptAction(encrypt bool) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
+		globalOptions, err := processRootCmdFlags(cmd)
+		if err != nil {
+			return err
+		}
 		var convertOpts = []converter.Opt{}
 		srcRawRef := args[0]
 		targetRawRef := args[1]
@@ -136,15 +140,7 @@ func getImgcryptAction(encrypt bool) func(cmd *cobra.Command, args []string) err
 		if err != nil {
 			return err
 		}
-		namespace, err := cmd.Flags().GetString("namespace")
-		if err != nil {
-			return err
-		}
-		address, err := cmd.Flags().GetString("address")
-		if err != nil {
-			return err
-		}
-		client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+		client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/image_prune.go
+++ b/cmd/nerdctl/image_prune.go
@@ -46,6 +46,10 @@ func newImagePruneCommand() *cobra.Command {
 }
 
 func imagePruneAction(cmd *cobra.Command, _ []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	all, err := cmd.Flags().GetBool("all")
 	if err != nil {
 		return err
@@ -74,15 +78,7 @@ func imagePruneAction(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -64,6 +64,12 @@ func addInspectFlags(cmd *cobra.Command) {
 }
 
 func inspectAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+	namespace := globalOptions.Namespace
+	address := globalOptions.Address
 	inspectType, err := cmd.Flags().GetString("type")
 	if err != nil {
 		return err
@@ -71,14 +77,6 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 
 	if len(inspectType) > 0 && !validInspectType[inspectType] {
 		return fmt.Errorf("%q is not a valid value for --type", inspectType)
-	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
 	}
 	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
 	if err != nil {
@@ -129,7 +127,7 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 			continue
 		}
 		if ni != 0 {
-			if err := imageInspectActionWithPlatform(cmd, []string{req}, ""); err != nil {
+			if err := imageInspectActionWithPlatform(cmd, []string{req}, "", globalOptions); err != nil {
 				errs = append(errs, err)
 			}
 			continue

--- a/cmd/nerdctl/internal_oci_hook.go
+++ b/cmd/nerdctl/internal_oci_hook.go
@@ -38,33 +38,23 @@ func newInternalOCIHookCommandCommand() *cobra.Command {
 }
 
 func internalOCIHookAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	event := ""
 	if len(args) > 0 {
 		event = args[0]
 	}
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
 	if event == "" {
 		return errors.New("event type needs to be passed")
 	}
-	dataStore, err := clientutil.DataStore(dataRoot, address)
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
 	if err != nil {
 		return err
 	}
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return err
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return err
-	}
+	cniPath := globalOptions.CNIPath
+	cniNetconfpath := globalOptions.CNINetConfPath
 	return ocihook.Run(os.Stdin, os.Stderr, event,
 		dataStore,
 		cniPath,

--- a/cmd/nerdctl/kill.go
+++ b/cmd/nerdctl/kill.go
@@ -49,6 +49,10 @@ func newKillCommand() *cobra.Command {
 }
 
 func killAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	killSignal, err := cmd.Flags().GetString("signal")
 	if err != nil {
 		return err
@@ -61,15 +65,7 @@ func killAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/logs.go
+++ b/cmd/nerdctl/logs.go
@@ -52,32 +52,20 @@ func newLogsCommand() *cobra.Command {
 }
 
 func logsAction(cmd *cobra.Command, args []string) error {
-	dataRoot, err := cmd.Flags().GetString("data-root")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	dataStore, err := clientutil.DataStore(dataRoot, address)
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 
-	ns, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	switch ns {
+	switch globalOptions.Namespace {
 	case "moby", "k8s.io":
 		logrus.Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d`")
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/main_unix.go
+++ b/cmd/nerdctl/main_unix.go
@@ -27,19 +27,18 @@ import (
 )
 
 func shellCompleteNamespaceNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
 	if rootlessutil.IsRootlessParent() {
 		_ = rootlessutil.ParentMain()
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -56,19 +55,15 @@ func shellCompleteNamespaceNames(cmd *cobra.Command, args []string, toComplete s
 }
 
 func shellCompleteSnapshotterNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
 	if rootlessutil.IsRootlessParent() {
 		_ = rootlessutil.ParentMain()
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/nerdctl/namespace.go
+++ b/cmd/nerdctl/namespace.go
@@ -63,15 +63,11 @@ func newNamespaceLsCommand() *cobra.Command {
 }
 
 func namespaceLsAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
@@ -92,11 +88,7 @@ func namespaceLsAction(cmd *cobra.Command, args []string) error {
 		}
 		return nil
 	}
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return err
-	}
-	dataStore, err := clientutil.DataStore(dataRoot, address)
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace_create.go
+++ b/cmd/nerdctl/namespace_create.go
@@ -37,19 +37,15 @@ func newNamespaceCreateCommand() *cobra.Command {
 }
 
 func namespaceCreateAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	flagVSlice, err := cmd.Flags().GetStringArray("label")
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace_inspect.go
+++ b/cmd/nerdctl/namespace_inspect.go
@@ -41,15 +41,11 @@ func newNamespaceInspectCommand() *cobra.Command {
 }
 
 func labelInspectAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace_rm.go
+++ b/cmd/nerdctl/namespace_rm.go
@@ -40,16 +40,12 @@ func newNamespaceRmCommand() *cobra.Command {
 }
 
 func namespaceRmAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	var exitErr error
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace_update.go
+++ b/cmd/nerdctl/namespace_update.go
@@ -35,19 +35,15 @@ func newNamespacelabelUpdateCommand() *cobra.Command {
 }
 
 func labelUpdateAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	flagVSlice, err := cmd.Flags().GetStringArray("label")
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -51,15 +51,14 @@ func newNetworkCreateCommand() *cobra.Command {
 }
 
 func networkCreateAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	name := args[0]
 	if err := identifiers.Validate(name); err != nil {
 		return fmt.Errorf("malformed name %s: %w", name, err)
 	}
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return err
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
 	if err != nil {
 		return err
 	}
@@ -103,7 +102,7 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_inspect.go
+++ b/cmd/nerdctl/network_inspect.go
@@ -50,15 +50,11 @@ func newNetworkInspectCommand() *cobra.Command {
 }
 
 func networkInspectAction(cmd *cobra.Command, args []string) error {
-	cniPath, err := cmd.Flags().GetString("cni-path")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return err
-	}
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_ls.go
+++ b/cmd/nerdctl/network_ls.go
@@ -57,6 +57,10 @@ type networkPrintable struct {
 }
 
 func networkLsAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
 		return err
@@ -86,15 +90,7 @@ func networkLsAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return err
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return err
-	}
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -44,28 +44,16 @@ func newNetworkRmCommand() *cobra.Command {
 }
 
 func networkRmAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	cniPath, err := cmd.Flags().GetString("cni-path")
-	if err != nil {
-		return err
-	}
-	cniNetconfpath, err := cmd.Flags().GetString("cni-netconfpath")
-	if err != nil {
-		return err
-	}
-	e, err := netutil.NewCNIEnv(cniPath, cniNetconfpath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/pause.go
+++ b/cmd/nerdctl/pause.go
@@ -42,15 +42,11 @@ func newPauseCommand() *cobra.Command {
 }
 
 func pauseAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/port.go
+++ b/cmd/nerdctl/port.go
@@ -43,7 +43,10 @@ func newPortCommand() *cobra.Command {
 }
 
 func portAction(cmd *cobra.Command, args []string) error {
-
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	argPort := -1
 	argProto := ""
 	portProto := ""
@@ -70,15 +73,7 @@ func portAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to parse %q", portProto)
 		}
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/ps.go
+++ b/cmd/nerdctl/ps.go
@@ -69,15 +69,11 @@ func newPsCommand() *cobra.Command {
 }
 
 func psAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/rename.go
+++ b/cmd/nerdctl/rename.go
@@ -43,32 +43,20 @@ func newRenameCommand() *cobra.Command {
 }
 
 func renameAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	ns, err := cmd.Flags().GetString("namespace")
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
 	if err != nil {
 		return err
 	}
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return err
-	}
-	dataStore, err := clientutil.DataStore(dataRoot, address)
-	if err != nil {
-		return err
-	}
-	namest, err := namestore.New(dataStore, ns)
+	namest, err := namestore.New(dataStore, globalOptions.Namespace)
 	if err != nil {
 		return err
 	}
@@ -82,7 +70,7 @@ func renameAction(cmd *cobra.Command, args []string) error {
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			return renameContainer(ctx, found.Container, args[1], ns, namest, hostst)
+			return renameContainer(ctx, found.Container, args[1], globalOptions.Namespace, namest, hostst)
 		},
 	}
 	req := args[0]

--- a/cmd/nerdctl/restart.go
+++ b/cmd/nerdctl/restart.go
@@ -42,6 +42,10 @@ func newRestartCommand() *cobra.Command {
 
 func restartAction(cmd *cobra.Command, args []string) error {
 	// Time to wait after sending a SIGTERM and before sending a SIGKILL.
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	var timeout *time.Duration
 	if cmd.Flags().Changed("time") {
 		timeValue, err := cmd.Flags().GetUint("time")
@@ -51,15 +55,7 @@ func restartAction(cmd *cobra.Command, args []string) error {
 		t := time.Duration(timeValue) * time.Second
 		timeout = &t
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/rmi.go
+++ b/cmd/nerdctl/rmi.go
@@ -47,6 +47,10 @@ func newRmiCommand() *cobra.Command {
 }
 
 func rmiAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err
@@ -58,15 +62,7 @@ func rmiAction(cmd *cobra.Command, args []string) error {
 	} else if !async {
 		delOpts = append(delOpts, images.SynchronousDelete())
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/run_freebsd.go
+++ b/cmd/nerdctl/run_freebsd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/spf13/cobra"
 )
 
@@ -42,6 +43,7 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 func setPlatformOptions(
 	ctx context.Context,
 	cmd *cobra.Command,
+	_ *types.GlobalCommandOptions,
 	client *containerd.Client,
 	id string,
 	internalLabels *internalLabels,

--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cap"
 	"github.com/containerd/containerd/pkg/userns"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/bypass4netnsutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
@@ -57,13 +58,7 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 	return nil, cobra.ShellCompDirectiveNoFileComp
 }
 
-func setPlatformOptions(
-	ctx context.Context,
-	cmd *cobra.Command,
-	client *containerd.Client,
-	id string,
-	internalLabels *internalLabels,
-) ([]oci.SpecOpts, error) {
+func setPlatformOptions(ctx context.Context, cmd *cobra.Command, globalOptions *types.GlobalCommandOptions, client *containerd.Client, id string, internalLabels *internalLabels) ([]oci.SpecOpts, error) {
 	var opts []oci.SpecOpts
 	opts = append(opts,
 		oci.WithDefaultUnixDevices,
@@ -75,7 +70,7 @@ func setPlatformOptions(
 			{Type: "cgroup", Source: "cgroup", Destination: "/sys/fs/cgroup", Options: []string{"ro", "nosuid", "noexec", "nodev"}},
 		}))
 
-	cgOpts, err := generateCgroupOpts(cmd, id)
+	cgOpts, err := generateCgroupOpts(cmd, globalOptions, id)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/nerdctl/run_runtime.go
+++ b/cmd/nerdctl/run_runtime.go
@@ -25,22 +25,19 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
-func generateRuntimeCOpts(cmd *cobra.Command) ([]containerd.NewContainerOpts, error) {
+func generateRuntimeCOpts(cmd *cobra.Command, globalOptions *types.GlobalCommandOptions) ([]containerd.NewContainerOpts, error) {
 	runtime := plugin.RuntimeRuncV2
 	var (
 		runcOpts    runcoptions.Options
 		runtimeOpts interface{} = &runcOpts
 	)
-	cgm, err := cmd.Flags().GetString("cgroup-manager")
-	if err != nil {
-		return nil, err
-	}
-	if cgm == "systemd" {
+	if globalOptions.CgroupManager == "systemd" {
 		runcOpts.SystemdCgroup = true
 	}
 	runtimeStr, err := cmd.Flags().GetString("runtime")
@@ -51,8 +48,8 @@ func generateRuntimeCOpts(cmd *cobra.Command) ([]containerd.NewContainerOpts, er
 		if strings.HasPrefix(runtimeStr, "io.containerd.") || runtimeStr == "wtf.sbk.runj.v1" {
 			runtime = runtimeStr
 			if !strings.HasPrefix(runtimeStr, "io.containerd.runc.") {
-				if cgm == "systemd" {
-					logrus.Warnf("cannot set cgroup manager to %q for runtime %q", cgm, runtimeStr)
+				if globalOptions.CgroupManager == "systemd" {
+					logrus.Warnf("cannot set cgroup manager to %q for runtime %q", globalOptions.CgroupManager, runtimeStr)
 				}
 				runtimeOpts = nil
 			}

--- a/cmd/nerdctl/run_windows.go
+++ b/cmd/nerdctl/run_windows.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
 )
@@ -44,6 +45,7 @@ func runShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]s
 func setPlatformOptions(
 	ctx context.Context,
 	cmd *cobra.Command,
+	_ *types.GlobalCommandOptions,
 	client *containerd.Client,
 	id string,
 	internalLabels *internalLabels,

--- a/cmd/nerdctl/save.go
+++ b/cmd/nerdctl/save.go
@@ -63,6 +63,10 @@ func newSaveCommand() *cobra.Command {
 }
 
 func saveAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	if len(args) == 0 {
 		return fmt.Errorf("requires at least 1 argument")
 	}
@@ -79,15 +83,7 @@ func saveAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -57,15 +57,11 @@ func newStartCommand() *cobra.Command {
 }
 
 func startAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/stop.go
+++ b/cmd/nerdctl/stop.go
@@ -50,6 +50,10 @@ func newStopCommand() *cobra.Command {
 
 func stopAction(cmd *cobra.Command, args []string) error {
 	// Time to wait after sending a SIGTERM and before sending a SIGKILL.
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	var timeout *time.Duration
 	if cmd.Flags().Changed("time") {
 		timeValue, err := cmd.Flags().GetInt("time")
@@ -59,15 +63,7 @@ func stopAction(cmd *cobra.Command, args []string) error {
 		t := time.Duration(timeValue) * time.Second
 		timeout = &t
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/tag.go
+++ b/cmd/nerdctl/tag.go
@@ -42,15 +42,11 @@ func newTagCommand() *cobra.Command {
 }
 
 func tagAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/top.go
+++ b/cmd/nerdctl/top.go
@@ -78,26 +78,18 @@ func newTopCommand() *cobra.Command {
 func topAction(cmd *cobra.Command, args []string) error {
 	// NOTE: rootless container does not rely on cgroupv1.
 	// more details about possible ways to resolve this concern: #223
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	if rootlessutil.IsRootless() && infoutil.CgroupsVersion() == "1" {
 		return fmt.Errorf("top requires cgroup v2 for rootless containers, see https://rootlesscontaine.rs/getting-started/common/cgroup2/")
 	}
 
-	cgroupManager, err := cmd.Flags().GetString("cgroup-manager")
-	if err != nil {
-		return err
-	}
-	if cgroupManager == "none" {
+	if globalOptions.CgroupManager == "none" {
 		return errors.New("cgroup manager must not be \"none\"")
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/unpause.go
+++ b/cmd/nerdctl/unpause.go
@@ -42,15 +42,11 @@ func newUnpauseCommand() *cobra.Command {
 }
 
 func unpauseAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume.go
+++ b/cmd/nerdctl/volume.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/spf13/cobra"
@@ -43,18 +44,6 @@ func newVolumeCommand() *cobra.Command {
 
 // getVolumeStore returns a volume store
 // that corresponds to a directory like `/var/lib/nerdctl/1935db59/volumes/default`
-func getVolumeStore(cmd *cobra.Command) (volumestore.VolumeStore, error) {
-	ns, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return nil, err
-	}
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return nil, err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, err
-	}
-	return volume.Store(ns, dataRoot, address)
+func getVolumeStore(globalOptions *types.GlobalCommandOptions) (volumestore.VolumeStore, error) {
+	return volume.Store(globalOptions.Namespace, globalOptions.DataRoot, globalOptions.Address)
 }

--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -39,12 +39,16 @@ func newVolumeCreateCommand() *cobra.Command {
 }
 
 func volumeCreateAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	name := args[0]
 	if err := identifiers.Validate(name); err != nil {
 		return fmt.Errorf("malformed name %s: %w", name, err)
 	}
 
-	volStore, err := getVolumeStore(cmd)
+	volStore, err := getVolumeStore(globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume_inspect.go
+++ b/cmd/nerdctl/volume_inspect.go
@@ -40,12 +40,16 @@ func newVolumeInspectCommand() *cobra.Command {
 }
 
 func volumeInspectAction(cmd *cobra.Command, args []string) error {
-	var volumeSize, err = cmd.Flags().GetBool("size")
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+	volumeSize, err := cmd.Flags().GetBool("size")
 	if err != nil {
 		return err
 	}
 
-	volStore, err := getVolumeStore(cmd)
+	volStore, err := getVolumeStore(globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume_ls.go
+++ b/cmd/nerdctl/volume_ls.go
@@ -17,7 +17,7 @@
 package main
 
 import (
-	types "github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 
@@ -46,6 +46,11 @@ func newVolumeLsCommand() *cobra.Command {
 }
 
 func volumeLsAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+
 	options := &types.VolumeLsCommandOptions{}
 	options.Writer = cmd.OutOrStdout()
 	quiet, err := cmd.Flags().GetBool("quiet")
@@ -68,40 +73,16 @@ func volumeLsAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	options.Filters = filters
-	ns, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	options.Namespace = ns
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return err
-	}
-	options.DataRoot = dataRoot
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	options.Address = address
+	options.Namespace = globalOptions.Namespace
+	options.DataRoot = globalOptions.DataRoot
+	options.Address = globalOptions.Address
 	return volume.Ls(options)
 }
 
-func getVolumes(cmd *cobra.Command) (map[string]native.Volume, error) {
-	ns, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return nil, err
-	}
-	dataRoot, err := cmd.Flags().GetString("data-root")
-	if err != nil {
-		return nil, err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return nil, err
-	}
+func getVolumes(cmd *cobra.Command, globalOptions *types.GlobalCommandOptions) (map[string]native.Volume, error) {
 	volumeSize, err := cmd.Flags().GetBool("size")
 	if err != nil {
 		return nil, err
 	}
-	return volume.Volumes(ns, dataRoot, address, volumeSize)
+	return volume.Volumes(globalOptions.Namespace, globalOptions.DataRoot, globalOptions.Address, volumeSize)
 }

--- a/cmd/nerdctl/volume_prune.go
+++ b/cmd/nerdctl/volume_prune.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/spf13/cobra"
 )
@@ -40,6 +41,10 @@ func newVolumePruneCommand() *cobra.Command {
 }
 
 func volumePruneAction(cmd *cobra.Command, _ []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return err
@@ -56,25 +61,17 @@ func volumePruneAction(cmd *cobra.Command, _ []string) error {
 			return nil
 		}
 	}
-	namespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
-		return err
-	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	return volumePrune(ctx, cmd, client)
+	return volumePrune(ctx, cmd, client, globalOptions)
 }
 
-func volumePrune(ctx context.Context, cmd *cobra.Command, client *containerd.Client) error {
-	volStore, err := getVolumeStore(cmd)
+func volumePrune(ctx context.Context, cmd *cobra.Command, client *containerd.Client, globalOptions *types.GlobalCommandOptions) error {
+	volStore, err := getVolumeStore(globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume_rm.go
+++ b/cmd/nerdctl/volume_rm.go
@@ -46,15 +46,11 @@ func newVolumeRmCommand() *cobra.Command {
 }
 
 func volumeRmAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}
@@ -63,7 +59,7 @@ func volumeRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	volStore, err := getVolumeStore(cmd)
+	volStore, err := getVolumeStore(globalOptions)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/wait.go
+++ b/cmd/nerdctl/wait.go
@@ -42,15 +42,11 @@ func newWaitCommand() *cobra.Command {
 }
 
 func containerWaitAction(cmd *cobra.Command, args []string) error {
-	namespace, err := cmd.Flags().GetString("namespace")
+	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return err
 	}
-	address, err := cmd.Flags().GetString("address")
-	if err != nil {
-		return err
-	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I'm so sorry I have to make a huge PR again.

After #1793, we have a `types.GlobalCommandOptions`, and for #1792 and #1791 and many refactor PR int he future, we may need to introduce a new helper function to process the global flag.

In this PR, I introduce the new helper function and use this function to process the global flag in all subcommand.

There may be some duplicated code for some subcommand like `nerdctl run`, I think this should be not a problem, I will merge it when I refactor the run command,



Signed-off-by: Zheao.Li <me@manjusaka.me>