### PR TITLE
Fix compose lacking support for replicas = 0

### DIFF
--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -216,7 +216,7 @@ func getReplicas(svc types.ServiceConfig) (int, error) {
 		replicas = int(*svc.Deploy.Replicas)
 	}
 
-	if replicas < 1 {
+	if replicas < 0 {
 		return 0, fmt.Errorf("invalid replicas: %d", replicas)
 	}
 	return replicas, nil

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -260,6 +260,10 @@ services:
           devices:
           - capabilities: ["utility"]
             count: all
+  qux: # replicas=0
+    image: nginx:alpine
+    deploy:
+      replicas: 0
 `
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -310,6 +314,16 @@ services:
 		assert.Assert(t, in(c.RunArgs, "--restart=no"))
 		assert.Assert(t, in(c.RunArgs, `--gpus=capabilities=utility,count=-1`))
 	}
+
+	quxSvc, err := project.GetService("qux")
+	assert.NilError(t, err)
+
+	qux, err := Parse(project, quxSvc)
+	assert.NilError(t, err)
+
+	t.Logf("qux: %+v", qux)
+	assert.Assert(t, len(qux.Containers) == 0)
+
 }
 
 func TestParseRelative(t *testing.T) {


### PR DESCRIPTION
Allow the compose service replica set to 0.

fix https://github.com/containerd/nerdctl/issues/2223

