### PR TITLE
Prevent timing flakyness for `--since/--until` in TestLogs.

### DIFF
--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -36,9 +36,15 @@ bar`
 	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
 		"sh", "-euxc", "echo foo; echo bar").AssertOK()
 
+	//test since / until flag
 	time.Sleep(3 * time.Second)
+	base.Cmd("logs", "--since", "1s", containerName).AssertNoOut(expected)
+	base.Cmd("logs", "--since", "10s", containerName).AssertOutContains(expected)
+	base.Cmd("logs", "--until", "10s", containerName).AssertNoOut(expected)
+	base.Cmd("logs", "--until", "1s", containerName).AssertOutContains(expected)
+
+	// Ensure follow flag works as expected:
 	base.Cmd("logs", "-f", containerName).AssertOutContains("bar")
-	// Run logs twice, make sure that the logs are not removed
 	base.Cmd("logs", "-f", containerName).AssertOutContains("foo")
 
 	//test timestamps flag
@@ -53,12 +59,6 @@ bar`
 		}
 		return nil
 	})
-
-	//test since / until flag
-	base.Cmd("logs", "--since", "1s", containerName).AssertNoOut(expected)
-	base.Cmd("logs", "--since", "5s", containerName).AssertOutContains(expected)
-	base.Cmd("logs", "--until", "5s", containerName).AssertNoOut(expected)
-	base.Cmd("logs", "--until", "1s", containerName).AssertOutContains(expected)
 
 	base.Cmd("rm", "-f", containerName).AssertOK()
 }


### PR DESCRIPTION
This patch updates `TestLogs` to prevent potential test timing issues while testing the behaviour of the `--since/--until` flags.

Although extremely rare, I have [encountered this timing issue in a workflow run](https://github.com/aznashwan/nerdctl/actions/runs/5255660956/jobs/9495877023#step:9:12594).