### PR TITLE
Add support for calculating virtual image size as well.

### DIFF
--- a/cmd/nerdctl/compose_images.go
+++ b/cmd/nerdctl/compose_images.go
@@ -137,7 +137,7 @@ func printComposeImages(ctx context.Context, cmd *cobra.Command, containers []co
 				return err
 			}
 
-			size, err := imgutil.UnpackedImageSize(ctx, sn, image)
+			size, err := imgutil.UnpackedImageSize(ctx, image)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -318,9 +318,7 @@ func getContainerSize(ctx context.Context, client *containerd.Client, c containe
 		return "", err
 	}
 
-	sn := client.SnapshotService(info.Snapshotter)
-
-	imageSize, err := imgutil.UnpackedImageSize(ctx, sn, image)
+	imageSize, err := imgutil.UnpackedImageSize(ctx, image)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -119,6 +119,7 @@ type imagePrintable struct {
 	Name         string // image name
 	Size         string // the size of the unpacked snapshots.
 	BlobSize     string // the size of the blobs in the content store (nerdctl extension)
+	VirtualSize  string
 	// TODO: "SharedSize", "UniqueSize", "VirtualSize"
 	Platform string // nerdctl extension
 }
@@ -231,7 +232,7 @@ func (x *imagePrinter) printImageSinglePlatform(ctx context.Context, img images.
 		logrus.WithError(err).Warnf("failed to get blob size of image %q for platform %q", img.Name, platforms.Format(ociPlatform))
 	}
 
-	size, err := imgutil.UnpackedImageSize(ctx, x.snapshotter, image)
+	size, err := imgutil.UnpackedImageSize(ctx, image)
 	if err != nil {
 		logrus.WithError(err).Warnf("failed to get unpacked size of image %q for platform %q", img.Name, platforms.Format(ociPlatform))
 	}
@@ -245,6 +246,7 @@ func (x *imagePrinter) printImageSinglePlatform(ctx context.Context, img images.
 		Tag:          tag,
 		Name:         img.Name,
 		Size:         progress.Bytes(size).String(),
+		VirtualSize:  progress.Bytes(size).String(),
 		BlobSize:     progress.Bytes(blobSize).String(),
 		Platform:     platforms.Format(ociPlatform),
 	}


### PR DESCRIPTION
Testing details

```
➜  nerdctl git:(virtual-size) ✗ nerdctl image list --format 'table ID:{{.ID}};Repo:{{.Repository}};Tag:{{.Tag}};Size:{{.Size}};VirtSize:{{.VirtualSize}}'

 table ID:f271e74b17ce;Repo:alpine;Tag:latest;Size:8.3 MiB;VirtSize:8.3 MiB table ID:3487c98481d1;Repo:fedora;Tag:latest;Size:195.1 MiB;VirtSize:195.1 MiB
```