### PR TITLE
Fix: nerdctl help command show hidden commands

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -69,6 +69,9 @@ func usage(c *cobra.Command) error {
 	var managementCommands, nonManagementCommands []*cobra.Command
 	for _, f := range c.Commands() {
 		f := f
+		if f.Hidden {
+			continue
+		}
 		if f.Annotations[Category] == Management {
 			managementCommands = append(managementCommands, f)
 		} else {


### PR DESCRIPTION
Fix #2124 