### PR TITLE
handle container deps removal with postsop hooks

### DIFF
--- a/cmd/nerdctl/container_restart_linux_test.go
+++ b/cmd/nerdctl/container_restart_linux_test.go
@@ -51,11 +51,11 @@ func TestRestartPIDContainer(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	baseContainerName := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", baseContainerName, testutil.AlpineImage, "sleep", "infinity").Run()
+	base.Cmd("run", "-d", "--name", baseContainerName, testutil.AlpineImage, "sleep", "infinity").AssertOK()
 	defer base.Cmd("rm", "-f", baseContainerName).Run()
 
-	sharedContainerName := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--pid=container:%s", baseContainerName), testutil.AlpineImage, "sleep", "infinity").Run()
+	sharedContainerName := fmt.Sprintf("%s-shared", baseContainerName)
+	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--pid=container:%s", baseContainerName), testutil.AlpineImage, "sleep", "infinity").AssertOK()
 	defer base.Cmd("rm", "-f", sharedContainerName).Run()
 
 	base.Cmd("restart", baseContainerName).AssertOK()

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -358,7 +358,6 @@ func runAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logURI := lab[labels.LogURI]
-
 	task, err := taskutil.NewTask(ctx, client, c, false, flagI, flagT, flagD, con, logURI)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container_run_network_linux_test.go
@@ -404,6 +404,7 @@ func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", "-f", containerName).Run()
 	base.Cmd("run", "--rm", "--name", containerName, "-p", "22200-22299:22200-22299", testutil.CommonImage).AssertFail()
 	base.Cmd("run", "--rm", "--name", containerName, "-p", "22200-22299:22200-22299", testutil.CommonImage).AssertCombinedOutContains(errdefs.ErrInvalidArgument.Error())
 	base.Cmd("run", "--rm", "--name", containerName, testutil.CommonImage).AssertOK()

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -122,10 +122,10 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		if retErr != nil {
 			return
 		}
-
 		if err := os.RemoveAll(stateDir); err != nil {
 			logrus.WithError(retErr).Warnf("failed to remove container state dir %s", stateDir)
 		}
+		// enforce release name here in case the poststop hook name release fails
 		if name != "" {
 			if err := namst.Release(name, id); err != nil {
 				logrus.WithError(retErr).Warnf("failed to release container name %s", name)
@@ -135,6 +135,8 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 			logrus.WithError(retErr).Warnf("failed to remove hosts file for container %q", id)
 		}
 	}()
+
+	// volume removal is not handled by the poststop hook lifecycle because it depends on removeAnonVolumes option
 	if anonVolumesJSON, ok := l[labels.AnonymousVolumes]; ok && removeAnonVolumes {
 		var anonVolumes []string
 		if err := json.Unmarshal([]byte(anonVolumesJSON), &anonVolumes); err != nil {

--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -138,6 +138,8 @@ func (x *store) Acquire(meta Meta) error {
 	return lockutil.WithDirLock(x.hostsD, fn)
 }
 
+// Release is triggered by Poststop hooks.
+// It is called after the containerd task is deleted but before the delete operation returns.
 func (x *store) Release(ns, id string) error {
 	fn := func() error {
 		metaPath := filepath.Join(x.hostsD, ns, id, metaJSON)


### PR DESCRIPTION
**#Before** 
the container deps ( `etchosts files`, `names`, `container state`) removal is deferred by [RemoveContainer](https://github.com/containerd/nerdctl/blob/main/pkg/cmd/container/remove.go#L118-LL152) which means container deletion happens before deps deletion.

**#After** 
Using  runtime-spec postStop Hook, we ensure that container deps deletion is successfully completed before the container deletion returns

Signed-off-by: fahed dorgaa <fahed.dorgaa@gmail.com>