### PR TITLE
refactor: extract main logic of image.List

### DIFF
--- a/cmd/nerdctl/image_list.go
+++ b/cmd/nerdctl/image_list.go
@@ -139,7 +139,7 @@ func imagesAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	return image.List(ctx, client, options)
+	return image.ListCommandHandler(ctx, client, options)
 }
 
 func imagesShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -44,16 +44,38 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func List(ctx context.Context, client *containerd.Client, options types.ImageListOptions) error {
-	var imageStore = client.ImageService()
-	imageList, err := imageStore.List(ctx, options.NameAndRefFilter...)
+// ListCommandHandler `List` and print images matching filters in `options`.
+func ListCommandHandler(ctx context.Context, client *containerd.Client, options types.ImageListOptions) error {
+	imageList, err := List(ctx, client, options.Filters, options.NameAndRefFilter)
 	if err != nil {
 		return err
 	}
-	if len(options.Filters) > 0 {
-		f, err := imgutil.ParseFilters(options.Filters)
+	return printImages(ctx, client, imageList, options)
+}
+
+// List queries containerd client to get image list and only returns those matching given filters.
+//
+// Supported filters:
+// - before=<image>[:<tag>]: Images created before given image (exclusive)
+// - since=<image>[:<tag>]: Images created after given image (exclusive)
+// - label=<key>[=<value>]: Matches images based on the presence of a label alone or a label and a value
+// - dangling=true: Filter images by dangling
+// - reference=<image>[:<tag>]: Filter images by reference (Matches both docker compatible wildcard pattern and regexp
+//
+// nameAndRefFilter has the format of `name==(<image>[:<tag>])|ID`,
+// and they will be used when getting images from containerd,
+// while the remaining filters are only applied after getting images from containerd,
+// which means that having nameAndRefFilter may speed up the process if there are a lot of images in containerd.
+func List(ctx context.Context, client *containerd.Client, filters, nameAndRefFilter []string) ([]images.Image, error) {
+	var imageStore = client.ImageService()
+	imageList, err := imageStore.List(ctx, nameAndRefFilter...)
+	if err != nil {
+		return nil, err
+	}
+	if len(filters) > 0 {
+		f, err := imgutil.ParseFilters(filters)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if f.Dangling != nil {
@@ -62,32 +84,32 @@ func List(ctx context.Context, client *containerd.Client, options types.ImageLis
 
 		imageList, err = filterByLabel(ctx, client, imageList, f.Labels)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		imageList, err = filterByReference(imageList, f.Reference)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		var beforeImages []images.Image
 		if len(f.Before) > 0 {
 			beforeImages, err = imageStore.List(ctx, f.Before...)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 		var sinceImages []images.Image
 		if len(f.Since) > 0 {
 			sinceImages, err = imageStore.List(ctx, f.Since...)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
 		imageList = imgutil.FilterImages(imageList, beforeImages, sinceImages)
 	}
-	return printImages(ctx, client, imageList, options)
+	return imageList, nil
 }
 
 func filterByReference(imageList []images.Image, filters []string) ([]images.Image, error) {


### PR DESCRIPTION
Fix #1855.

The naming pattern of `ListCommandHandler` (i.e., called by `cmd/nerdctl`) and `List` (i.e., contains "main logic") come from https://github.com/containerd/nerdctl/issues/1855#issuecomment-1397034834. If this PR makes sense to you, to make the naming consistent, I can create a one-shot PR to rename all functions to be `XXXCommandHandler` according to https://github.com/containerd/nerdctl/issues/1855#issuecomment-1400837364.

Notes:

- The function comment of `List` comes from [command reference](https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-blue_square-nerdctl-images). Not 100% sure about the comment of `nameAndRefFilter`, please let me know if it's inaccurate, thanks!

Signed-off-by: Hsing-Yu (David) Chen <davidhsingyuchen@gmail.com>