### PR TITLE
ipfs: allow configuring ipfs daemon address

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,9 @@ Verify flags:
 - :nerd_face: `--verify`: Verify the image (none|cosign). See [`docs/cosign.md`](./docs/cosign.md) for details.
 - :nerd_face: `--cosign-key`: Path to the public key file, KMS, URI or Kubernetes Secret for `--verify=cosign`
 
+IPFS flags:
+- :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
+
 Unimplemented `docker run` flags:
     `--attach`, `--blkio-weight-device`, `--cpu-rt-*`, `--detach-keys`, `--device-*`,
     `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--ip6`, `--isolation`, `--no-healthcheck`,
@@ -886,6 +889,7 @@ Flags:
 - :whale: `-q, --quiet`: Suppress verbose output
 - :nerd_face: `--verify`: Verify the image (none|cosign). See [`docs/cosign.md`](./docs/cosign.md) for details.
 - :nerd_face: `--cosign-key`: Path to the public key file, KMS, URI or Kubernetes Secret for `--verify=cosign`
+- :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true)
 
@@ -1399,6 +1403,7 @@ Usage: `nerdctl compose [OPTIONS] [COMMAND]`
 Flags:
 - :whale: `-f, --file`: Specify an alternate compose file
 - :whale: `-p, --project-name`: Specify an alternate project name
+- :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 ### :whale: nerdctl compose up
 Create and start containers

