### PR TITLE
Support create anonymous volume 

### DIFF
--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -25,9 +25,9 @@ import (
 
 func newVolumeCreateCommand() *cobra.Command {
 	volumeCreateCommand := &cobra.Command{
-		Use:           "create [flags] VOLUME",
+		Use:           "create [flags] [VOLUME]",
 		Short:         "Create a volume",
-		Args:          IsExactArgs(1),
+		Args:          cobra.MaximumNArgs(1),
 		RunE:          volumeCreateAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -57,7 +57,11 @@ func volumeCreateAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return nil
 	}
-	_, err = volume.Create(args[0], options)
+	volumeName := ""
+	if len(args) > 0 {
+		volumeName = args[0]
+	}
+	_, err = volume.Create(volumeName, options)
 
 	return err
 }

--- a/pkg/cmd/volume/create.go
+++ b/pkg/cmd/volume/create.go
@@ -22,10 +22,16 @@ import (
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/strutil"
+	"github.com/docker/docker/pkg/stringid"
 )
 
 func Create(name string, options types.VolumeCreateOptions) (*native.Volume, error) {
+	if name == "" {
+		name = stringid.GenerateRandomID()
+		options.Labels = append(options.Labels, labels.AnonymousVolumes+"=")
+	}
 	if err := identifiers.Validate(name); err != nil {
 		return nil, fmt.Errorf("malformed name %s: %w", name, err)
 	}


### PR DESCRIPTION
Add a feature to create an anonymous volume like docker.

When investigating the https://github.com/containerd/nerdctl/issues/2421,  the `docker system prune` behavior is updated by the https://github.com/moby/moby/pull/44216.
So the  create anonymous volume should be support first :-)

to Fix: https://github.com/containerd/nerdctl/issues/2432