### PR TITLE
mv pkg/cmd/info/info.go pkg/cmd/system/info.go

### DIFF
--- a/cmd/nerdctl/info.go
+++ b/cmd/nerdctl/info.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/cmd/info"
+	"github.com/containerd/nerdctl/pkg/cmd/system"
 	"github.com/spf13/cobra"
 )
 
@@ -70,5 +70,5 @@ func infoAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return info.Info(cmd.Context(), options)
+	return system.Info(cmd.Context(), options)
 }

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package info
+package system
 
 import (
 	"context"


### PR DESCRIPTION
As the canonical form of `nerdctl info` is `nerdctl system info`.
