### PR TITLE
[Refactor] add comment for api types

### DIFF
--- a/pkg/api/types/apparmor_types.go
+++ b/pkg/api/types/apparmor_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// ApparmorListCommandOptions specifies options for `nerdctl apparmor ls`.
 type ApparmorListCommandOptions struct {
 	// Only display profile names
 	Quiet bool

--- a/pkg/api/types/build_types.go
+++ b/pkg/api/types/build_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// BuildCommandOptions specifies options for `nerdctl (image/builder) build`.
 type BuildCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -16,7 +16,7 @@
 
 package types
 
-// KillCommandOptions specifies options for `nerdctl kill`.
+// KillCommandOptions specifies options for `nerdctl (container) kill`.
 type KillCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// ImageListCommandOptions specifies options for `nerdctl image ls`.
 type ImageListCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -37,6 +38,7 @@ type ImageListCommandOptions struct {
 	All bool
 }
 
+// ImageConvertCommandOptions specifies options for `nerdctl image convert`.
 type ImageConvertCommandOptions struct {
 	GOptions GlobalCommandOptions
 
@@ -109,6 +111,7 @@ type ImageConvertCommandOptions struct {
 
 }
 
+// ImageCryptCommandOptions specifies options for `nerdctl image encrypt` and `nerdctl image decrypt`.
 type ImageCryptCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Platforms convert content for a specific platform
@@ -127,6 +130,7 @@ type ImageCryptCommandOptions struct {
 	Recipients []string
 }
 
+// ImageInspectCommandOptions specifies options for `nerdctl image inspect`.
 type ImageInspectCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Mode Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output
@@ -137,6 +141,7 @@ type ImageInspectCommandOptions struct {
 	Platform string
 }
 
+// ImagePushCommandOptions specifies options for `nerdctl (image) push`.
 type ImagePushCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Platforms convert content for a specific platform
@@ -158,6 +163,7 @@ type ImagePushCommandOptions struct {
 	AllowNondistributableArtifacts bool
 }
 
+// ImageTagCommandOptions specifies options for `nerdctl (image) tag`.
 type ImageTagCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions

--- a/pkg/api/types/info_types.go
+++ b/pkg/api/types/info_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// InfoCommandOptions specifies options for `nerdctl (system) info`.
 type InfoCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions

--- a/pkg/api/types/load_types.go
+++ b/pkg/api/types/load_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// LoadCommandOptions specifies options for `nerdctl (image) load`.
 type LoadCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Input read from tar archive file, instead of STDIN

--- a/pkg/api/types/namespace_types.go
+++ b/pkg/api/types/namespace_types.go
@@ -16,20 +16,24 @@
 
 package types
 
+// NamespaceCreateCommandOptions specifies options for `nerdctl namespace create`.
 type NamespaceCreateCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Labels are the namespace labels
 	Labels []string
 }
 
+// NamespaceUpdateCommandOptions specifies options for `nerdctl namespace update`.
 type NamespaceUpdateCommandOptions NamespaceCreateCommandOptions
 
+// NamespaceRemoveCommandOptions specifies options for `nerdctl namespace rm`.
 type NamespaceRemoveCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// CGroup delete the namespace's cgroup
 	CGroup bool
 }
 
+// NamespaceInspectCommandOptions specifies options for `nerdctl namespace inspect`.
 type NamespaceInspectCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Format the output using the given Go template, e.g, '{{json .}}'

--- a/pkg/api/types/network_types.go
+++ b/pkg/api/types/network_types.go
@@ -18,7 +18,7 @@ package types
 
 import "github.com/containerd/nerdctl/pkg/netutil"
 
-// NetworkCreateCommandOptions specifies options for nerdctl network create
+// NetworkCreateCommandOptions specifies options for `nerdctl network create`.
 type NetworkCreateCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -26,7 +26,7 @@ type NetworkCreateCommandOptions struct {
 	CreateOptions netutil.CreateOptions
 }
 
-// NetworkCreateCommandOptions specifies options for nerdctl network inspect
+// NetworkInspectCommandOptions specifies options for `nerdctl network inspect`.
 type NetworkInspectCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -38,7 +38,7 @@ type NetworkInspectCommandOptions struct {
 	Networks []string
 }
 
-// NetworkCreateCommandOptions specifies options for nerdctl network ls
+// NetworkListCommandOptions specifies options for `nerdctl network ls`.
 type NetworkListCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -48,7 +48,7 @@ type NetworkListCommandOptions struct {
 	Format string
 }
 
-// NetworkCreateCommandOptions specifies options for nerdctl network prune
+// NetworkPruneCommandOptions specifies options for `nerdctl network prune`.
 type NetworkPruneCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
@@ -56,7 +56,7 @@ type NetworkPruneCommandOptions struct {
 	NetworkDriversToKeep []string
 }
 
-// NetworkCreateCommandOptions specifies options for nerdctl network rm
+// NetworkRemoveCommandOptions specifies options for `nerdctl network rm`.
 type NetworkRemoveCommandOptions struct {
 	// GOptions is the global options
 	GOptions GlobalCommandOptions

--- a/pkg/api/types/pull_types.go
+++ b/pkg/api/types/pull_types.go
@@ -16,6 +16,7 @@
 
 package types
 
+// PullCommandOptions specifies options for `nerdctl (image) pull`.
 type PullCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Unpack the image for the current single platform (auto/true/false)

--- a/pkg/api/types/volume_types.go
+++ b/pkg/api/types/volume_types.go
@@ -16,12 +16,14 @@
 
 package types
 
+// VolumeCreateCommandOptions specifies options for `nerdctl volume create`.
 type VolumeCreateCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Labels are the volume labels
 	Labels []string
 }
 
+// VolumeInspectCommandOptions specifies options for `nerdctl volume inspect`.
 type VolumeInspectCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Format the output using the given go template
@@ -30,6 +32,7 @@ type VolumeInspectCommandOptions struct {
 	Size bool
 }
 
+// VolumeListCommandOptions specifies options for `nerdctl volume ls`.
 type VolumeListCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Only display volume names
@@ -42,12 +45,14 @@ type VolumeListCommandOptions struct {
 	Filters []string
 }
 
+// VolumePruneCommandOptions specifies options for `nerdctl volume prune`.
 type VolumePruneCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Do not prompt for confirmation
 	Force bool
 }
 
+// VolumeRemoveCommandOptions specifies options for `nerdctl volume rm`.
 type VolumeRemoveCommandOptions struct {
 	GOptions GlobalCommandOptions
 	// Force the removal of one or more volumes


### PR DESCRIPTION
part of #1680 

There are many options struct missing comments.
This PR fixes `export struct lack comment` in those existing files and some typos.

Signed-off-by: suyanhanx <suyanhanx@gmail.com>