### PR TITLE
Refactor codebase and re-enable `revive` linter rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -139,19 +139,4 @@ issues:
   exclude-rules:
     - linters:
         - revive
-      text: "if-return"
-    - linters:
-        - revive
-      text: "empty-block"
-    - linters:
-        - revive
-      text: "superfluous-else"
-    - linters:
-        - revive
       text: "unused-parameter"
-    - linters:
-        - revive
-      text: "unreachable-code"
-    - linters:
-        - revive
-      text: "redefines-builtin-id"

--- a/cmd/nerdctl/builder_build.go
+++ b/cmd/nerdctl/builder_build.go
@@ -206,8 +206,5 @@ func buildAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	if err := builder.Build(ctx, client, options); err != nil {
-		return err
-	}
-	return nil
+	return builder.Build(ctx, client, options)
 }

--- a/cmd/nerdctl/container_update.go
+++ b/cmd/nerdctl/container_update.go
@@ -362,19 +362,16 @@ func updateContainer(ctx context.Context, client *containerd.Client, id string, 
 		}
 		return fmt.Errorf("failed to get task:%w", err)
 	}
-	if err := task.Update(ctx, containerd.WithResources(spec.Linux.Resources)); err != nil {
-		return err
-	}
-	return nil
+	return task.Update(ctx, containerd.WithResources(spec.Linux.Resources))
 }
 
 func updateContainerSpec(ctx context.Context, container containerd.Container, spec *runtimespec.Spec) error {
 	if err := container.Update(ctx, func(ctx context.Context, client *containerd.Client, c *containers.Container) error {
-		any, err := typeurl.MarshalAny(spec)
+		a, err := typeurl.MarshalAny(spec)
 		if err != nil {
 			return fmt.Errorf("failed to marshal spec %+v:%w", spec, err)
 		}
-		c.Spec = any
+		c.Spec = a
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to update container spec:%w", err)

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -323,10 +323,9 @@ func generateRootfsOpts(args []string, id string, ensured *imgutil.EnsuredImage,
 		for ind, env := range ensured.ImageConfig.Env {
 			if strings.HasPrefix(env, "PATH=") {
 				break
-			} else {
-				if ind == len(ensured.ImageConfig.Env)-1 {
-					opts = append(opts, oci.WithDefaultPathEnv)
-				}
+			}
+			if ind == len(ensured.ImageConfig.Env)-1 {
+				opts = append(opts, oci.WithDefaultPathEnv)
 			}
 		}
 	} else {

--- a/pkg/cmd/container/run_gpus.go
+++ b/pkg/cmd/container/run_gpus.go
@@ -72,8 +72,8 @@ func parseGPUOpt(value string) (oci.SpecOpts, error) {
 	}
 	var nvidiaCaps []nvidia.Capability
 	for _, c := range req.Capabilities {
-		if cap, isNvidiaCap := str2cap[c]; isNvidiaCap {
-			nvidiaCaps = append(nvidiaCaps, cap)
+		if cp, isNvidiaCap := str2cap[c]; isNvidiaCap {
+			nvidiaCaps = append(nvidiaCaps, cp)
 		}
 	}
 	if len(nvidiaCaps) != 0 {

--- a/pkg/cmd/container/top.go
+++ b/pkg/cmd/container/top.go
@@ -61,10 +61,7 @@ func Top(ctx context.Context, client *containerd.Client, containers []string, op
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			if err := containerTop(ctx, opt.Stdout, client, found.Container.ID(), strings.Join(containers[1:], " ")); err != nil {
-				return err
-			}
-			return nil
+			return containerTop(ctx, opt.Stdout, client, found.Container.ID(), strings.Join(containers[1:], " "))
 		},
 	}
 

--- a/pkg/composer/config.go
+++ b/pkg/composer/config.go
@@ -59,17 +59,14 @@ func (c *Composer) Config(ctx context.Context, w io.Writer, co ConfigOptions) er
 		if co.Hash != "*" {
 			services = strings.Split(co.Hash, ",")
 		}
-		if err := c.project.WithServices(services, func(svc types.ServiceConfig) error {
+		return c.project.WithServices(services, func(svc types.ServiceConfig) error {
 			hash, err := ServiceHash(svc)
 			if err != nil {
 				return err
 			}
 			fmt.Fprintf(w, "%s %s\n", svc.Name, hash)
 			return nil
-		}); err != nil {
-			return err
-		}
-		return nil
+		})
 	}
 	projectYAML, err := yaml.Marshal(c.project)
 	if err != nil {

--- a/pkg/composer/create.go
+++ b/pkg/composer/create.go
@@ -144,10 +144,7 @@ func (c *Composer) createService(ctx context.Context, ps *serviceparser.Service,
 			return nil
 		})
 	}
-	if err := runEG.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return runEG.Wait()
 }
 
 // createServiceContainer must be called after ensureServiceImage

--- a/pkg/composer/pipetagger/pipetagger.go
+++ b/pkg/composer/pipetagger/pipetagger.go
@@ -107,8 +107,5 @@ func (x *PipeTagger) Run() error {
 			)
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		return err
-	}
-	return nil
+	return scanner.Err()
 }

