### PR TITLE
golangci-lint v1.53.3 and refactor linter rules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.6.0
         with:
-          version: v1.51.1
+          version: v1.53.3
           args: --verbose
       - name: yamllint-lint
         run: yamllint .

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,13 +5,13 @@ run:
 linters:
   disable-all: true
   enable:
-    - depguard
+    # - depguard
     - gofmt
     - goimports
     - govet
     - ineffassign
     - misspell
-    - nakedret
+    # - nakedret
     - prealloc
     - typecheck
     # - asciicheck
@@ -134,3 +134,24 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+
+issues:
+  exclude-rules:
+    - linters:
+        - revive
+      text: "if-return"
+    - linters:
+        - revive
+      text: "empty-block"
+    - linters:
+        - revive
+      text: "superfluous-else"
+    - linters:
+        - revive
+      text: "unused-parameter"
+    - linters:
+        - revive
+      text: "unreachable-code"
+    - linters:
+        - revive
+      text: "redefines-builtin-id"


### PR DESCRIPTION
This PR bumps up golangci-lint to v1.53.3: https://github.com/golangci/golangci-lint/releases/tag/v1.53.3

This PR also disables the following strict linters and rules that aren't enabled in `containerd/containerd` https://github.com/containerd/containerd/blob/v1.7.2/.golangci.yml

- linters 
  - depguard
  - nakedret
- rules of `revive`
  - if-return
  - empty-block
  - superfluous-else
  - unused-parameter
  - unreachable-code
  - redefines-builtin-id

Note that the recent revive seems to become (very) strict by the above newly added revive rules. Especially unused-parameter reports a lot of "unused-parameter" errors (e.g. unused ctx context.Context argument on a function)

```
pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go:96:21: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func NewHostOptions(ctx context.Context, refHostname string, optFuncs ...Opt) (*dockerconfig.HostOptions, error) {
                    ^
```

We can re-enable some of them when needed in the future.