### PR TITLE
nerdctl system prune: skip pruning build cache if buildkit is not running

### DIFF
--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/system"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +60,8 @@ func processSystemPruneOptions(cmd *cobra.Command) (types.SystemPruneOptions, er
 
 	buildkitHost, err := getBuildkitHost(cmd, globalOptions.Namespace)
 	if err != nil {
-		return types.SystemPruneOptions{}, err
+		logrus.WithError(err).Warn("BuildKit is not running. Build caches will not be pruned.")
+		buildkitHost = ""
 	}
 
 	return types.SystemPruneOptions{

--- a/pkg/cmd/system/prune.go
+++ b/pkg/cmd/system/prune.go
@@ -61,20 +61,23 @@ func Prune(ctx context.Context, client *containerd.Client, options types.SystemP
 	}); err != nil {
 		return nil
 	}
-	prunedObjects, err := builder.Prune(ctx, types.BuilderPruneOptions{
-		Stderr:       options.Stderr,
-		GOptions:     options.GOptions,
-		All:          options.All,
-		BuildKitHost: options.BuildKitHost,
-	})
-	if err != nil {
-		return err
-	}
 
-	if len(prunedObjects) > 0 {
-		fmt.Fprintln(options.Stdout, "Deleted build cache objects:")
-		for _, item := range prunedObjects {
-			fmt.Fprintln(options.Stdout, item.ID)
+	if options.BuildKitHost != "" {
+		prunedObjects, err := builder.Prune(ctx, types.BuilderPruneOptions{
+			Stderr:       options.Stderr,
+			GOptions:     options.GOptions,
+			All:          options.All,
+			BuildKitHost: options.BuildKitHost,
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(prunedObjects) > 0 {
+			fmt.Fprintln(options.Stdout, "Deleted build cache objects:")
+			for _, item := range prunedObjects {
+				fmt.Fprintln(options.Stdout, item.ID)
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously, `nerdctl system prune` was not executable when BuildKit is not running.