### PR TITLE
[Refactor] move withBindMountHostProcfs from cmd to pkg/containerutil.

### DIFF
--- a/cmd/nerdctl/run_linux.go
+++ b/cmd/nerdctl/run_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/bypass4netnsutil"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
@@ -280,7 +281,7 @@ func generatePIDOpts(ctx context.Context, client *containerd.Client, pid string)
 	case "host":
 		opts = append(opts, oci.WithHostNamespace(specs.PIDNamespace))
 		if rootlessutil.IsRootless() {
-			opts = append(opts, withBindMountHostProcfs)
+			opts = append(opts, containerutil.WithBindMountHostProcfs)
 		}
 	default: // container:<id|name>
 		parsed := strings.Split(pid, ":")

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -20,13 +20,17 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/runtime/restart"
 	"github.com/containerd/nerdctl/pkg/portutil"
+	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // PrintHostPort writes to `writer` the public (HostIP:HostPort) of a given `containerPort/protocol` in a container.
@@ -94,4 +98,34 @@ func UpdateExplicitlyStoppedLabel(ctx context.Context, container containerd.Cont
 		restart.ExplicitlyStoppedLabel: strconv.FormatBool(explicitlyStopped),
 	})
 	return container.Update(ctx, containerd.UpdateContainerOpts(opt))
+}
+
+// WithBindMountHostProcfs replaces procfs mount with rbind.
+// Required for --pid=host on rootless.
+//
+// https://github.com/moby/moby/pull/41893/files
+// https://github.com/containers/podman/blob/v3.0.0-rc1/pkg/specgen/generate/oci.go#L248-L257
+func WithBindMountHostProcfs(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+	for i, m := range s.Mounts {
+		if path.Clean(m.Destination) == "/proc" {
+			newM := specs.Mount{
+				Destination: "/proc",
+				Type:        "bind",
+				Source:      "/proc",
+				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
+			}
+			s.Mounts[i] = newM
+		}
+	}
+
+	// Remove ReadonlyPaths for /proc/*
+	newROP := s.Linux.ReadonlyPaths[:0]
+	for _, x := range s.Linux.ReadonlyPaths {
+		x = path.Clean(x)
+		if !strings.HasPrefix(x, "/proc/") {
+			newROP = append(newROP, x)
+		}
+	}
+	s.Linux.ReadonlyPaths = newROP
+	return nil
 }


### PR DESCRIPTION
Splitting pr #1864 
Same with pr #1857, prepare for refactor the container start command.

Checklist:

- [x] Move withBindMountHostProcfs from cmd to pkg/containerutil

Signed-off-by: Laitron <meetlq@outlook.com>