### PR TITLE
test: add test for piping of `nerdctl run` with `-t`

### DIFF
--- a/cmd/nerdctl/container_run_linux_test.go
+++ b/cmd/nerdctl/container_run_linux_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
 )
 
 func TestRunCustomRootfs(t *testing.T) {
@@ -246,6 +247,10 @@ func TestRunTTY(t *testing.T) {
 	base.CmdWithHelper(unbuffer, "run", "--rm", "-t", testutil.CommonImage, "stty").AssertOutContains(sttyPartialOutput)
 	base.Cmd("run", "--rm", "-i", testutil.CommonImage, "stty").AssertFail()
 	base.Cmd("run", "--rm", testutil.CommonImage, "stty").AssertFail()
+
+	// tests pipe works
+	res := icmd.RunCmd(icmd.Command("unbuffer", "/bin/sh", "-c", fmt.Sprintf("%q run --rm -it %q echo hi | grep hi", base.Binary, testutil.CommonImage)))
+	assert.Equal(t, 0, res.ExitCode, res.Combined())
 }
 
 func TestRunWithFluentdLogDriver(t *testing.T) {


### PR DESCRIPTION
Following-up: https://github.com/containerd/nerdctl/pull/2167#issuecomment-1506488861

This adds an integration test for piping `nerdctl run` with `-t` flag.

main branch

```
=== CONT  TestRunTTY
--- PASS: TestRunTTY (10.93s)
PASS
```

 v1.3.0

```
=== CONT  TestRunTTY
    container_run_linux_test.go:253: assertion failed: 0 (int) != 1 (res.ExitCode int): ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.1 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.2 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.3 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.4 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.5 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org: resolving      |--------------------------------------| 
        elapsed: 0.6 s                             total:   0.0 B (0.0 B/s)                                         
        ghcr.io/stargz-containers/alpine:3.13-org:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
        index-sha256:ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a:    done           |++++++++++++++++++++++++++++++++++++++| 
        manifest-sha256:e103c1b4bf019dc290bcc7aca538dc2bf7a9d0fc836e186f5fa34945c5168310: waiting        |--------------------------------------| 
        elapsed: 0.7 s                                                                    total:  1.6 Ki (2.3 KiB/s)                                       
        ghcr.io/stargz-containers/alpine:3.13-org:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
        index-sha256:ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a:    done           |++++++++++++++++++++++++++++++++++++++| 
        manifest-sha256:e103c1b4bf019dc290bcc7aca538dc2bf7a9d0fc836e186f5fa34945c5168310: waiting        |--------------------------------------| 
        config-sha256:49f356fa4513676c5e22e3a8404aad6c7262cc7aaed15341458265320786c58c:   done           |++++++++++++++++++++++++++++++++++++++| 
        layer-sha256:ca3cd42a7c9525f6ce3d64c1a70982613a8235f0cc057ec9244052921853ef15:    done           |++++++++++++++++++++++++++++++++++++++| 
        elapsed: 0.8 s                                                                    total:  2.7 Mi (3.4 MiB/s)                                       
        ghcr.io/stargz-containers/alpine:3.13-org:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
        index-sha256:ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a:    done           |++++++++++++++++++++++++++++++++++++++| 
        manifest-sha256:e103c1b4bf019dc290bcc7aca538dc2bf7a9d0fc836e186f5fa34945c5168310: waiting        |--------------------------------------| 
        config-sha256:49f356fa4513676c5e22e3a8404aad6c7262cc7aaed15341458265320786c58c:   done           |++++++++++++++++++++++++++++++++++++++| 
        layer-sha256:ca3cd42a7c9525f6ce3d64c1a70982613a8235f0cc057ec9244052921853ef15:    done           |++++++++++++++++++++++++++++++++++++++| 
        elapsed: 0.9 s                                                                    total:  2.7 Mi (3.0 MiB/s)                                       
        ghcr.io/stargz-containers/alpine:3.13-org:                                        resolved       |++++++++++++++++++++++++++++++++++++++| 
        index-sha256:ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a:    done           |++++++++++++++++++++++++++++++++++++++| 
        manifest-sha256:e103c1b4bf019dc290bcc7aca538dc2bf7a9d0fc836e186f5fa34945c5168310: done           |++++++++++++++++++++++++++++++++++++++| 
        config-sha256:49f356fa4513676c5e22e3a8404aad6c7262cc7aaed15341458265320786c58c:   done           |++++++++++++++++++++++++++++++++++++++| 
        layer-sha256:ca3cd42a7c9525f6ce3d64c1a70982613a8235f0cc057ec9244052921853ef15:    done           |++++++++++++++++++++++++++++++++++++++| 
        elapsed: 1.0 s                                                                    total:  2.7 Mi (2.7 MiB/s)                                       
        hi
        
--- FAIL: TestRunTTY (6.13s)
FAIL
```
