### PR TITLE
feat: add network flag to nerdctl build

### DIFF
--- a/cmd/nerdctl/builder_build.go
+++ b/cmd/nerdctl/builder_build.go
@@ -56,7 +56,10 @@ If Dockerfile is not present and -f is not specified, it will look for Container
 	buildCommand.Flags().StringArray("cache-from", nil, "External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
 	buildCommand.Flags().StringArray("cache-to", nil, "Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)")
 	buildCommand.Flags().Bool("rm", true, "Remove intermediate containers after a successful build")
-
+	buildCommand.Flags().String("network", "default", "Set type of network for build (format:network=default|none|host)")
+	buildCommand.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"default", "host", "none"}, cobra.ShellCompDirectiveNoFileComp
+	})
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	buildCommand.Flags().StringSlice("platform", []string{}, "Set target platform for build (e.g., \"amd64\", \"arm64\")")
@@ -153,6 +156,10 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 	if err != nil {
 		return types.BuilderBuildOptions{}, err
 	}
+	network, err := cmd.Flags().GetString("network")
+	if err != nil {
+		return types.BuilderBuildOptions{}, err
+	}
 	return types.BuilderBuildOptions{
 		GOptions:     globalOptions,
 		BuildKitHost: buildKitHost,
@@ -176,6 +183,7 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 		Stdout:       cmd.OutOrStdout(),
 		Stderr:       cmd.OutOrStderr(),
 		Stdin:        cmd.InOrStdin(),
+		NetworkMode:  network,
 	}, nil
 }
 

--- a/cmd/nerdctl/completion_linux_test.go
+++ b/cmd/nerdctl/completion_linux_test.go
@@ -47,7 +47,7 @@ func TestCompletion(t *testing.T) {
 	base.Cmd(gsc, "run", "-it", "").AssertOutContains(testutil.AlpineImage)
 	base.Cmd(gsc, "run", "-it", "--rm", "").AssertOutContains(testutil.AlpineImage)
 
-	// Tests with an network
+	// Tests with a network
 	testNetworkName := "nerdctl-test-completion"
 	defer base.Cmd("network", "rm", testNetworkName).Run()
 	base.Cmd("network", "create", testNetworkName).AssertOK()

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -655,8 +655,9 @@ Flags:
 - :whale: `--iidfile=FILE`: Write the image ID to the file
 - :nerd_face: `--ipfs`: Build image with pulling base images from IPFS. See [`ipfs.md`](./ipfs.md) for details.
 - :whale: `--label`: Set metadata for an image
+- :whale: `--network=(default|host|none)`: Set the networking mode for the RUN instructions during build.(compatible with `buildctl build`)
 
-Unimplemented `docker build` flags: `--add-host`, `--network`, `--squash`
+Unimplemented `docker build` flags: `--add-host`, `--squash`
 
 ### :whale: nerdctl commit
 

--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -61,6 +61,8 @@ type BuilderBuildOptions struct {
 	Label []string
 	// BuildContext is the build context
 	BuildContext string
+	// NetworkMode mode for the build context
+	NetworkMode string
 }
 
 // BuilderPruneOptions specifies options for `nerdctl builder prune`.

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -358,6 +358,18 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 		buildctlArgs = append(buildctlArgs, "--metadata-file="+metaFile)
 	}
 
+	if options.NetworkMode != "" {
+		switch options.NetworkMode {
+		case "none":
+			buildctlArgs = append(buildctlArgs, "--opt=force-network-mode="+options.NetworkMode)
+		case "host":
+			buildctlArgs = append(buildctlArgs, "--opt=force-network-mode="+options.NetworkMode, "--allow=network.host", "--allow=security.insecure")
+		case "", "default":
+		default:
+			logrus.Debugf("ignoring network build arg %s", options.NetworkMode)
+		}
+	}
+
 	return buildctlBinary, buildctlArgs, needsLoading, metaFile, tags, cleanup, nil
 }
 


### PR DESCRIPTION
### What does this PR do?
Add's support for `--network` flag to `nerdctl build`. Fixes: https://github.com/containerd/nerdctl/issues/2233

### Details

- Supported values `host|none|default`. Compatible with `buildctl build`
- Insecure entitlements in daemon insecure-entitlements = [ "network.host", "security.insecure" ] required for `--network=host`. Additionally pass `--allow=network.host` and  `--allow=security.insecure` to buildctlArgs

### Testing

- Added tests in `builder_build_test.go` for `--network=default|""|none`. Tested `--network=host` manually since it requires modifying `buildkitd.toml` file. 