### PR TITLE
fix: shutdown logger after container process exits

### DIFF
--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -143,3 +143,49 @@ func TestLogsWithFailingContainer(t *testing.T) {
 	base.Cmd("logs", "-f", containerName).AssertNoOut("baz")
 	base.Cmd("rm", "-f", containerName).AssertOK()
 }
+
+func TestLogsWithRunningContainer(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", containerName).Run()
+	expected := []string{}
+	for i := 1; i <= 10; i++ {
+		expected = append(expected, fmt.Sprint(i))
+	}
+
+	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
+		"sh", "-euc", "for i in `seq 1 10`; do echo $i; sleep 1; done").AssertOK()
+	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
+	base.Cmd("rm", "-f", containerName).AssertOK()
+}
+
+func TestLogsWithoutNewline(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", containerName).Run()
+	expected := []string{"Hello World!", "There is no newline"}
+	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
+		"printf", "'Hello World!\nThere is no newline'").AssertOK()
+	time.Sleep(3 * time.Second)
+	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
+	base.Cmd("rm", "-f", containerName).AssertOK()
+}
+
+func TestLogsAfterRestartingContainer(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", containerName).Run()
+	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
+		"printf", "'Hello World!\nThere is no newline'").AssertOK()
+	expected := []string{"Hello World!", "There is no newline"}
+	time.Sleep(3 * time.Second)
+	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
+	// restart and check logs again
+	base.Cmd("start", containerName)
+	time.Sleep(3 * time.Second)
+	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
+	base.Cmd("rm", "-f", containerName).AssertOK()
+}

--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -148,36 +148,34 @@ func TestLogsWithRunningContainer(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", containerName).Run()
-	expected := []string{}
-	for i := 1; i <= 10; i++ {
-		expected = append(expected, fmt.Sprint(i))
+	defer base.Cmd("rm", "-f", containerName).Run()
+	expected := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		expected[i] = fmt.Sprint(i + 1)
 	}
 
 	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
 		"sh", "-euc", "for i in `seq 1 10`; do echo $i; sleep 1; done").AssertOK()
 	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
-	base.Cmd("rm", "-f", containerName).AssertOK()
 }
 
-func TestLogsWithoutNewline(t *testing.T) {
+func TestLogsWithoutNewlineOrEOF(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).Run()
 	expected := []string{"Hello World!", "There is no newline"}
 	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
 		"printf", "'Hello World!\nThere is no newline'").AssertOK()
 	time.Sleep(3 * time.Second)
 	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
-	base.Cmd("rm", "-f", containerName).AssertOK()
 }
 
 func TestLogsAfterRestartingContainer(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", containerName).Run()
+	defer base.Cmd("rm", "-f", containerName).Run()
 	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
 		"printf", "'Hello World!\nThere is no newline'").AssertOK()
 	expected := []string{"Hello World!", "There is no newline"}
@@ -187,5 +185,4 @@ func TestLogsAfterRestartingContainer(t *testing.T) {
 	base.Cmd("start", containerName)
 	time.Sleep(3 * time.Second)
 	base.Cmd("logs", "-f", containerName).AssertOutContainsAll(expected...)
-	base.Cmd("rm", "-f", containerName).AssertOK()
 }

--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -160,6 +161,9 @@ func TestLogsWithRunningContainer(t *testing.T) {
 }
 
 func TestLogsWithoutNewlineOrEOF(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("FIXME: test does not work on Windows yet because containerd doesn't send an exit event appropriately after task exit on Windows")
+	}
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
@@ -172,6 +176,9 @@ func TestLogsWithoutNewlineOrEOF(t *testing.T) {
 }
 
 func TestLogsAfterRestartingContainer(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("FIXME: test does not work on Windows yet. Restarting a container fails with: failed to create shim task: hcs::CreateComputeSystem <id>: The requested operation for attach namespace failed.: unknown")
+	}
 	t.Parallel()
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -161,7 +161,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// 1, nerdctl run --name demo -it imagename
 	// 2, ctrl + c to stop demo container
 	// 3, nerdctl start/restart demo
-	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace)
+	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, &options.GOptions)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -655,8 +655,9 @@ func writeCIDFile(path, id string) error {
 }
 
 // generateLogConfig creates a LogConfig for the current container store
-func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns string) (logConfig logging.LogConfig, err error) {
+func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, gOpt *types.GlobalCommandOptions) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
+	logConfig.HostAddress = gOpt.Address
 	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
 		logConfig.LogURI = logDriver
 	} else {
@@ -674,7 +675,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 		if err != nil {
 			return
 		}
-		if err = logDriverInst.Init(dataStore, ns, id); err != nil {
+		if err = logDriverInst.Init(dataStore, gOpt.Namespace, id); err != nil {
 			return
 		}
 
@@ -683,7 +684,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 			return
 		}
 
-		logConfigFilePath := logging.LogConfigFilePath(dataStore, ns, id)
+		logConfigFilePath := logging.LogConfigFilePath(dataStore, gOpt.Namespace, id)
 		if err = os.WriteFile(logConfigFilePath, logConfigB, 0600); err != nil {
 			return
 		}

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -161,7 +161,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// 1, nerdctl run --name demo -it imagename
 	// 2, ctrl + c to stop demo container
 	// 3, nerdctl start/restart demo
-	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, &options.GOptions)
+	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -655,9 +655,9 @@ func writeCIDFile(path, id string) error {
 }
 
 // generateLogConfig creates a LogConfig for the current container store
