### PR TITLE
run: make tty output behaviour compatible to docker and `nerdctl exec`

### DIFF
--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -81,7 +81,7 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			}
 			in = con
 		}
-		ioCreator = cio.NewCreator(cio.WithStreams(in, con, nil), cio.WithTerminal)
+		ioCreator = cio.NewCreator(cio.WithStreams(in, os.Stdout, nil), cio.WithTerminal)
 	} else if flagD && logURI != "" {
 		// TODO: support logURI for `nerdctl run -it`
 		u, err := url.Parse(logURI)


### PR DESCRIPTION
Fixes: https://github.com/containerd/nerdctl/issues/560

Piping/redirecting `nerdctl run -t` seems incompatible to docker and `nerdctl exec`.

### Redirection

`nerdctl run`(main branch):
```
$ nerdctl run --rm -t ghcr.io/stargz-containers/ubuntu:22.04 echo hi > /tmp/testfile
hi
$ cat /tmp/testfile
```

(nothing is written to /tmp/testfile)

docker:
```
$ docker run --rm -t ghcr.io/stargz-containers/ubuntu:22.04 echo hi > /tmp/testfile
$ cat /tmp/testfile
hi
```

`nerdctl exec`:
```
$ nerdctl exec -it test echo hi > /tmp/testfile
$ cat /tmp/testfile
hi
```

It looks like `nerdctl run` ignores redirection but directly writes output to the console. This commit fixes this behaviour to make it compatible to docker.

This PR:

```
$ nerdctl run --rm -t ghcr.io/stargz-containers/ubuntu:22.04 echo hi > /tmp/testfile
$ cat /tmp/testfile
hi
```

### Pipe

This commit also fixes incompatible behaviour on pipe.

`nerdctl run`(main branch):

```
$ nerdctl run --rm -it ghcr.io/stargz-containers/ubuntu:22.04 echo hi | wc -l
hi
0
```

docker:

```
$ docker run --rm -it ghcr.io/stargz-containers/ubuntu:22.04 echo hi | wc -l
1
```

`nerdctl exec`:

```
$ nerdctl exec -it test echo hi | wc -l
1
```

this PR:

```
$ nerdctl run --rm -it ghcr.io/stargz-containers/ubuntu:22.04 echo hi | wc -l
1
```



