### PR TITLE
Optimize id walkers and muti error handling

### DIFF
--- a/cmd/nerdctl/container_stats.go
+++ b/cmd/nerdctl/container_stats.go
@@ -277,13 +277,8 @@ func statsAction(cmd *cobra.Command, args []string) error {
 			},
 		}
 
-		for _, req := range args {
-			n, err := walker.Walk(ctx, req)
-			if err != nil {
-				return err
-			} else if n == 0 {
-				return fmt.Errorf("no such container %s", req)
-			}
+		if err := walker.WalkAll(ctx, args, false); err != nil {
+			return err
 		}
 
 		// make sure each container get at least one valid stat data

--- a/cmd/nerdctl/container_update.go
+++ b/cmd/nerdctl/container_update.go
@@ -110,15 +110,8 @@ func updateAction(cmd *cobra.Command, args []string) error {
 			return err
 		},
 	}
-	for _, req := range args {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
-	return nil
+
+	return walker.WalkAll(ctx, args, true)
 }
 
 func getUpdateOption(cmd *cobra.Command, globalOptions types.GlobalCommandOptions) (updateResourceOptions, error) {

--- a/cmd/nerdctl/image_history.go
+++ b/cmd/nerdctl/image_history.go
@@ -143,19 +143,7 @@ func historyAction(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	var errs []error
-	for _, req := range args {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			errs = append(errs, err)
-		} else if n == 0 {
-			errs = append(errs, fmt.Errorf("no such object: %s", req))
-		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%d errors: %v", len(errs), errs)
-	}
-	return nil
+	return walker.WalkAll(ctx, args, true)
 }
 
 type historyPrinter struct {

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -60,15 +60,8 @@ func Kill(ctx context.Context, client *containerd.Client, reqs []string, options
 			return err
 		},
 	}
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
-	return nil
+
+	return walker.WalkAll(ctx, reqs, true)
 }
 
 func killContainer(ctx context.Context, container containerd.Container, signal syscall.Signal) error {

--- a/pkg/cmd/container/pause.go
+++ b/pkg/cmd/container/pause.go
@@ -18,9 +18,7 @@ package container
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
@@ -45,18 +43,5 @@ func Pause(ctx context.Context, client *containerd.Client, reqs []string, option
 		},
 	}
 
-	var errs []string
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			errs = append(errs, err.Error())
-		} else if n == 0 {
-			errs = append(errs, fmt.Sprintf("no such container %s", req))
-		}
-	}
-
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
-	}
-	return nil
+	return walker.WalkAll(ctx, reqs, true)
 }

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -77,20 +77,13 @@ func Remove(ctx context.Context, client *containerd.Client, containers []string,
 			return err
 		},
 	}
-	for _, req := range containers {
-		n, err := walker.Walk(ctx, req)
-		if err == nil && n == 0 {
-			err = fmt.Errorf("no such container %s", req)
-		}
-		if err != nil {
-			if options.Force {
-				logrus.Error(err)
-			} else {
-				return err
-			}
-		}
+
+	err := walker.WalkAll(ctx, containers, true)
+	if err != nil && options.Force {
+		logrus.Error(err)
+		return nil
 	}
-	return nil
+	return err
 }
 
 // RemoveContainer removes a container from containerd store.

--- a/pkg/cmd/container/restart.go
+++ b/pkg/cmd/container/restart.go
@@ -44,14 +44,6 @@ func Restart(ctx context.Context, client *containerd.Client, containers []string
 			return err
 		},
 	}
-	for _, req := range containers {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
 
-	return nil
+	return walker.WalkAll(ctx, containers, true)
 }

--- a/pkg/cmd/container/start.go
+++ b/pkg/cmd/container/start.go
@@ -52,13 +52,5 @@ func Start(ctx context.Context, client *containerd.Client, reqs []string, option
 		},
 	}
 
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
-	return nil
+	return walker.WalkAll(ctx, reqs, true)
 }

--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
+// Stop stops a list of containers specified by `reqs`.
 func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt types.ContainerStopOptions) error {
 	walker := &containerwalker.ContainerWalker{
 		Client: client,
@@ -45,13 +46,6 @@ func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt typ
 			return err
 		},
 	}
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		} else if n == 0 {
-			return fmt.Errorf("no such container %s", req)
-		}
-	}
-	return nil
+
+	return walker.WalkAll(ctx, reqs, true)
 }

