### PR TITLE
feat: Add support for copying files in and out of stopped containers

### DIFF
--- a/cmd/nerdctl/container_cp_linux.go
+++ b/cmd/nerdctl/container_cp_linux.go
@@ -17,20 +17,16 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
-	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/spf13/cobra"
 )
 
 func newCpCommand() *cobra.Command {
-
 	shortHelp := "Copy files/folders between a running container and the local filesystem."
 
 	longHelp := shortHelp + `
@@ -65,11 +61,26 @@ func cpAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if rootlessutil.IsRootless() {
+		options.GOptions.Address, err = rootlessutil.RootlessContainredSockAddress()
+		if err != nil {
+			return err
+		}
+	}
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
 
-	return container.Cp(cmd.Context(), options)
+	return container.Cp(ctx, client, options)
 }
 
 func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptions, error) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return types.ContainerCpOptions{}, err
+	}
 	flagL, err := cmd.Flags().GetBool("follow-link")
 	if err != nil {
 		return types.ContainerCpOptions{}, err
@@ -105,32 +116,10 @@ func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptio
 	} else {
 		container = *destSpec.Container
 	}
-	ctx := cmd.Context()
-
-	// cp works in the host namespace (for inspecting file permissions), so we can't directly use the Go client.
-
-	selfExe, inspectArgs := globalFlags(cmd)
-	inspectArgs = append(inspectArgs, "container", "inspect", "--mode=native", "--format={{json .Process}}", container)
-	inspectCmd := exec.CommandContext(ctx, selfExe, inspectArgs...)
-	inspectCmd.Stderr = os.Stderr
-	inspectOut, err := inspectCmd.Output()
-	if err != nil {
-		return types.ContainerCpOptions{}, fmt.Errorf("failed to execute %v: %w", inspectCmd.Args, err)
-	}
-	var proc native.Process
-	if err := json.Unmarshal(inspectOut, &proc); err != nil {
-		return types.ContainerCpOptions{}, err
-	}
-	if proc.Status.Status != containerd.Running {
-		return types.ContainerCpOptions{}, fmt.Errorf("expected container status %v, got %v", containerd.Running, proc.Status.Status)
-	}
-	if proc.Pid <= 0 {
-		return types.ContainerCpOptions{}, fmt.Errorf("got non-positive PID %v", proc.Pid)
-	}
-
 	return types.ContainerCpOptions{
+		GOptions:       globalOptions,
 		Container2Host: container2host,
-		Pid:            proc.Pid,
+		ContainerReq:   container,
 		DestPath:       destSpec.Path,
 		SrcPath:        srcSpec.Path,
 		FollowSymLink:  flagL,

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -410,9 +410,11 @@ type ContainerListOptions struct {
 
 // ContainerCpOptions specifies options for `nerdctl (container) cp`
 type ContainerCpOptions struct {
+	// GOptions is the global options.
+	GOptions GlobalCommandOptions
+	// ContainerReq is name, short ID, or long ID of container to copy to/from.
+	ContainerReq   string
 	Container2Host bool
-	// Process id
-	Pid int
 	// Destination path to copy file to.
 	DestPath string
 	// Source path to copy file from.

--- a/pkg/cmd/container/cp_linux.go
+++ b/pkg/cmd/container/cp_linux.go
@@ -18,18 +18,38 @@ package container
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
 // Cp copies files/folders between a running container and the local filesystem.
-func Cp(ctx context.Context, options types.ContainerCpOptions) error {
-	return containerutil.CopyFiles(
-		ctx,
-		options.Container2Host,
-		options.Pid,
-		options.DestPath,
-		options.SrcPath,
-		options.FollowSymLink)
+func Cp(ctx context.Context, client *containerd.Client, options types.ContainerCpOptions) error {
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			return containerutil.CopyFiles(
+				ctx,
+				client,
+				found.Container,
+				options.Container2Host,
+				options.DestPath,
+				options.SrcPath,
+				options.GOptions.Snapshotter,
+				options.FollowSymLink)
+		},
+	}
+	count, err := walker.Walk(ctx, options.ContainerReq)
+
+	if count < 1 {
+		err = fmt.Errorf("could not find container: %s, with error: %w", options.ContainerReq, err)
+	}
+
+	return err
 }

--- a/pkg/rootlessutil/rootlessutil_linux.go
+++ b/pkg/rootlessutil/rootlessutil_linux.go
@@ -67,3 +67,16 @@ func NewRootlessKitClient() (client.Client, error) {
 	apiSock := filepath.Join(stateDir, "api.sock")
 	return client.New(apiSock)
 }
+
+// RootlessContainredSockAddress returns sock address of rootless containerd based on https://github.com/containerd/nerdctl/blob/main/docs/faq.md#containerd-socket-address
+func RootlessContainredSockAddress() (string, error) {
+	stateDir, err := RootlessKitStateDir()
+	if err != nil {
+		return "", err
+	}
+	childPid, err := RootlessKitChildPid(stateDir)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(fmt.Sprintf("/proc/%d/root/run/containerd/containerd.sock", childPid)), nil
+}


### PR DESCRIPTION
### What does this PR do 

This adds support to copy files in and out of non running containers **only in rootful mode** thereby  improving feature compatibility with podman and docker. It fixes https://github.com/containerd/nerdctl/issues/1058

### High level design

This PR adds logic in 4 packages

- ~~main(Modifies parsing logic for `nerdctl cp` command)~~
- types(Modifies `ContainerCpOptions` struct)
- container(Adds logic to search for container by long/short Id)
- containerutil(Adds logic to copy files out and into non running containers)
- rootlessutil(Add a function to retrieve rootless containerd socket address)

### Fine level Details

#### [cmd/nerdctl/container_cp_linux.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-a6cc11fee8c6a93b90ff0594ba0ad1550e9e95de1f7a5f544cd47b8751c82add)

- Modifies `processCpOptions` function to include `GlobalCommandOptions`. Deletes logic for `container inspect` as we don't rely on inspect to find `pid` of the running container. For rootless mode `options.GOptions.Address=/proc/<PID of containerd>/root/run/containerd/containerd.sock` based on [faq.md](https://github.com/containerd/nerdctl/blob/main/docs/faq.md#containerd-socket-address)
- ~~Modifies `cpAction` to include `containerd.Client` which is used for searching container by long/short id and by `SnapshotService` to get the underlying `Snapshotter`.~~

#### ~~[main_linux.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-f9cc0f02d389d208c96ceb05e4014d58dfebb5e8071b039836e7b1a055c04b6d)~~

- ~~Modifies `appNeedsRootlessParentMain` to return true for `nerdctl cp` and `nerdctl container cp`. This is necessary to access containerd.sock in rootless mode.~~

#### [pkg/api/types/container_types.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-ba3b04d57ead8362915cc38b5a4ad5162a5b6d49f47595097204639cbaacd6d2)

- Modifies `ContainerCpOptions` to add `GlobalCommandOptions` and `ContainerReq`. ` GlobalCommandOptions` are necessary for determining namespace, conatinerd socket address and name of underlying snapshotter. `ContainerReq` required for finding container by short/long id. 

#### [pkg/cmd/container/cp_linux.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-6dbbf4a38e8014b0d33feae0a7ea8107317000ae2d16a9f27ee47951f1f79f97)

- Searches for container specified in `nerdctl cp <containerid>` command using `ContainerWalker`. If multiple containers are found it returns an error. 
- It returns an error when the specified container for copy is not found. 

#### [pkg/containerutil/cp_linux.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-2167aef78f978368dfab2db8ef6002a9fbcf827896d649f0986744122ac3813d)

- Use [containerd snapshot service](https://github.com/containerd/containerd/blob/main/api/services/snapshots/v1/snapshots.proto#L29) to copy files into and out of created/stopped containers. 
- It tries to find `[Task](https://github.com/containerd/containerd/blob/main/task.go#L154)` from containerd. If it's not found(which is the case on `nerdctl container create`, it mounts the snapshot onto a temporary directory for copying. Any other type of error returns an error. 
- If the status of the containerd task is Running, then the root filesystem of the running process is used for copying files into /out of the container. (unchanged from previous commits)
- If task is found and status is not Running(Exited container), then we fallback to the snapshot service for copying. 
- ~~For rootless mode it deletes the nsenter command to enter the namespace of the container process since it's already in the namespace of the rootlesskit child pid.~~ 
- Introduces a helper function `mountSnapshotForContainer` which returns the temp directory that the container shapshot is mounted on. 

#### [pkg/rootlessutil/rootlessutil_linux.go](https://github.com/containerd/nerdctl/pull/2355/files#diff-116470a846123b134de3715c584f11eef78e330070ecf12bcfef9c478a0d0cfd)

- Adds a function to retrieve rootless containerd socket address


### Testing

Added tests for [stopped containers](https://github.com/containerd/nerdctl/pull/2355/files#diff-fc1f66854a3bb061fe38564a668b1b07c4be8fe9f404e8248b80ab2edad6e22f) for exactly the same existing test cases as running containers. Tests are skipped in rootless mode on stopped containers. 