### PR TITLE
nerdctl images: Remove TODOs about VirtualSize

### DIFF
--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -119,7 +119,7 @@ type imagePrintable struct {
 	Name         string // image name
 	Size         string // the size of the unpacked snapshots.
 	BlobSize     string // the size of the blobs in the content store (nerdctl extension)
-	// TODO: "SharedSize", "UniqueSize", "VirtualSize"
+	// TODO: "SharedSize", "UniqueSize"
 	Platform string // nerdctl extension
 }
 

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -66,7 +66,6 @@ type Image struct {
 	Os string
 	// TODO: OsVersion     string `json:",omitempty"`
 	Size int64 // Size is the unpacked size of the image
-	// TODO: VirtualSize   int64
 	// TODO: GraphDriver     GraphDriverData
 	RootFS   RootFS
 	Metadata ImageMetadata


### PR DESCRIPTION
VirtualSize was removed in moby/moby#45469 (API v1.44, Docker v25)