### PR TITLE
Support `-q` in `nerdctl push`

### DIFF
--- a/cmd/nerdctl/image_push.go
+++ b/cmd/nerdctl/image_push.go
@@ -57,6 +57,8 @@ func newPushCommand() *cobra.Command {
 	pushCommand.Flags().String("notation-key-name", "", "Signing key name for a key previously added to notation's key list for --sign=notation")
 	// #endregion
 
+	pushCommand.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
+
 	pushCommand.Flags().Bool(allowNonDistFlag, false, "Allow pushing images with non-distributable blobs")
 
 	return pushCommand
@@ -87,6 +89,10 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return types.ImagePushOptions{}, err
+	}
 	allowNonDist, err := cmd.Flags().GetBool(allowNonDistFlag)
 	if err != nil {
 		return types.ImagePushOptions{}, err
@@ -103,6 +109,7 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 		Estargz:                        estargz,
 		IpfsEnsureImage:                ipfsEnsureImage,
 		IpfsAddress:                    ipfsAddress,
+		Quiet:                          quiet,
 		AllowNondistributableArtifacts: allowNonDist,
 		Stdout:                         cmd.OutOrStdout(),
 	}, nil

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -163,6 +163,8 @@ type ImagePushOptions struct {
 	IpfsEnsureImage bool
 	// IpfsAddress multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)
 	IpfsAddress string
+	// Suppress verbose output
+	Quiet bool
 	// AllowNondistributableArtifacts allow pushing non-distributable artifacts
 	AllowNondistributableArtifacts bool
 }

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -45,6 +45,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Push pushes an image specified by `rawRef`.
 func Push(ctx context.Context, client *containerd.Client, rawRef string, options types.ImagePushOptions) error {
 	if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(rawRef); err == nil {
 		if scheme != "ipfs" {
@@ -116,7 +117,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 	}
 
 	pushFunc := func(r remotes.Resolver) error {
-		return push.Push(ctx, client, r, options.Stdout, pushRef, ref, platMC, options.AllowNondistributableArtifacts)
+		return push.Push(ctx, client, r, options.Stdout, pushRef, ref, platMC, options.AllowNondistributableArtifacts, options.Quiet)
 	}
 
 	var dOpts []dockerconfigresolver.Opt
@@ -150,6 +151,10 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 
 	if err = signutil.Sign(rawRef, options.GOptions.Experimental, options.SignOptions); err != nil {
 		return err
+	}
+
+	if options.Quiet {
+		fmt.Fprintln(options.Stdout, ref)
 	}
 	return nil
 }

--- a/pkg/imgutil/push/push.go
+++ b/pkg/imgutil/push/push.go
@@ -39,8 +39,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Push pushes an image to a remote registry.
 func Push(ctx context.Context, client *containerd.Client, resolver remotes.Resolver, stdout io.Writer,
-	localRef, remoteRef string, platform platforms.MatchComparer, allowNonDist bool) error {
+	localRef, remoteRef string, platform platforms.MatchComparer, allowNonDist, quiet bool) error {
 	img, err := client.ImageService().Get(ctx, localRef)
 	if err != nil {
 		return fmt.Errorf("unable to resolve image to manifest: %w", err)
@@ -77,37 +78,39 @@ func Push(ctx context.Context, client *containerd.Client, resolver remotes.Resol
 		)
 	})
 
-	eg.Go(func() error {
-		var (
-			ticker = time.NewTicker(100 * time.Millisecond)
-			fw     = progress.NewWriter(stdout)
-			start  = time.Now()
-			done   bool
-		)
+	if !quiet {
+		eg.Go(func() error {
+			var (
+				ticker = time.NewTicker(100 * time.Millisecond)
+				fw     = progress.NewWriter(stdout)
+				start  = time.Now()
+				done   bool
+			)
 
-		defer ticker.Stop()
+			defer ticker.Stop()
 
-		for {
-			select {
-			case <-ticker.C:
-				fw.Flush()
-
-				tw := tabwriter.NewWriter(fw, 1, 8, 1, ' ', 0)
-
-				jobs.Display(tw, ongoing.status(), start)
-				tw.Flush()
-
-				if done {
+			for {
+				select {
+				case <-ticker.C:
 					fw.Flush()
-					return nil
+
+					tw := tabwriter.NewWriter(fw, 1, 8, 1, ' ', 0)
+
+					jobs.Display(tw, ongoing.status(), start)
+					tw.Flush()
+
+					if done {
+						fw.Flush()
+						return nil
+					}
+				case <-doneCh:
+					done = true
+				case <-ctx.Done():
+					done = true // allow ui to update once more
 				}
-			case <-doneCh:
-				done = true
-			case <-ctx.Done():
-				done = true // allow ui to update once more
 			}
-		}
-	})
+		})
+	}
 	return eg.Wait()
 }
 


### PR DESCRIPTION
```shell
# snd = sudo nerdctl
$ snd push xxx/alpine
INFO[0000] pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.list.v2+json, sha256:b8c628ebeabe71102d6d889930d80a21ce2593c3ac17461b7a875220f2d876ab)
index-sha256:b8c628ebeabe71102d6d889930d80a21ce2593c3ac17461b7a875220f2d876ab:    done           |++++++++++++++++++++++++++++++++++++++|
manifest-sha256:93d5a28ff72d288d69b5997b8ba47396d2cbb62a72b5d87cd3351094b5d578a0: done           |++++++++++++++++++++++++++++++++++++++|
config-sha256:042a816809aac8d0f7d7cacac7965782ee2ecac3f21bcf9f24b1de1a7387b769:   done           |++++++++++++++++++++++++++++++++++++++|
elapsed: 0.2 s                                                                    total:  2.3 Ki (11.3 KiB/s)
$ snd push -q xxx/alpine
INFO[0000] pushing as a reduced-platform image (application/vnd.docker.distribution.manifest.list.v2+json, sha256:b8c628ebeabe71102d6d889930d80a21ce2593c3ac17461b7a875220f2d876ab)
```

As a comparison, in docker:

```shell
# d = docker
$ d push xxx/alpine
Using default tag: latest
The push refers to repository [docker.io/xxx/alpine]
7cd52847ad77: Mounted from library/alpine
latest: digest: sha256:e2e16842c9b54d985bf1ef9242a313f36b856181f188de21313820e177002501 size: 528
$ d push -q xxx/alpine
docker.io/xxx/alpine:latest
```