### PR TITLE
cmd/compose: add support for profiles

### DIFF
--- a/cmd/nerdctl/compose.go
+++ b/cmd/nerdctl/compose.go
@@ -36,6 +36,7 @@ func newComposeCommand() *cobra.Command {
 	composeCommand.PersistentFlags().StringP("project-name", "p", "", "Specify an alternate project name")
 	composeCommand.PersistentFlags().String("env-file", "", "Specify an alternate environment file")
 	composeCommand.PersistentFlags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
+	composeCommand.PersistentFlags().StringArray("profile", []string{}, "Specify a profile to enable")
 
 	composeCommand.AddCommand(
 		newComposeUpCommand(),
@@ -87,11 +88,16 @@ func getComposeOptions(cmd *cobra.Command, debugFull, experimental bool) (compos
 	if err != nil {
 		return composer.Options{}, err
 	}
+	profiles, err := cmd.Flags().GetStringArray("profile")
+	if err != nil {
+		return composer.Options{}, err
+	}
 
 	return composer.Options{
 		Project:          projectName,
 		ProjectDirectory: projectDirectory,
 		ConfigPaths:      files,
+		Profiles:         profiles,
 		EnvFile:          envFile,
 		NerdctlCmd:       nerdctlCmd,
 		NerdctlArgs:      nerdctlArgs,

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -114,6 +114,7 @@ func composeUpAction(cmd *cobra.Command, services []string) error {
 	if err != nil {
 		return err
 	}
+	options.Services = services
 	c, err := compose.New(client, globalOptions, options, cmd.OutOrStdout(), cmd.ErrOrStderr())
 	if err != nil {
 		return err

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1304,6 +1304,7 @@ Flags:
 - :whale: `-f, --file`: Specify an alternate compose file
 - :whale: `-p, --project-name`: Specify an alternate project name
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
+- :whale: `--profile: Specify a profile to enable
 
 ### :whale: nerdctl compose up
 

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -37,6 +37,8 @@ type Options struct {
 	Project          string // empty for default
 	ProjectDirectory string
 	ConfigPaths      []string
+	Profiles         []string
+	Services         []string
 	EnvFile          string
 	NerdctlCmd       string
 	NerdctlArgs      []string
@@ -82,6 +84,15 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if len(o.Services) > 0 {
+		s, err := project.GetServices(o.Services...)
+		if err != nil {
+			return nil, err
+		}
+		o.Profiles = append(o.Profiles, s.GetProfiles()...)
+	}
+	project.ApplyProfiles(o.Profiles)
 
 	if o.DebugPrintFull {
 		projectJSON, _ := json.MarshalIndent(project, "", "    ")


### PR DESCRIPTION
From https://github.com/compose-spec/compose-spec/blob/master/spec.md#profiles:
```
Profiles allow to adjust the Compose application model for various usages and environments. 
A Compose implementation SHOULD allow the user to define a set of active profiles. The exact 
mechanism is implementation specific and MAY include command line flags, environment variables, etc.
```


Closes #1831

Signed-off-by: danishprakash <danish.prakash@suse.com>
