### PR TITLE
Port Windows device support from containerd

### DIFF
--- a/cmd/nerdctl/container_run_windows.go
+++ b/cmd/nerdctl/container_run_windows.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
@@ -131,6 +133,22 @@ func setPlatformOptions(
 	opts = append(opts,
 		oci.WithWindowNetworksAllowUnqualifiedDNSQuery(),
 		oci.WithWindowsIgnoreFlushesDuringBoot())
+
+	device, err := cmd.Flags().GetStringSlice("device")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, dev := range device {
+		idType, devID, ok := strings.Cut(dev, "://")
+		if !ok {
+			return nil, errors.New("devices must be in the format IDType://ID")
+		}
+		if idType == "" {
+			return nil, errors.New("devices must have a non-empty IDType")
+		}
+		opts = append(opts, oci.WithWindowsDevice(idType, devID))
+	}
 
 	return opts, nil
 }

--- a/cmd/nerdctl/container_run_windows_test.go
+++ b/cmd/nerdctl/container_run_windows_test.go
@@ -108,3 +108,20 @@ func TestRunProcessContainer(t *testing.T) {
 
 	assert.Assert(t, !strings.Contains(inspectOutput, "hyperv"))
 }
+
+// Note that the current implementation of this test is not ideal, since it relies on internal HCS details that
+// Microsoft could decide to change in the future (breaking both this unit test and the one in containerd itself):
+// https://github.com/containerd/containerd/pull/6618#discussion_r823302852
+func TestRunProcessContainerWithDevice(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+
+	base.Cmd(
+		"run",
+		"--rm",
+		"--isolation=process",
+		"--device", "class://5B45201D-F2F2-4F3B-85BB-30FF1F953599",
+		testutil.WindowsNano,
+		"cmd", "/S", "/C", "dir C:\\Windows\\System32\\HostDriverStore",
+	).AssertOutContains("FileRepository")
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -205,7 +205,7 @@ Resource flags:
 - :whale: `--cgroupns=(host|private)`: Cgroup namespace to use
   - Default: "private" on cgroup v2 hosts, "host" on cgroup v1 hosts
 - :whale: `--cgroup-parent`: Optional parent cgroup for the container
-- :whale: `--device`: Add a host device to the container
+- :whale: :blue_square: `--device`: Add a host device to the container
 
 Intel RDT flags:
 


### PR DESCRIPTION
(Contributes to the high-level goal of supporting Windows containers, as outlined in #28.)

This change adds support for exposing host devices to Windows containers using the `--device` flag with `nerdctl run`. The code itself is directly ported from containerd, where it was first contributed by @TBBle in [#6618](https://github.com/containerd/containerd/pull/6618) (relevant [diff lines here](https://github.com/containerd/containerd/commit/d4641e1ce1e07393115cd52bd71041ee8a99a180#diff-429f43dc8c50d9510c331066067fcaabfd8f0dc883ccd74119e9465844e9cec4)), and subsequently modified by @thaJeztah to use `strings.Cut()` in commit [eaedadbe](https://github.com/containerd/containerd/commit/eaedadbed01219f6d074e739574f40ad7d72b126#diff-429f43dc8c50d9510c331066067fcaabfd8f0dc883ccd74119e9465844e9cec4). My only unique contribution here is to update the command reference and adorn the `--device` flag with the little blue square which denotes Windows support. :laughing:

It's worth noting that I haven't added any unit tests to cover this functionality. Most of the existing Windows unit tests appear to run containers and check their output, but I don't know of a decent way to test this without requiring that a GPU be present on the underlying host system. I can see that Windows unit tests are currently run as [part of the Cirrus CI workflow](https://github.com/containerd/nerdctl/blob/v1.2.1/.cirrus.yml#L21), but I suspect that the cloud VMs being used for the tests do not have GPUs, and any test requiring one would fail. If a simpler kind of unit test would be desirable (e.g. one that just tests the parsing behaviour for device `IDType://ID` values without actually running a container) then I would certainly be happy to write one.