### PR TITLE
mv pkg/cmd/load/load.go pkg/cmd/image/load.go

### DIFF
--- a/cmd/nerdctl/load.go
+++ b/cmd/nerdctl/load.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/cmd/load"
+	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
 
@@ -75,5 +75,5 @@ func loadAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return load.Load(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), options)
+	return image.Load(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout(), options)
 }

--- a/pkg/cmd/image/load.go
+++ b/pkg/cmd/image/load.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package load
+package image
 
 import (
 	"context"


### PR DESCRIPTION
Because the canonical form of `nerdctl load` is `nerdctl image load`