### PR TITLE
Add Compose `shm_size` service option support

### DIFF
--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -92,6 +92,7 @@ func warnUnknownFields(svc types.ServiceConfig) {
 		"Secrets",
 		"Scale",
 		"SecurityOpt",
+		"ShmSize",
 		"StopGracePeriod",
 		"StopSignal",
 		"Sysctls",
@@ -646,6 +647,10 @@ func newContainer(project *types.Project, parsed *Service, i int) (*Container, e
 
 	if svc.Runtime != "" {
 		c.RunArgs = append(c.RunArgs, "--runtime="+svc.Runtime)
+	}
+
+	if svc.ShmSize > 0 {
+		c.RunArgs = append(c.RunArgs, fmt.Sprintf("--shm-size=%d", svc.ShmSize))
 	}
 
 	for _, v := range svc.SecurityOpt {

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -104,6 +104,7 @@ services:
     volumes:
       - wordpress:/var/www/html
     pids_limit: 100
+    shm_size: 1G
     dns:
       - 8.8.8.8
       - 8.8.4.4
@@ -171,6 +172,7 @@ volumes:
 	assert.Assert(t, in(wp1.RunArgs, "--log-opt=max-file=2"))
 	assert.Assert(t, in(wp1.RunArgs, "--add-host=test.com:172.19.1.1"))
 	assert.Assert(t, in(wp1.RunArgs, "--add-host=test2.com:172.19.1.2"))
+	assert.Assert(t, in(wp1.RunArgs, "--shm-size=1073741824"))
 
 	dbSvc, err := project.GetService("db")
 	assert.NilError(t, err)


### PR DESCRIPTION
Since `--shm-size` option [is supported by `nerdctl run` command](https://github.com/containerd/nerdctl/pull/240), it is also nice to have its counterpart from [Compose file specification](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#shm_size).

Example configuration
```yaml
version: '3.9'

services:
  test-plain:
    image: debian:buster-slim
    command: grep shm /proc/self/mounts
  test-shm:
    image: debian:buster-slim
    shm_size: 1G
    command: grep shm /proc/self/mounts
```

Before fix:
```
$ nerdctl compose -f compose.yml run test-plain
INFO[0000] Ensuring image debian:buster-slim
INFO[0000] Creating container nerdctl_test-plain_run_bdf02686b2bc
shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k,uid=501,gid=1000,inode64 0 0

$ nerdctl compose -f compose.yml run test-shm
WARN[0000] Ignoring: service test-shm: [ShmSize]
INFO[0000] Ensuring image debian:buster-slim
INFO[0000] Creating container nerdctl_test-shm_run_0715f6c50f71
shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k,uid=501,gid=1000,inode64 0 0
```

After fix:
```
$ nerdctl compose -f compose.yml run test-plain
INFO[0000] Ensuring image debian:buster-slim
INFO[0000] Creating container nerdctl_test-plain_run_128ffac7cffb
shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=65536k,uid=501,gid=1000,inode64 0 0

$ nerdctl compose -f compose.yml run test-shm
INFO[0000] Ensuring image debian:buster-slim
INFO[0000] Creating container nerdctl_test-shm_run_e6afbb4dbe93
shm /dev/shm tmpfs rw,nosuid,nodev,noexec,relatime,size=1048576k,uid=501,gid=1000,inode64 0 0
```