### PR TITLE
Add TestRunAddGroup_CVE_2023_25173

### DIFF
--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -24,6 +24,7 @@ func mirrorOf(s string) string {
 }
 
 var (
+	BusyboxImage                = "ghcr.io/containerd/busybox:1.28"
 	AlpineImage                 = mirrorOf("alpine:3.13")
 	NginxAlpineImage            = mirrorOf("nginx:1.19-alpine")
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"


### PR DESCRIPTION
https://github.com/advisories/GHSA-hmfx-3pcx-653p

The CVE fix is applied to nerdctl in 6b9fc94442380c0b1a34061e1390e531d93818d7 (PR #2019).

https://github.com/containerd/containerd/commit/3eda46af12b1deedab3d0802adb2e81cb3521950