### PR TITLE
refactor: extract the printing logic out of pkg for container list

### DIFF
--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -391,7 +391,6 @@ type ContainerExecOptions struct {
 
 // ContainerListOptions specifies options for `nerdctl (container) list`.
 type ContainerListOptions struct {
-	Stdout io.Writer
 	// GOptions is the global options.
 	GOptions GlobalCommandOptions
 	// Show all containers (default shows just running).
@@ -401,12 +400,8 @@ type ContainerListOptions struct {
 	LastN int
 	// Truncate output (e.g., container ID, command of the container main process, etc.) or not.
 	Truncate bool
-	// Only display container IDs.
-	Quiet bool
 	// Display total file sizes.
 	Size bool
-	// Format the output using the given Go template (e.g., '{{json .}}', 'table', 'wide').
-	Format string
 	// Filters matches containers based on given conditions.
 	Filters []string
 }

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -288,7 +288,7 @@ func (cl *containerFilterContext) matchesNameFilter(info containers.Container) b
 	if len(cl.nameFilterFuncs) == 0 {
 		return true
 	}
-	cName := getPrintableContainerName(info.Labels)
+	cName := getContainerName(info.Labels)
 	for _, nameFilterFunc := range cl.nameFilterFuncs {
 		if !nameFilterFunc(cName) {
 			continue
@@ -367,7 +367,7 @@ func idOrNameFilter(ctx context.Context, containers []containerd.Container, valu
 		if err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(info.ID, value) || strings.Contains(getPrintableContainerName(info.Labels), value) {
+		if strings.HasPrefix(info.ID, value) || strings.Contains(getContainerName(info.Labels), value) {
 			return &info, nil
 		}
 	}


### PR DESCRIPTION
> And in the community, people may need to add some features of their own, like https://github.com/containerd/nerdctl/issues/1631, so it's time to refactor the command package!

Based on the [issue](https://github.com/containerd/nerdctl/issues/1680), one of the reason of refactoring nerdctl is to make it easy for developers to import subcommand package. The current refactoring pattern of container list mixed printing logic in List() in pkg, which makes it not flexible to be imported to use. The printing logic is very specific to nerdctl cmd layer, so the idea is to moving the printing logic out of pkg, and let List() return a generic container list.

This is not the only solution to unblock the use case. The alternative is to simply make filterContainers and other functions public. 