### PR TITLE
feat: add 'nerdctl container attach'

### DIFF
--- a/cmd/nerdctl/container.go
+++ b/cmd/nerdctl/container.go
@@ -50,6 +50,7 @@ func newContainerCommand() *cobra.Command {
 		newRenameCommand(),
 		newContainerPruneCommand(),
 		newStatsCommand(),
+		newAttachCommand(),
 	)
 	addCpCommand(containerCommand)
 	return containerCommand

--- a/cmd/nerdctl/container_attach.go
+++ b/cmd/nerdctl/container_attach.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/containerd/containerd"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
+	"github.com/containerd/nerdctl/pkg/cmd/container"
+	"github.com/containerd/nerdctl/pkg/consoleutil"
+	"github.com/spf13/cobra"
+)
+
+func newAttachCommand() *cobra.Command {
+	var attachCommand = &cobra.Command{
+		Use:  "attach [flags] CONTAINER",
+		Args: cobra.ExactArgs(1),
+		Short: `Attach stdin, stdout, and stderr to a running container. For example:
+
+1. 'nerdctl run -it --name test busybox' to start a container with a pty
+2. 'ctrl-p ctrl-q' to detach from the container
+3. 'nerdctl attach test' to attach to the container
+
+Caveats:
+
+- Currently only one attach session is allowed. When the second session tries to attach, currently no error will be returned from nerdctl.
+  However, since behind the scenes, there's only one FIFO for stdin, stdout, and stderr respectively,
+  if there are multiple sessions, all the sessions will be reading from and writing to the same 3 FIFOs, which will result in mixed input and partial output.
+- Until dual logging (issue #1946) is implemented,
+  a container that is spun up by either 'nerdctl run -d' or 'nerdctl start' (without '--attach') cannot be attached to.`,
+		RunE:              containerAttachAction,
+		ValidArgsFunction: attachShellComplete,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
+	}
+	attachCommand.Flags().String("detach-keys", consoleutil.DefaultDetachKeys, "Override the default detach keys")
+	return attachCommand
+}
+
+func processContainerAttachOptions(cmd *cobra.Command) (types.ContainerAttachOptions, error) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return types.ContainerAttachOptions{}, err
+	}
+	detachKeys, err := cmd.Flags().GetString("detach-keys")
+	if err != nil {
+		return types.ContainerAttachOptions{}, err
+	}
+	return types.ContainerAttachOptions{
+		GOptions:   globalOptions,
+		Stdin:      cmd.InOrStdin(),
+		Stdout:     cmd.OutOrStdout(),
+		Stderr:     cmd.ErrOrStderr(),
+		DetachKeys: detachKeys,
+	}, nil
+}
+
+func containerAttachAction(cmd *cobra.Command, args []string) error {
+	options, err := processContainerAttachOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Attach(ctx, client, args[0], options)
+}
+
+func attachShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	statusFilterFn := func(st containerd.ProcessStatus) bool {
+		return st == containerd.Running
+	}
+	return shellCompleteContainerNames(cmd, statusFilterFn)
+}

--- a/cmd/nerdctl/container_attach_linux_test.go
+++ b/cmd/nerdctl/container_attach_linux_test.go
@@ -1,0 +1,103 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+// skipAttachForDocker should be called by attach-related tests that assert 'read detach keys' in stdout.
+func skipAttachForDocker(t *testing.T) {
+	t.Helper()
+	if testutil.GetTarget() == testutil.Docker {
+		t.Skip("When detaching from a container, for a session started with 'docker attach'" +
+			", it prints 'read escape sequence', but for one started with 'docker (run|start)', it prints nothing." +
+			" However, the flag is called '--detach-keys' in all cases" +
+			", so nerdctl prints 'read detach keys' for all cases" +
+			", and that's why this test is skipped for Docker.")
+	}
+}
+
+// prepareContainerToAttach spins up a container (entrypoint = shell) with `-it` and detaches from it
+// so that it can be re-attached to later.
+func prepareContainerToAttach(base *testutil.Base, containerName string) {
+	opts := []func(*testutil.Cmd){
+		testutil.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader(
+			[]byte{16, 17}, // ctrl+p,ctrl+q, see https://www.physics.udel.edu/~watson/scen103/ascii.html
+		))),
+	}
+	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
+	// unbuffer(1) can be installed with `apt-get install expect`.
+	//
+	// "-p" is needed because we need unbuffer to read from stdin, and from [1]:
+	// "Normally, unbuffer does not read from stdin. This simplifies use of unbuffer in some situations.
+	//  To use unbuffer in a pipeline, use the -p flag."
+	//
+	// [1] https://linux.die.net/man/1/unbuffer
+	base.CmdWithHelper([]string{"unbuffer", "-p"}, "run", "-it", "--name", containerName, testutil.CommonImage).
+		CmdOption(opts...).AssertOutContains("read detach keys")
+	container := base.InspectContainer(containerName)
+	assert.Equal(base.T, container.State.Running, true)
+}
+
+func TestAttach(t *testing.T) {
+	t.Parallel()
+
+	skipAttachForDocker(t)
+
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
+	prepareContainerToAttach(base, containerName)
+
+	opts := []func(*testutil.Cmd){
+		testutil.WithStdin(testutil.NewDelayOnceReader(strings.NewReader("expr 1 + 1\nexit\n"))),
+	}
+	// `unbuffer -p` returns 0 even if the underlying nerdctl process returns a non-zero exit code,
+	// so the exit code cannot be easily tested here.
+	base.CmdWithHelper([]string{"unbuffer", "-p"}, "attach", containerName).CmdOption(opts...).AssertOutContains("2")
+	container := base.InspectContainer(containerName)
+	assert.Equal(base.T, container.State.Running, false)
+}
+
+func TestAttachDetachKeys(t *testing.T) {
+	t.Parallel()
+
+	skipAttachForDocker(t)
+
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
+	prepareContainerToAttach(base, containerName)
+
+	opts := []func(*testutil.Cmd){
+		testutil.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader(
+			[]byte{1, 2}, // https://www.physics.udel.edu/~watson/scen103/ascii.html
+		))),
+	}
+	base.CmdWithHelper([]string{"unbuffer", "-p"}, "attach", "--detach-keys=ctrl-a,ctrl-b", containerName).
+		CmdOption(opts...).AssertOutContains("read detach keys")
+	container := base.InspectContainer(containerName)
+	assert.Equal(base.T, container.State.Running, true)
+}

