### PR TITLE
FreeBSD: CNI plugins

### DIFF
--- a/Vagrantfile.freebsd
+++ b/Vagrantfile.freebsd
@@ -21,10 +21,6 @@ Vagrant.configure("2") do |config|
 
   memory = 2048
   cpus = 1
-  config.vm.provider :virtualbox do |v, o|
-    v.memory = memory
-    v.cpus = cpus
-  end
   config.vm.provider :libvirt do |v|
     v.memory = memory
     v.cpus = cpus
@@ -36,9 +32,20 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
         #!/usr/bin/env bash
         set -eux -o pipefail
-        pkg install -y go containerd runj
+        pkg install -y go containerd runj containernetworking-plugins
         cd /vagrant
         go install ./cmd/nerdctl
+
+        mkdir -p /etc/nerdctl
+        cat << EOF > /etc/nerdctl/runj.ext.json
+        {
+          "network": {
+            "vnet": {
+              "mode": "new"
+            }
+          }
+        }
+        EOF
     SHELL
   end
 
@@ -55,9 +62,20 @@ Vagrant.configure("2") do |config|
     sh.inline = <<~SHELL
         #!/usr/bin/env bash
         set -eux -o pipefail
+
+        # Firewall config, needed for CNI plugins.
+        cat << EOF > /etc/pf.conf
+        nat on em0 inet from <cni-nat> to any -> (em0)
+        rdr-anchor "cni-rdr/*"
+        table <cni-nat>
+        EOF
+
+        service pf onestart
+
         daemon -o containerd.out containerd
         sleep 3
-        /root/go/bin/nerdctl run --rm --net=none dougrabson/freebsd-minimal:13 echo "Nerdctl is up and running."
+        /root/go/bin/nerdctl run --rm --net=none dougrabson/freebsd-small:13 echo "Nerdctl is up and running."
+        /root/go/bin/nerdctl run --rm dougrabson/freebsd-small:13 nc -zw1 1.1.1.1 443
     SHELL
   end
 

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -51,7 +51,7 @@ func newRunCommand() *cobra.Command {
 		longHelp += "WARNING: `nerdctl run` is experimental on Windows and currently broken (https://github.com/containerd/nerdctl/issues/28)"
 	case "freebsd":
 		longHelp += "\n"
-		longHelp += "WARNING: `nerdctl run` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
+		longHelp += "WARNING: `nerdctl run` is experimental on FreeBSD (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
 	}
 	var runCommand = &cobra.Command{
 		Use:               "run [flags] IMAGE [COMMAND] [ARG...]",

--- a/docs/freebsd.md
+++ b/docs/freebsd.md
@@ -12,22 +12,54 @@ You will need the most up-to-date containerd build along with a containerd shim,
 such as [runj](https://github.com/samuelkarp/runj). Follow the build
 instructions in the respective repositories.
 
+The runj runtime must be configured to create vnet jails by default. To do this, you need to create
+
+`/etc/nerdctl/runj.ext.json` with the following content.
+
+```
+{
+  "network": {
+    "vnet": {
+      "mode": "new"
+    }
+  }
+}
+```
+
 ## Usage
 
 You can use the `dougrabson/freebsd13.2-small` image to run a FreeBSD 13 jail:
 
 ```sh
-nerdctl run --net none -it dougrabson/freebsd13.2-small
+nerdctl run --net=none -it dougrabson/freebsd13.2-small
 ```
 
 Alternatively use `--platform` parameter to run linux containers
 
 ```sh
-nerdctl run --platform linux --net none -it amazonlinux:2
+nerdctl run --platform linux --net=none -it amazonlinux:2
+```
+
+:warning: running linux containers requires `linux64` module loaded:
+
+```
+kldload linux64
 ```
 
 
-## Limitations & Bugs
+## CNI networking
 
-- :warning: CNI & CNI plugins are not yet ported to FreeBSD. The only supported
-  network type is `none`
+| :construction:        CNI networking requires host OS to be version 13.3 and higher. Lower versions are not guaranteed to work. |
+|---------------------------------------------------------------------------------------------------------------------------------|
+
+CNI plugins can be installed from the repository
+
+```sh
+pkg install net/containernetworking-plugins
+```
+
+You can then drop the `--net=none` flag and run commands as usual.
+
+```sh
+nerdctl run -it dougrabson/freebsd13.2-small ping 1.1.1.1
+```

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -225,11 +225,8 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	}
 	opts = append(opts, umaskOpts...)
 
-	rtCOpts, err := generateRuntimeCOpts(options.GOptions.CgroupManager, options.Runtime)
-	if err != nil {
-		return nil, nil, err
-	}
-	cOpts = append(cOpts, rtCOpts...)
+	rtOpts := generateRuntimeOpts(options)
+	cOpts = append(cOpts, rtOpts)
 
 	lCOpts, err := withContainerLabels(options.Label, options.LabelFile)
 	if err != nil {

--- a/pkg/containerutil/container_network_manager_unix.go
+++ b/pkg/containerutil/container_network_manager_unix.go
@@ -1,3 +1,5 @@
+//go:build linux || freebsd
+
 /*
    Copyright The containerd Authors.
 

--- a/pkg/containerutil/container_network_manager_unsupported.go
+++ b/pkg/containerutil/container_network_manager_unsupported.go
@@ -1,4 +1,4 @@
-//go:build darwin || freebsd || netbsd || openbsd
+//go:build darwin || netbsd || openbsd
 
 /*
    Copyright The containerd Authors.

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -28,8 +28,7 @@ func DataRoot() string {
 }
 
 func CNIPath() string {
-	// default: /opt/cni/bin
-	return gocni.DefaultCNIDir
+	return "/usr/local/libexec/cni"
 }
 
 func CNINetConfPath() string {

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -266,29 +266,6 @@ func getExtraHosts(state *specs.State) (map[string]string, error) {
 	return hosts, nil
 }
 
-func getNetNSPath(state *specs.State) (string, error) {
-	// If we have a network-namespace annotation we use it over the passed Pid.
-	netNsPath, netNsFound := state.Annotations[NetworkNamespace]
-	if netNsFound {
-		if _, err := os.Stat(netNsPath); err != nil {
-			return "", err
-		}
-
-		return netNsPath, nil
-	}
-
-	if state.Pid == 0 && !netNsFound {
-		return "", errors.New("both state.Pid and the netNs annotation are unset")
-	}
-
-	// We dont't have a networking namespace annotation, but we have a PID.
-	s := fmt.Sprintf("/proc/%d/ns/net", state.Pid)
-	if _, err := os.Stat(s); err != nil {
-		return "", err
-	}
-	return s, nil
-}
-
 func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 	if len(opts.ports) > 0 {
 		if !rootlessutil.IsRootlessChild() {


### PR DESCRIPTION
FreeBSD has the CNI plugins ported:
https://www.freshports.org/net/containernetworking-plugins/. This allows us to enable CNI networking for FreeBSD containers.

This change adapts the existing linux codebase to work on freebsd:

- containerutil: use nullfs instead of bind mounts for resolv.conf, etc.
- ocihook: freebsd's bridge plugin uses jail names in contrast to linux's network namespace usages