### PR TITLE
Update usage pattern for build

### DIFF
--- a/cmd/nerdctl/build.go
+++ b/cmd/nerdctl/build.go
@@ -33,7 +33,7 @@ import (
 
 func newBuildCommand() *cobra.Command {
 	var buildCommand = &cobra.Command{
-		Use:   "build [flags] PATH",
+		Use:   "build PATH [flags]",
 		Short: "Build an image from a Dockerfile. Needs buildkitd to be running.",
 		Long: `Build an image from a Dockerfile. Needs buildkitd to be running.
 If Dockerfile is not present and -f is not specified, it will look for Containerfile and build with it. `,


### PR DESCRIPTION
**Issue:** #1778 
The build usage pattern enables us in building and loading the image from the Dockerfile. If we put flags before the PATH likely `nerdctl build -f local.Dockerfile` then it will return an error. However, if we add PATH to the Dockerfile before the flags, it will run as expected. 

**Description of changes:**  
Adding the PATH to Dockerfile before the `[flags]` in the Build usage pattern. 

Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>