### PR TITLE
[Refactor] Move getContainerNetNSPath from cmd to pkg/containerutil

### DIFF
--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/cmd/ctr/commands/tasks"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
@@ -212,7 +213,7 @@ func reconfigNetContainer(ctx context.Context, c containerd.Container, client *c
 		if err != nil {
 			return err
 		}
-		netNSPath, err := getContainerNetNSPath(ctx, targetCon)
+		netNSPath, err := containerutil.ContainerNetNSPath(ctx, targetCon)
 		if err != nil {
 			return err
 		}

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -68,3 +68,19 @@ func ContainerStatus(ctx context.Context, c containerd.Container) (containerd.St
 
 	return task.Status(ctx)
 }
+
+// ContainerNetNSPath returns the netns path of a container.
+func ContainerNetNSPath(ctx context.Context, c containerd.Container) (string, error) {
+	task, err := c.Task(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	status, err := task.Status(ctx)
+	if err != nil {
+		return "", err
+	}
+	if status.Status != containerd.Running {
+		return "", fmt.Errorf("invalid target container: %s, should be running", c.ID())
+	}
+	return fmt.Sprintf("/proc/%d/ns/net", task.Pid()), nil
+}


### PR DESCRIPTION
Splitting pr #1864 
Same with pr #1857, prepare for refactor the container start command.

Checklist:

- [x] Move getContainerNetNSPath from cmd to pkg/containerutil

Signed-off-by: Laitron <meetlq@outlook.com>