### PR TITLE
Refactor the network command flagging process

### DIFF
--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -19,8 +19,9 @@ package main
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/network"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 
@@ -96,34 +97,18 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 	}
 	labels = strutil.DedupeStrSlice(labels)
 
-	if subnetStr == "" {
-		if gatewayStr != "" || ipRangeStr != "" {
-			return fmt.Errorf("cannot set gateway or ip-range without subnet, specify --subnet manually")
-		}
-	}
-
-	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
-	if err != nil {
-		return err
-	}
-	createOpts := netutil.CreateOptions{
-		Name:        name,
-		Driver:      driver,
-		Options:     strutil.ConvertKVStringsToMap(opts),
-		IPAMDriver:  ipamDriver,
-		IPAMOptions: strutil.ConvertKVStringsToMap(ipamOpts),
-		Subnet:      subnetStr,
-		Gateway:     gatewayStr,
-		IPRange:     ipRangeStr,
-		Labels:      labels,
-	}
-	net, err := e.CreateNetwork(createOpts)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			return fmt.Errorf("network with name %s already exists", name)
-		}
-		return err
-	}
-	_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", *net.NerdctlID)
-	return err
+	return network.Create(types.NetworkCreateCommandOptions{
+		GOptions: globalOptions,
+		CreateOptions: netutil.CreateOptions{
+			Name:        name,
+			Driver:      driver,
+			Options:     strutil.ConvertKVStringsToMap(opts),
+			IPAMDriver:  ipamDriver,
+			IPAMOptions: strutil.ConvertKVStringsToMap(ipamOpts),
+			Subnet:      subnetStr,
+			Gateway:     gatewayStr,
+			IPRange:     ipRangeStr,
+			Labels:      labels,
+		},
+	}, cmd.OutOrStdout())
 }

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -17,14 +17,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/containerd/nerdctl/pkg/clientutil"
-	"github.com/containerd/nerdctl/pkg/errutil"
-	"github.com/containerd/nerdctl/pkg/idutil/netwalker"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/network"
 	"github.com/containerd/nerdctl/pkg/netutil"
-	"github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"
 )
@@ -49,71 +44,10 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
-	if err != nil {
-		return err
-	}
-
-	usedNetworkInfo, err := netutil.UsedNetworks(ctx, client)
-	if err != nil {
-		return err
-	}
-
-	walker := netwalker.NetworkWalker{
-		Client: e,
-		OnFound: func(ctx context.Context, found netwalker.Found) error {
-			if found.MatchCount > 1 {
-				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
-			}
-			if value, ok := usedNetworkInfo[found.Network.Name]; ok {
-				return fmt.Errorf("network %q is in use by container %q", found.Req, value)
-			}
-			if found.Network.NerdctlID == nil {
-				return fmt.Errorf("%s is managed outside nerdctl and cannot be removed", found.Req)
-			}
-			if found.Network.File == "" {
-				return fmt.Errorf("%s is a pre-defined network and cannot be removed", found.Req)
-			}
-			if err := e.RemoveNetwork(found.Network); err != nil {
-				return err
-			}
-			fmt.Fprintln(cmd.OutOrStdout(), found.Req)
-			return nil
-		},
-	}
-
-	code := 0
-	for _, name := range args {
-		if name == "host" || name == "none" {
-			code = 1
-			logrus.Errorf("pseudo network %q cannot be removed", name)
-			continue
-		}
-
-		n, err := walker.Walk(cmd.Context(), name)
-		if err != nil {
-			code = 1
-			logrus.Error(err)
-			continue
-
-		} else if n == 0 {
-			code = 1
-			logrus.Errorf("No such network: %s", name)
-			continue
-		}
-	}
-
-	// compatible with docker
-	// ExitCodeError is to allow the program to exit with status code 1 without outputting an error message.
-	if code != 0 {
-		return errutil.NewExitCoderErr(code)
-	}
-	return nil
+	return network.Remove(cmd.Context(), types.NetworkRemoveCommandOptions{
+		GOptions: globalOptions,
+		Networks: args,
+	}, cmd.OutOrStdout())
 }
 
 func networkRmShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/cmd/network"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -103,7 +104,10 @@ func systemPruneAction(cmd *cobra.Command, args []string) error {
 	if err := containerPrune(ctx, cmd, client, globalOptions); err != nil {
 		return err
 	}