--- a/pkg/cmd/container/unpause.go
+++ b/pkg/cmd/container/unpause.go
@@ -18,9 +18,7 @@ package container
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
@@ -45,18 +43,5 @@ func Unpause(ctx context.Context, client *containerd.Client, reqs []string, opti
 		},
 	}
 
-	var errs []string
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			errs = append(errs, err.Error())
-		} else if n == 0 {
-			errs = append(errs, fmt.Sprintf("no such container %s", req))
-		}
-	}
-
-	if len(errs) > 0 {
-		return errors.New(strings.Join(errs, "\n"))
-	}
-	return nil
+	return walker.WalkAll(ctx, reqs, true)
 }

--- a/pkg/cmd/container/wait.go
+++ b/pkg/cmd/container/wait.go
@@ -41,15 +41,11 @@ func Wait(ctx context.Context, client *containerd.Client, reqs []string, options
 		},
 	}
 
-	for _, req := range reqs {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return fmt.Errorf("no such container: %s", req)
-		}
+	// check if all containers from `reqs` exist
+	if err := walker.WalkAll(ctx, reqs, false); err != nil {
+		return err
 	}
+
 	var allErr error
 	w := options.Stdout
 	for _, container := range containers {

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/pkg/imageinspector"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
+	"github.com/sirupsen/logrus"
 )
 
 // Inspect prints detailed information of each image in `images`.
@@ -60,19 +61,13 @@ func Inspect(ctx context.Context, client *containerd.Client, images []string, op
 		},
 	}
 
-	var errs []error
-	for _, req := range images {
-		n, err := walker.Walk(ctx, req)
-		if err != nil {
-			errs = append(errs, err)
-		} else if n == 0 {
-			errs = append(errs, fmt.Errorf("no such object: %s", req))
+	err := walker.WalkAll(ctx, images, true)
+	if len(f.entries) > 0 {
+		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, f.entries); formatErr != nil {
+			logrus.Error(formatErr)
 		}
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%d errors: %v", len(errs), errs)
-	}
-	return formatter.FormatSlice(options.Format, options.Stdout, f.entries)
+	return err
 }
 
 type imageInspector struct {

--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -88,18 +88,11 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 			return nil
 		},
 	}
-	for _, req := range args {
-		n, err := walker.Walk(ctx, req)
-		if err == nil && n == 0 {
-			err = fmt.Errorf("no such image %s", req)
-		}
-		if err != nil {
-			if options.Force {
-				logrus.Error(err)
-			} else {
-				return err
-			}
-		}
+
+	err = walker.WalkAll(ctx, args, true)
+	if err != nil && options.Force {
+		logrus.Error(err)
+		return nil
 	}
-	return nil
+	return err
 }

--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -77,14 +77,10 @@ func SaveImages(ctx context.Context, client *containerd.Client, images []string,
 		},
 	}
 
-	for _, img := range images {
-		count, err := walker.Walk(ctx, img)
-		if err != nil {
-			return err
-		}
-		if count == 0 {
-			return fmt.Errorf("no such image: %s", img)
-		}
+	// check if all images exist
+	if err := walker.WalkAll(ctx, images, false); err != nil {
+		return err
 	}
+
 	return client.Export(ctx, options.Stdout, exportOpts...)
 }

--- a/pkg/idutil/imagewalker/imagewalker.go
+++ b/pkg/idutil/imagewalker/imagewalker.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
@@ -82,4 +83,31 @@ func (w *ImageWalker) Walk(ctx context.Context, req string) (int, error) {
 		}
 	}
 	return matchCount, nil
+}
+
+// WalkAll calls `Walk` for each req in `reqs`.
+//
+// It can be used when the matchCount is not important (e.g., only care if there
+// is any error or if matchCount == 0 (not found error) when walking all reqs).
+// If `forceAll`, it calls `Walk` on every req
+// and return all errors joined by `\n`. If not `forceAll`, it returns the first error
+// encountered while calling `Walk`.
+func (w *ImageWalker) WalkAll(ctx context.Context, reqs []string, forceAll bool) error {
+	var errs []string
+	for _, req := range reqs {
+		n, err := w.Walk(ctx, req)
+		if err == nil && n == 0 {
+			err = fmt.Errorf("no such image: %s", req)
+		}
+		if err != nil {
+			if !forceAll {
+				return err
+			}
+			errs = append(errs, err.Error())
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%d errors:\n%s", len(errs), strings.Join(errs, "\n"))
+	}
+	return nil
 }


### PR DESCRIPTION
Unify multi error handling when a container|image walker walks multiple containers/images.

Fix #1969

Signed-off-by: Jin Dong <jindon@amazon.com>