### PR TITLE
Fix flaky tests in IPFS tests

### DIFF
--- a/cmd/nerdctl/ipfs_build_linux_test.go
+++ b/cmd/nerdctl/ipfs_build_linux_test.go
@@ -38,7 +38,7 @@ func TestIPFSBuild(t *testing.T) {
 	ipfsCIDBase := strings.TrimPrefix(ipfsCID, "ipfs://")
 
 	imageName := testutil.Identifier(t)
-	defer base.Cmd("rmi", imageName).Run()
+	defer base.Cmd("rmi", "-f", imageName).AssertOK()
 
 	dockerfile := fmt.Sprintf(`FROM localhost:5050/ipfs/%s
 CMD ["echo", "nerdctl-build-test-string"]

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -83,7 +83,7 @@ func runIPFSDaemonContainer(t *testing.T, base *testutil.Base) (ipfsAddress stri
 	ipfsaddr := fmt.Sprintf("/ip4/%s/tcp/5001", matches[1])
 	return ipfsaddr, func() {
 		base.Cmd("kill", "test-ipfs-address").AssertOK()
-		base.Cmd("rm", "test-ipfs-address").AssertOK()
+		base.Cmd("rm", "-f", "test-ipfs-address").AssertOK()
 	}
 }
 
@@ -146,13 +146,13 @@ func TestIPFSWithLazyPullingCommit(t *testing.T) {
 
 	base.Cmd("pull", ipfsCID2).AssertOK()
 	base.Cmd("run", "--rm", ipfsCID2, "/bin/sh", "-c", "ls /.stargz-snapshotter && cat /hello").AssertOK()
-	base.Cmd("image", "rm", ipfsCID2).AssertOK()
+	base.Cmd("image", "rm", "-f", ipfsCID2).AssertOK()
 }
 
 func pushImageToIPFS(t *testing.T, base *testutil.Base, name string, opts ...string) string {
 	base.Cmd("pull", name).AssertOK()
 	ipfsCID := cidOf(t, base.Cmd(append([]string{"push"}, append(opts, "ipfs://"+name)...)...).OutLines())
-	base.Cmd("rmi", name).AssertOK()
+	base.Cmd("rmi", "-f", name).AssertOK()
 	return ipfsCID
 }
 


### PR DESCRIPTION
Sometimes; in tests containers are stopped and image removal fails
in ipfs tests making them flaky. This PR should fix those.
Unfortunately, I do not have the logs to prove that as it was found
in one of my branches and a retest was triggered.