### PR TITLE
Make confirm logic in `volume prune` be consistent with other Prune

### DIFF
--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -121,7 +121,6 @@ func systemPruneAction(cmd *cobra.Command, args []string) error {
 			GOptions: globalOptions,
 			Force:    true,
 			Stdout:   cmd.OutOrStdout(),
-			Stdin:    cmd.InOrStdin(),
 		}); err != nil {
 			return err
 		}

--- a/pkg/api/types/volume_types.go
+++ b/pkg/api/types/volume_types.go
@@ -53,7 +53,6 @@ type VolumeListOptions struct {
 // VolumePruneOptions specifies options for `nerdctl volume prune`.
 type VolumePruneOptions struct {
 	Stdout   io.Writer
-	Stdin    io.Reader
 	GOptions GlobalCommandOptions
 	// Do not prompt for confirmation
 	Force bool

--- a/pkg/cmd/volume/prune.go
+++ b/pkg/cmd/volume/prune.go
@@ -19,24 +19,12 @@ package volume
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
 )
 
 func Prune(ctx context.Context, client *containerd.Client, options types.VolumePruneOptions) error {
-	if !options.Force {
-		var confirm string
-		msg := "This will remove all local volumes not used by at least one container."
-		msg += "\nAre you sure you want to continue? [y/N] "
-		fmt.Fprintf(options.Stdout, "WARNING! %s", msg)
-		fmt.Fscanf(options.Stdin, "%s", &confirm)
-
-		if strings.ToLower(confirm) != "y" {
-			return nil
-		}
-	}
 	volStore, err := Store(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address)
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, in the logic of `volume prune`, `Stdin` is only used for confirmation of `force` flag. Therefore, this PR moves the confirmation logic from `pkg` to `cmd` side, and removes `Stdin` from the options at the same time.

This is also the case for other prune commands.

reference: https://github.com/containerd/nerdctl/pull/1985#discussion_r1110022415

Signed-off-by: Han Xu <suyanhanx@gmail.com>