### PR TITLE
Fix `nerdctl create --restart=unless-stopped`  restart policy behaviour inconsistent with docker

### DIFF
--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -274,6 +274,9 @@ func processCreateCommandFlagsInRun(cmd *cobra.Command) (opt types.ContainerCrea
 	if err != nil {
 		return
 	}
+
+	opt.InRun = true
+
 	opt.Interactive, err = cmd.Flags().GetBool("interactive")
 	if err != nil {
 		return

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -54,6 +54,9 @@ type ContainerCreateOptions struct {
 	// NerdctlArgs is the arguments of nerdctl
 	NerdctlArgs []string
 
+	// InRun is true when it's generated in the `run` command
+	InRun bool
+
 	// #region for basic flags
 	// Interactive keep STDIN open even if not attached
 	Interactive bool

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -167,7 +167,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	}
 	internalLabels.logURI = logConfig.LogURI
 
-	restartOpts, err := generateRestartOpts(ctx, client, options.Restart, logConfig.LogURI)
+	restartOpts, err := generateRestartOpts(ctx, client, options.Restart, logConfig.LogURI, options.InRun)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cmd/container/run_restart.go
+++ b/pkg/cmd/container/run_restart.go
@@ -50,7 +50,7 @@ func checkRestartCapabilities(ctx context.Context, client *containerd.Client, re
 	return true, nil
 }
 
-func generateRestartOpts(ctx context.Context, client *containerd.Client, restartFlag, logURI string) ([]containerd.NewContainerOpts, error) {
+func generateRestartOpts(ctx context.Context, client *containerd.Client, restartFlag, logURI string, inRun bool) ([]containerd.NewContainerOpts, error) {
 	if restartFlag == "" || restartFlag == "no" {
 		return nil, nil
 	}
@@ -62,7 +62,11 @@ func generateRestartOpts(ctx context.Context, client *containerd.Client, restart
 	if err != nil {
 		return nil, err
 	}
-	opts := []containerd.NewContainerOpts{restart.WithPolicy(policy), restart.WithStatus(containerd.Running)}
+	desireStatus := containerd.Created
+	if inRun {
+		desireStatus = containerd.Running
+	}
+	opts := []containerd.NewContainerOpts{restart.WithPolicy(policy), restart.WithStatus(desireStatus)}
 	if logURI != "" {
 		opts = append(opts, restart.WithLogURIString(logURI))
 	}


### PR DESCRIPTION
The PR is to fix the https://github.com/containerd/nerdctl/issues/2270 by using the `containerd.io/restart.status` label.

In containerd the label is used as the desiredStatus : https://github.com/containerd/containerd/blob/main/runtime/restart/monitor/monitor.go#L152

## After Fixed:

```
#  ./_output/nerdctl create --restart=always docker.m.daocloud.io/nginx
c59503699e2319491f398669a47697ead68ac081ee44afd431f7a684cc3221c1
#  ./_output/nerdctl run -d --restart=always docker.m.daocloud.io/nginx
fb95a1146e94d47b6441da6082b530b7d639d713e8c7d067e20cf4a6e2b7384f
# ./_output/nerdctl ps -a |grep nginx
c59503699e23    docker.m.daocloud.io/nginx:latest                             "/docker-entrypoint.…"    17 seconds ago    Created             nginx-c5950
fb95a1146e94    docker.m.daocloud.io/nginx:latest                             "/docker-entrypoint.…"    17 seconds ago    Up                  nginx-fb95
```

The container would not start after being created with the restart policy.  The behavior is consistent with docker




