### PR TITLE
[Refactor] Move exit_coder from cmd to pkg/errutil

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/nerdctl/pkg/config"
 	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
+	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/logging"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/version"
@@ -113,7 +114,7 @@ func usage(c *cobra.Command) error {
 
 func main() {
 	if err := xmain(); err != nil {
-		HandleExitCoder(err)
+		errutil.HandleExitCoder(err)
 		logrus.Fatal(err)
 	}
 }
@@ -339,30 +340,6 @@ func globalFlags(cmd *cobra.Command) (string, []string) {
 		}
 	})
 	return args0, args
-}
-
-type ExitCoder interface {
-	error
-	ExitCode() int
-}
-
-type ExitCodeError struct {
-	error
-	exitCode int
-}
-
-func (e ExitCodeError) ExitCode() int {
-	return e.exitCode
-}
-
-func HandleExitCoder(err error) {
-	if err == nil {
-		return
-	}
-
-	if exitErr, ok := err.(ExitCoder); ok {
-		os.Exit(exitErr.ExitCode())
-	}
 }
 
 // unknownSubcommandAction is needed to let `nerdctl system non-existent-command` fail

--- a/cmd/nerdctl/network_rm.go
+++ b/cmd/nerdctl/network_rm.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/idutil/netwalker"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/sirupsen/logrus"
@@ -110,9 +111,7 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 	// compatible with docker
 	// ExitCodeError is to allow the program to exit with status code 1 without outputting an error message.
 	if code != 0 {
-		return ExitCodeError{
-			exitCode: code,
-		}
+		return errutil.NewExitCoderErr(code)
 	}
 	return nil
 }

--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/defaults"
+	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
@@ -398,9 +399,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if code != 0 {
-		return ExitCodeError{
-			exitCode: int(code),
-		}
+		return errutil.NewExitCoderErr(int(code))
 	}
 	return nil
 }

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/labels"
@@ -184,9 +185,7 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 		return err
 	}
 	if code != 0 {
-		return ExitCodeError{
-			exitCode: int(code),
-		}
+		return errutil.NewExitCoderErr(int(code))
 	}
 	return nil
 }

--- a/pkg/errutil/exit_coder.go
+++ b/pkg/errutil/exit_coder.go
@@ -1,0 +1,50 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package errutil
+
+import "os"
+
+type ExitCoder interface {
+	error
+	ExitCode() int
+}
+
+// ExitCodeError is to allow the program to exit with status code without outputting an error message.
+type ExitCodeError struct {
+	error
+	exitCode int
+}
+
+func NewExitCoderErr(exitCode int) ExitCodeError {
+	return ExitCodeError{
+		exitCode: exitCode,
+	}
+}
+
+func (e ExitCodeError) ExitCode() int {
+	return e.exitCode
+}
+
+func HandleExitCoder(err error) {
+	if err == nil {
+		return
+	}
+
+	if exitErr, ok := err.(ExitCoder); ok {
+		os.Exit(exitErr.ExitCode())
+	}
+}


### PR DESCRIPTION
Checklist:
- [x]  move `ExitCodeError` from `cmd` to ~~`pkg/exitcoder`~~`pkg/errutil`

https://github.com/containerd/nerdctl/blob/0b051a5ddbb29d6673b853f7b1b1863d331f1f3d/cmd/nerdctl/start.go#L187-L190
When I refactor the container start command,  I have discovered  that `ExitCodeError` from `cmd` is blocking my work.

https://github.com/containerd/nerdctl/blob/0b051a5ddbb29d6673b853f7b1b1863d331f1f3d/cmd/nerdctl/main.go#L343-L367
Maybe we should refactor `ExitCodeError` first, by moving it to `pkg/exitcoder`. Then we can continue with our other tasks.

Signed-off-by: Laitron <meetlq@outlook.com>