### PR TITLE
Refactor image sign and verify logic

### DIFF
--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -797,11 +797,7 @@ func createContainer(ctx context.Context, cmd *cobra.Command, client *containerd
 // When refactor `nerdctl run`, this func should be removed and replaced by
 // creating a `PullCommandOptions` directly from `RunCommandOptions`.
 func processPullCommandFlagsInRun(cmd *cobra.Command) (types.ImagePullOptions, error) {
-	verifier, err := cmd.Flags().GetString("verify")
-	if err != nil {
-		return types.ImagePullOptions{}, err
-	}
-	cosignKey, err := cmd.Flags().GetString("cosign-key")
+	imageVerifyOptions, err := processImageVerifyOptions(cmd)
 	if err != nil {
 		return types.ImagePullOptions{}, err
 	}
@@ -810,11 +806,10 @@ func processPullCommandFlagsInRun(cmd *cobra.Command) (types.ImagePullOptions, e
 		return types.ImagePullOptions{}, err
 	}
 	return types.ImagePullOptions{
-		Verify:      verifier,
-		CosignKey:   cosignKey,
-		IPFSAddress: ipfsAddressStr,
-		Stdout:      cmd.OutOrStdout(),
-		Stderr:      cmd.ErrOrStderr(),
+		VerifyOptions: imageVerifyOptions,
+		IPFSAddress:   ipfsAddressStr,
+		Stdout:        cmd.OutOrStdout(),
+		Stderr:        cmd.ErrOrStderr(),
 	}, nil
 }
 

--- a/cmd/nerdctl/flagutil.go
+++ b/cmd/nerdctl/flagutil.go
@@ -21,6 +21,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func processImageSignOptions(cmd *cobra.Command) (opt types.ImageSignOptions, err error) {
+	if opt.Provider, err = cmd.Flags().GetString("sign"); err != nil {
+		return
+	}
+	if opt.CosignKey, err = cmd.Flags().GetString("cosign-key"); err != nil {
+		return
+	}
+	if opt.NotationKeyName, err = cmd.Flags().GetString("notation-key-name"); err != nil {
+		return
+	}
+	return
+}
+
+func processImageVerifyOptions(cmd *cobra.Command) (opt types.ImageVerifyOptions, err error) {
+	if opt.Provider, err = cmd.Flags().GetString("verify"); err != nil {
+		return
+	}
+	if opt.CosignKey, err = cmd.Flags().GetString("cosign-key"); err != nil {
+		return
+	}
+	return
+}
+
 func processRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error) {
 	debug, err := cmd.Flags().GetBool("debug")
 	if err != nil {

--- a/cmd/nerdctl/image_pull.go
+++ b/cmd/nerdctl/image_pull.go
@@ -81,29 +81,24 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 	if err != nil {
 		return types.ImagePullOptions{}, err
 	}
-	verifier, err := cmd.Flags().GetString("verify")
-	if err != nil {
-		return types.ImagePullOptions{}, err
-	}
-	cosignKey, err := cmd.Flags().GetString("cosign-key")
-	if err != nil {
-		return types.ImagePullOptions{}, err
-	}
 	ipfsAddressStr, err := cmd.Flags().GetString("ipfs-address")
 	if err != nil {
 		return types.ImagePullOptions{}, err
 	}
+	verifyOptions, err := processImageVerifyOptions(cmd)
+	if err != nil {
+		return types.ImagePullOptions{}, err
+	}
 	return types.ImagePullOptions{
-		GOptions:     globalOptions,
-		AllPlatforms: allPlatforms,
-		Platform:     platform,
-		Unpack:       unpackStr,
-		Quiet:        quiet,
-		Verify:       verifier,
-		CosignKey:    cosignKey,
-		IPFSAddress:  ipfsAddressStr,
-		Stdout:       cmd.OutOrStdout(),
-		Stderr:       cmd.OutOrStderr(),
+		GOptions:      globalOptions,
+		VerifyOptions: verifyOptions,
+		AllPlatforms:  allPlatforms,
+		Platform:      platform,
+		Unpack:        unpackStr,
+		Quiet:         quiet,
+		IPFSAddress:   ipfsAddressStr,
+		Stdout:        cmd.OutOrStdout(),
+		Stderr:        cmd.OutOrStderr(),
 	}, nil
 }
 

--- a/cmd/nerdctl/image_push.go
+++ b/cmd/nerdctl/image_push.go
@@ -87,32 +87,22 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
-	sign, err := cmd.Flags().GetString("sign")
-	if err != nil {
-		return types.ImagePushOptions{}, err
-	}
-	cosignKey, err := cmd.Flags().GetString("cosign-key")
-	if err != nil {
-		return types.ImagePushOptions{}, err
-	}
-	notationKeyName, err := cmd.Flags().GetString("notation-key-name")
-	if err != nil {
-		return types.ImagePushOptions{}, err
-	}
 	allowNonDist, err := cmd.Flags().GetBool(allowNonDistFlag)
+	if err != nil {
+		return types.ImagePushOptions{}, err
+	}
+	signOptions, err := processImageSignOptions(cmd)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
 	return types.ImagePushOptions{
 		GOptions:                       globalOptions,
+		SignOptions:                    signOptions,
 		Platforms:                      platform,
 		AllPlatforms:                   allPlatforms,
 		Estargz:                        estargz,
 		IpfsEnsureImage:                ipfsEnsureImage,
 		IpfsAddress:                    ipfsAddress,
-		Sign:                           sign,
-		CosignKey:                      cosignKey,
-		NotationKeyName:                notationKeyName,
 		AllowNondistributableArtifacts: allowNonDist,
 		Stdout:                         cmd.OutOrStdout(),
 	}, nil

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -149,8 +149,9 @@ type ImageInspectOptions struct {
 
 // ImagePushOptions specifies options for `nerdctl (image) push`.
 type ImagePushOptions struct {
-	Stdout   io.Writer
-	GOptions GlobalCommandOptions
+	Stdout      io.Writer
+	GOptions    GlobalCommandOptions
+	SignOptions ImageSignOptions
 	// Platforms convert content for a specific platform
 	Platforms []string
 	// AllPlatforms convert content for all platforms
@@ -162,31 +163,22 @@ type ImagePushOptions struct {
 	IpfsEnsureImage bool
 	// IpfsAddress multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)
 	IpfsAddress string
-	// Sign the image (none|cosign|notation)
-	Sign string
-	// CosignKey Path to the private key file, KMS URI or Kubernetes Secret for --sign=cosign
-	CosignKey string
-	// NotationKeyName Signing key name for a key previously added to notation's key list for --sign=notation
-	NotationKeyName string
 	// AllowNondistributableArtifacts allow pushing non-distributable artifacts
 	AllowNondistributableArtifacts bool
 }
 
 // ImagePullOptions specifies options for `nerdctl (image) pull`.
 type ImagePullOptions struct {
-	Stdout   io.Writer
-	Stderr   io.Writer
-	GOptions GlobalCommandOptions
+	Stdout        io.Writer
+	Stderr        io.Writer
+	GOptions      GlobalCommandOptions
+	VerifyOptions ImageVerifyOptions
 	// Unpack the image for the current single platform (auto/true/false)
 	Unpack string
 	// Pull content for a specific platform
 	Platform []string
 	// Pull content for all platforms
 	AllPlatforms bool
-	// Verify the image (none|cosign|notation)
-	Verify string
-	// Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign
-	CosignKey string
 	// Suppress verbose output
 	Quiet bool
 	// multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)
@@ -233,4 +225,24 @@ type ImageSaveOptions struct {
 	AllPlatforms bool
 	// Export content for a specific platform
 	Platform []string
+}
+
+// ImageSignOptions contains options for signing an image. It contains options from
+// all providers. The `provider“ field determines which provider is used.
+type ImageSignOptions struct {
+	// Provider used to sign the image (none|cosign|notation)
+	Provider string
+	// CosignKey Path to the private key file, KMS URI or Kubernetes Secret for --sign=cosign
+	CosignKey string
+	// NotationKeyName Signing key name for a key previously added to notation's key list for --sign=notation
+	NotationKeyName string
+}
+
+// ImageVerifyOptions contains options for verifying an image. It contains options from
+// all providers. The `provider“ field determines which provider is used.
+type ImageVerifyOptions struct {
+	// Provider used to verify the image (none|cosign|notation)
+	Provider string
+	// CosignKey Path to the public key file, KMS URI or Kubernetes Secret for --verify=cosign
+	CosignKey string
 }

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -148,34 +148,9 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		return err
 	}
 
-	switch options.Sign {
-	case "cosign":
-
-		if !options.GOptions.Experimental {
-			return fmt.Errorf("cosign only work with enable experimental feature")
-		}
-
-		err = signutil.SignCosign(rawRef, options.CosignKey)
-		if err != nil {
-			return err
-		}
-	case "notation":
-
-		if !options.GOptions.Experimental {
-			return fmt.Errorf("notation only work with enable experimental feature")
-		}
-
-		err = signutil.SignNotation(rawRef, options.NotationKeyName)
-		if err != nil {
-			return err
-		}
-	case "none":
-		logrus.Debugf("signing process skipped")
-	default:
-		return fmt.Errorf("no signers found: %s", options.Sign)
-
+	if err = signutil.Sign(rawRef, options.GOptions.Experimental, options.SignOptions); err != nil {
+		return err
 	}
-
 	return nil
 }
 

--- a/pkg/signutil/signutil.go
+++ b/pkg/signutil/signutil.go
@@ -1,0 +1,80 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package signutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/sirupsen/logrus"
+)
+
+// Sign signs an image using a signer and options provided in options.
+func Sign(rawRef string, experimental bool, options types.ImageSignOptions) error {
+	switch options.Provider {
+	case "cosign":
+		if !experimental {
+			return fmt.Errorf("cosign only work with enable experimental feature")
+		}
+
+		if err := SignCosign(rawRef, options.CosignKey); err != nil {
+			return err
+		}
+	case "notation":
+		if !experimental {
+			return fmt.Errorf("notation only work with enable experimental feature")
+		}
+
+		if err := SignNotation(rawRef, options.NotationKeyName); err != nil {
+			return err
+		}
+	case "", "none":
+		logrus.Debugf("signing process skipped")
+	default:
+		return fmt.Errorf("no signers found: %s", options.Provider)
+	}
+	return nil
+}
+
+// Verify verifies an image using a verifier and options provided in options.
+func Verify(ctx context.Context, rawRef string, hostsDirs []string, experimental bool, options types.ImageVerifyOptions) (ref string, err error) {
+	switch options.Provider {
+	case "cosign":
+		if !experimental {
+			return "", fmt.Errorf("cosign only work with enable experimental feature")
+		}
+
+		if ref, err = VerifyCosign(ctx, rawRef, options.CosignKey, hostsDirs); err != nil {
+			return "", err
+		}
+	case "notation":
+		if !experimental {
+			return "", fmt.Errorf("notation only work with enable experimental feature")
+		}
+
+		if ref, err = VerifyNotation(ctx, rawRef, hostsDirs); err != nil {
+			return "", err
+		}
+	case "", "none":
+		ref = rawRef
+		logrus.Debugf("verifying process skipped")
+	default:
+		return "", fmt.Errorf("no verifiers found: %s", options.Provider)
+	}
+	return ref, nil
+}


### PR DESCRIPTION
This PR extracts image sign/verify options into their own option strcut and move the switch logic into a signutil helper which reduces duplications and make further modification simplier. This also makes sign/verify related logic more centralized in a single package `signutil`.

Some examples:

1. To move one tool out of experimental:

before: change logic in push, pull, and compose.
after: only change logic in `signutil.go`.

2. To add a new verify flag (suppose it's used in `n` cmds):

before: add the flag to (1) `n` cobra cmds, (2) `n` cmd process funcs, (3) `n` cmd option structs.
after: add the flag to (1) `n` cobra cmds, (2). only 1 cmd process logic (the newly added `processImageVerifyOptions`).

3. To add a new tool (not consider flags which is similar to 2):

before: update the switch logic in all places (pull, push, compose).
after: update the switch logic only in `signutil.go`.