-	if err := networkPrune(ctx, cmd, client, globalOptions); err != nil {
+	if err := network.Prune(ctx, types.NetworkPruneCommandOptions{
+		GOptions:             globalOptions,
+		NetworkDriversToKeep: networkDriversToKeep,
+	}, cmd.InOrStdin(), cmd.OutOrStdout()); err != nil {
 		return err
 	}
 	if vFlag {

--- a/pkg/api/types/network_types.go
+++ b/pkg/api/types/network_types.go
@@ -16,6 +16,29 @@
 
 package types
 
+import "github.com/containerd/nerdctl/pkg/netutil"
+
+// NetworkCreateCommandOptions specifies options for nerdctl network create
+type NetworkCreateCommandOptions struct {
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// CreateOptions is the option for creating network
+	CreateOptions netutil.CreateOptions
+}
+
+// NetworkCreateCommandOptions specifies options for nerdctl network inspect
+type NetworkInspectCommandOptions struct {
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output
+	Mode string
+	// Format the output using the given Go template, e.g, '{{json .}}'
+	Format string
+	// Networks are the networks to be inspected
+	Networks []string
+}
+
+// NetworkCreateCommandOptions specifies options for nerdctl network ls
 type NetworkListCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -23,4 +46,20 @@ type NetworkListCommandOptions struct {
 	Quiet bool
 	// Format the output using the given Go template, e.g, '{{json .}}', 'wide'
 	Format string
+}
+
+// NetworkCreateCommandOptions specifies options for nerdctl network prune
+type NetworkPruneCommandOptions struct {
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Network drivers to keep while pruning
+	NetworkDriversToKeep []string
+}
+
+// NetworkCreateCommandOptions specifies options for nerdctl network rm
+type NetworkRemoveCommandOptions struct {
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Networks are the networks to be removed
+	Networks []string
 }

--- a/pkg/cmd/network/create.go
+++ b/pkg/cmd/network/create.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package network
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/netutil"
+)
+
+func Create(options types.NetworkCreateCommandOptions, stdout io.Writer) error {
+	if options.CreateOptions.Subnet == "" {
+		if options.CreateOptions.Gateway != "" || options.CreateOptions.IPRange != "" {
+			return fmt.Errorf("cannot set gateway or ip-range without subnet, specify --subnet manually")
+		}
+	}
+
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	if err != nil {
+		return err
+	}
+	net, err := e.CreateNetwork(options.CreateOptions)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			return fmt.Errorf("network with name %s already exists", options.CreateOptions.Name)
+		}
+		return err
+	}
+	_, err = fmt.Fprintf(stdout, "%s\n", *net.NerdctlID)
+	return err
+}

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -1,0 +1,72 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/formatter"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/pkg/netutil"
+)
+
+func Inspect(options types.NetworkInspectCommandOptions, stdout io.Writer) error {
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	if err != nil {
+		return err
+	}
+
+	netMap, err := e.NetworkMap()
+	if err != nil {
+		return err
+	}
+
+	result := make([]interface{}, len(options.Networks))
+	for i, name := range options.Networks {
+		if name == "host" || name == "none" {
+			return fmt.Errorf("pseudo network %q cannot be inspected", name)
+		}
+		l, ok := netMap[name]
+		if !ok {
+			return fmt.Errorf("no such network: %s", name)
+		}
+
+		r := &native.Network{
+			CNI:           json.RawMessage(l.Bytes),
+			NerdctlID:     l.NerdctlID,
+			NerdctlLabels: l.NerdctlLabels,
+			File:          l.File,
+		}
+		switch options.Mode {
+		case "native":
+			result[i] = r
+		case "dockercompat":
+			compat, err := dockercompat.NetworkFromNative(r)
+			if err != nil {
+				return err
+			}
+			result[i] = compat
+		default:
+			return fmt.Errorf("unknown mode %q", options.Mode)
+		}
+	}
+	return formatter.FormatSlice(options.Format, stdout, result)
+}

