### PR TITLE
[Refactor] Refactor the new client outside pkg/cmd.

### DIFF
--- a/cmd/nerdctl/builder_build.go
+++ b/cmd/nerdctl/builder_build.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/builder"
 	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/strutil"
@@ -198,7 +199,14 @@ func buildAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := builder.Build(cmd.Context(), options); err != nil {
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	if err := builder.Build(ctx, client, options); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/nerdctl/container_commit.go
+++ b/cmd/nerdctl/container_commit.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
@@ -78,7 +79,14 @@ func commitAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return container.Commit(cmd.Context(), args[1], args[0], options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Commit(ctx, client, args[1], args[0], options)
 }
 
 func commitShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/container_kill.go
+++ b/cmd/nerdctl/container_kill.go
@@ -19,6 +19,7 @@ package main
 import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
@@ -46,12 +47,20 @@ func killAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return container.Kill(cmd.Context(), args, types.KillOptions{
+	options := types.KillOptions{
 		GOptions:   globalOptions,
 		KillSignal: killSignal,
 		Stdout:     cmd.OutOrStdout(),
 		Stderr:     cmd.ErrOrStderr(),
-	})
+	}
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Kill(ctx, client, args, options)
 }
 
 func killShellComplete(cmd *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/container_logs.go
+++ b/cmd/nerdctl/container_logs.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
@@ -92,7 +93,14 @@ func logsAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return container.Logs(cmd.Context(), args[0], options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Logs(ctx, client, args[0], options)
 }
 
 func logsShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/container_remove.go
+++ b/cmd/nerdctl/container_remove.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
@@ -50,12 +51,20 @@ func rmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return container.Remove(cmd.Context(), args, types.ContainerRemoveOptions{
+	options := types.ContainerRemoveOptions{
 		GOptions: globalOptions,
 		Force:    force,
 		Volumes:  removeAnonVolumes,
 		Stdout:   cmd.OutOrStdout(),
-	})
+	}
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Remove(ctx, client, args, options)
 }
 
 func rmShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/container_stop.go
+++ b/cmd/nerdctl/container_stop.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
@@ -66,7 +67,14 @@ func stopAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return container.Stop(cmd.Context(), args, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Stop(ctx, client, args, options)
 }
 
 func stopShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image_convert.go
+++ b/cmd/nerdctl/image_convert.go
@@ -20,6 +20,7 @@ import (
 	"compress/gzip"
 
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -263,7 +264,14 @@ func imageConvertAction(cmd *cobra.Command, args []string) error {
 	}
 	srcRawRef := args[0]
 	destRawRef := args[1]
-	return image.Convert(cmd.Context(), srcRawRef, destRawRef, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Convert(ctx, client, srcRawRef, destRawRef, options)
 }
 
 func imageConvertShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image_cryptutil.go
+++ b/cmd/nerdctl/image_cryptutil.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -108,7 +109,14 @@ func getImgcryptAction(encrypt bool) func(cmd *cobra.Command, args []string) err
 		}
 		srcRawRef := args[0]
 		targetRawRef := args[1]
-		return image.Crypt(cmd.Context(), srcRawRef, targetRawRef, encrypt, options)
+
+		client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
+		return image.Crypt(ctx, client, srcRawRef, targetRawRef, encrypt, options)
 	}
 }
 

--- a/cmd/nerdctl/image_list.go
+++ b/cmd/nerdctl/image_list.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
 	"github.com/spf13/cobra"
@@ -131,7 +132,14 @@ func imagesAction(cmd *cobra.Command, args []string) error {
 	if !options.All {
 		options.All = true
 	}
-	return image.List(cmd.Context(), options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.List(ctx, client, options)
 }
 
 func imagesShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image_load.go
+++ b/cmd/nerdctl/image_load.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -77,5 +78,12 @@ func loadAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return image.Load(cmd.Context(), options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Load(ctx, client, options)
 }

--- a/cmd/nerdctl/image_pull.go
+++ b/cmd/nerdctl/image_pull.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -107,10 +108,16 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 }
 
 func pullAction(cmd *cobra.Command, args []string) error {
-	var pullOptions, err = processPullCommandFlags(cmd)
+	options, err := processPullCommandFlags(cmd)
 	if err != nil {
 		return err
 	}
 
-	return image.Pull(cmd.Context(), args[0], pullOptions)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Pull(ctx, client, args[0], options)
 }

