### PR TITLE
refactor: image tag flagging process

### DIFF
--- a/cmd/nerdctl/image_tag.go
+++ b/cmd/nerdctl/image_tag.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/cmd/image"
+
+	"github.com/spf13/cobra"
+)
+
+func newTagCommand() *cobra.Command {
+	var tagCommand = &cobra.Command{
+		Use:               "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
+		Short:             "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
+		Args:              IsExactArgs(2),
+		RunE:              tagAction,
+		ValidArgsFunction: tagShellComplete,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+	}
+	return tagCommand
+}
+
+func tagAction(cmd *cobra.Command, args []string) error {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return err
+	}
+	return image.Tag(cmd.Context(), types.ImageTagCommandOptions{
+		GOptions: globalOptions,
+		Source:   args[0],
+		Target:   args[1],
+	})
+}
+
+func tagShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) < 2 {
+		// show image names
+		return shellCompleteImageNames(cmd)
+	}
+	return nil, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -157,3 +157,12 @@ type ImagePushCommandOptions struct {
 	// AllowNondistributableArtifacts allow pushing non-distributable artifacts
 	AllowNondistributableArtifacts bool
 }
+
+type ImageTagCommandOptions struct {
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Source is the image to be referenced.
+	Source string
+	// Target is the image to be created.
+	Target string
+}


### PR DESCRIPTION
Part of https://github.com/containerd/nerdctl/issues/1680

- [x] Create a file in `pkg/api/types/${cmd}_types.go`, and define the CommandOption for this command
- [x] Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

Notes:

- Also renamed `cmd/nerdctl/tag.go` to `cmd/nerdctl/image_tag.go` because it's [the canonical name](https://github.com/containerd/nerdctl/pull/1836#discussion_r1068872873). Please let me know if it should be done in another PR instead.
- The field names of `ImageTagCommandOptions` (i.e., `Source` and `Target`) come from [the description of the command](https://github.com/containerd/nerdctl/blob/2fa1777ceef949786ff1f730c0ad8ef0c7670dc9/cmd/nerdctl/tag.go#L34).
- Noticed that `cmd/nerdctl/images.go` is [parsing the image references](https://github.com/containerd/nerdctl/blob/66be3c85133945c9f2a596d1e6c70c39680fa283/cmd/nerdctl/images.go#L77), but that should be because [the filters need to be created based on those references](https://github.com/containerd/nerdctl/blob/66be3c85133945c9f2a596d1e6c70c39680fa283/cmd/nerdctl/images.go#L81-L82) as it makes sense to let [`image.List()`](https://github.com/containerd/nerdctl/blob/66be3c85133945c9f2a596d1e6c70c39680fa283/cmd/nerdctl/images.go#L133) only accept filters as an uniformed interface. As a result, I left the image reference parsing code in `pkg/cmd/image/tag.go` instead.

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>