### PR TITLE
Add nerdctl builder build command

### DIFF
--- a/cmd/nerdctl/builder.go
+++ b/cmd/nerdctl/builder.go
@@ -38,6 +38,7 @@ func newBuilderCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	builderCommand.AddCommand(
+		newBuildCommand(),
 		newBuilderPruneCommand(),
 		newBuilderDebugCommand(),
 	)


### PR DESCRIPTION
Allows invocation of `nerdctl builder build` to build an image from a Dockerfile. Shares the same underlying implementation as `nerdctl build`.

Fixes #1828 

Signed-off-by: Austin Vazquez <macedonv@amazon.com>