### PR TITLE
CI: test compilation with an old release of Go

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,17 +153,20 @@ jobs:
   cross:
     runs-on: ubuntu-22.04
     timeout-minutes: 40
+    strategy:
+      matrix:
+        go-version: ["1.19.x", "1.20.x"]
     steps:
       - uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 1
       - uses: actions/setup-go@v3
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: ${{ matrix.go-version }}
           cache: true
           check-latest: true
       - name: "Cross"
-        run: make artifacts
+        run: GO_VERSION="$(echo ${{ matrix.go-version }} | sed -e s/.x//)" make artifacts
 
   test-integration-docker-compatibility:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ install:
 	install -D -m 755 $(CURDIR)/extras/rootless/containerd-rootless-setuptool.sh $(DESTDIR)$(BINDIR)/containerd-rootless-setuptool.sh
 
 define make_artifact_full_linux
-	DOCKER_BUILDKIT=1 docker build --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) $(CURDIR)
+	DOCKER_BUILDKIT=1 docker build --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) --build-arg GO_VERSION $(CURDIR)
 	gzip -9 $(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar
 endef
 


### PR DESCRIPTION
We have to support Go 1.19 as well as 1.20.
