### PR TITLE
mv pkg/cmd/build pkg/cmd/builder

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
-	"github.com/containerd/nerdctl/pkg/cmd/build"
+	"github.com/containerd/nerdctl/pkg/cmd/builder"
 	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/strutil"
 
@@ -196,7 +196,7 @@ func buildAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := build.Build(cmd.Context(), options, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
+	if err := builder.Build(cmd.Context(), options, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr()); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package build
+package builder
 
 import (
 	"context"


### PR DESCRIPTION
Because the canonical form of `nerdctl build` is `nerdctl builder build`
