### PR TITLE
[Refactor] Refactor the container start command flagging process

### DIFF
--- a/cmd/nerdctl/compose_start.go
+++ b/cmd/nerdctl/compose_start.go
@@ -109,7 +109,7 @@ func startContainers(ctx context.Context, client *containerd.Client, containers 
 			}
 
 			// in compose, always disable attach
-			if err := startContainer(ctx, c, false, client); err != nil {
+			if err := containerutil.Start(ctx, c, false, client); err != nil {
 				return err
 			}
 			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)

--- a/cmd/nerdctl/container_restart.go
+++ b/cmd/nerdctl/container_restart.go
@@ -71,7 +71,7 @@ func restartAction(cmd *cobra.Command, args []string) error {
 			if err := containerutil.Stop(ctx, found.Container, timeout); err != nil {
 				return err
 			}
-			if err := startContainer(ctx, found.Container, false, client); err != nil {
+			if err := containerutil.Start(ctx, found.Container, false, client); err != nil {
 				return err
 			}
 			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s\n", found.Req)

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -21,6 +21,15 @@ import (
 	"time"
 )
 
+// ContainerStartOptions specifies options for the `nerdctl (container) start`.
+type ContainerStartOptions struct {
+	Stdout io.Writer
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Attach specifies whether to attach to the container's stdio.
+	Attach bool
+}
+
 // KillOptions specifies options for `nerdctl (container) kill`.
 type KillOptions struct {
 	Stdout io.Writer

--- a/pkg/cmd/container/start.go
+++ b/pkg/cmd/container/start.go
@@ -1,0 +1,64 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+)
+
+// Start starts a list of `containers`. If attach is true, it only starts a single container.
+func Start(ctx context.Context, client *containerd.Client, reqs []string, options types.ContainerStartOptions) error {
+	if options.Attach && len(reqs) > 1 {
+		return fmt.Errorf("you cannot start and attach multiple containers at once")
+	}
+
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			var err error
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			if err := containerutil.Start(ctx, found.Container, options.Attach, client); err != nil {
+				return err
+			}
+			if !options.Attach {
+				_, err := fmt.Fprintf(options.Stdout, "%s\n", found.Req)
+				if err != nil {
+					return err
+				}
+			}
+			return err
+		},
+	}
+
+	for _, req := range reqs {
+		n, err := walker.Walk(ctx, req)
+		if err != nil {
+			return err
+		} else if n == 0 {
+			return fmt.Errorf("no such container %s", req)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Part of https://github.com/containerd/nerdctl/issues/1680

Checklist:
- [x] Move startContainer from cmd to pkg/containerutil
- [x] Create a file in pkg/api/types/${cmd}_types.go, and define the CommandOption for this command
- [x] Create some file in pkg/cmd/${cmd}, and move the command entry point in real into this package

Signed-off-by: Laitron <meetlq@outlook.com>