### PR TITLE
Update system prune flag `--all` confirmation prompt

### DIFF
--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -63,13 +63,13 @@ type BuilderBuildOptions struct {
 	BuildContext string
 }
 
-// BuilderPruneOptions specifies options for `nerdctl builder build`.
+// BuilderPruneOptions specifies options for `nerdctl builder prune`.
 type BuilderPruneOptions struct {
 	Stderr io.Writer
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
 	// BuildKitHost is the buildkit host
 	BuildKitHost string
-	// All will remove all unused build cache, not just dangling ones
+	// All will remove all unused images and all build cache, not just dangling ones
 	All bool
 }

--- a/pkg/cmd/system/prune.go
+++ b/pkg/cmd/system/prune.go
@@ -57,7 +57,7 @@ func Prune(ctx context.Context, client *containerd.Client, options types.SystemP
 	if err := image.Prune(ctx, client, types.ImagePruneOptions{
 		Stdout:   options.Stdout,
 		GOptions: options.GOptions,
-		All:      true,
+		All:      options.All,
 	}); err != nil {
 		return nil
 	}


### PR DESCRIPTION
As both `image.Prune` and `builder.Prune` now support only removing dangling items or not, the confirmation prompt for the flag `--all` of `system prune` need to update.

---
I'm sorry that some code changes were reverted due to my mistake in operating the `git rebase`.
https://github.com/containerd/nerdctl/blob/17b61660106cd243ae5e26f4dc50253293cbe9af/cmd/nerdctl/system_prune.go#L83-L87

This PR removed them.

Signed-off-by: Han Xu <suyanhanx@gmail.com>