### PR TITLE
Fix unsupported restart policy message

### DIFF
--- a/cmd/nerdctl/container_run_restart.go
+++ b/cmd/nerdctl/container_run_restart.go
@@ -45,7 +45,7 @@ func checkRestartCapabilities(ctx context.Context, client *containerd.Client, re
 		capabilities = []string{"always"}
 	}
 	if !strutil.InStringSlice(capabilities, policySlice[0]) {
-		return false, fmt.Errorf("unsupported restart policy %q, supported policies are: %q", policySlice[0], restartPlugin.Capabilities)
+		return false, fmt.Errorf("unsupported restart policy %q, supported policies are: %q", policySlice[0], capabilities)
 	}
 	return true, nil
 }


### PR DESCRIPTION
The unsupported restart policy message is not showing the supported value (when no capabilities are found, and the default "always" is set):
---
Bug
<img width="665" alt="Screenshot 2023-02-20 at 02 26 14" src="https://user-images.githubusercontent.com/8320519/220016419-62432432-73bb-42e2-a733-75fcc061befa.png">

Fixed
<img width="737" alt="Screenshot 2023-02-20 at 02 26 06" src="https://user-images.githubusercontent.com/8320519/220016451-e48404d9-78ae-49e8-acd8-c1463e810e69.png">

Fixes this [Issue](https://github.com/containerd/nerdctl/issues/2034)!

Signed-off-by: Bruno Henrique <bruno.henriquy@gmail.com>