--- a/pkg/composer/restart.go
+++ b/pkg/composer/restart.go
@@ -43,10 +43,7 @@ func (c *Composer) Restart(ctx context.Context, opt RestartOptions, services []s
 			return err
 		}
 
-		if err := c.restartContainers(ctx, containers, opt); err != nil {
-			return err
-		}
-		return nil
+		return c.restartContainers(ctx, containers, opt)
 	})
 }
 

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -202,11 +202,7 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 		}
 	}
 
-	if err := c.runServices(ctx, parsedServices, ro); err != nil {
-		return err
-	}
-
-	return nil
+	return c.runServices(ctx, parsedServices, ro)
 }
 
 func (c *Composer) runServices(ctx context.Context, parsedServices []*serviceparser.Service, ro RunOptions) error {

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -102,11 +102,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 		}
 	}
 
-	if err := c.upServices(ctx, parsedServices, uo); err != nil {
-		return err
-	}
-
-	return nil
+	return c.upServices(ctx, parsedServices, uo)
 }
 
 func validateFileObjectConfig(obj types.FileObjectConfig, shortName, objType string, project *types.Project) error {

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -106,10 +106,7 @@ func (c *Composer) ensureServiceImage(ctx context.Context, ps *serviceparser.Ser
 	}
 
 	logrus.Infof("Ensuring image %s", ps.Image)
-	if err := c.EnsureImage(ctx, ps.Image, ps.PullMode, ps.Unparsed.Platform, ps, quiet); err != nil {
-		return err
-	}
-	return nil
+	return c.EnsureImage(ctx, ps.Image, ps.PullMode, ps.Unparsed.Platform, ps, quiet)
 }
 
 // upServiceContainer must be called after ensureServiceImage

--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -60,10 +60,7 @@ func (u *updater) update() error {
 		return err
 	}
 	// phase2: write hosts
-	if err := u.phase2(); err != nil {
-		return err
-	}
-	return nil
+	return u.phase2()
 }
 
 // phase1: read meta.json
@@ -98,10 +95,7 @@ func (u *updater) phase1() error {
 		}
 		return nil
 	}
-	if err := filepath.Walk(u.hostsD, readMetaWF); err != nil {
-		return err
-	}
-	return nil
+	return filepath.Walk(u.hostsD, readMetaWF)
 }
 
 // phase2: write hosts
@@ -162,10 +156,7 @@ func (u *updater) phase2() error {
 		}
 		return nil
 	}
-	if err := filepath.Walk(u.hostsD, writeHostsWF); err != nil {
-		return err
-	}
-	return nil
+	return filepath.Walk(u.hostsD, writeHostsWF)
 }
 
 // createLine returns a line string slice.

