### PR TITLE
refactor: move updateContainerStoppedLabel to containerutil

### DIFF
--- a/cmd/nerdctl/run_restart.go
+++ b/cmd/nerdctl/run_restart.go
@@ -19,7 +19,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/containerd/containerd"
@@ -68,13 +67,6 @@ func generateRestartOpts(ctx context.Context, client *containerd.Client, restart
 		opts = append(opts, restart.WithLogURIString(logURI))
 	}
 	return opts, nil
-}
-
-func updateContainerStoppedLabel(ctx context.Context, container containerd.Container, stopped bool) error {
-	opt := containerd.WithAdditionalContainerLabels(map[string]string{
-		restart.ExplicitlyStoppedLabel: strconv.FormatBool(stopped),
-	})
-	return container.Update(ctx, containerd.UpdateContainerOpts(opt))
 }
 
 func updateContainerRestartPolicyLabel(ctx context.Context, client *containerd.Client, container containerd.Container, restartFlag string) error {

--- a/cmd/nerdctl/start.go
+++ b/cmd/nerdctl/start.go
@@ -144,7 +144,7 @@ func startContainer(ctx context.Context, container containerd.Container, flagA b
 		logrus.Warnf("container %s is already running", container.ID())
 		return nil
 	}
-	if err := updateContainerStoppedLabel(ctx, container, false); err != nil {
+	if err := containerutil.UpdateExplicitlyStoppedLabel(ctx, container, false); err != nil {
 		return err
 	}
 	if oldTask, err := container.Task(ctx, nil); err == nil {

--- a/cmd/nerdctl/stop.go
+++ b/cmd/nerdctl/stop.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/containerd"
@@ -98,7 +99,7 @@ func stopAction(cmd *cobra.Command, args []string) error {
 }
 
 func stopContainer(ctx context.Context, container containerd.Container, timeout *time.Duration) error {
-	if err := updateContainerStoppedLabel(ctx, container, true); err != nil {
+	if err := containerutil.UpdateExplicitlyStoppedLabel(ctx, container, true); err != nil {
 		return err
 	}
 

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/runtime/restart"
 	"github.com/containerd/nerdctl/pkg/portutil"
 )
 
@@ -83,4 +85,13 @@ func ContainerNetNSPath(ctx context.Context, c containerd.Container) (string, er
 		return "", fmt.Errorf("invalid target container: %s, should be running", c.ID())
 	}
 	return fmt.Sprintf("/proc/%d/ns/net", task.Pid()), nil
+}
+
+// UpdateExplicitlyStoppedLabel updates the "containerd.io/restart.explicitly-stopped"
+// label of the container according to the value of explicitlyStopped.
+func UpdateExplicitlyStoppedLabel(ctx context.Context, container containerd.Container, explicitlyStopped bool) error {
+	opt := containerd.WithAdditionalContainerLabels(map[string]string{
+		restart.ExplicitlyStoppedLabel: strconv.FormatBool(explicitlyStopped),
+	})
+	return container.Update(ctx, containerd.UpdateContainerOpts(opt))
 }


### PR DESCRIPTION
PR is a blocker of refactoring `container stop` and `container start` as part of #1680.

Thought process:

1. I removed `Container` from the function name to [avoid stuttering](https://stackoverflow.com/a/45886055) with the package name (i.e., `containerutil`). Also, one of the parameters is `container containerd.Container`, so the semantics should be already clear.
2. I noticed that `stopped bool` is a bit misleading as it seems to say whether the container is stopped, but the point is to convey whether the container is *explicitly* stopped so that containerd can decide if the container should be restarted. As a result, I renamed the parameter and the function accordingly.

Please let me know if I should do this in a follow-up PR instead, or it just doesn't make sense and shouldn't be done at all, thanks!

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>