### PR TITLE
Remove warning msg when inspect containers without task

### DIFF
--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/typeurl/v2"
 	"github.com/sirupsen/logrus"
@@ -42,7 +43,9 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 	}
 	task, err := container.Task(ctx, nil)
 	if err != nil {
-		logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Task")
+		if !errdefs.IsNotFound(err) {
+			logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Task")
+		}
 		return n, nil
 	}
 	n.Process = &native.Process{


### PR DESCRIPTION
#2269 
Remove warning message when `inspect` containers without task.
Sorry I messed a previous one with a merge main.