### PR TITLE
Completely skip syslog-related tests on Windows.

### DIFF
--- a/cmd/nerdctl/container_run_log_driver_syslog_test.go
+++ b/cmd/nerdctl/container_run_log_driver_syslog_test.go
@@ -32,6 +32,10 @@ import (
 )
 
 func runSyslogTest(t *testing.T, networks []string, syslogFacilities map[string]syslog.Priority, fmtValidFuncs map[string]func(string, string, string, string, syslog.Priority, bool) error) {
+	if runtime.GOOS == "windows" {
+		t.Skip("syslog container logging is not officially supported on Windows")
+	}
+
 	base := testutil.NewBase(t)
 	base.Cmd("pull", testutil.CommonImage).AssertOK()
 	hostname, err := os.Hostname()


### PR DESCRIPTION
Syslog driver support is not currently being tested on Windows at all, as `rootlessutil.IsRootlessParent()` will [always return `true` on Windows](https://github.com/containerd/nerdctl/blob/main/pkg/rootlessutil/parent.go#L33), which will lead to [`rottlessutil.IsRootless()` always being `true` here](https://github.com/containerd/nerdctl/blob/main/pkg/testutil/testsyslog/testsyslog.go#L103), and thus no syslog protocols will ever be considered supported.

Considering the root cause of the issue is `rootlessutil` (pun not intended), this patch completely skips the syslog tests on Windows for now, leading to faster execution and cleaner `go test` output.

Before:
```
=== RUN   TestSyslogNetwork
=== RUN   TestSyslogNetwork/udp_user_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'udp' for rootless containers are not supported
=== RUN   TestSyslogNetwork/udp_1_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'udp' for rootless containers are not supported
=== RUN   TestSyslogNetwork/tcp_user_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'tcp' for rootless containers are not supported
=== RUN   TestSyslogNetwork/tcp_1_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'tcp' for rootless containers are not supported
=== RUN   TestSyslogNetwork/tcp_tls_user_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'tcp+tls' for rootless containers are not supported
=== RUN   TestSyslogNetwork/tcp_tls_1_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'tcp+tls' for rootless containers are not supported
=== RUN   TestSyslogNetwork/unix_user_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'unix' for rootless containers are not supported
=== RUN   TestSyslogNetwork/unix_1_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'unix' for rootless containers are not supported
=== RUN   TestSyslogNetwork/unixgram_user_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'unixgram' for rootless containers are not supported
=== RUN   TestSyslogNetwork/unixgram_1_rfc5424
    container_run_log_driver_syslog_test.go:67: skipping on windows/amd64; 'unixgram' for rootless containers are not supported
--- PASS: TestSyslogNetwork (4.88s)
    --- SKIP: TestSyslogNetwork/udp_user_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/udp_1_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/tcp_user_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/tcp_1_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/tcp_tls_user_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/tcp_tls_1_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/unix_user_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/unix_1_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/unixgram_user_rfc5424 (0.00s)
    --- SKIP: TestSyslogNetwork/unixgram_1_rfc5424 (0.00s)
```

After:
```
=== RUN   TestSyslogNetwork
    container_run_log_driver_syslog_test.go:36: syslog container logging is not officially supported on Windows
--- SKIP: TestSyslogNetwork (0.00s)
```