### PR TITLE
Fix `rmi` bug when checking containers with deleted image

### DIFF
--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -68,7 +68,11 @@ func newJWEKeyPair(t testing.TB) *jweKeyPair {
 func rmiAll(base *testutil.Base) {
 	base.T.Logf("Pruning images")
 	imageIDs := base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
-	base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).AssertOK()
+	// remove empty output line at the end
+	imageIDs = imageIDs[:len(imageIDs)-1]
+	// use `Run` on purpose (same below) because `rmi all` may fail on individual
+	// image id that has an expected running container (e.g. a registry)
+	base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).Run()
 
 	base.T.Logf("Pruning build caches")
 	if _, err := buildkitutil.GetBuildkitHost(testutil.Namespace); err == nil {
@@ -97,7 +101,7 @@ func rmiAll(base *testutil.Base) {
 
 		base.T.Logf("Pruning all images (again?)")
 		imageIDs = base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
-		base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).AssertOK()
+		base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).Run()
 	}
 }
 


### PR DESCRIPTION
Fix #1988 (~and part of #1997~ fixed in a separate PR).

Previous: when `rmi` checks `runningImages` by containers, return directly if there is error.
Now: skip this container (since no image returned from it).



Signed-off-by: Jin Dong <jindon@amazon.com>