--- a/pkg/imgutil/jobs/jobs.go
+++ b/pkg/imgutil/jobs/jobs.go
@@ -101,11 +101,10 @@ outer:
 						if !errdefs.IsNotFound(err) {
 							log.G(ctx).WithError(err).Error("failed to get content info")
 							continue outer
-						} else {
-							statuses[key] = StatusInfo{
-								Ref:    key,
-								Status: StatusWaiting,
-							}
+						}
+						statuses[key] = StatusInfo{
+							Ref:    key,
+							Status: StatusWaiting,
 						}
 					} else if info.CreatedAt.After(start) {
 						statuses[key] = StatusInfo{

--- a/pkg/logging/cri_logger_test.go
+++ b/pkg/logging/cri_logger_test.go
@@ -157,9 +157,8 @@ func TestParseLog(t *testing.T) {
 		if err != nil {
 			if test.err {
 				continue
-			} else {
-				t.Errorf("ParseCRILog err %s ", err.Error())
 			}
+			t.Errorf("ParseCRILog err %s ", err.Error())
 		}
 
 		if !reflect.DeepEqual(test.msg, logmsg) {

--- a/pkg/mountutil/volumestore/volumestore.go
+++ b/pkg/mountutil/volumestore/volumestore.go
@@ -107,10 +107,7 @@ func (vs *volumeStore) Create(name string, labels []string) (*native.Volume, err
 		}
 
 		volFilePath := filepath.Join(volPath, volumeJSONFileName)
-		if err := os.WriteFile(volFilePath, labelsJSON, 0644); err != nil {
-			return err
-		}
-		return nil
+		return os.WriteFile(volFilePath, labelsJSON, 0644)
 	}
 
 	if err := lockutil.WithDirLock(vs.dir, fn); err != nil {
@@ -139,11 +136,9 @@ func (vs *volumeStore) Get(name string, size bool) (*native.Volume, error) {
 	volFilePath := filepath.Join(vs.dir, name, volumeJSONFileName)
 	volumeDataBytes, err := os.ReadFile(volFilePath)
 	if err != nil {
-		if os.IsNotExist(err) {
-			//volume.json does not exists should not be blocking for inspect operation
-		} else {
+		if !os.IsNotExist(err) {
 			return nil, err
-		}
+		} // on else, volume.json does not exists should not be blocking for inspect operation
 	}
 
 	entry := native.Volume{

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -127,10 +127,7 @@ func namespaceUsedNetworks(ctx context.Context, containers []containerd.Containe
 
 func WithDefaultNetwork() CNIEnvOpt {
 	return func(e *CNIEnv) error {
-		if err := e.ensureDefaultNetworkConfig(); err != nil {
-			return err
-		}
-		return nil
+		return e.ensureDefaultNetworkConfig()
 	}
 }
 
@@ -256,10 +253,7 @@ func (e *CNIEnv) CreateNetwork(opts CreateOptions) (*NetworkConfig, error) { //n
 		if err != nil {
 			return err
 		}
-		if err := e.writeNetworkConfig(net); err != nil {
-			return err
-		}
-		return nil
+		return e.writeNetworkConfig(net)
 	}
 	err = lockutil.WithDirLock(e.NetconfPath, fn)
 	if err != nil {
@@ -273,10 +267,7 @@ func (e *CNIEnv) RemoveNetwork(net *NetworkConfig) error {
 		if err := os.RemoveAll(net.File); err != nil {
 			return err
 		}
-		if err := net.clean(); err != nil {
-			return err
-		}
-		return nil
+		return net.clean()
 	}
 	return lockutil.WithDirLock(e.NetconfPath, fn)
 }
@@ -410,10 +401,7 @@ func (e *CNIEnv) writeNetworkConfig(net *NetworkConfig) error {
 	if _, err := os.Stat(filename); err == nil {
 		return errdefs.ErrAlreadyExists
 	}
-	if err := os.WriteFile(filename, net.Bytes, 0644); err != nil {
-		return err
-	}
-	return nil
+	return os.WriteFile(filename, net.Bytes, 0644)
 }
 
 // networkConfigList loads config from dir if dir exists.

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -315,9 +315,7 @@ func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 			if hostIP := net.ParseIP(p.HostIP); hostIP != nil && !hostIP.IsUnspecified() {
 				// loopback address is always bindable in the child namespace, but other addresses are unlikely.
 				if !hostIP.IsLoopback() {
-					if childIP != nil && childIP.Equal(hostIP) {
-						// this is fine
-					} else {
+					if !(childIP != nil && childIP.Equal(hostIP)) {
 						if portDriverDisallowsLoopbackChildIP {
 							p.HostIP = childIP.String()
 						} else {

--- a/pkg/signutil/cosignutil.go
+++ b/pkg/signutil/cosignutil.go
@@ -57,11 +57,7 @@ func SignCosign(rawRef string, keyRef string) error {
 		return err
 	}
 
-	if err := cosignCmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return cosignCmd.Wait()
 }
 
 // VerifyCosign verifies an image(`rawRef`) with a cosign public key(`keyRef`)

--- a/pkg/signutil/notationutil.go
+++ b/pkg/signutil/notationutil.go
@@ -53,11 +53,7 @@ func SignNotation(rawRef string, keyNameRef string) error {
 		return err
 	}
 
-	if err := notationCmd.Wait(); err != nil {
-		return err
-	}
-
-	return nil
+	return notationCmd.Wait()
 }
 
 // VerifyNotation verifies an image(`rawRef`) with the pre-configured notation trust policy


### PR DESCRIPTION
Following-up: https://github.com/containerd/nerdctl/pull/2369#pullrequestreview-1523484288

This PR refactors the codebase and re-enable the following `revive` linter rules

- if-return
- empty-block
- superfluous-else
- unreachable-code
- redefines-builtin-id

The following linter errors have been fixed by this PR:

```console
$ golangci-lint run --max-same-issues 0 | grep revive
cmd/nerdctl/builder_build.go:209:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
cmd/nerdctl/container_update.go:365:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
cmd/nerdctl/container_update.go:373:3: redefines-builtin-id: redefinition of the built-in type any (revive)
pkg/composer/create.go:147:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/composer/restart.go:46:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/composer/up_service.go:109:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/composer/up.go:105:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/composer/run.go:205:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/composer/config.go:62:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/signutil/cosignutil.go:60:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/signutil/notationutil.go:56:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/cmd/container/create.go:326:11: superfluous-else: if block ends with a break statement, so drop this else and outdent its block (revive)
pkg/cmd/container/run_gpus.go:75:6: redefines-builtin-id: redefinition of the built-in function cap (revive)
pkg/cmd/container/top.go:64:4: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/ocihook/ocihook.go:318:49: empty-block: this block is empty, you can remove it (revive)
pkg/composer/pipetagger/pipetagger.go:110:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/dnsutil/hostsstore/updater.go:63:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/dnsutil/hostsstore/updater.go:101:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/dnsutil/hostsstore/updater.go:165:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/logging/cri_logger_test.go:160:11: superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (revive)
pkg/imgutil/jobs/jobs.go:104:14: superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (revive)
pkg/mountutil/volumestore/volumestore.go:110:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/mountutil/volumestore/volumestore.go:142:25: empty-block: this block is empty, you can remove it (revive)
pkg/netutil/netutil.go:130:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/netutil/netutil.go:259:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/netutil/netutil.go:276:3: if-return: redundant if ...; err != nil check, just return error instead. (revive)
pkg/netutil/netutil.go:413:2: if-return: redundant if ...; err != nil check, just return error instead. (revive)
```