--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -35,6 +35,7 @@ func newComposeCommand() *cobra.Command {
 	composeCommand.PersistentFlags().String("project-directory", "", "Specify an alternate working directory")
 	composeCommand.PersistentFlags().StringP("project-name", "p", "", "Specify an alternate project name")
 	composeCommand.PersistentFlags().String("env-file", "", "Specify an alternate environment file")
+	composeCommand.PersistentFlags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
 
 	composeCommand.AddCommand(
 		newComposeUpCommand(),
@@ -82,6 +83,10 @@ func getComposeOptions(cmd *cobra.Command, debugFull, experimental bool) (compos
 	if err != nil {
 		return composer.Options{}, err
 	}
+	ipfsAddressStr, err := cmd.Flags().GetString("ipfs-address")
+	if err != nil {
+		return composer.Options{}, err
+	}
 
 	return composer.Options{
 		Project:          projectName,
@@ -92,5 +97,6 @@ func getComposeOptions(cmd *cobra.Command, debugFull, experimental bool) (compos
 		NerdctlArgs:      nerdctlArgs,
 		DebugPrintFull:   debugFull,
 		Experimental:     experimental,
+		IPFSAddress:      ipfsAddressStr,
 	}, nil
 }

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -71,14 +71,14 @@ volumes:
 `, testutil.WordpressImage, testutil.MariaDBImage))
 }
 
-func testComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string) {
+func testComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string, opts ...string) {
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
 
 	projectName := comp.ProjectName()
 	t.Logf("projectName=%q", projectName)
 
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
+	base.ComposeCmd(append(append([]string{"-f", comp.YAMLFullPath()}, opts...), "up", "-d")...).AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
 	base.Cmd("volume", "inspect", fmt.Sprintf("%s_db", projectName)).AssertOK()
 	base.Cmd("network", "inspect", fmt.Sprintf("%s_default", projectName)).AssertOK()

--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -31,10 +31,14 @@ import (
 func TestIPFSComposeUp(t *testing.T) {
 	testutil.RequireExecutable(t, "ipfs")
 	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	ipfsaddr, done := runIPFSDaemonContainer(t, base)
+	defer done()
 	tests := []struct {
 		name           string
 		snapshotter    string
 		pushOptions    []string
+		composeOptions []string
 		requiresStargz bool
 	}{
 		{
@@ -46,6 +50,12 @@ func TestIPFSComposeUp(t *testing.T) {
 			snapshotter:    "stargz",
 			pushOptions:    []string{"--estargz"},
 			requiresStargz: true,
+		},
+		{
+			name:           "ipfs-address",
+			snapshotter:    "overlayfs",
+			pushOptions:    []string{fmt.Sprintf("--ipfs-address=%s", ipfsaddr)},
+			composeOptions: []string{fmt.Sprintf("--ipfs-address=%s", ipfsaddr)},
 		},
 	}
 	for _, tt := range tests {
@@ -95,7 +105,7 @@ services:
 volumes:
   wordpress:
   db:
-`, ipfsImgs[0], ipfsImgs[1]))
+`, ipfsImgs[0], ipfsImgs[1]), tt.composeOptions...)
 		})
 	}
 }

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -274,6 +274,8 @@ func setCreateFlags(cmd *cobra.Command) {
 	})
 	cmd.Flags().String("cosign-key", "", "Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign")
 	// #endregion
+
+	cmd.Flags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
 }
 
 // runAction is heavily based on ctr implementation:

--- a/docs/ipfs.md
+++ b/docs/ipfs.md
@@ -34,6 +34,8 @@ containerd-rootless-setuptool.sh -- install-ipfs --init
 
 :information_source: If you don't want IPFS to communicate with nodes on the internet, you can run IPFS daemon in offline mode using `--offline` flag or you can create a private IPFS network as described [here](https://github.com/containerd/stargz-snapshotter/blob/main/docs/ipfs.md#appendix-1-creating-ipfs-private-network).
 
+:information_source: Instead of locally launching IPFS daemon, you can specify the address of the IPFS API using `--ipfs-address` flag.
+
 ## IPFS-enabled image and OCI Compatibility
 
 Image distribution on IPFS is achieved by OCI-compatible *IPFS-enabled image format*.

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/containerd/nydus-snapshotter v0.5.0
 	github.com/containerd/stargz-snapshotter v0.13.0
 	github.com/containerd/stargz-snapshotter/estargz v0.13.0
-	github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20221214033845-6814ce4c2bf4
+	github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20230106161838-6844dbb4c428
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67
 	github.com/containernetworking/cni v1.1.2
 	github.com/containernetworking/plugins v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -104,7 +104,6 @@ github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim v0.9.4/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.5/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim v0.10.0-rc.1 h1:Lms8jwpaIdIUvoBNee8ZuvIi1XnNy9uvnxSC9L1q1x4=
 github.com/Microsoft/hcsshim v0.10.0-rc.1/go.mod h1:7XX96hdvnwWGdXnksDNdhfFcUH1BtQY6bL2L3f9Abyk=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
@@ -236,7 +235,6 @@ github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc
 github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
 github.com/containerd/containerd v1.6.8/go.mod h1:By6p5KqPK0/7/CgO/A6t/Gz+CUYUu2zf1hUaaymVXB0=
 github.com/containerd/containerd v1.6.9/go.mod h1:XVicUvkxOrftE2Q1YWUXgZwkkAxwQYNOFzYWvfVfEfQ=
-github.com/containerd/containerd v1.6.10/go.mod h1:CVqfxdJ95PDgORwA219AwwLrREZgrTFybXu2HfMKRG0=
 github.com/containerd/containerd v1.7.0-beta.2 h1:GWmC96y8j7jlFJX0Wh+covft0M1hHBqQL7lo+N6qvxg=
 github.com/containerd/containerd v1.7.0-beta.2/go.mod h1:RR01Jsm/jovDKK48sFCVqWyKAH2APMPi88Aeu1on63I=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
@@ -286,8 +284,8 @@ github.com/containerd/stargz-snapshotter v0.13.0/go.mod h1:01uOvoNzN1T4kV+8HeVt9
 github.com/containerd/stargz-snapshotter/estargz v0.4.1/go.mod h1:x7Q9dg9QYb4+ELgxmo4gBUeJB0tl5dqH1Sdz0nJU1QM=
 github.com/containerd/stargz-snapshotter/estargz v0.13.0 h1:fD7AwuVV+B40p0d9qVkH/Au1qhp8hn/HWJHIYjpEcfw=
 github.com/containerd/stargz-snapshotter/estargz v0.13.0/go.mod h1:m+9VaGJGlhCnrcEUod8mYumTmRgblwd3rC5UCEh2Yp0=
-github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20221214033845-6814ce4c2bf4 h1:ReVKY+lGLupesorAUthXO0oLdQPepLMNISPe1N+mgEc=
-github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20221214033845-6814ce4c2bf4/go.mod h1:b7vEGFciUxKxCBURTeZoyZgWAMl7Ni3c5ZCjf299qPU=
+github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20230106161838-6844dbb4c428 h1:azct97pvPcgqSH3cHh3IYsVyEM2ZxMzodz19TUy8CNs=
+github.com/containerd/stargz-snapshotter/ipfs v0.13.1-0.20230106161838-6844dbb4c428/go.mod h1:J1NjiZfaNyZ7oo5aDgE3c9LMibP+9kmFhDzInXyOogI=
 github.com/containerd/ttrpc v0.0.0-20190828154514-0e0f228740de/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20190828172938-92c8520ef9f8/go.mod h1:PvCDdDGpgqzQIzDW1TphrGLssLDZp2GuS+X5DkEJB8o=
 github.com/containerd/ttrpc v0.0.0-20191028202541-4f1b8fe65a5c/go.mod h1:LPm1u0xBw8r8NOKoOdNMeVHSawSsltak+Ihv+etqsE8=

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -46,6 +46,7 @@ type Options struct {
 	EnsureImage      func(ctx context.Context, imageName, pullMode, platform string, ps *serviceparser.Service, quiet bool) error
 	DebugPrintFull   bool // full debug print, may leak secret env var to logs
 	Experimental     bool // enable experimental features
+	IPFSAddress      string
 }
 
 func New(o Options, client *containerd.Client) (*Composer, error) {

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -41,7 +41,7 @@ import (
 )
 
 // EnsureImage pull the specified image from IPFS.
-func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr io.Writer, snapshotter string, scheme string, ref string, mode imgutil.PullMode, ocispecPlatforms []ocispec.Platform, unpack *bool, quiet bool) (*imgutil.EnsuredImage, error) {
+func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr io.Writer, snapshotter string, scheme string, ref string, mode imgutil.PullMode, ocispecPlatforms []ocispec.Platform, unpack *bool, quiet bool, ipfsPath *string) (*imgutil.EnsuredImage, error) {
 	switch mode {
 	case "always", "missing", "never":
 		// NOP
@@ -68,8 +68,13 @@ func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr 
 	if mode == "never" {
 		return nil, fmt.Errorf("image %q is not available", ref)
 	}
+	var ipath string
+	if ipfsPath != nil {
+		ipath = *ipfsPath
+	}
 	r, err := ipfs.NewResolver(ipfs.ResolverOptions{
-		Scheme: scheme,
+		Scheme:   scheme,
+		IPFSPath: ipath,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -33,6 +33,7 @@ var (
 	MariaDBImage                = mirrorOf("mariadb:10.5")
 	DockerAuthImage             = mirrorOf("cesanta/docker_auth:1.7")
 	FluentdImage                = mirrorOf("fluent/fluentd:v1.14-1")
+	KuboImage                   = mirrorOf("ipfs/kubo:v0.16.0")
 
 	// Source: https://gist.github.com/cpuguy83/fcf3041e5d8fb1bb5c340915aabeebe0
 	NonDistBlobImage = "ghcr.io/cpuguy83/non-dist-blob:latest"


### PR DESCRIPTION
Fixes #1781
Depends on https://github.com/containerd/stargz-snapshotter/pull/1050

This commit adds `--ipfs-address` flag to `nerdctl pull`, `nerdctl run`, `nerdctl compose`.
This allows nerdctl to use an arbitrary IPFS API address instead of the local daemon, as proposed in #1781 .
