### PR TITLE
[Refactor] Refactor the (container) pause command flagging process

### DIFF
--- a/cmd/nerdctl/compose_pause.go
+++ b/cmd/nerdctl/compose_pause.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/compose"
+	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -76,7 +77,7 @@ func composePauseAction(cmd *cobra.Command, args []string) error {
 	for _, c := range containers {
 		c := c
 		eg.Go(func() error {
-			if err := pauseContainer(ctx, client, c.ID()); err != nil {
+			if err := containerutil.Pause(ctx, client, c.ID()); err != nil {
 				return err
 			}
 			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)

--- a/cmd/nerdctl/container_pause.go
+++ b/cmd/nerdctl/container_pause.go
@@ -17,14 +17,10 @@
 package main
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/cio"
+	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
-	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
-
+	"github.com/containerd/nerdctl/pkg/cmd/container"
 	"github.com/spf13/cobra"
 )
 
@@ -41,66 +37,30 @@ func newPauseCommand() *cobra.Command {
 	return pauseCommand
 }
 
-func pauseAction(cmd *cobra.Command, args []string) error {
+func processContainerPauseOptions(cmd *cobra.Command) (types.ContainerPauseOptions, error) {
 	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return types.ContainerPauseOptions{}, err
+	}
+	return types.ContainerPauseOptions{
+		GOptions: globalOptions,
+		Stdout:   cmd.OutOrStdout(),
+	}, nil
+}
+
+func pauseAction(cmd *cobra.Command, args []string) error {
+	options, err := processContainerPauseOptions(cmd)
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
 	if err != nil {
 		return err
 	}
 	defer cancel()
 
-	walker := &containerwalker.ContainerWalker{
-		Client: client,
-		OnFound: func(ctx context.Context, found containerwalker.Found) error {
-			if found.MatchCount > 1 {
-				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
-			}
-			if err := pauseContainer(ctx, client, found.Container.ID()); err != nil {
-				return err
-			}
-
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "%s\n", found.Req)
-			return err
-		},
-	}
-	for _, req := range args {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
-	return nil
-}
-
-func pauseContainer(ctx context.Context, client *containerd.Client, id string) error {
-	container, err := client.LoadContainer(ctx, id)
-	if err != nil {
-		return err
-	}
-
-	task, err := container.Task(ctx, cio.Load)
-	if err != nil {
-		return err
-	}
-
-	status, err := task.Status(ctx)
-	if err != nil {
-		return err
-	}
-
-	switch status.Status {
-	case containerd.Paused:
-		return fmt.Errorf("container %s is already paused", id)
-	case containerd.Created, containerd.Stopped:
-		return fmt.Errorf("container %s is not running", id)
-	default:
-		return task.Pause(ctx)
-	}
+	return container.Pause(ctx, client, args, options)
 }
 
 func pauseShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -58,6 +58,13 @@ type ContainerTopOptions struct {
 	GOptions GlobalCommandOptions
 }
 
+// ContainerPauseOptions specifies options for `nerdctl (container) pause`.
+type ContainerPauseOptions struct {
+	Stdout io.Writer
+	// GOptions is the global options
+	GOptions GlobalCommandOptions
+}
+
 // ContainerRemoveOptions specifies options for `nerdctl (container) rm`.
 type ContainerRemoveOptions struct {
 	Stdout io.Writer

--- a/pkg/cmd/container/pause.go
+++ b/pkg/cmd/container/pause.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+)
+
+func Pause(ctx context.Context, client *containerd.Client, reqs []string, options types.ContainerPauseOptions) error {
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			if err := containerutil.Pause(ctx, client, found.Container.ID()); err != nil {
+				return err
+			}
+
+			_, err := fmt.Fprintf(options.Stdout, "%s\n", found.Req)
+			return err
+		},
+	}
+	for _, req := range reqs {
+		n, err := walker.Walk(ctx, req)
+		if err != nil {
+			return err
+		} else if n == 0 {
+			return fmt.Errorf("no such container %s", req)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Part of https://github.com/containerd/nerdctl/issues/1680

Checklist:
- [x] Move pauseContainer from cmd to pkg/containerutil
- [x] Create a file in pkg/api/types/${cmd}_types.go, and define the CommandOption for this command
- [x] Create some file in pkg/cmd/${cmd}, and move the command entry point in real into this package


Signed-off-by: Laitron <meetlq@outlook.com>