-func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, gOpt *types.GlobalCommandOptions) (logConfig logging.LogConfig, err error) {
+func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, hostAddress string) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
-	logConfig.HostAddress = gOpt.Address
+	logConfig.HostAddress = hostAddress
 	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
 		logConfig.LogURI = logDriver
 	} else {
@@ -675,7 +675,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 		if err != nil {
 			return
 		}
-		if err = logDriverInst.Init(dataStore, gOpt.Namespace, id); err != nil {
+		if err = logDriverInst.Init(dataStore, ns, id); err != nil {
 			return
 		}
 
@@ -684,7 +684,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 			return
 		}
 
-		logConfigFilePath := logging.LogConfigFilePath(dataStore, gOpt.Namespace, id)
+		logConfigFilePath := logging.LogConfigFilePath(dataStore, ns, id)
 		if err = os.WriteFile(logConfigFilePath, logConfigB, 0600); err != nil {
 			return
 		}

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
@@ -90,6 +91,8 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 						// Setup goroutine to send stop event if container task finishes:
 						go func() {
 							<-waitCh
+							// wait 100ms to let logViewer process data sent after container exit, if any
+							time.Sleep(100 * time.Millisecond)
 							logrus.Debugf("container task has finished, sending kill signal to log viewer")
 							stopChannel <- os.Interrupt
 						}()

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -157,46 +157,37 @@ func viewLogsJSONFileDirect(lvopts LogViewOptions, jsonLogFilePath string, stdou
 			return fmt.Errorf("error occurred while trying to seek JSON logfile %q at position %d: %s", jsonLogFilePath, lastPos, err)
 		}
 		fin.Close()
-
-		readFromLastPos := func() error {
-			// Re-open the file and seek to the last-consumed offset.
-			fin, err = os.OpenFile(jsonLogFilePath, os.O_RDONLY, 0400)
-			if err != nil {
-				fin.Close()
-				return fmt.Errorf("error occurred while trying to re-open JSON logfile %q: %s", jsonLogFilePath, err)
-			}
-			_, err = fin.Seek(lastPos, 0)
-			if err != nil {
-				fin.Close()
-				return fmt.Errorf("error occurred while trying to seek JSON logfile %q at position %d: %s", jsonLogFilePath, lastPos, err)
-			}
-
-			err = jsonfile.Decode(stdout, stderr, fin, lvopts.Timestamps, lvopts.Since, lvopts.Until, 0)
-			if err != nil {
-				fin.Close()
-				return fmt.Errorf("error occurred while doing follow-up decoding of JSON logfile %q at starting position %d: %s", jsonLogFilePath, lastPos, err)
-			}
-
-			// Record current file seek position before looping again.
-			lastPos, err = fin.Seek(0, io.SeekCurrent)
-			if err != nil {
-				fin.Close()
-				return fmt.Errorf("error occurred while trying to seek JSON logfile %q at current position: %s", jsonLogFilePath, err)
-			}
-			fin.Close()
-			return nil
-		}
-
 		for {
 			select {
 			case <-stopChannel:
-				logrus.Debugf("received stop signal, re-reading JSON logfile and returning")
-				// read final logs before returning
-				return readFromLastPos()
+				logrus.Debugf("received stop signal while re-reading JSON logfile, returning")
+				return nil
 			default:
-				if err = readFromLastPos(); err != nil {
-					return err
+				// Re-open the file and seek to the last-consumed offset.
+				fin, err = os.OpenFile(jsonLogFilePath, os.O_RDONLY, 0400)
+				if err != nil {
+					fin.Close()
+					return fmt.Errorf("error occurred while trying to re-open JSON logfile %q: %s", jsonLogFilePath, err)
 				}
+				_, err = fin.Seek(lastPos, 0)
+				if err != nil {
+					fin.Close()
+					return fmt.Errorf("error occurred while trying to seek JSON logfile %q at position %d: %s", jsonLogFilePath, lastPos, err)
+				}
+
+				err = jsonfile.Decode(stdout, stderr, fin, lvopts.Timestamps, lvopts.Since, lvopts.Until, 0)
+				if err != nil {
+					fin.Close()
+					return fmt.Errorf("error occurred while doing follow-up decoding of JSON logfile %q at starting position %d: %s", jsonLogFilePath, lastPos, err)
+				}
+
+				// Record current file seek position before looping again.
+				lastPos, err = fin.Seek(0, io.SeekCurrent)
+				if err != nil {
+					fin.Close()
+					return fmt.Errorf("error occurred while trying to seek JSON logfile %q at current position: %s", jsonLogFilePath, err)
+				}
+				fin.Close()
 			}
 			// Give the OS a second to breathe before re-opening the file:
 			time.Sleep(time.Second)
@@ -233,8 +224,6 @@ func viewLogsJSONFileThroughTailExec(lvopts LogViewOptions, jsonLogFilePath stri
 	// Setup killing goroutine:
 	go func() {
 		<-stopChannel
-		// sleep 100ms to get logs post container exit
-		time.Sleep(100 * time.Millisecond)
 		logrus.Debugf("killing tail logs process with PID: %d", cmd.Process.Pid)
 		cmd.Process.Kill()
 	}()


### PR DESCRIPTION
Addresses #2313 

Container task is not deleted after it exits, leaving the runtime shim and logger open throughout the lifecycle of a container. This can be a problem when there is unprocessed `stdout` data after a container task finishes and the logger is blocked forever waiting for a newline or EOF.

This PR fixes the issue by piping container output instead of reading directly from `stdout` and `stderr` file descriptors. Closing the io pipes upon task exit allows the logger to shutdown gracefully and process leftover data without a newline .