### PR TITLE
refactor(container-list): separate main logic out of printing logic

### DIFF
--- a/cmd/nerdctl/container_list.go
+++ b/cmd/nerdctl/container_list.go
@@ -124,5 +124,5 @@ func psAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	return container.List(ctx, client, options)
+	return container.ListCommandHandler(ctx, client, options)
 }


### PR DESCRIPTION
PR moves the "exclude non-running containers if `All` is `true`" logic out of `printContainers`. The naming pattern in #1923 (i.e., `XXXCommandHandler()` for use by `cmd/nerdctl` & `XXX()` for the main logic func) is followed.