### PR TITLE
Refactor (un)pause in nerdctl and compose

### DIFF
--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -66,6 +66,9 @@ type ContainerPauseOptions struct {
 	GOptions GlobalCommandOptions
 }
 
+// ContainerUnpauseOptions specifies options for `nerdctl (container) unpause`.
+type ContainerUnpauseOptions ContainerPauseOptions
+
 // ContainerRemoveOptions specifies options for `nerdctl (container) rm`.
 type ContainerRemoveOptions struct {
 	Stdout io.Writer

--- a/pkg/cmd/container/unpause.go
+++ b/pkg/cmd/container/unpause.go
@@ -28,15 +28,15 @@ import (
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
-// Pause pauses all containers specified by `reqs`.
-func Pause(ctx context.Context, client *containerd.Client, reqs []string, options types.ContainerPauseOptions) error {
+// Unpause unpauses all containers specified by `reqs`.
+func Unpause(ctx context.Context, client *containerd.Client, reqs []string, options types.ContainerUnpauseOptions) error {
 	walker := &containerwalker.ContainerWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found containerwalker.Found) error {
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			if err := containerutil.Pause(ctx, client, found.Container.ID()); err != nil {
+			if err := containerutil.Unpause(ctx, client, found.Container.ID()); err != nil {
 				return err
 			}
 

--- a/pkg/composer/pause.go
+++ b/pkg/composer/pause.go
@@ -1,0 +1,101 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package composer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/labels"
+	"golang.org/x/sync/errgroup"
+)
+
+// Pause pauses service containers belonging to `services`.
+func (c *Composer) Pause(ctx context.Context, services []string, writer io.Writer) error {
+	serviceNames, err := c.ServiceNames(services...)
+	if err != nil {
+		return err
+	}
+	containers, err := c.Containers(ctx, serviceNames...)
+	if err != nil {
+		return err
+	}
+
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, container := range containers {
+		container := container
+		eg.Go(func() error {
+			if err := containerutil.Pause(ctx, c.client, container.ID()); err != nil {
+				return err
+			}
+			info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			_, err = fmt.Fprintf(writer, "%s\n", info.Labels[labels.Name])
+
+			return err
+		})
+	}
+
+	return eg.Wait()
+}
+
+// Unpause unpauses service containers belonging to `services`.
+func (c *Composer) Unpause(ctx context.Context, services []string, writer io.Writer) error {
+	serviceNames, err := c.ServiceNames(services...)
+	if err != nil {
+		return err
+	}
+	containers, err := c.Containers(ctx, serviceNames...)
+	if err != nil {
+		return err
+	}
+
+	var mu sync.Mutex
+
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, container := range containers {
+		container := container
+		eg.Go(func() error {
+			if err := containerutil.Unpause(ctx, c.client, container.ID()); err != nil {
+				return err
+			}
+			info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+			if err != nil {
+				return err
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			_, err = fmt.Fprintf(writer, "%s\n", info.Labels[labels.Name])
+
+			return err
+		})
+	}
+
+	return eg.Wait()
+}


### PR DESCRIPTION
Part of #1680.

Refactor `nerdctl unpause`, `nerdctl compose (un)pause`.

Signed-off-by: Jin Dong <jindon@amazon.com>