### PR TITLE
Upgrade cosign to 2.0.0 in tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -282,7 +282,7 @@ WORKDIR /go/src/github.com/containerd/nerdctl
 VOLUME /tmp
 ENV CGO_ENABLED=0
 # copy cosign binary for integration test
-COPY --from=gcr.io/projectsigstore/cosign:v1.3.1@sha256:3cd9b3a866579dc2e0cf2fdea547f4c9a27139276cc373165c26842bc594b8bd /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.0.0@sha256:728944a9542a7235b4358c4ab2bcea855840e9d4b9594febca5c2207f5da7f38 /ko-app/cosign /usr/local/bin/cosign
 # enable offline ipfs for integration test
 COPY ./Dockerfile.d/test-integration-etc_containerd-stargz-grpc_config.toml /etc/containerd-stargz-grpc/config.toml
 COPY ./Dockerfile.d/test-integration-ipfs-offline.service /usr/local/lib/systemd/system/

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -12,6 +12,18 @@ the [fulcio](https://github.com/sigstore/fulcio) root CA. Signatures are stored 
 the [rekor](https://github.com/sigstore/rekor) transparency log, which automatically provides an attestation as to when
 the signature was created.
 
+Cosign would use prompt to confirm the statement below during `sign`. Nerdctl added `--yes` to Cosign command, which says yes and prevents this prompt.
+Using Nerdctl push with signing by Cosign means that users agree the statement.
+
+
+```
+Note that there may be personally identifiable information associated with this signed artifact.
+This may include the email address associated with the account with which you authenticate.
+This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
+
+By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
+```
+
 You can enable container signing and verifying features with `push` and `pull` commands of `nerdctl` by using `cosign`
 under the hood with make use of flags `--sign` while pushing the container image, and `--verify` while pulling the
 container image.

--- a/pkg/signutil/cosignutil.go
+++ b/pkg/signutil/cosignutil.go
@@ -46,6 +46,7 @@ func SignCosign(rawRef string, keyRef string) error {
 		cosignCmd.Env = append(cosignCmd.Env, "COSIGN_EXPERIMENTAL=true")
 	}
 
+	cosignCmd.Args = append(cosignCmd.Args, "--yes")
 	cosignCmd.Args = append(cosignCmd.Args, rawRef)
 
 	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)


### PR DESCRIPTION
Upgrade cosign to 2.0.0 in tests.

Need to add --yes to skip prompt because the [prompt](https://github.com/sigstore/cosign/pull/1909) was added in 1.9.0.