### PR TITLE
pkg/mountutil: improve error messages

### DIFF
--- a/cmd/nerdctl/container_run_mount.go
+++ b/cmd/nerdctl/container_run_mount.go
@@ -87,7 +87,7 @@ func parseMountFlags(cmd *cobra.Command, volStore volumestore.VolumeStore) ([]*m
 	for _, v := range strutil.DedupeStrSlice(flagVSlice) {
 		x, err := mountutil.ProcessFlagV(v, volStore)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error while parsing %q: %w", v, err)
 		}
 		parsed = append(parsed, x)
 	}

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -65,7 +65,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		logrus.Debugf("creating anonymous volume %q, for %q", res.AnonymousVolume, s)
 		anonVol, err := volStore.Create(res.AnonymousVolume, []string{})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to create an anonymous volume %q: %w", res.AnonymousVolume, err)
 		}
 		src = anonVol.Mountpoint
 		res.Type = Volume
@@ -80,10 +80,10 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 				if errors.Is(err, errdefs.ErrNotFound) {
 					vol, err = volStore.Create(src, nil)
 					if err != nil {
-						return nil, err
+						return nil, fmt.Errorf("failed to create volume %q: %w", src, err)
 					}
 				} else {
-					return nil, err
+					return nil, fmt.Errorf("failed to get volume %q: %w", src, err)
 				}
 			}
 			// src is now full path
@@ -95,7 +95,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 			var err error
 			src, err = filepath.Abs(src)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to get the absolute path of %q: %w", src, err)
 			}
 		}
 		if !filepath.IsAbs(dst) {
@@ -112,7 +112,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 		var specOpts []oci.SpecOpts
 		options, specOpts, err = parseVolumeOptions(res.Type, src, rawOpts)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to parse volume options (%q, %q, %q): %w", res.Type, src, rawOpts, err)
 		}
 		res.Opts = append(res.Opts, specOpts...)
 	default:
@@ -146,7 +146,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore) (*Processed, error
 	if userns.RunningInUserNS() {
 		unpriv, err := UnprivilegedMountFlags(src)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to get unprivileged mount flags for %q: %w", src, err)
 		}
 		res.Mount.Options = strutil.DedupeStrSlice(append(res.Mount.Options, unpriv...))
 	}

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -19,6 +19,7 @@ package mountutil
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -53,7 +54,7 @@ import (
 func UnprivilegedMountFlags(path string) ([]string, error) {
 	var statfs unix.Statfs_t
 	if err := unix.Statfs(path, &statfs); err != nil {
-		return nil, err
+		return nil, &fs.PathError{Op: "stat", Path: path, Err: err}
 	}
 
 	// The set of keys come from https://github.com/torvalds/linux/blob/v4.13/fs/namespace.c#L1034-L1048.


### PR DESCRIPTION
Example:
```yaml
services:
  foo:
    image: hello-world
    volumes:
      - ./foo:/mnt
```

Before:
```console
$ nerdctl compose up
WARN[0000] Ignoring: volume: Bind: [CreateHostPath]
INFO[0000] Ensuring image hello-world
INFO[0000] Creating container tmp_foo_1
FATA[0000] no such file or directory
FATA[0000] error while creating container tmp_foo_1: exit status 1
```

After:
```console
$ nerdctl compose up
WARN[0000] Ignoring: volume: Bind: [CreateHostPath]
INFO[0000] Ensuring image hello-world
INFO[0000] Creating container tmp_foo_1
FATA[0000] error while parsing "/home/suda/tmp/compose/tmp/foo:/mnt": failed to get unprivileged mount flags for "/home/suda/tmp/compose/tmp/foo": stat /home/suda/tmp/compose/tmp/foo: no such file or directory
FATA[0000] error while creating container tmp_foo_1: exit status 1
```

Fix #2072