### PR TITLE
[Refactor] refactor container restart flagging process

### DIFF
--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -51,11 +51,12 @@ type ContainerStopOptions struct {
 	Timeout *time.Duration
 }
 
-// ContainerTopOptions specifies options for `nerdctl top`.
-type ContainerTopOptions struct {
-	Stdout io.Writer
-	// GOptions is the global options
-	GOptions GlobalCommandOptions
+// ContainerRestartOptions specifies options for `nerdctl (container) restart`.
+type ContainerRestartOptions struct {
+	Stdout  io.Writer
+	GOption GlobalCommandOptions
+	// Time to wait after sending a SIGTERM and before sending a SIGKILL.
+	Timeout *time.Duration
 }
 
 // ContainerRemoveOptions specifies options for `nerdctl (container) rm`.
@@ -67,6 +68,13 @@ type ContainerRemoveOptions struct {
 	Force bool
 	// Volumes removes anonymous volumes associated with the container
 	Volumes bool
+}
+
+// ContainerTopOptions specifies options for `nerdctl top`.
+type ContainerTopOptions struct {
+	Stdout io.Writer
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
 }
 
 // ContainerInspectOptions specifies options for `nerdctl container inspect`

--- a/pkg/cmd/container/restart.go
+++ b/pkg/cmd/container/restart.go
@@ -1,0 +1,57 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+)
+
+// Restart will restart one or more containers.
+func Restart(ctx context.Context, client *containerd.Client, containers []string, options types.ContainerRestartOptions) error {
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			if err := containerutil.Stop(ctx, found.Container, options.Timeout); err != nil {
+				return err
+			}
+			if err := containerutil.Start(ctx, found.Container, false, client); err != nil {
+				return err
+			}
+			_, err := fmt.Fprintf(options.Stdout, "%s\n", found.Req)
+			return err
+		},
+	}
+	for _, req := range containers {
+		n, err := walker.Walk(ctx, req)
+		if err != nil {
+			return err
+		} else if n == 0 {
+			return fmt.Errorf("no such container %s", req)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
part of #1680 

Checklist:

* [x]  Create a file in `pkg/api/types/${cmd}_types.go`, and define the CommandOption for this command
* [x]  Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

waiting for the finish of
- #1864 
- #1896 

Signed-off-by: suyanhanx <suyanhanx@gmail.com>