### PR TITLE
Remove warning msg when inspect containers without task

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Microsoft/hcsshim v0.10.0-rc.8
 	github.com/compose-spec/compose-go v1.14.0
 	github.com/containerd/accelerated-container-image v0.6.7
-	github.com/containerd/cgroups/v3 v3.0.1
+	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/console v1.0.3
 	github.com/containerd/containerd v1.7.2
 	github.com/containerd/continuity v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,8 @@ github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f2
 github.com/containerd/cgroups v1.0.3/go.mod h1:/ofk34relqNjSGyqPrmEULrO4Sc8LJhvJmWbUCUKqj8=
 github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
 github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
-github.com/containerd/cgroups/v3 v3.0.1 h1:4hfGvu8rfGIwVIDd+nLzn/B9ZXx4BcCjzt5ToenJRaE=
-github.com/containerd/cgroups/v3 v3.0.1/go.mod h1:/vtwk1VXrtoa5AaZLkypuOJgA/6DyPMZHJPGQNtlHnw=
+github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=
+github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20181022165439-0650fd9eeb50/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/console v0.0.0-20191206165004-02ecf6a7291e/go.mod h1:8Pf4gM6VEbTNRIT26AyyU7hxdQU3MvAvxVI0sc00XBE=

--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/typeurl/v2"
 	"github.com/sirupsen/logrus"
@@ -42,7 +43,9 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 	}
 	task, err := container.Task(ctx, nil)
 	if err != nil {
-		logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Task")
+		if !errdefs.IsNotFound(err) {
+			logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Task")
+		}
 		return n, nil
 	}
 	n.Process = &native.Process{

--- a/pkg/portutil/port_allocate_linux.go
+++ b/pkg/portutil/port_allocate_linux.go
@@ -25,8 +25,11 @@ import (
 
 const (
 	// This port range is compatible with Docker, FYI https://github.com/moby/moby/blob/eb9e42a09ee123af1d95bf7d46dd738258fa2109/libnetwork/portallocator/portallocator_unix.go#L7-L12
+	allocateEnd = 60999
+)
+
+var (
 	allocateStart = 49153
-	allocateEnd   = 60999
 )
 
 func filter(ss []procnet.NetworkDetail, filterFunc func(detail procnet.NetworkDetail) bool) (ret []procnet.NetworkDetail) {
@@ -96,6 +99,7 @@ func portAllocate(protocol string, ip string, count uint64) (uint64, uint64, err
 			}
 		}
 		if needReturn {
+			allocateStart = int(start + count)
 			return start, start + count - 1, nil
 		}
 		start += count


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/2269
Removed the warning message when `nerdctl inspect` a container that doesn't have a task.