### PR TITLE
fix: Add destination ports to used ports when allocating ports

### DIFF
--- a/cmd/nerdctl/container_run_network_base_test.go
+++ b/cmd/nerdctl/container_run_network_base_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -228,4 +229,22 @@ func valuesOfMapStringString(m map[string]string) map[string]struct{} {
 		res[v] = struct{}{}
 	}
 	return res
+}
+
+func extractHostPort(portMapping string) (string, error) {
+	// Regular expression to extract host port from port mapping information
+	re := regexp.MustCompile(`\d+/tcp ->.*?0.0.0.0:(?P<portNumber>\d{1,5}).*?`)
+
+	// Find the matches
+	matches := re.FindStringSubmatch(portMapping)
+
+	// Check if there is a match
+	if len(matches) < 2 {
+		return "", fmt.Errorf("could not extract host port from port mapping: %s", portMapping)
+	}
+
+	// Extract the host port number
+	hostPort := matches[1]
+
+	return hostPort, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/containerd/ttrpc v1.2.1 // indirect
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67 // indirect
 	github.com/containers/ocicrypt v1.1.6 // indirect
+	github.com/coreos/go-iptables v0.6.0
 	github.com/distribution/distribution/v3 v3.0.0-20230214150026-36d8c594d7aa // indirect
 	github.com/djherbis/times v1.5.0 // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-iptables v0.5.0/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
+github.com/coreos/go-iptables v0.6.0 h1:is9qnZMPYjLd8LYqmm/qlE+wwEgJIkTYdhV3rfZo4jk=
 github.com/coreos/go-iptables v0.6.0/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/pkg/portutil/iptable/iptables.go
+++ b/pkg/portutil/iptable/iptables.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package iptable
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// ParseIPTableRules takes a slice of iptables rules as input and returns a slice of
+// uint64 containing the parsed destination port numbers from the rules.
+func ParseIPTableRules(rules []string) []uint64 {
+	ports := []uint64{}
+
+	// Regex to match the '--dports' option followed by the port number
+	dportRegex := regexp.MustCompile(`--dports (\d+)`)
+
+	for _, rule := range rules {
+		matches := dportRegex.FindStringSubmatch(rule)
+		if len(matches) > 1 {
+			port64, err := strconv.ParseUint(matches[1], 10, 16)
+			if err != nil {
+				continue
+			}
+			ports = append(ports, port64)
+		}
+	}
+
+	return ports
+}

--- a/pkg/portutil/iptable/iptables_linux.go
+++ b/pkg/portutil/iptable/iptables_linux.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package iptable
+
+import (
+	"github.com/coreos/go-iptables/iptables"
+)
+
+// Chain used for port forwarding rules: https://www.cni.dev/plugins/current/meta/portmap/#dnat
+const cniDnatChain = "CNI-HOSTPORT-DNAT"
+
+func ReadIPTables(table string) ([]string, error) {
+	ipt, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+
+	var rules []string
+	chainExists, _ := ipt.ChainExists(table, cniDnatChain)
+	if chainExists {
+		rules, err = ipt.List(table, cniDnatChain)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return rules, nil
+}

--- a/pkg/portutil/iptable/iptables_test.go
+++ b/pkg/portutil/iptable/iptables_test.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package iptable
+
+import (
+	"testing"
+)
+
+func TestParseIPTableRules(t *testing.T) {
+	testCases := []struct {
+		name  string
+		rules []string
+		want  []uint64
+	}{
+		{
+			name:  "Empty input",
+			rules: []string{},
+			want:  []uint64{},
+		},
+		{
+			name: "Single rule with single port",
+			rules: []string{
+				"-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment \"dnat name: \"bridge\" id: \"some-id\"\" -m multiport --dports 8080 -j CNI-DN-some-hash",
+			},
+			want: []uint64{8080},
+		},
+		{
+			name: "Multiple rules with multiple ports",
+			rules: []string{
+				"-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment \"dnat name: \"bridge\" id: \"some-id\"\" -m multiport --dports 8080 -j CNI-DN-some-hash",
+				"-A CNI-HOSTPORT-DNAT -p tcp -m comment --comment \"dnat name: \"bridge\" id: \"some-id\"\" -m multiport --dports 9090 -j CNI-DN-some-hash",
+			},
+			want: []uint64{8080, 9090},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ParseIPTableRules(tc.rules)
+			if !equal(got, tc.want) {
+				t.Errorf("ParseIPTableRules(%v) = %v; want %v", tc.rules, got, tc.want)
+			}
+		})
+	}
+}
+
+func equal(a, b []uint64) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Fixes: https://github.com/containerd/nerdctl/issues/2164

`sudo nerdctl run -p <container-port> <image>` always chooses `49153` as host port. Due to multiple containers using the same forwarding port on the host, it becomes impossible to reach them from the host.

Before this change. 

```
# Run 2 containers with -p option. 
$ sudo nerdctl run -d --name my-nginx -p 80 nginx
59f081b2459bdb41bd2a0a024959b6627fa937d74d2d4775f4ab1803a253d76c
$  sudo nerdctl run -d --name my-httpd -p 80 httpd
b280792d4aa2554af45b5aaff7f26b019c8558fe48d8e8e698d62620b593d350

# Host port is always mapped to 49153
$ sudo nerdctl ps -a
CONTAINER ID    IMAGE                             COMMAND                   CREATED           STATUS    PORTS                    NAMES
59f081b2459b    docker.io/library/nginx:latest    "/docker-entrypoint.…"    35 seconds ago    Up        0.0.0.0:49153->80/tcp    my-nginx
b280792d4aa2    docker.io/library/httpd:latest    "httpd-foreground"        4 seconds ago     Up        0.0.0.0:49153->80/tcp    my-httpd
```
Both the containers have host port 49153.
Can't reach nginx from host. Forwarding port now maps to httpd. 

```
$ curl localhost:49153
<html><body><h1>It works!</h1></body></html>
```

After this change

```
$ sudo nerdctl run -d --name my-nginx -p 80 nginx
adb1a0b4e7a88849ffbb78c445d9eec7d4d32ee6ce06e6abed92be02d940235b

$ sudo nerdctl run -d --name my-httpd -p 80 httpd
dd83e29209f6646bb095942feb3039916c445d7eb7a08648ada02f8130663cba

# Second container httpd uses unique port
$  sudo nerdctl ps -a
CONTAINER ID    IMAGE                             COMMAND                   CREATED           STATUS    PORTS                    NAMES
adb1a0b4e7a8    docker.io/library/nginx:latest    "/docker-entrypoint.…"    13 seconds ago    Up        0.0.0.0:49153->80/tcp    my-nginx
dd83e29209f6    docker.io/library/httpd:latest    "httpd-foreground"        6 seconds ago     Up        0.0.0.0:49154->80/tcp    my-httpd
```

Can reach both `my-nginx` and `my-httpd` from host. 
```
$ curl localhost:49153
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>

<p>For online documentation and support please refer to
<a href="http://nginx.org/">nginx.org</a>.<br/>
Commercial support is available at
<a href="http://nginx.com/">nginx.com</a>.</p>

<p><em>Thank you for using nginx.</em></p>
</body>
</html>

$ curl localhost:49154
<html><body><h1>It works!</h1></body></html>
```
