### PR TITLE
`nerdctl cp`: Support copying from unstarted containers

### DIFF
--- a/cmd/nerdctl/container_cp_linux.go
+++ b/cmd/nerdctl/container_cp_linux.go
@@ -17,15 +17,11 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 
-	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
-	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/spf13/cobra"
 )
 
@@ -66,10 +62,21 @@ func cpAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return container.Cp(cmd.Context(), options)
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+
+	return container.Cp(ctx, client, options)
 }
 
 func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptions, error) {
+	globalOptions, err := processRootCmdFlags(cmd)
+	if err != nil {
+		return types.ContainerCpOptions{}, err
+	}
+
 	flagL, err := cmd.Flags().GetBool("follow-link")
 	if err != nil {
 		return types.ContainerCpOptions{}, err
@@ -105,32 +112,12 @@ func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptio
 	} else {
 		container = *destSpec.Container
 	}
-	ctx := cmd.Context()
-
 	// cp works in the host namespace (for inspecting file permissions), so we can't directly use the Go client.
 
-	selfExe, inspectArgs := globalFlags(cmd)
-	inspectArgs = append(inspectArgs, "container", "inspect", "--mode=native", "--format={{json .Process}}", container)
-	inspectCmd := exec.CommandContext(ctx, selfExe, inspectArgs...)
-	inspectCmd.Stderr = os.Stderr
-	inspectOut, err := inspectCmd.Output()
-	if err != nil {
-		return types.ContainerCpOptions{}, fmt.Errorf("failed to execute %v: %w", inspectCmd.Args, err)
-	}
-	var proc native.Process
-	if err := json.Unmarshal(inspectOut, &proc); err != nil {
-		return types.ContainerCpOptions{}, err
-	}
-	if proc.Status.Status != containerd.Running {
-		return types.ContainerCpOptions{}, fmt.Errorf("expected container status %v, got %v", containerd.Running, proc.Status.Status)
-	}
-	if proc.Pid <= 0 {
-		return types.ContainerCpOptions{}, fmt.Errorf("got non-positive PID %v", proc.Pid)
-	}
-
 	return types.ContainerCpOptions{
+		GOptions:       globalOptions,
 		Container2Host: container2host,
-		Pid:            proc.Pid,
+		ContainerReq:   container,
 		DestPath:       destSpec.Path,
 		SrcPath:        srcSpec.Path,
 		FollowSymLink:  flagL,

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -408,9 +408,10 @@ type ContainerListOptions struct {
 
 // ContainerCpOptions specifies options for `nerdctl (container) cp`
 type ContainerCpOptions struct {
+	// GOptions is the global options.
+	GOptions       GlobalCommandOptions
 	Container2Host bool
-	// Process id
-	Pid int
+	ContainerReq   string
 	// Destination path to copy file to.
 	DestPath string
 	// Source path to copy file from.

--- a/pkg/cmd/container/cp_linux.go
+++ b/pkg/cmd/container/cp_linux.go
@@ -18,18 +18,43 @@ package container
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerutil"
+	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 )
 
 // Cp copies files/folders between a running container and the local filesystem.
-func Cp(ctx context.Context, options types.ContainerCpOptions) error {
-	return containerutil.CopyFiles(
-		ctx,
-		options.Container2Host,
-		options.Pid,
-		options.DestPath,
-		options.SrcPath,
-		options.FollowSymLink)
+func Cp(ctx context.Context, client *containerd.Client, options types.ContainerCpOptions) error {
+	walker := &containerwalker.ContainerWalker{
+		Client: client,
+		OnFound: func(ctx context.Context, found containerwalker.Found) error {
+			if found.MatchCount > 1 {
+				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			return containerutil.CopyFiles(
+				ctx,
+				options.Container2Host,
+				client,
+				found.Container,
+				options.GOptions.Snapshotter,
+				options.DestPath,
+				options.SrcPath,
+				options.FollowSymLink)
+		},
+	}
+
+	count, err := walker.Walk(ctx, options.ContainerReq)
+
+	if err != nil {
+		return err
+	}
+
+	if count < 1 {
+		err = fmt.Errorf("could not find container: %s", options.ContainerReq)
+	}
+
+	return err
 }


### PR DESCRIPTION
Per comments in #1058, use the containerd snapshots service to copy files around.

For better compatibility, we still use the code way when copying to/from a running container.  Otherwise we seem to hit an error about stale file if:
- `nerdctl cp <host> <container>:<path>`
- `nerdctl exec <container> rm <path>`

@vsiravar Please let me know if you have a PR you prefer to use instead, or if you would like a `Co-authored-by:` trailer, or anything like that. I'm happy to edit.

Scheduling note: I'll be away for a bit, so response may be a bit slow.