### PR TITLE
create service containers not detached by default

### DIFF
--- a/pkg/composer/serviceparser/build_test.go
+++ b/pkg/composer/serviceparser/build_test.go
@@ -54,6 +54,9 @@ services:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -65,6 +68,9 @@ services:
 	assert.NilError(t, err)
 
 	bar, err := Parse(project, barSvc)
+	for i := range bar.Containers {
+		bar.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("bar: %+v", foo)

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -462,7 +462,6 @@ func newContainer(project *types.Project, parsed *Service, i int) (*Container, e
 		c.Name = svc.ContainerName
 	}
 
-	c.Detached = true
 	c.RunArgs = []string{
 		"--name=" + c.Name,
 		"--pull=never", // because image will be ensured before running replicas with `nerdctl run`.

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -143,6 +143,9 @@ volumes:
 	assert.NilError(t, err)
 
 	wp, err := Parse(project, wpSvc)
+	for i := range wp.Containers {
+		wp.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("wordpress: %+v", wp)
@@ -176,6 +179,9 @@ volumes:
 	assert.NilError(t, err)
 
 	db, err := Parse(project, dbSvc)
+	for i := range db.Containers {
+		db.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("db: %+v", db)
@@ -211,6 +217,9 @@ services:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -268,6 +277,9 @@ services:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -285,6 +297,9 @@ services:
 	assert.NilError(t, err)
 
 	bar, err := Parse(project, barSvc)
+	for i := range bar.Containers {
+		bar.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("bar: %+v", bar)
@@ -299,6 +314,9 @@ services:
 	assert.NilError(t, err)
 
 	baz, err := Parse(project, bazSvc)
+	for i := range baz.Containers {
+		baz.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("baz: %+v", baz)
@@ -331,6 +349,9 @@ services:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -363,6 +384,9 @@ services:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -374,6 +398,9 @@ services:
 	assert.NilError(t, err)
 
 	bar, err := Parse(project, barSvc)
+	for i := range bar.Containers {
+		bar.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("bar: %+v", bar)
@@ -428,6 +455,9 @@ configs:
 	assert.NilError(t, err)
 
 	foo, err := Parse(project, fooSvc)
+	for i := range foo.Containers {
+		foo.Containers[i].Detached = true
+	}
 	assert.NilError(t, err)
 
 	t.Logf("foo: %+v", foo)
@@ -467,6 +497,9 @@ services:
 		svcConfig, err := project.GetService(svcName)
 		assert.NilError(t, err)
 		svc, err := Parse(project, svcConfig)
+		for i := range svc.Containers {
+			svc.Containers[i].Detached = true
+		}
 		assert.NilError(t, err)
 
 		return svc.Containers


### PR DESCRIPTION
Fixes #1879

service parsing uses a utility function `newContainer` to create container objects. `compose up` and `compose run` are meant to create containers as not detached by default, but this function was explicitly setting the detached option on new containers to true, causing stderr IO from issues in `compose up` to be suppressed.

Signed-off-by: Gavin Inglis <giinglis@amazon.com>

compose up using example docker-compose.yaml from #1879 :

```
sudo nerdctl compose up
WARN[0000] Ignoring: volume: Bind: [CreateHostPath]
INFO[0000] Ensuring image alpine
INFO[0000] Re-creating container nerdctl_db_1
FATA[0000] failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/ho
me/ec2-user/nerdctl/nonexist/folder" to rootfs at "/var/lib/postgresql/db": stat /home/ec2-user/nerdctl/nonexist/folder: no such file or directory: unknown
FATA[0000] error while creating container nerdctl_db_1: exit status 1
```

compose run using example docker-compose.yaml from #1879 :

```
$ sudo nerdctl compose run db
WARN[0000] Ignoring: volume: Bind: [CreateHostPath]
INFO[0000] Ensuring image alpine
INFO[0000] Creating container nerdctl_db_run_2bba37ce5184
FATA[0000] failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/ec2-user/nerdctl/nonexist/folder" to rootfs at "/var/lib/postgresql/db": stat /home/ec2-user/nerdctl/nonexist/folder: no such file or directory: unknown
FATA[0000] error while creating container nerdctl_db_run_2bba37ce5184: exit status 1
```