### PR TITLE
Skip the BuildKit tests in the rootless integration 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
         run: DOCKER_BUILDKIT=1 docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged ${TEST_TARGET}
+        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=1 ${TEST_TARGET}
 
   cross:
     runs-on: ubuntu-22.04

--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -21,9 +21,9 @@ if [[ "$(id -u)" = "0" ]]; then
 		nerdctl apparmor load
 	fi
 
-	: "${WORKAROUND_CIRRUS:=}"
-	if [[ "$WORKAROUND_CIRRUS" = "1" ]]; then
-		touch /workaround-cirrus
+	: "${WORKAROUND_ISSUE_622:=}"
+	if [[ "$WORKAROUND_ISSUE_622" = "1" ]]; then
+		touch /workaround-issue-622
 	fi
 
 	# Switch to the rootless user via SSH
@@ -35,8 +35,8 @@ else
 		containerd-rootless-setuptool.sh nsenter -- sh -euc 'echo "options use-vc" >>/etc/resolv.conf'
 	fi
 
-	if [[ -e /workaround-cirrus ]]; then
-		echo "WORKAROUND_CIRRUS: Not enabling BuildKit (https://github.com/containerd/nerdctl/issues/622)" >&2
+	if [[ -e /workaround-issue-622 ]]; then
+		echo "WORKAROUND_ISSUE_622: Not enabling BuildKit (https://github.com/containerd/nerdctl/issues/622)" >&2
 	else
 		CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-setuptool.sh install-buildkit-containerd
 	fi

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -357,6 +357,7 @@ func TestRunWithJournaldLogDriverAndLogOpt(t *testing.T) {
 }
 
 func TestRunWithLogBinary(t *testing.T) {
+	testutil.RequiresBuild(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("buildkit is not enabled on windows, this feature may work on windows.")
 	}

--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -107,6 +107,7 @@ func rmiAll(base *testutil.Base) {
 }
 
 func TestImageEncryptJWE(t *testing.T) {
+	testutil.RequiresBuild(t)
 	testutil.DockerIncompatible(t)
 	keyPair := newJWEKeyPair(t)
 	defer keyPair.cleanup()

--- a/cmd/nerdctl/image_push_linux_test.go
+++ b/cmd/nerdctl/image_push_linux_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestPushPlainHTTPFails(t *testing.T) {
+	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()
@@ -46,6 +47,7 @@ func TestPushPlainHTTPFails(t *testing.T) {
 }
 
 func TestPushPlainHTTPLocalhost(t *testing.T) {
+	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	reg := testregistry.NewPlainHTTP(base, 5000)
 	defer reg.Cleanup()
@@ -62,6 +64,7 @@ func TestPushPlainHTTPLocalhost(t *testing.T) {
 }
 
 func TestPushPlainHTTPInsecure(t *testing.T) {
+	testutil.RequiresBuild(t)
 	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
 	testutil.DockerIncompatible(t)
 
@@ -79,6 +82,7 @@ func TestPushPlainHTTPInsecure(t *testing.T) {
 }
 
 func TestPushPlainHttpInsecureWithDefaultPort(t *testing.T) {
+	testutil.RequiresBuild(t)
 	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
 	testutil.DockerIncompatible(t)
 
@@ -96,6 +100,7 @@ func TestPushPlainHttpInsecureWithDefaultPort(t *testing.T) {
 }
 
 func TestPushInsecureWithLogin(t *testing.T) {
+	testutil.RequiresBuild(t)
 	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
 	testutil.DockerIncompatible(t)
 
@@ -116,6 +121,7 @@ func TestPushInsecureWithLogin(t *testing.T) {
 }
 
 func TestPushWithHostsDir(t *testing.T) {
+	testutil.RequiresBuild(t)
 	// Skip docker, because Docker doesn't have `--hosts-dir` option, and we don't want to contaminate the global /etc/docker/certs.d during this test
 	testutil.DockerIncompatible(t)
 
@@ -135,6 +141,7 @@ func TestPushWithHostsDir(t *testing.T) {
 }
 
 func TestPushNonDistributableArtifacts(t *testing.T) {
+	testutil.RequiresBuild(t)
 	// Skip docker, because "dockerd --insecure-registries" requires restarting the daemon
 	// Skip docker, because "--allow-nondistributable-artifacts" is a daemon-only option and requires restarting the daemon
 	testutil.DockerIncompatible(t)


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/622 is too much flaky
The CI is often broken by the issue.

So like https://github.com/containerd/nerdctl/pull/734, skip the test in the rootless integration .