### PR TITLE
Optimize for itoa operations

### DIFF
--- a/cmd/nerdctl/container_run_log_driver_syslog_test.go
+++ b/cmd/nerdctl/container_run_log_driver_syslog_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -53,7 +54,7 @@ func runSyslogTest(t *testing.T, networks []string, syslogFacilities map[string]
 		for rFK, rFV := range syslogFacilities {
 			fPriV := rFV
 			// test both string and number facility
-			for _, fPriK := range []string{rFK, fmt.Sprintf("%d", int(fPriV)>>3)} {
+			for _, fPriK := range []string{rFK, strconv.Itoa(int(fPriV) >> 3)} {
 				for fmtK, fmtValidFunc := range fmtValidFuncs {
 					fmtKT := "empty"
 					if fmtK != "" {

--- a/pkg/ipfs/registry.go
+++ b/pkg/ipfs/registry.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -84,7 +85,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", mediaType)
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	if r.Method == "GET" {
 		http.ServeContent(w, r, "", time.Now(), content)
 		logrus.WithField("CID", cid).Debugf("served file")

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -204,7 +204,7 @@ func viewLogsJSONFileThroughTailExec(lvopts LogViewOptions, jsonLogFilePath stri
 	if lvopts.Tail == 0 {
 		args = append(args, "+0")
 	} else {
-		args = append(args, fmt.Sprintf("%d", lvopts.Tail))
+		args = append(args, strconv.FormatUint(uint64(lvopts.Tail), 10))
 	}
 
 	if lvopts.Follow {

--- a/pkg/statsutil/stats.go
+++ b/pkg/statsutil/stats.go
@@ -18,6 +18,7 @@ package statsutil
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -205,5 +206,5 @@ func (s *StatsEntry) PIDs() string {
 	if s.IsInvalid {
 		return "--"
 	}
-	return fmt.Sprintf("%d", s.PidsCurrent)
+	return strconv.FormatUint(s.PidsCurrent, 10)
 }


### PR DESCRIPTION
Use `strconv` package for itoa operations instead of `fmt.Sprintf`. Note this change is non-functional and is not required.