### PR TITLE
cmd/nerdctl: withBindMountHostIPC: slight refactor

### DIFF
--- a/cmd/nerdctl/run.go
+++ b/cmd/nerdctl/run.go
@@ -901,23 +901,14 @@ func generateRootfsOpts(ctx context.Context, client *containerd.Client, platform
 // Required for --ipc=host on rootless.
 func withBindMountHostIPC(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
 	for i, m := range s.Mounts {
-		if path.Clean(m.Destination) == "/dev/shm" {
-			newM := specs.Mount{
-				Destination: "/dev/shm",
+		switch p := path.Clean(m.Destination); p {
+		case "/dev/shm", "/dev/mqueue":
+			s.Mounts[i] = specs.Mount{
+				Destination: p,
 				Type:        "bind",
-				Source:      "/dev/shm",
+				Source:      p,
 				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
 			}
-			s.Mounts[i] = newM
-		}
-		if path.Clean(m.Destination) == "/dev/mqueue" {
-			newM := specs.Mount{
-				Destination: "/dev/mqueue",
-				Type:        "bind",
-				Source:      "/dev/mqueue",
-				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
-			}
-			s.Mounts[i] = newM
 		}
 	}
 	return nil


### PR DESCRIPTION
porting the changes from https://github.com/moby/moby/pull/44852

Use a switch so that path.Clean() is not called repeatedly, and unify the implementation for both mount paths.
