### PR TITLE
Split rootless driver tests by network driver and portdriver.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,15 +113,32 @@ jobs:
         include:
           - ubuntu: 20.04
             containerd: v1.5.17
+            target: test-integration-rootless
           - ubuntu: 20.04
             containerd: v1.6.16
+            target: test-integration-rootless
           - ubuntu: 22.04
             containerd: v1.6.16
+            target: test-integration-rootless
           - ubuntu: 22.04
             containerd: main
+            target: test-integration-rootless
+          - ubuntu: 20.04
+            containerd: v1.5.17
+            target: test-integration-rootless-port-slirp4netns
+          - ubuntu: 20.04
+            containerd: v1.6.16
+            target: test-integration-rootless-port-slirp4netns
+          - ubuntu: 22.04
+            containerd: v1.6.16
+            target: test-integration-rootless-port-slirp4netns
+          - ubuntu: 22.04
+            containerd: main
+            target: test-integration-rootless-port-slirp4netns
     env:
       UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
+      TEST_TARGET: "${{ matrix.target }}"
     steps:
       - uses: actions/checkout@v3.3.0
         with:
@@ -129,13 +146,9 @@ jobs:
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
-        run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless --target test-integration-rootless --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
-      - name: "Test    (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged test-integration-rootless
-      - name: "Prepare (network driver=slirp4netns, port driver=slirp4netns)"
-        run: DOCKER_BUILDKIT=1 docker build -t test-integration-rootless-port-slirp4netns --target test-integration-rootless-port-slirp4netns --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
-      - name: "Test    (network driver=slirp4netns, port driver=slirp4netns)"
-        run: docker run -t --rm --privileged test-integration-rootless-port-slirp4netns
+        run: DOCKER_BUILDKIT=1 docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+      - name: "Test (network driver=slirp4netns, port driver=builtin)"
+        run: docker run -t --rm --privileged ${TEST_TARGET}
 
   cross:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Each combination of networkdriver and port driver takes around 20 mins and since they were serialized it took around 40 mins. By Splitting into different jobs, the test runs can run faster.

Signed-off-by: Manu Gupta <manugupt1@gmail.com>