### PR TITLE
CI: Pass GITHUB_TOKEN to containerd/project-checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/nerdctl
+          repo-access-token: ${{ secrets.GITHUB_TOKEN }}
       - run: ./hack/verify-no-patent.sh
         working-directory: src/github.com/containerd/nerdctl
 


### PR DESCRIPTION
Should fix the annoying (and cryptic) jq error message that was the result of a rate limit for the CI.

See: https://github.com/containerd/containerd/pull/7913 (Thanks @kevpar for finding this)