### PR TITLE
FIX-1811: CI: test-integration often hits the 30min limit

### DIFF
--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func TestIPFSComposeUp(t *testing.T) {
+	t.Parallel()
 	testutil.RequireExecutable(t, "ipfs")
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
@@ -111,6 +112,7 @@ volumes:
 }
 
 func TestIPFSComposeUpBuild(t *testing.T) {
+	t.Parallel()
 	testutil.RequireExecutable(t, "ipfs")
 	testutil.DockerIncompatible(t)
 	testutil.RequiresBuild(t)


### PR DESCRIPTION
Fixes: #1811 

- Parallelize the TestIPFSComposeUp since it was taking ~300 sec to run.