--- a/cmd/nerdctl/image_push.go
+++ b/cmd/nerdctl/image_push.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -117,7 +118,14 @@ func pushAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	rawRef := args[0]
-	return image.Push(cmd.Context(), rawRef, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Push(ctx, client, rawRef, options)
 }
 
 func pushShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image_remove.go
+++ b/cmd/nerdctl/image_remove.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -67,7 +68,13 @@ func rmiAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return image.Remove(cmd.Context(), args, options)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Remove(ctx, client, args, options)
 }
 
 func rmiShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image_tag.go
+++ b/cmd/nerdctl/image_tag.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 
 	"github.com/spf13/cobra"
@@ -41,11 +42,20 @@ func tagAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return image.Tag(cmd.Context(), types.ImageTagOptions{
+
+	options := types.ImageTagOptions{
 		GOptions: globalOptions,
 		Source:   args[0],
 		Target:   args[1],
-	})
+	}
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Tag(ctx, client, options)
 }
 
 func tagShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/namespace_create.go
+++ b/cmd/nerdctl/namespace_create.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/namespace"
 	"github.com/spf13/cobra"
 )
@@ -56,5 +57,12 @@ func namespaceCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return namespace.Create(cmd.Context(), args[0], options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return namespace.Create(ctx, client, args[0], options)
 }

--- a/cmd/nerdctl/namespace_inspect.go
+++ b/cmd/nerdctl/namespace_inspect.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/namespace"
 	"github.com/spf13/cobra"
 )
@@ -59,5 +60,12 @@ func labelInspectAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return namespace.Inspect(cmd.Context(), args, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return namespace.Inspect(ctx, client, args, options)
 }

--- a/cmd/nerdctl/namespace_remove.go
+++ b/cmd/nerdctl/namespace_remove.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/namespace"
 	"github.com/spf13/cobra"
 )
@@ -57,5 +58,12 @@ func namespaceRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return namespace.Remove(cmd.Context(), args, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return namespace.Remove(ctx, client, args, options)
 }

--- a/cmd/nerdctl/namespace_update.go
+++ b/cmd/nerdctl/namespace_update.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/namespace"
 	"github.com/spf13/cobra"
 )
@@ -55,5 +56,12 @@ func labelUpdateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return namespace.Update(cmd.Context(), args[0], options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return namespace.Update(ctx, client, args[0], options)
 }

--- a/cmd/nerdctl/network_prune.go
+++ b/cmd/nerdctl/network_prune.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/network"
 	"github.com/spf13/cobra"
 )
@@ -67,5 +68,12 @@ func networkPruneAction(cmd *cobra.Command, _ []string) error {
 		NetworkDriversToKeep: networkDriversToKeep,
 		Stdout:               cmd.OutOrStdout(),
 	}
-	return network.Prune(cmd.Context(), options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return network.Prune(ctx, client, options)
 }

--- a/cmd/nerdctl/network_remove.go
+++ b/cmd/nerdctl/network_remove.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/network"
 	"github.com/containerd/nerdctl/pkg/netutil"
 
@@ -44,11 +45,20 @@ func networkRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return network.Remove(cmd.Context(), types.NetworkRemoveOptions{
+
+	options := types.NetworkRemoveOptions{
 		GOptions: globalOptions,
 		Networks: args,
 		Stdout:   cmd.OutOrStdout(),
-	})
+	}
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return network.Remove(ctx, client, options)
 }
 
 func networkRmShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/system_info.go
+++ b/cmd/nerdctl/system_info.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/system"
 	"github.com/spf13/cobra"
 )
@@ -70,5 +71,12 @@ func infoAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return system.Info(cmd.Context(), options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return system.Info(ctx, client, options)
 }

