### PR TITLE
Ignore dependencies for compose build and logs

### DIFF
--- a/cmd/nerdctl/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose_build_linux_test.go
@@ -34,6 +34,8 @@ services:
     image: %s
     ports:
     - 8080:80
+    depends_on:
+    - svc1
   svc1:
     build: .
     image: %s
@@ -56,7 +58,7 @@ services:
 	defer base.Cmd("rmi", imageSvc0).Run()
 	defer base.Cmd("rmi", imageSvc1).Run()
 
-	// 1. build only 1 service
+	// 1. build only 1 service without triggering the dependency service build
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0").AssertOK()
 	base.Cmd("images").AssertOutContains(imageSvc0)
 	base.Cmd("images").AssertOutNotContains(imageSvc1)

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -43,7 +43,7 @@ func (c *Composer) Build(ctx context.Context, bo BuildOptions, services []string
 			return c.buildServiceImage(ctx, ps.Image, ps.Build, ps.Unparsed.Platform, bo)
 		}
 		return nil
-	})
+	}, types.IgnoreDependencies)
 }
 
 func (c *Composer) buildServiceImage(ctx context.Context, image string, b *serviceparser.Build, platform string, bo BuildOptions) error {

--- a/pkg/composer/logs.go
+++ b/pkg/composer/logs.go
@@ -23,6 +23,7 @@ import (
 	"os/signal"
 	"strings"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/composer/pipetagger"
 	"github.com/containerd/nerdctl/pkg/labels"
@@ -39,7 +40,11 @@ type LogsOptions struct {
 }
 
 func (c *Composer) Logs(ctx context.Context, lo LogsOptions, services []string) error {
-	serviceNames, err := c.ServiceNames(services...)
+	var serviceNames []string
+	err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
+		serviceNames = append(serviceNames, svc.Name)
+		return nil
+	}, types.IgnoreDependencies)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/2261

No existing unit tests for compose logs yet (will try to add later). Manual test for `compose logs`:
```
Admin:~/nerdctl (depends) $ sudo ./_output/nerdctl compose logs svc1
svc1_1 |/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
svc1_1 |/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
svc1_1 |/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
svc1_1 |10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
svc1_1 |10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
svc1_1 |/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
svc1_1 |/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
svc1_1 |/docker-entrypoint.sh: Configuration complete; ready for start up
```