### PR TITLE
[VMware Photon OS] Add dbus-user-session related files

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -348,6 +348,12 @@ sudo apt-get install -y dbus-user-session
 systemctl --user start dbus
 ```
 
+To manually install the dbus-user-session files, consume them from:
+
+https://github.com/sshedi/nerdctl/tree/main/extras/dbus-user-session
+
+And do: `cp -pr extras/dbus-user-session/* /usr/lib/systemd/user/`
+
 ### How to uninstall ? / Can't remove `~/.local/share/containerd`
 
 Run the following commands:

--- a/extras/dbus-user-session/dbus.service
+++ b/extras/dbus-user-session/dbus.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=D-Bus User Message Bus
+Documentation=man:dbus-daemon(1)
+Requires=dbus.socket
+
+[Service]
+Type=notify
+NotifyAccess=main
+ExecStart=/usr/bin/dbus-daemon --session --address=systemd: --nofork --nopidfile --systemd-activation --syslog-only
+ExecReload=/usr/bin/dbus-send --print-reply --session --type=method_call --dest=org.freedesktop.DBus / org.freedesktop.DBus.ReloadConfig
+Slice=session.slice

--- a/extras/dbus-user-session/dbus.socket
+++ b/extras/dbus-user-session/dbus.socket
@@ -1,0 +1,6 @@
+[Unit]
+Description=D-Bus User Message Bus Socket
+
+[Socket]
+ListenStream=%t/bus
+ExecStartPost=-/bin/systemctl --user set-environment DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus

--- a/extras/dbus-user-session/sockets.target.wants/dbus.socket
+++ b/extras/dbus-user-session/sockets.target.wants/dbus.socket
@@ -1,0 +1,6 @@
+[Unit]
+Description=D-Bus User Message Bus Socket
+
+[Socket]
+ListenStream=%t/bus
+ExecStartPost=-/bin/systemctl --user set-environment DBUS_SESSION_BUS_ADDRESS=unix:path=%t/bus


### PR DESCRIPTION
In Photon OS or in Redhat derivatives, there is no dbus-user-session package. It is better to keep them in the repo and users can use these files on the need basis on cgroup v2 systems.

I have tested this on Photon OS with 6.x kernel and cgroup v2 enabled.

Update the FAQ for the same.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>