--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -104,7 +104,7 @@ func systemPruneAction(cmd *cobra.Command, args []string) error {
 	if err := containerPrune(ctx, cmd, client, globalOptions); err != nil {
 		return err
 	}
-	if err := network.Prune(ctx, types.NetworkPruneOptions{
+	if err := network.Prune(ctx, client, types.NetworkPruneOptions{
 		GOptions:             globalOptions,
 		NetworkDriversToKeep: networkDriversToKeep,
 		Stdout:               cmd.OutOrStdout(),
@@ -112,7 +112,7 @@ func systemPruneAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if vFlag {
-		if err := volume.Prune(ctx, types.VolumePruneOptions{
+		if err := volume.Prune(ctx, client, types.VolumePruneOptions{
 			GOptions: globalOptions,
 			Force:    true,
 			Stdout:   cmd.OutOrStdout(),

--- a/cmd/nerdctl/volume_prune.go
+++ b/cmd/nerdctl/volume_prune.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/spf13/cobra"
 )
@@ -58,5 +59,12 @@ func volumePruneAction(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return volume.Prune(cmd.Context(), options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return volume.Prune(ctx, client, options)
 }

--- a/cmd/nerdctl/volume_remove.go
+++ b/cmd/nerdctl/volume_remove.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/spf13/cobra"
 )
@@ -59,7 +60,14 @@ func volumeRmAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return volume.Remove(cmd.Context(), args, options)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return volume.Remove(ctx, client, args, options)
 }
 
 func volumeRmShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/imgutil/commit"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
@@ -31,7 +31,7 @@ import (
 )
 
 // Commit will commit a container’s file changes or settings into a new image.
-func Commit(ctx context.Context, rawRef string, req string, options types.ContainerCommitOptions) error {
+func Commit(ctx context.Context, client *containerd.Client, rawRef string, req string, options types.ContainerCommitOptions) error {
 	named, err := referenceutil.ParseDockerRef(rawRef)
 	if err != nil {
 		return err
@@ -49,11 +49,6 @@ func Commit(ctx context.Context, rawRef string, req string, options types.Contai
 		Pause:   options.Pause,
 		Changes: changes,
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	walker := &containerwalker.ContainerWalker{
 		Client: client,

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -27,13 +27,13 @@ import (
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/moby/sys/signal"
 	"github.com/sirupsen/logrus"
 )
 
-func Kill(ctx context.Context, reqs []string, options types.KillOptions) error {
+// Kill kills a list of containers
+func Kill(ctx context.Context, client *containerd.Client, reqs []string, options types.KillOptions) error {
 	if !strings.HasPrefix(options.KillSignal, "SIG") {
 		options.KillSignal = "SIG" + options.KillSignal
 	}
@@ -42,11 +42,6 @@ func Kill(ctx context.Context, reqs []string, options types.KillOptions) error {
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	walker := &containerwalker.ContainerWalker{
 		Client: client,

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -34,7 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Logs(ctx context.Context, container string, options types.ContainerLogsOptions) error {
+func Logs(ctx context.Context, client *containerd.Client, container string, options types.ContainerLogsOptions) error {
 	dataStore, err := clientutil.DataStore(options.GOptions.DataRoot, options.GOptions.Address)
 	if err != nil {
 		return err
@@ -44,11 +44,6 @@ func Logs(ctx context.Context, container string, options types.ContainerLogsOpti
 	case "moby":
 		logrus.Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d` or CRI")
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	stopChannel := make(chan os.Signal, 1)
 	// catch OS signals:

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -60,13 +60,7 @@ func NewStatusError(id string, status containerd.ProcessStatus) error {
 }
 
 // Remove removes a list of `containers`.
-func Remove(ctx context.Context, containers []string, options types.ContainerRemoveOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Remove(ctx context.Context, client *containerd.Client, containers []string, options types.ContainerRemoveOptions) error {
 	walker := &containerwalker.ContainerWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found containerwalker.Found) error {
@@ -79,7 +73,7 @@ func Remove(ctx context.Context, containers []string, options types.ContainerRem
 				}
 				return err
 			}
-			_, err = fmt.Fprintf(options.Stdout, "%s\n", found.Req)
+			_, err := fmt.Fprintf(options.Stdout, "%s\n", found.Req)
 			return err
 		},
 	}

--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -20,20 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
-func Stop(ctx context.Context, reqs []string, opt types.ContainerStopOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, opt.GOptions.Namespace, opt.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt types.ContainerStopOptions) error {
 	walker := &containerwalker.ContainerWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found containerwalker.Found) error {

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	overlaybdconvert "github.com/containerd/accelerated-container-image/pkg/convertor"
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
@@ -46,7 +47,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Convert(ctx context.Context, srcRawRef, targetRawRef string, options types.ImageConvertOptions) error {
+func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, options types.ImageConvertOptions) error {
 	var (
 		convertOpts = []converter.Opt{}
 	)
@@ -72,11 +73,6 @@ func Convert(ctx context.Context, srcRawRef, targetRawRef string, options types.
 	}
 	convertOpts = append(convertOpts, converter.WithPlatform(platMC))
 
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 	estargz := options.Estargz
 	zstdchunked := options.ZstdChunked
 	overlaybd := options.Overlaybd

--- a/pkg/cmd/image/crypt.go
+++ b/pkg/cmd/image/crypt.go
@@ -21,18 +21,18 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/imgcrypt/images/encryption"
 	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-func Crypt(ctx context.Context, srcRawRef, targetRawRef string, encrypt bool, options types.ImageCryptOptions) error {
+func Crypt(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, encrypt bool, options types.ImageCryptOptions) error {
 	var convertOpts = []converter.Opt{}
 	if srcRawRef == "" || targetRawRef == "" {
 		return errors.New("src and target image need to be specified")
@@ -60,11 +60,6 @@ func Crypt(ctx context.Context, srcRawRef, targetRawRef string, encrypt bool, op
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	srcImg, err := client.ImageService().Get(ctx, srcRef)
 	if err != nil {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -37,7 +37,6 @@ import (
 	dockerreference "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/opencontainers/image-spec/identity"
@@ -45,13 +44,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func List(ctx context.Context, options types.ImageListOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func List(ctx context.Context, client *containerd.Client, options types.ImageListOptions) error {
 	var imageStore = client.ImageService()
 	imageList, err := imageStore.List(ctx, options.NameAndRefFilter...)
 	if err != nil {

--- a/pkg/cmd/image/pull.go
+++ b/pkg/cmd/image/pull.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cosignutil"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/ipfs"
@@ -36,13 +35,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Pull(ctx context.Context, rawRef string, options types.ImagePullOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Pull(ctx context.Context, client *containerd.Client, rawRef string, options types.ImagePullOptions) error {
 	ocispecPlatforms, err := platformutil.NewOCISpecPlatformSlice(options.AllPlatforms, options.Platform)
 	if err != nil {
 		return err

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -23,13 +23,13 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cosignutil"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/imgutil/dockerconfigresolver"
@@ -45,13 +45,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Push(ctx context.Context, rawRef string, options types.ImagePushOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Push(ctx context.Context, client *containerd.Client, rawRef string, options types.ImagePushOptions) error {
 	if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(rawRef); err == nil {
 		if scheme != "ipfs" {
 			return fmt.Errorf("ipfs scheme is only supported but got %q", scheme)

--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -21,26 +21,21 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/sirupsen/logrus"
 )
 
 // Remove removes a list of `images`.
-func Remove(ctx context.Context, args []string, options types.ImageRemoveOptions) error {
+func Remove(ctx context.Context, client *containerd.Client, args []string, options types.ImageRemoveOptions) error {
 	var delOpts []images.DeleteOpt
 	if !options.Async {
 		delOpts = append(delOpts, images.SynchronousDelete())
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	cs := client.ContentStore()
 	is := client.ImageService()

--- a/pkg/cmd/image/tag.go
+++ b/pkg/cmd/image/tag.go
@@ -20,20 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
 )
 
-func Tag(ctx context.Context, options types.ImageTagOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Tag(ctx context.Context, client *containerd.Client, options types.ImageTagOptions) error {
 	imageService := client.ImageService()
 	var srcName string
 	imagewalker := &imagewalker.ImageWalker{

--- a/pkg/cmd/namespace/create.go
+++ b/pkg/cmd/namespace/create.go
@@ -19,16 +19,11 @@ package namespace
 import (
 	"context"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 )
 
-func Create(ctx context.Context, namespace string, options types.NamespaceCreateOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
+func Create(ctx context.Context, client *containerd.Client, namespace string, options types.NamespaceCreateOptions) error {
 	labelsArg := objectWithLabelArgs(options.Labels)
 	namespaces := client.NamespaceService()
 	return namespaces.Create(ctx, namespace, labelsArg)

--- a/pkg/cmd/namespace/inspect.go
+++ b/pkg/cmd/namespace/inspect.go
@@ -19,20 +19,14 @@ package namespace
 import (
 	"context"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 )
 
-func Inspect(ctx context.Context, inspectedNamespaces []string, options types.NamespaceInspectOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Inspect(ctx context.Context, client *containerd.Client, inspectedNamespaces []string, options types.NamespaceInspectOptions) error {
 	result := make([]interface{}, len(inspectedNamespaces))
 	for index, ns := range inspectedNamespaces {
 		ctx = namespaces.WithNamespace(ctx, ns)

--- a/pkg/cmd/namespace/remove.go
+++ b/pkg/cmd/namespace/remove.go
@@ -20,19 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 )
 
-func Remove(ctx context.Context, deletedNamespaces []string, options types.NamespaceRemoveOptions) error {
+func Remove(ctx context.Context, client *containerd.Client, deletedNamespaces []string, options types.NamespaceRemoveOptions) error {
 	var exitErr error
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 	opts, err := namespaceDeleteOpts(options.CGroup)
 	if err != nil {
 		return err

--- a/pkg/cmd/namespace/update.go
+++ b/pkg/cmd/namespace/update.go
@@ -19,16 +19,11 @@ package namespace
 import (
 	"context"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 )
 
-func Update(ctx context.Context, namespace string, options types.NamespaceUpdateOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
+func Update(ctx context.Context, client *containerd.Client, namespace string, options types.NamespaceUpdateOptions) error {
 	labelsArg := objectWithLabelArgs(options.Labels)
 	namespaces := client.NamespaceService()
 	for k, v := range labelsArg {

--- a/pkg/cmd/network/prune.go
+++ b/pkg/cmd/network/prune.go
@@ -20,20 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/sirupsen/logrus"
 )
 
-func Prune(ctx context.Context, options types.NetworkPruneOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Prune(ctx context.Context, client *containerd.Client, options types.NetworkPruneOptions) error {
 	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
 	if err != nil {
 		return err

--- a/pkg/cmd/network/remove.go
+++ b/pkg/cmd/network/remove.go
@@ -20,20 +20,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/idutil/netwalker"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/sirupsen/logrus"
 )
 
-func Remove(ctx context.Context, options types.NetworkRemoveOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
+func Remove(ctx context.Context, client *containerd.Client, options types.NetworkRemoveOptions) error {
 	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
 	if err != nil {
 		return err

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -24,12 +24,12 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
 	"github.com/containerd/containerd/api/services/introspection/v1"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/infoutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
@@ -40,7 +40,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func Info(ctx context.Context, options types.SystemInfoOptions) error {
+func Info(ctx context.Context, client *containerd.Client, options types.SystemInfoOptions) error {
 	var (
 		tmpl *template.Template
 		err  error
@@ -51,11 +51,6 @@ func Info(ctx context.Context, options types.SystemInfoOptions) error {
 			return err
 		}
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	var (
 		infoNative *native.Info

--- a/pkg/cmd/volume/prune.go
+++ b/pkg/cmd/volume/prune.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 )
 
-func Prune(ctx context.Context, options types.VolumePruneOptions) error {
+func Prune(ctx context.Context, client *containerd.Client, options types.VolumePruneOptions) error {
 	if !options.Force {
 		var confirm string
 		msg := "This will remove all local volumes not used by at least one container."
@@ -45,11 +45,6 @@ func Prune(ctx context.Context, options types.VolumePruneOptions) error {
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
 
 	containers, err := client.Containers(ctx)
 	if err != nil {

--- a/pkg/cmd/volume/rm.go
+++ b/pkg/cmd/volume/rm.go
@@ -23,19 +23,12 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/mountutil"
 )
 
-func Remove(ctx context.Context, volumes []string, options types.VolumeRemoveOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+func Remove(ctx context.Context, client *containerd.Client, volumes []string, options types.VolumeRemoveOptions) error {
 	containers, err := client.Containers(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
fixes #1907

Checklist:

- [X] move newClient from pkg/cmd to the location where call it.

Signed-off-by: Laitron <meetlq@outlook.com>