### PR TITLE
Add lease and remove special case

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -30,10 +30,7 @@ windows_task:
   matrix:
     - name: "Windows/containerd-1.7"
       env:
-        # containerd >= 1.7.2 can't pass nerdctl CI:
-        # `hcsshim::PrepareLayer failed in Win32: The parameter is incorrect. (0x57)`
-        # https://github.com/containerd/containerd/issues/8891
-        ctrdVersion: 1.7.1
+        ctrdVersion: 1.7.3
   env:
     CGO_ENABLED: 0
   build_script:

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -186,19 +186,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 			}
 		}
 
-		if runtime.GOOS == "windows" {
-			for _, m := range mounts {
-				defer unmounter(m.Source)
-				// appending the layerID to the root.
-				mountPath := filepath.Join(tempDir, filepath.Base(m.Source))
-				if err := m.Mount(mountPath); err != nil {
-					if err := s.Remove(ctx, tempDir); err != nil && !errdefs.IsNotFound(err) {
-						return nil, nil, nil, err
-					}
-					return nil, nil, nil, err
-				}
-			}
-		} else if runtime.GOOS == "linux" {
+		if runtime.GOOS == "linux" {
 			defer unmounter(tempDir)
 			for _, m := range mounts {
 				m := m


### PR DESCRIPTION
This change adds a lease to the view creation. Without a lease, there is a high probability that the newly created view will be removed by the containerd garbage collector shortly after we create the view and before we get a chance to use it.

Depending on when the GC runs during the call to `m.Mount()`, we may get a set of different errors (at least on Windows) ranging from `The system cannot find the path specified` to `The parameter is incorrect` to `Access is denied.`

Adding a lease prevents containerd from removing the view mid-flight. 

This change also adds a drive-by fix. The special case for Windows when mounting the view, was removed. 

Fixes https://github.com/containerd/containerd/issues/8891