### PR TITLE
Mark `cri` log viewer as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ To load an image archive (`docker save` format or OCI format) into local Kuberne
 # nerdctl --namespace k8s.io load < /path/to/image.tar
 ```
 
+To read logs (experimental):
+```console
+# nerdctl --namespace=k8s.io ps -a
+CONTAINER ID    IMAGE                                                      COMMAND                   CREATED          STATUS    PORTS    NAMES
+...
+e8793b8cca8b    registry.k8s.io/coredns/coredns:v1.9.3                     "/coredns -conf /etc…"    2 minutes ago    Up                 k8s://kube-system/coredns-787d4945fb-mfx6b/coredns
+...
+
+# nerdctl --namespace=k8s.io logs -f e8793b8cca8b
+[INFO] plugin/reload: Running configuration SHA512 = 591cf328cccc12bc490481273e738df59329c62c0b729d94e8b61db9961c2fa5f046dd37f1cf888b953814040d180f52594972691cd6ff41be96639138a43908
+CoreDNS-1.9.3
+linux/amd64, go1.18.2, 45b0a11
+...
+```
+
 ### Rootless mode
 
 To launch rootless containerd:

--- a/cmd/nerdctl/container_logs.go
+++ b/cmd/nerdctl/container_logs.go
@@ -27,10 +27,19 @@ import (
 )
 
 func newLogsCommand() *cobra.Command {
+	const shortUsage = "Fetch the logs of a container. Expected to be used with 'nerdctl run -d'."
+	const longUsage = `Fetch the logs of a container.
+
+The following containers are supported:
+- Containers created with 'nerdctl run -d'. The log is currently empty for containers created without '-d'.
+- Containers created with 'nerdctl compose'.
+- Containers created with Kubernetes (EXPERIMENTAL).
+`
 	var logsCommand = &cobra.Command{
 		Use:               "logs [flags] CONTAINER",
 		Args:              IsExactArgs(1),
-		Short:             "Fetch the logs of a container. Currently, only containers created with `nerdctl run -d` are supported.",
+		Short:             shortUsage,
+		Long:              longUsage,
 		RunE:              logsAction,
 		ValidArgsFunction: logsShellComplete,
 		SilenceUsage:      true,

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -11,3 +11,4 @@ See [`./config.md`](config.md) about how to enable these features.
 - [Image Sign and Verify (cosign)](./cosign.md)
 - [Rootless container networking acceleration with bypass4netns](./rootless.md#bypass4netns)
 - [Interactive debugging of Dockerfile](./builder-debug.md)
+- Kubernetes (`cri`) log viewer: `nerdctl --namespace=k8s.io logs`

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -102,7 +102,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 				Since:             options.Since,
 				Until:             options.Until,
 			}
-			logViewer, err := logging.InitContainerLogViewer(l, logViewOpts, stopChannel)
+			logViewer, err := logging.InitContainerLogViewer(l, logViewOpts, stopChannel, options.GOptions.Experimental)
 			if err != nil {
 				return err
 			}

--- a/pkg/logging/log_viewer.go
+++ b/pkg/logging/log_viewer.go
@@ -115,7 +115,7 @@ type ContainerLogViewer struct {
 
 // Validates the given LogViewOptions, loads the logging config for the
 // given container and returns a ContainerLogViewer.
-func InitContainerLogViewer(containerLabels map[string]string, lvopts LogViewOptions, stopChannel chan os.Signal) (contlv *ContainerLogViewer, err error) {
+func InitContainerLogViewer(containerLabels map[string]string, lvopts LogViewOptions, stopChannel chan os.Signal, experimental bool) (contlv *ContainerLogViewer, err error) {
 	var lcfg LogConfig
 	if _, ok := containerLabels[k8slabels.ContainerType]; ok {
 		lcfg.Driver = "cri"
@@ -128,6 +128,10 @@ func InitContainerLogViewer(containerLabels map[string]string, lvopts LogViewOpt
 		if err != nil {
 			return nil, fmt.Errorf("failed to load logging config: %s", err)
 		}
+	}
+
+	if lcfg.Driver == "cri" && !experimental {
+		return nil, fmt.Errorf("the `cri` log viewer requires nerdctl to be running in experimental mode")
 	}
 
 	lv := &ContainerLogViewer{


### PR DESCRIPTION
Follow-up to 
- #1847

Due to
- https://github.com/containerd/nerdctl/issues/1956
- https://github.com/containerd/nerdctl/issues/1957


cc @zhaojizhuang