### PR TITLE
[Draft] Vsiravar/fix 1058

### DIFF
--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -408,9 +408,10 @@ type ContainerListOptions struct {
 
 // ContainerCpOptions specifies options for `nerdctl (container) cp`
 type ContainerCpOptions struct {
+	// GOptions is the global options.
+	GOptions       GlobalCommandOptions
+	ContainerReq   string
 	Container2Host bool
-	// Process id
-	Pid int
 	// Destination path to copy file to.
 	DestPath string
 	// Source path to copy file from.

--- a/pkg/cmd/container/cp_linux.go
+++ b/pkg/cmd/container/cp_linux.go
@@ -18,18 +18,38 @@ package container
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
 // Cp copies files/folders between a running container and the local filesystem.
-func Cp(ctx context.Context, options types.ContainerCpOptions) error {
-	return containerutil.CopyFiles(
-		ctx,
-		options.Container2Host,
-		options.Pid,
-		options.DestPath,
-		options.SrcPath,
-		options.FollowSymLink)
+func Cp(ctx context.Context, client *containerd.Client, options types.ContainerCpOptions) error {
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			return containerutil.CopyFiles(
+				ctx,
+				client,
+				found.Container,
+				options.Container2Host,
+				options.DestPath,
+				options.SrcPath,
+				options.GOptions.Snapshotter,
+				options.FollowSymLink)
+		},
+	}
+	count, err := walker.Walk(ctx, options.ContainerReq)
+
+	if count < 1 {
+		err = fmt.Errorf("could not find container: %s, with error: %w", options.ContainerReq, err)
+	}
+
+	return err
 }


### PR DESCRIPTION
Fixes: https://github.com/containerd/nerdctl/issues/1058

### Changes
1. Use [containerd snapshot service](https://github.com/containerd/containerd/blob/main/api/services/snapshots/v1/snapshots.proto#L29) to copy files into and out of created/stopped containers.
2. When container is running stick to using the root filesystem of the process to copy files for backward compatibility. 

PTAL and lmk if this works. I will add additional integration tests. 