### PR TITLE
Optimize inspect commands

### DIFF
--- a/cmd/nerdctl/image_inspect.go
+++ b/cmd/nerdctl/image_inspect.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/spf13/cobra"
 )
@@ -84,7 +85,14 @@ func imageInspectAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return image.Inspect(cmd.Context(), args, options)
+
+	client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address, options.Platform)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return image.Inspect(ctx, client, args, options)
 }
 
 func imageInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/containerd/nerdctl/pkg/cmd/image"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
@@ -79,6 +81,9 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 	if len(inspectType) > 0 && !validInspectType[inspectType] {
 		return fmt.Errorf("%q is not a valid value for --type", inspectType)
 	}
+
+	// container and image inspect can share the same client, since no `platform`
+	// flag will be passed for image inspect.
 	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), namespace, address)
 	if err != nil {
 		return err
@@ -99,49 +104,53 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 		},
 	}
 
+	inspectImage := len(inspectType) == 0 || inspectType == "image"
+	inspectContainer := len(inspectType) == 0 || inspectType == "container"
+
+	var imageInspectOptions types.ImageInspectOptions
+	var containerInspectOptions types.ContainerInspectOptions
+	if inspectImage {
+		platform := ""
+		imageInspectOptions, err = processImageInspectOptions(cmd, &platform)
+		if err != nil {
+			return err
+		}
+	}
+	if inspectContainer {
+		containerInspectOptions, err = processContainerInspectOptions(cmd)
+		if err != nil {
+			return err
+		}
+	}
+
 	var errs []error
 	for _, req := range args {
 		var ni int
 		var nc int
 
-		if len(inspectType) == 0 || inspectType == "image" {
+		if inspectImage {
 			ni, err = imagewalker.Walk(ctx, req)
 			if err != nil {
 				return err
 			}
 		}
-
-		if len(inspectType) == 0 || inspectType == "container" {
+		if inspectContainer {
 			nc, err = containerwalker.Walk(ctx, req)
 			if err != nil {
 				return err
 			}
 		}
 
-		if nc == 0 && ni == 0 {
-			return fmt.Errorf("no such object %s", req)
-		}
-		if nc != 0 {
-			if err := containerInspectAction(cmd, []string{req}); err != nil {
-				errs = append(errs, err)
-			}
-			continue
-		}
-		if ni != 0 {
-			platform := ""
-			imageInspectOptions, err := processImageInspectOptions(cmd, &platform)
-			if err != nil {
-				return err
-			}
-			client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), imageInspectOptions.GOptions.Namespace, imageInspectOptions.GOptions.Address, imageInspectOptions.Platform)
-			if err != nil {
-				return err
-			}
-			defer cancel()
+		if ni == 0 && nc == 0 {
+			errs = append(errs, fmt.Errorf("no such object %s", req))
+		} else if ni > 0 {
 			if err := image.Inspect(ctx, client, []string{req}, imageInspectOptions); err != nil {
 				errs = append(errs, err)
 			}
-			continue
+		} else if nc > 0 {
+			if err := container.Inspect(ctx, client, []string{req}, containerInspectOptions); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 

--- a/cmd/nerdctl/inspect.go
+++ b/cmd/nerdctl/inspect.go
@@ -130,11 +130,15 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 		if ni != 0 {
 			platform := ""
 			imageInspectOptions, err := processImageInspectOptions(cmd, &platform)
-			imageInspectOptions.Stdout = cmd.OutOrStdout()
 			if err != nil {
 				return err
 			}
-			if err := image.Inspect(cmd.Context(), []string{req}, imageInspectOptions); err != nil {
+			client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), imageInspectOptions.GOptions.Namespace, imageInspectOptions.GOptions.Address, imageInspectOptions.Platform)
+			if err != nil {
+				return err
+			}
+			defer cancel()
+			if err := image.Inspect(ctx, client, []string{req}, imageInspectOptions); err != nil {
 				errs = append(errs, err)
 			}
 			continue

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -62,8 +62,6 @@ type ContainerInspectOptions struct {
 	Format string
 	// Inspect mode, either dockercompat or native
 	Mode string
-	// Containers are the containers to be inspected
-	Containers []string
 }
 
 // ContainerCommitOptions specifies options for `nerdctl (container) commit`.

--- a/pkg/cmd/container/inspect.go
+++ b/pkg/cmd/container/inspect.go
@@ -21,21 +21,16 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/containerinspector"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 )
 
-func Inspect(ctx context.Context, options types.ContainerInspectOptions) error {
-	client, ctx, cancel, err := clientutil.NewClient(ctx, options.GOptions.Namespace, options.GOptions.Address)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
+// Inspect prints detailed information for each container in `containers`.
+func Inspect(ctx context.Context, client *containerd.Client, containers []string, options types.ContainerInspectOptions) error {
 	f := &containerInspector{
 		mode: options.Mode,
 	}
@@ -46,7 +41,7 @@ func Inspect(ctx context.Context, options types.ContainerInspectOptions) error {
 	}
 
 	var errs []error
-	for _, req := range options.Containers {
+	for _, req := range containers {
 		n, err := walker.Walk(ctx, req)
 		if err != nil {
 			errs = append(errs, err)


### PR DESCRIPTION
Fix #1909

1. Refactor `container|image inspect`: move client creation to `./cmd`.
2. Optimize `inspect`:
    1. Reduce duplicated client/options creation by moving them out of for loop.
    2. Continue to the next arg if error due to no object is found.

Signed-off-by: Jin Dong <jindon@amazon.com>