### PR TITLE
refactor: system events flagging process

### DIFF
--- a/cmd/nerdctl/system_events.go
+++ b/cmd/nerdctl/system_events.go
@@ -17,23 +17,10 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"text/template"
-	"time"
-
-	"github.com/containerd/containerd/events"
-	"github.com/containerd/containerd/log"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
-	"github.com/containerd/nerdctl/pkg/formatter"
-	"github.com/containerd/typeurl"
-
+	"github.com/containerd/nerdctl/pkg/cmd/system"
 	"github.com/spf13/cobra"
-
-	// Register grpc event types
-	_ "github.com/containerd/containerd/api/events"
 )
 
 func newEventsCommand() *cobra.Command {
@@ -55,84 +42,31 @@ func newEventsCommand() *cobra.Command {
 	return eventsCommand
 }
 
-type Out struct {
-	Timestamp time.Time
-	Namespace string
-	Topic     string
-	Event     string
+func processSystemEventsOptions(cmd *cobra.Command) (types.SystemEventsOptions, error) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return types.SystemEventsOptions{}, err
+	}
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return types.SystemEventsOptions{}, err
+	}
+	return types.SystemEventsOptions{
+		Stdout:   cmd.OutOrStdout(),
+		GOptions: globalOptions,
+		Format:   format,
+	}, nil
 }
 
-// eventsActions is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go
 func eventsAction(cmd *cobra.Command, args []string) error {
-	globalOptions, err := processRootCmdFlags(cmd)
+	options, err := processSystemEventsOptions(cmd)
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	eventsClient := client.EventService()
-	eventsCh, errCh := eventsClient.Subscribe(ctx)
-
-	var tmpl *template.Template
-	format, err := cmd.Flags().GetString("format")
-	if err != nil {
-		return err
-	}
-	switch format {
-	case "":
-		tmpl = nil
-	case "raw", "table", "wide":
-		return errors.New("unsupported format: \"raw\", \"table\", and \"wide\"")
-	default:
-		tmpl, err = formatter.ParseTemplate(format)
-		if err != nil {
-			return err
-		}
-	}
-	for {
-		var e *events.Envelope
-		select {
-		case e = <-eventsCh:
-		case err = <-errCh:
-			return err
-		}
-		if e != nil {
-			var out []byte
-			if e.Event != nil {
-				v, err := typeurl.UnmarshalAny(e.Event)
-				if err != nil {
-					log.G(ctx).WithError(err).Warn("cannot unmarshal an event from Any")
-					continue
-				}
-				out, err = json.Marshal(v)
-				if err != nil {
-					log.G(ctx).WithError(err).Warn("cannot marshal Any into JSON")
-					continue
-				}
-			}
-			if tmpl != nil {
-				out := Out{e.Timestamp, e.Namespace, e.Topic, string(out)}
-				var b bytes.Buffer
-				if err := tmpl.Execute(&b, out); err != nil {
-					return err
-				}
-				if _, err := fmt.Fprintln(cmd.OutOrStdout(), b.String()+"\n"); err != nil {
-					return err
-				}
-			} else {
-				if _, err := fmt.Fprintln(
-					cmd.OutOrStdout(),
-					e.Timestamp,
-					e.Namespace,
-					e.Topic,
-					string(out),
-				); err != nil {
-					return err
-				}
-			}
-		}
-	}
+	return system.Events(ctx, client, options)
 }

--- a/pkg/api/types/system_types.go
+++ b/pkg/api/types/system_types.go
@@ -29,3 +29,12 @@ type SystemInfoOptions struct {
 	// Format the output using the given Go template, e.g, '{{json .}}
 	Format string
 }
+
+// SystemEventsOptions specifies options for `nerdctl (system) events`.
+type SystemEventsOptions struct {
+	Stdout io.Writer
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+	// Format the output using the given Go template, e.g, '{{json .}}
+	Format string
+}

--- a/pkg/cmd/system/events.go
+++ b/pkg/cmd/system/events.go
@@ -1,0 +1,105 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package system
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"text/template"
+	"time"
+
+	"github.com/containerd/containerd"
+	_ "github.com/containerd/containerd/api/events" // Register grpc event types
+	"github.com/containerd/containerd/events"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/formatter"
+	"github.com/containerd/typeurl"
+)
+
+// EventOut contains information about an event.
+type EventOut struct {
+	Timestamp time.Time
+	Namespace string
+	Topic     string
+	Event     string
+}
+
+// Events is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go
+func Events(ctx context.Context, client *containerd.Client, options types.SystemEventsOptions) error {
+	eventsClient := client.EventService()
+	eventsCh, errCh := eventsClient.Subscribe(ctx)
+	var tmpl *template.Template
+	switch options.Format {
+	case "":
+		tmpl = nil
+	case "raw", "table", "wide":
+		return errors.New("unsupported format: \"raw\", \"table\", and \"wide\"")
+	default:
+		var err error
+		tmpl, err = formatter.ParseTemplate(options.Format)
+		if err != nil {
+			return err
+		}
+	}
+	for {
+		var e *events.Envelope
+		select {
+		case e = <-eventsCh:
+		case err := <-errCh:
+			return err
+		}
+		if e != nil {
+			var out []byte
+			if e.Event != nil {
+				v, err := typeurl.UnmarshalAny(e.Event)
+				if err != nil {
+					log.G(ctx).WithError(err).Warn("cannot unmarshal an event from Any")
+					continue
+				}
+				out, err = json.Marshal(v)
+				if err != nil {
+					log.G(ctx).WithError(err).Warn("cannot marshal Any into JSON")
+					continue
+				}
+			}
+			if tmpl != nil {
+				out := EventOut{e.Timestamp, e.Namespace, e.Topic, string(out)}
+				var b bytes.Buffer
+				if err := tmpl.Execute(&b, out); err != nil {
+					return err
+				}
+				if _, err := fmt.Fprintln(options.Stdout, b.String()+"\n"); err != nil {
+					return err
+				}
+			} else {
+				if _, err := fmt.Fprintln(
+					options.Stdout,
+					e.Timestamp,
+					e.Namespace,
+					e.Topic,
+					string(out),
+				); err != nil {
+					return err
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Part of https://github.com/containerd/nerdctl/issues/1680

- [x] Create a file in `pkg/api/types/${cmd}_types.go`, and define the CommandOption for this command
- [x] Create some file in `pkg/cmd/${cmd}`, and move the command entry point in real into this package

Major changes:

- Move `_ "github.com/containerd/containerd/api/events"` to the `/pkg` file.
- Move `// Events is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go` to the `/pkg` function.

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>