### PR TITLE
Fix: inspect multiple networks stops at first inspect fail

### DIFF
--- a/cmd/nerdctl/network_inspect.go
+++ b/cmd/nerdctl/network_inspect.go
@@ -56,7 +56,7 @@ func networkInspectAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return network.Inspect(types.NetworkInspectOptions{
+	return network.Inspect(cmd.Context(), types.NetworkInspectOptions{
 		GOptions: globalOptions,
 		Mode:     mode,
 		Format:   format,


### PR DESCRIPTION
n: aliased to sudo nerdctl
``` bash
 ~ n network ls                                         
NETWORK ID      NAME               FILE
                k8s-pod-network    /etc/cni/net.d/10-calico.conflist
44262d4ba0d3    58de8b120c68       /etc/cni/net.d/nerdctl-58de8b120c68.conflist
17f29b073143    bridge             /etc/cni/net.d/nerdctl-bridge.conflist
f9d6cec6deab    deleteme           /etc/cni/net.d/nerdctl-deleteme.conflist
58de8b120c68    nerdctl_default    /etc/cni/net.d/nerdctl-nerdctl_default.conflist
84584c571686    xiu_default        /etc/cni/net.d/nerdctl-xiu_default.conflist
                host               
                none 
```
## 1、Add the option to inspect a network by id

before:
``` bash
~ n network inspect f9d6cec6deab                                   
FATA[0000] no such network: f9d6cec6deab
```

after:
```bash
n network inspect f9d6cec6deab
[
    {
        "Name": "deleteme",
        "Id": "f9d6cec6deabf54691804bb7c1bf02ad7f461ab07f31a18398495b9de1cabf28",
        "IPAM": {
            "Config": [
                {
                    "Subnet": "10.10.11.0/24",
                    "Gateway": "10.10.11.1"
                }
            ]
        },
        "Labels": {}
    }
]
```

## 2、Fix: inspect multiple networks stops at first inspect fail

before:
```bash
n network inspect notfound bridge f9d6cec6deab k8s-pod-network notfound2
FATA[0000] no such network: notfound 
```
after:
```bash
n network inspect notfound bridge f9d6cec6deab k8s-pod-network notfound2
[
    {
        "Name": "bridge",
        "Id": "17f29b073143d8cd97b5bbe492bdeffec1c5fee55cc1fe2112c8b9335f8b6121",
        "IPAM": {
            "Config": [
                {
                    "Subnet": "10.4.0.0/24",
                    "Gateway": "10.4.0.1"
                }
            ]
        },
        "Labels": {}
    },
    {
        "Name": "deleteme",
        "Id": "f9d6cec6deabf54691804bb7c1bf02ad7f461ab07f31a18398495b9de1cabf28",
        "IPAM": {
            "Config": [
                {
                    "Subnet": "10.10.11.0/24",
                    "Gateway": "10.10.11.1"
                }
            ]
        },
        "Labels": {}
    },
    {
        "Name": "k8s-pod-network",
        "IPAM": {},
        "Labels": null
    }
]
ERRO[0000] No such network: notfound                    
ERRO[0000] No such network: notfound2
```
Signed-off-by: yaozhenxiu <946666800@qq.com>