### PR TITLE
fix nerdctl exec init console size 0 0 problem

### DIFF
--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -161,6 +161,11 @@ func generateExecProcessSpec(ctx context.Context, client *containerd.Client, con
 
 	pspec := spec.Process
 	pspec.Terminal = options.TTY
+	if pspec.Terminal {
+		if size, err := console.Current().Size(); err == nil {
+			pspec.ConsoleSize = &specs.Box{Height: uint(size.Height), Width: uint(size.Width)}
+		}
+	}
 	pspec.Args = args[1:]
 
 	if options.Workdir != "" {


### PR DESCRIPTION
currently `nerdctl exec -it` initial tty size is `0 0`, switch it to current console size