### PR TITLE
[Refactor] refactor commit flagging process

### DIFF
--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -51,3 +51,18 @@ type ContainerInspectOptions struct {
 	// Containers are the containers to be inspected
 	Containers []string
 }
+
+// ContainerCommitOptions specifies options for `nerdctl (container) commit`.
+type ContainerCommitOptions struct {
+	Stdout io.Writer
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Author (e.g., "nerdctl contributor <nerdctl-dev@example.com>")
+	Author string
+	// Commit message
+	Message string
+	// Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])
+	Change []string
+	// Pause container during commit
+	Pause bool
+}

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -1,0 +1,121 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/pkg/imgutil/commit"
+	"github.com/containerd/nerdctl/pkg/referenceutil"
+	"github.com/sirupsen/logrus"
+)
+
+// Commit will commit a container’s file changes or settings into a new image.
+func Commit(ctx context.Context, rawRef string, req string, options types.ContainerCommitOptions) error {
+	named, err := referenceutil.ParseDockerRef(rawRef)
+	if err != nil {
+		return err
+	}
+
+	changes, err := parseChanges(options.Change)
+	if err != nil {
+		return err
+	}
+
+	opts := &commit.Opts{
+		Author:  options.Author,
+		Message: options.Message,
+		Ref:     named.String(),
+		Pause:   options.Pause,
+		Changes: changes,
+	}
+	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			imageID, err := commit.Commit(ctx, client, found.Container, opts)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(options.Stdout, "%s\n", imageID)
+			return err
+		},
+	}
+	n, err := walker.Walk(ctx, req)
+	if err != nil {
+		return err
+	} else if n == 0 {
+		return fmt.Errorf("no such container %s", req)
+	}
+	return nil
+}
+
+func parseChanges(userChanges []string) (commit.Changes, error) {
+	const (
+		// XXX: Where can I get a constants for this?
+		commandDirective    = "CMD"
+		entrypointDirective = "ENTRYPOINT"
+	)
+	if userChanges == nil {
+		return commit.Changes{}, nil
+	}
+	var changes commit.Changes
+	for _, change := range userChanges {
+		if change == "" {
+			return commit.Changes{}, fmt.Errorf("received an empty value in change flag")
+		}
+		changeFields := strings.Fields(change)
+
+		switch changeFields[0] {
+		case commandDirective:
+			var overrideCMD []string
+			if err := json.Unmarshal([]byte(change[len(changeFields[0]):]), &overrideCMD); err != nil {
+				return commit.Changes{}, fmt.Errorf("malformed json in change flag value %q", change)
+			}
+			if changes.CMD != nil {
+				logrus.Warn("multiple change flags supplied for the CMD directive, overriding with last supplied")
+			}
+			changes.CMD = overrideCMD
+		case entrypointDirective:
+			var overrideEntrypoint []string
+			if err := json.Unmarshal([]byte(change[len(changeFields[0]):]), &overrideEntrypoint); err != nil {
+				return commit.Changes{}, fmt.Errorf("malformed json in change flag value %q", change)
+			}
+			if changes.Entrypoint != nil {
+				logrus.Warnf("multiple change flags supplied for the Entrypoint directive, overriding with last supplied")
+			}
+			changes.Entrypoint = overrideEntrypoint
+		default: // TODO: Support the rest of the change directives
+			return commit.Changes{}, fmt.Errorf("unknown change directive %q", changeFields[0])
+		}
+	}
+	return changes, nil
+}


### PR DESCRIPTION
part of #1680 

Checklist:

* [x]  Create a file in `pkg/api/types/${cmd}_types.go`, and define the CommandOption for this command
* [x]  Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

Signed-off-by: suyanhanx <suyanhanx@gmail.com>