### PR TITLE
refactor: pass an io.Writer to image.List

### DIFF
--- a/cmd/nerdctl/images.go
+++ b/cmd/nerdctl/images.go
@@ -66,7 +66,7 @@ Properties:
 	return imagesCommand
 }
 
-func processImagesFlag(cmd *cobra.Command, args []string) (types.ImageListOptions, error) {
+func processImageListOptions(cmd *cobra.Command, args []string) (types.ImageListOptions, error) {
 	globalOptions, err := processRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageListOptions{}, err
@@ -118,12 +118,13 @@ func processImagesFlag(cmd *cobra.Command, args []string) (types.ImageListOption
 		Digests:          digests,
 		Names:            names,
 		All:              true,
+		Stdout:           cmd.OutOrStdout(),
 	}, nil
 
 }
 
 func imagesAction(cmd *cobra.Command, args []string) error {
-	options, err := processImagesFlag(cmd, args)
+	options, err := processImageListOptions(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -18,8 +18,9 @@ package types
 
 import "io"
 
-// ImageListOptions specifies options for `nerdctl image ls`.
+// ImageListOptions specifies options for `nerdctl image list`.
 type ImageListOptions struct {
+	Stdout io.Writer
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
 	// Quiet only show numeric IDs

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 	"text/tabwriter"
@@ -95,7 +94,7 @@ func List(ctx context.Context, options types.ImageListOptions) error {
 
 		imageList = imgutil.FilterImages(imageList, beforeImages, sinceImages)
 	}
-	return printImages(ctx, options, client, imageList)
+	return printImages(ctx, client, imageList, options)
 }
 
 func filterByReference(imageList []images.Image, filters []string) ([]images.Image, error) {
@@ -181,10 +180,9 @@ type imagePrintable struct {
 	Platform string // nerdctl extension
 }
 
-func printImages(ctx context.Context, options types.ImageListOptions, client *containerd.Client, imageList []images.Image) error {
+func printImages(ctx context.Context, client *containerd.Client, imageList []images.Image, options types.ImageListOptions) error {
+	w := options.Stdout
 	digestsFlag := options.Digests
-	var w io.Writer
-	w = os.Stdout
 	if options.Format == "wide" {
 		digestsFlag = true
 	}


### PR DESCRIPTION
Part of #1856

Also rearrange the parameter order of `printImages` (i.e., move `imageList` to be right after `ctx`) according to the reason stated in https://github.com/containerd/nerdctl/pull/1837#discussion_r1072461623.

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>