--- a/cmd/nerdctl/container_start_linux_test.go
+++ b/cmd/nerdctl/container_start_linux_test.go
@@ -28,13 +28,7 @@ import (
 func TestStartDetachKeys(t *testing.T) {
 	t.Parallel()
 
-	if testutil.GetTarget() == testutil.Docker {
-		t.Skip("When detaching from a container, for a session started with 'docker attach'" +
-			", it prints 'read escape sequence', but for one started with 'docker (run|start)', it prints nothing." +
-			" However, the flag is called '--detach-keys' in all cases" +
-			", so nerdctl prints 'read detach keys' for all cases" +
-			", and that's why this test is skipped for Docker.")
-	}
+	skipAttachForDocker(t)
 
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -259,6 +259,7 @@ Config file ($NERDCTL_TOML): %s
 		newCommitCommand(),
 		newWaitCommand(),
 		newRenameCommand(),
+		newAttachCommand(),
 		// #endregion
 
 		// Build

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -31,6 +31,7 @@ It does not necessarily mean that the corresponding features are missing in cont
   - [:whale: nerdctl pause](#whale-nerdctl-pause)
   - [:whale: nerdctl unpause](#whale-nerdctl-unpause)
   - [:whale: nerdctl rename](#whale-nerdctl-rename)
+  - [:whale: nerdctl attach](#whale-nerdctl-attach)
   - [:whale: nerdctl container prune](#whale-nerdctl-container-prune)
 - [Build](#build)
   - [:whale: nerdctl build](#whale-nerdctl-build)
@@ -608,6 +609,30 @@ Usage: `nerdctl unpause CONTAINER [CONTAINER...]`
 Rename a container.
 
 Usage: `nerdctl rename CONTAINER NEW_NAME`
+
+### :whale: nerdctl attach
+
+Attach stdin, stdout, and stderr to a running container. For example:
+
+1. `nerdctl run -it --name test busybox` to start a container with a pty
+2. `ctrl-p ctrl-q` to detach from the container
+3. `nerdctl attach test` to attach to the container
+
+Caveats:
+
+- Currently only one attach session is allowed. When the second session tries to attach, currently no error will be returned from nerdctl.
+  However, since behind the scenes, there's only one FIFO for stdin, stdout, and stderr respectively,
+  if there are multiple sessions, all the sessions will be reading from and writing to the same 3 FIFOs, which will result in mixed input and partial output.
+- Until dual logging (issue #1946) is implemented,
+  a container that is spun up by either `nerdctl run -d` or `nerdctl start` (without `--attach`) cannot be attached to.
+
+Usage: `nerdctl attach CONTAINER`
+
+Flags:
+
+- :whale: `--detach-keys`: Override the default detach keys
+
+Unimplemented `docker attach` flags: `--no-stdin`, `--sig-proxy`
 
 ### :whale: nerdctl container prune
 
@@ -1620,7 +1645,6 @@ See [`./config.md`](./config.md).
 
 Container management:
 
-- `docker attach`
 - `docker diff`
 - `docker checkpoint *`
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -370,6 +370,18 @@ type ContainerWaitOptions struct {
 	GOptions GlobalCommandOptions
 }
 
+// ContainerAttachOptions specifies options for `nerdctl (container) attach`.
+type ContainerAttachOptions struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+
+	// GOptions is the global options.
+	GOptions GlobalCommandOptions
+	// DetachKeys is the key sequences to detach from the container.
+	DetachKeys string
+}
+
 // ContainerExecOptions specifies options for `nerdctl (container) exec`
 type ContainerExecOptions struct {
 	GOptions GlobalCommandOptions

--- a/pkg/cmd/container/attach.go
+++ b/pkg/cmd/container/attach.go
@@ -1,0 +1,137 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/containerd/console"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/cio"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/consoleutil"
+	"github.com/containerd/nerdctl/pkg/errutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/pkg/signalutil"
+	"github.com/sirupsen/logrus"
+)
+
+// Attach attaches stdin, stdout, and stderr to a running container.
+func Attach(ctx context.Context, client *containerd.Client, req string, options types.ContainerAttachOptions) error {
+	// Find the container.
+	var container containerd.Container
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			container = found.Container
+			return nil
+		},
+	}
+	n, err := walker.Walk(ctx, req)
+	if err != nil {
+		return fmt.Errorf("error when trying to find the container: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("no container is found given the string: %s", req)
+	} else if n > 1 {
+		return fmt.Errorf("more than one containers are found given the string: %s", req)
+	}
+
+	// Attach to the container.
+	var task containerd.Task
+	detachC := make(chan struct{})
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get the OCI runtime spec for the container: %w", err)
+	}
+	var (
+		opt cio.Opt
+		con console.Console
+	)
+	if spec.Process.Terminal {
+		con = console.Current()
+		defer con.Reset()
+		if err := con.SetRaw(); err != nil {
+			return fmt.Errorf("failed to set the console to raw mode: %w", err)
+		}
+		closer := func() {
+			detachC <- struct{}{}
+			// task will be set by container.Task later.
+			//
+			// We cannot use container.Task(ctx, cio.Load) to get the IO here
+			// because the `cancel` field of the returned `*cio` is nil. [1]
+			//
+			// [1] https://github.com/containerd/containerd/blob/8f756bc8c26465bd93e78d9cd42082b66f276e10/cio/io.go#L358-L359
+			io := task.IO()
+			if io == nil {
+				logrus.Errorf("got a nil io")
+				return
+			}
+			io.Cancel()
+		}
+		in, err := consoleutil.NewDetachableStdin(con, options.DetachKeys, closer)
+		if err != nil {
+			return err
+		}
+		opt = cio.WithStreams(in, con, nil)
+	} else {
+		opt = cio.WithStreams(options.Stdin, options.Stdout, options.Stderr)
+	}
+	task, err = container.Task(ctx, cio.NewAttach(opt))
+	if err != nil {
+		return fmt.Errorf("failed to attach to the container: %w", err)
+	}
+	if spec.Process.Terminal {
+		if err := consoleutil.HandleConsoleResize(ctx, task, con); err != nil {
+			logrus.WithError(err).Error("console resize")
+		}
+	}
+	sigC := signalutil.ForwardAllSignals(ctx, task)
+	defer signalutil.StopCatch(sigC)
+
+	// Wait for the container to exit.
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to init an async wait for the container to exit: %w", err)
+	}
+	select {
+	// io.Wait() would return when either 1) the user detaches from the container OR 2) the container is about to exit.
+	//
+	// If we replace the `select` block with io.Wait() and
+	// directly use task.Status() to check the status of the container after io.Wait() returns,
+	// it can still be running even though the container is about to exit (somehow especially for Windows).
+	//
+	// As a result, we need a separate detachC to distinguish from the 2 cases mentioned above.
+	case <-detachC:
+		io := task.IO()
+		if io == nil {
+			return errors.New("got a nil IO from the task")
+		}
+		io.Wait()
+	case status := <-statusC:
+		code, _, err := status.Result()
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			return errutil.NewExitCoderErr(int(code))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

PR is unblocked by #2128. After this PR, for a container started in attached mode, a user can detach from it (enabled by #2128) and then re-attach to it using `nerdctl attach` (enabled by this PR).

However, since ["dual logging"](https://github.com/containerd/nerdctl/issues/1946#issuecomment-1443649307) is not implemented yet, containers spun up in detached mode, namely via `nerdctl run -d` or `nerdctl start` (without `-a`), cannot be `nerdctl attach`ed, which is mentioned in `nerdctl attach --help` and `command-reference.md`. To be specific, for a container started in detached mode, `cio.LogURI` instead of `cio.NewCreator` is used, which means the FIFOs that store the container's stdin/stdout/stderr and will be used by `cio.NewAttach` won't be there.

## Notes

- `ContainerAttachOptions.GOptions` is not used by `container.Attach` at the moment, but I still added it for consistency across commands.
- To keep this PR as simple as possible, only the bare minimum CLI parameters are supported in it. In other words, out of [all the parameters supported by `docker attach`](https://docs.docker.com/engine/reference/commandline/attach/#options), only `--detach-keys` is supported, and both `--no-stdin` and `sig-proxy` are not supported yet. We can add support for them in follow-up PRs.
- `cio.Terminal` is not really used by `cio.NewAttach` (i.e., whether the container is with a terminal is already decided when the container is created/started), so I omit the logic to decide if it should be passed to `cio.NewAttach`.
- Currently only one attach session is supported because [only one reader can be attached to a task](https://github.com/containerd/containerd/blob/e208c24256a0435e4a22c64f31dda19ef14724a5/container.go#L67-L68) under `containerd`'s current design. Supporting multiple attach sessions at nerdctl side implies quite a bit complexity, so maybe we can leave it to another PR, or even consider doing it at containerd side.