### PR TITLE
Retag commonimage before loading to ensure it does not fail.

### DIFF
--- a/cmd/nerdctl/image_load_linux_test.go
+++ b/cmd/nerdctl/image_load_linux_test.go
@@ -29,12 +29,15 @@ import (
 )
 
 func TestLoadStdinFromPipe(t *testing.T) {
+	t.Parallel()
 	base := testutil.NewBase(t)
 
 	tmp := t.TempDir()
+	img := testutil.Identifier(t) + "image"
 	base.Cmd("pull", testutil.CommonImage).AssertOK()
-	base.Cmd("save", testutil.CommonImage, "-o", filepath.Join(tmp, "common.tar")).AssertOK()
-	base.Cmd("rmi", testutil.CommonImage).AssertOK()
+	base.Cmd("tag", testutil.CommonImage, img).AssertOK()
+	base.Cmd("save", img, "-o", filepath.Join(tmp, "common.tar")).AssertOK()
+	base.Cmd("rmi", "-f", img).AssertOK()
 	loadCmd := strings.Join(base.Cmd("load").Command, " ")
 	output := filepath.Join(tmp, "output")
 
@@ -43,8 +46,8 @@ func TestLoadStdinFromPipe(t *testing.T) {
 	fb, err := os.ReadFile(output)
 	assert.NilError(t, err)
 
-	assert.Assert(t, strings.Contains(string(fb), fmt.Sprintf("Loaded image: %s", testutil.CommonImage)))
-	base.Cmd("images").AssertOutContains(strings.Split(testutil.CommonImage, ":")[0])
+	assert.Assert(t, strings.Contains(string(fb), fmt.Sprintf("Loaded image: %s:latest", img)))
+	base.Cmd("images").AssertOutContains(strings.Split(img, ":")[0])
 }
 
 func TestLoadStdinEmpty(t *testing.T) {

--- a/pkg/cmd/image/load.go
+++ b/pkg/cmd/image/load.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/images/archive"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/platformutil"
 )
 
@@ -103,7 +104,8 @@ func loadImage(ctx context.Context, client *containerd.Client, in io.Reader, pla
 		if quiet {
 			fmt.Fprintln(options.Stdout, img.Target.Digest)
 		} else {
-			fmt.Fprintf(options.Stdout, "Loaded image: %s\n", img.Name)
+			repo, tag := imgutil.ParseRepoTag(img.Name)
+			fmt.Fprintf(options.Stdout, "Loaded image: %s:%s\n", repo, tag)
 		}
 	}
 


### PR DESCRIPTION
Removing CommonImage can fail if testimage can be used by some other test. This leads to flakiness. Retagging to ensure that it does not fail. Also add t.Parallel() to ensure this test can run concurrently.

Failed test case can be found here: [TestLoadStdinFromPipe](https://github.com/containerd/nerdctl/actions/runs/4171221656/jobs/7220936048)

Signed-off-by: Manu Gupta <manugupt1@gmail.com>

