### PR TITLE
Resolve Go cache warning in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 40
     steps:
+    - uses: actions/checkout@v3.5.1
     - uses: actions/setup-go@v4
       with:
         go-version: 1.20.x
-    - uses: actions/checkout@v3.5.1
     - name: "Compile binaries"
       run: make artifacts
     - name: "SHA256SUMS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: src/github.com/containerd/nerdctl
       - uses: containerd/project-checks@v1.1.0
         with:
           working-directory: src/github.com/containerd/nerdctl


### PR DESCRIPTION
actions/setup-go@v4.0.0 release enabled Go cache by default. This resulted in a warning in the release workflow for restore cache failure. Resolve the warning by having checkout before setup-go step.

A recent [release workflow run](https://github.com/containerd/nerdctl/actions/runs/4618402058) with Go cache restore failure warning.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>