--- a/pkg/cmd/network/prune.go
+++ b/pkg/cmd/network/prune.go
@@ -1,0 +1,79 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/netutil"
+	"github.com/containerd/nerdctl/pkg/strutil"
+	"github.com/sirupsen/logrus"
+)
+
+func Prune(ctx context.Context, options types.NetworkPruneCommandOptions, stdin io.Reader, stdout io.Writer) error {
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	if err != nil {
+		return err
+	}
+
+	usedNetworks, err := netutil.UsedNetworks(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	networkConfigs, err := e.NetworkList()
+	if err != nil {
+		return err
+	}
+
+	var removedNetworks []string // nolint: prealloc
+	for _, net := range networkConfigs {
+		if strutil.InStringSlice(options.NetworkDriversToKeep, net.Name) {
+			continue
+		}
+		if net.NerdctlID == nil || net.File == "" {
+			continue
+		}
+		if _, ok := usedNetworks[net.Name]; ok {
+			continue
+		}
+		if err := e.RemoveNetwork(net); err != nil {
+			logrus.WithError(err).Errorf("failed to remove network %s", net.Name)
+			continue
+		}
+		removedNetworks = append(removedNetworks, net.Name)
+	}
+
+	if len(removedNetworks) > 0 {
+		fmt.Fprintln(stdout, "Deleted Networks:")
+		for _, name := range removedNetworks {
+			fmt.Fprintln(stdout, name)
+		}
+		fmt.Fprintln(stdout, "")
+	}
+	return nil
+}

--- a/pkg/cmd/network/remove.go
+++ b/pkg/cmd/network/remove.go
@@ -1,0 +1,98 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package network
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/errutil"
+	"github.com/containerd/nerdctl/pkg/idutil/netwalker"
+	"github.com/containerd/nerdctl/pkg/netutil"
+	"github.com/sirupsen/logrus"
+)
+
+func Remove(ctx context.Context, options types.NetworkRemoveCommandOptions, stdout io.Writer) error {
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	if err != nil {
+		return err
+	}
+
+	usedNetworkInfo, err := netutil.UsedNetworks(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	walker := netwalker.NetworkWalker{
+		Client: e,
+		OnFound: func(ctx context.Context, found netwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			if value, ok := usedNetworkInfo[found.Network.Name]; ok {
+				return fmt.Errorf("network %q is in use by container %q", found.Req, value)
+			}
+			if found.Network.NerdctlID == nil {
+				return fmt.Errorf("%s is managed outside nerdctl and cannot be removed", found.Req)
+			}
+			if found.Network.File == "" {
+				return fmt.Errorf("%s is a pre-defined network and cannot be removed", found.Req)
+			}
+			if err := e.RemoveNetwork(found.Network); err != nil {
+				return err
+			}
+			fmt.Fprintln(stdout, found.Req)
+			return nil
+		},
+	}
+
+	code := 0
+	for _, name := range options.Networks {
+		if name == "host" || name == "none" {
+			code = 1
+			logrus.Errorf("pseudo network %q cannot be removed", name)
+			continue
+		}
+
+		n, err := walker.Walk(ctx, name)
+		if err != nil {
+			code = 1
+			logrus.Error(err)
+			continue
+
+		} else if n == 0 {
+			code = 1
+			logrus.Errorf("No such network: %s", name)
+			continue
+		}
+	}
+
+	// compatible with docker
+	// ExitCodeError is to allow the program to exit with status code 1 without outputting an error message.
+	if code != 0 {
+		return errutil.NewExitCoderErr(code)
+	}
+	return nil
+}


### PR DESCRIPTION
See https://github.com/containerd/nerdctl/issues/1680

- [x] Create a file in pkg/api/types/${cmd}_types.go, and define the CommandOption for this command
- [x] Create some file in pkg/cmd/${cmd}, and move the command entry point in real into this package