### PR TITLE
Add metadata to volume create return

### DIFF
--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -57,5 +57,7 @@ func volumeCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return nil
 	}
-	return volume.Create(args[0], options)
+	_, err = volume.Create(args[0], options)
+
+	return err
 }

--- a/pkg/cmd/volume/create.go
+++ b/pkg/cmd/volume/create.go
@@ -21,21 +21,23 @@ import (
 
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/strutil"
 )
 
-func Create(name string, options types.VolumeCreateOptions) error {
+func Create(name string, options types.VolumeCreateOptions) (*native.Volume, error) {
 	if err := identifiers.Validate(name); err != nil {
-		return fmt.Errorf("malformed name %s: %w", name, err)
+		return nil, fmt.Errorf("malformed name %s: %w", name, err)
 	}
 	volStore, err := Store(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	labels := strutil.DedupeStrSlice(options.Labels)
-	if _, err := volStore.Create(name, labels); err != nil {
-		return err
+	vol, err := volStore.Create(name, labels)
+	if err != nil {
+		return nil, err
 	}
 	fmt.Fprintf(options.Stdout, "%s\n", name)
-	return nil
+	return vol, nil
 }


### PR DESCRIPTION
Adds the `*native.Volume` to the volume create return, currently this is discarded.  This is beneficial as if you use nerdctl as a library it allows you to more easily inspect the newly created volume.

**NOTE**: I was not able to find any unit tests or integ tests for this, where should I add testing?