### PR TITLE
Fix the container will be created when `nerdctl run -d --rm`

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -305,6 +305,15 @@ func runAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	rm, err := cmd.Flags().GetBool("rm")
+	if err != nil {
+		return err
+	}
+
+	if rm && flagD {
+		return errors.New("flags -d and --rm cannot be specified together")
+	}
+
 	container, gc, err := createContainer(ctx, cmd, globalOptions, client, args, platform, flagI, flagT, flagD)
 	if err != nil {
 		if gc != nil {
@@ -314,14 +323,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 	}
 
 	id := container.ID()
-	rm, err := cmd.Flags().GetBool("rm")
-	if err != nil {
-		return err
-	}
-	if rm {
-		if flagD {
-			return errors.New("flag -d and --rm cannot be specified together")
-		}
+	if rm && !flagD {
 		defer func() {
 			if err := removeContainer(ctx, cmd, globalOptions, container, true, true); err != nil {
 				logrus.WithError(err).Warnf("failed to remove container %s", id)


### PR DESCRIPTION
The error caused by the parameter problem should be returned before the container is created

```bash
$ nerdctl run --rm -d ubuntu:latest ps aux
FATA[0000] flag -d and --rm cannot be specified together

$ nerdctl ps -a
CONTAINER ID    IMAGE                                                                                                                         COMMAND                   CREATED           STATUS     PORTS    NAMES
09d12b1005ba    docker.io/library/ubuntu:latest                                                                                               "ps aux"                  31 seconds ago    Created             ubuntu-09d12

$  ctr containers list
CONTAINER                                                           IMAGE                                                                                                                         RUNTIME         
09d12b1005ba9dbeac8dbfd614f97c79d3a7906befa754a0ebb9feeacd0c0a56    docker.io/library/ubuntu:latest                                                                                               io.containerd.runc.v2
```