### PR TITLE
CI: Add check for go mod tidy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         working-directory: src/github.com/containerd/nerdctl
       - run: ./hack/verify-pkg-isolation.sh
         working-directory: src/github.com/containerd/nerdctl
+      - run: ./hack/valiate-vendor.sh
+        working-directory: src/github.com/containerd/nerdctl
 
   lint:
     runs-on: ubuntu-22.04

--- a/hack/valiate-vendor.sh
+++ b/hack/valiate-vendor.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eux -o pipefail
+
+TMPDIR=$(mktemp -d)
+cp -R . ${TMPDIR}
+(cd ${TMPDIR} && go mod tidy)
+diff -r -u -q . ${TMPDIR}
+rm -rf ${TMPDIR}


### PR DESCRIPTION
This commit adds a check for go.mod/go.sum similarly as containerd has https://github.com/containerd/containerd/blob/b0f587d65d0e5a66867e6efda1a3dcc02ec96a06/.github/workflows/ci.yml#L77