### PR TITLE
Update Windows tests to use the check HyperV helper

### DIFF
--- a/cmd/nerdctl/container_top_windows_test.go
+++ b/cmd/nerdctl/container_top_windows_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
-	"golang.org/x/sys/windows/svc/mgr"
 )
 
 func TestTopProcessContainer(t *testing.T) {
@@ -34,21 +33,9 @@ func TestTopProcessContainer(t *testing.T) {
 }
 
 func TestTopHyperVContainer(t *testing.T) {
-	// Hyper-V Virtual Machine Management service
-	hypervServiceName := "vmms"
-
-	m, err := mgr.Connect()
-	if err != nil {
-		t.Fatalf("unable to access Windows service control manager: %s", err)
-	}
-	defer m.Disconnect()
-
-	s, err := m.OpenService(hypervServiceName)
-	// hyperv service is not present, hyperv is not enabled
-	if err != nil {
+	if !testutil.HyperVSupported() {
 		t.Skip("HyperV is not enabled, skipping test")
 	}
-	defer s.Close()
 
 	testContainerName := testutil.Identifier(t)
 


### PR DESCRIPTION
The new `HyperVSupported` helper was intoduced in `testutil_windows` to check if HyperV is enabled on the host. Updating old Windows tests to reflect this. 