### PR TITLE
Deflake the Cirrus CI / Windows/containerd-1.7

### DIFF
--- a/hack/configure-windows-ci.ps1
+++ b/hack/configure-windows-ci.ps1
@@ -3,13 +3,18 @@ $ErrorActionPreference = "Stop"
 #install build dependencies
 choco install --limitoutput --no-progress -y git golang
 
+#cleanup containerd
+echo "Stopping containerd"
+Stop-Service containerd
+sc.exe delete containerd
+
 #install containerd
 $version=$env:ctrdVersion
 echo "Installing containerd $version"
 curl.exe -L https://github.com/containerd/containerd/releases/download/v$version/containerd-$version-windows-amd64.tar.gz -o containerd-windows-amd64.tar.gz
 tar.exe xvf containerd-windows-amd64.tar.gz
 mkdir -force "$Env:ProgramFiles\containerd"
-mv ./bin/* "$Env:ProgramFiles\containerd"
+cp ./bin/* "$Env:ProgramFiles\containerd"
 
 & $Env:ProgramFiles\containerd\containerd.exe config default | Out-File "$Env:ProgramFiles\containerd\config.toml" -Encoding ascii
 & $Env:ProgramFiles\containerd\containerd.exe --register-service


### PR DESCRIPTION
Deflake the Cirrus CI / Windows/containerd-1.7.

From Log
```
mv : Cannot create a file when that file already exists.
At C:\Windows\TEMP\cirrus-ci-build\hack\configure-windows-ci.ps1:12 char:1
+ mv ./bin/* "$Env:ProgramFiles\containerd"
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : WriteError: (C:\Windows\TEMP...\containerd.exe:FileInfo) [Move-Item], IOException
    + FullyQualifiedErrorId : MoveFileInfoItemIOError,Microsoft.PowerShell.Commands.MoveItemCommand
```

It seems because of https://github.com/PowerShell/PowerShell/issues/16990, the file cannot move it some process is open it in Windows.

