### PR TITLE
[Refactor] Refactor the namespace command flagging process

### DIFF
--- a/cmd/nerdctl/namespace_update.go
+++ b/cmd/nerdctl/namespace_update.go
@@ -17,7 +17,8 @@
 package main
 
 import (
-	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/namespace"
 	"github.com/spf13/cobra"
 )
 
@@ -34,26 +35,25 @@ func newNamespacelabelUpdateCommand() *cobra.Command {
 	return namespaceLableCommand
 }
 
-func labelUpdateAction(cmd *cobra.Command, args []string) error {
+func processNamespaceUpdateCommandOption(cmd *cobra.Command) (types.NamespaceUpdateCommandOptions, error) {
 	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
-		return err
+		return types.NamespaceUpdateCommandOptions{}, err
 	}
-	flagVSlice, err := cmd.Flags().GetStringArray("label")
+	labels, err := cmd.Flags().GetStringArray("label")
+	if err != nil {
+		return types.NamespaceUpdateCommandOptions{}, err
+	}
+	return types.NamespaceUpdateCommandOptions{
+		GOptions: globalOptions,
+		Labels:   labels,
+	}, nil
+}
+
+func labelUpdateAction(cmd *cobra.Command, args []string) error {
+	options, err := processNamespaceUpdateCommandOption(cmd)
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-	labelsArg := ObjectWithLabelArgs(flagVSlice)
-	namespaces := client.NamespaceService()
-	for k, v := range labelsArg {
-		if err := namespaces.SetLabel(ctx, args[0], k, v); err != nil {
-			return err
-		}
-	}
-	return nil
+	return namespace.Update(cmd.Context(), args[0], options)
 }

--- a/pkg/api/types/namespace_types.go
+++ b/pkg/api/types/namespace_types.go
@@ -14,14 +14,24 @@
    limitations under the License.
 */
 
-package main
+package types
 
-import (
-	"github.com/containerd/containerd/namespaces"
-	"github.com/spf13/cobra"
-)
+type NamespaceCreateCommandOptions struct {
+	GOptions GlobalCommandOptions
+	// Labels are the namespace labels
+	Labels []string
+}
 
-func namespaceDeleteOpts(cmd *cobra.Command) ([]namespaces.DeleteOpts, error) {
-	var delOpts []namespaces.DeleteOpts
-	return delOpts, nil
+type NamespaceUpdateCommandOptions NamespaceCreateCommandOptions
+
+type NamespaceRemoveCommandOptions struct {
+	GOptions GlobalCommandOptions
+	// CGroup delete the namespace's cgroup
+	CGroup bool
+}
+
+type NamespaceInspectCommandOptions struct {
+	GOptions GlobalCommandOptions
+	// Format the output using the given Go template, e.g, '{{json .}}'
+	Format string
 }

--- a/pkg/cmd/namespace/common.go
+++ b/pkg/cmd/namespace/common.go
@@ -1,0 +1,26 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import "github.com/containerd/containerd/cmd/ctr/commands"
+
+func objectWithLabelArgs(args []string) map[string]string {
+	if len(args) >= 1 {
+		return commands.LabelArgs(args)
+	}
+	return nil
+}

--- a/pkg/cmd/namespace/create.go
+++ b/pkg/cmd/namespace/create.go
@@ -14,14 +14,22 @@
    limitations under the License.
 */
 
-package main
+package namespace
 
 import (
-	"github.com/containerd/containerd/namespaces"
-	"github.com/spf13/cobra"
+	"context"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 )
 
-func namespaceDeleteOpts(cmd *cobra.Command) ([]namespaces.DeleteOpts, error) {
-	var delOpts []namespaces.DeleteOpts
-	return delOpts, nil
+func Create(ctx context.Context, namespace string, options types.NamespaceCreateCommandOptions) error {
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	labelsArg := objectWithLabelArgs(options.Labels)
+	namespaces := client.NamespaceService()
+	return namespaces.Create(ctx, namespace, labelsArg)
 }

--- a/pkg/cmd/namespace/inspect.go
+++ b/pkg/cmd/namespace/inspect.go
@@ -1,0 +1,51 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"io"
+
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/formatter"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+)
+
+func Inspect(ctx context.Context, inspectedNamespaces []string, options types.NamespaceInspectCommandOptions, stdout io.Writer) error {
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	result := make([]interface{}, len(inspectedNamespaces))
+	for index, ns := range inspectedNamespaces {
+		ctx = namespaces.WithNamespace(ctx, ns)
+		labels, err := client.NamespaceService().Labels(ctx, ns)
+		if err != nil {
+			return err
+		}
+		nsInspect := native.Namespace{
+			Name:   ns,
+			Labels: &labels,
+		}
+		result[index] = nsInspect
+	}
+	return formatter.FormatSlice(options.Format, stdout, result)
+}

--- a/pkg/cmd/namespace/namespace_freebsd.go
+++ b/pkg/cmd/namespace/namespace_freebsd.go
@@ -1,0 +1,26 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import (
+	"github.com/containerd/containerd/namespaces"
+)
+
+func namespaceDeleteOpts(cgroup bool) ([]namespaces.DeleteOpts, error) {
+	var delOpts []namespaces.DeleteOpts
+	return delOpts, nil
+}

--- a/pkg/cmd/namespace/namespace_linux.go
+++ b/pkg/cmd/namespace/namespace_linux.go
@@ -1,0 +1,30 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import (
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/runtime/opts"
+)
+
+func namespaceDeleteOpts(cgroup bool) ([]namespaces.DeleteOpts, error) {
+	var delOpts []namespaces.DeleteOpts
+	if cgroup {
+		delOpts = append(delOpts, opts.WithNamespaceCgroupDeletion)
+	}
+	return delOpts, nil
+}

--- a/pkg/cmd/namespace/namespace_windows.go
+++ b/pkg/cmd/namespace/namespace_windows.go
@@ -1,0 +1,26 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import (
+	"github.com/containerd/containerd/namespaces"
+)
+
+func namespaceDeleteOpts(cgroup bool) ([]namespaces.DeleteOpts, error) {
+	var delOpts []namespaces.DeleteOpts
+	return delOpts, nil
+}

--- a/pkg/cmd/namespace/remove.go
+++ b/pkg/cmd/namespace/remove.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+)
+
+func Remove(ctx context.Context, deletedNamespaces []string, options types.NamespaceRemoveCommandOptions, stdout io.Writer) error {
+	var exitErr error
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	opts, err := namespaceDeleteOpts(options.CGroup)
+	if err != nil {
+		return err
+	}
+	namespaces := client.NamespaceService()
+	for _, target := range deletedNamespaces {
+		if err := namespaces.Delete(ctx, target, opts...); err != nil {
+			if !errdefs.IsNotFound(err) {
+				if exitErr == nil {
+					exitErr = fmt.Errorf("unable to delete %s", target)
+				}
+				log.G(ctx).WithError(err).Errorf("unable to delete %v", target)
+				continue
+			}
+		}
+		_, err := fmt.Fprintf(stdout, "%s\n", target)
+		return err
+	}
+	return exitErr
+}


### PR DESCRIPTION
Checklist:

- [x] Create a file in `pkg/api/types/${cmd}_types.go`, and define the CommandOption for this command
- [x] Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

Signed-off-by: Zheao.Li <me@manjusaka.me>