### PR TITLE
pkg/version: fulfill fields from `debug/buildinfo`

### DIFF
--- a/cmd/nerdctl/compose_version.go
+++ b/cmd/nerdctl/compose_version.go
@@ -47,7 +47,7 @@ func composeVersionAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if short {
-		fmt.Fprintln(cmd.OutOrStdout(), strings.TrimPrefix(version.Version, "v"))
+		fmt.Fprintln(cmd.OutOrStdout(), strings.TrimPrefix(version.GetVersion(), "v"))
 		return nil
 	}
 
@@ -57,7 +57,7 @@ func composeVersionAction(cmd *cobra.Command, args []string) error {
 	}
 	switch format {
 	case "pretty":
-		fmt.Fprintln(cmd.OutOrStdout(), "nerdctl Compose version "+version.Version)
+		fmt.Fprintln(cmd.OutOrStdout(), "nerdctl Compose version "+version.GetVersion())
 	case "json":
 		fmt.Fprintf(cmd.OutOrStdout(), "{\"version\":\"%v\"}\n", version.Version)
 	default:

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -194,7 +194,7 @@ Config file ($NERDCTL_TOML): %s
 		Use:              "nerdctl",
 		Short:            short,
 		Long:             long,
-		Version:          strings.TrimPrefix(version.Version, "v"),
+		Version:          strings.TrimPrefix(version.GetVersion(), "v"),
 		SilenceUsage:     true,
 		SilenceErrors:    true,
 		TraverseChildren: true, // required for global short hands like -a, -H, -n

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -115,8 +115,8 @@ func GetSnapshotterNames(ctx context.Context, introService introspection.Service
 
 func ClientVersion() dockercompat.ClientVersion {
 	return dockercompat.ClientVersion{
-		Version:   version.Version,
-		GitCommit: version.Revision,
+		Version:   version.GetVersion(),
+		GitCommit: version.GetRevision(),
 		GoVersion: runtime.Version(),
 		Os:        runtime.GOOS,
 		Arch:      runtime.GOARCH,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -16,9 +16,64 @@
 
 package version
 
+import (
+	"runtime/debug"
+	"strconv"
+)
+
 var (
 	// Version is filled via Makefile
-	Version = "<unknown>"
+	Version = ""
 	// Revision is filled via Makefile
-	Revision = "<unknown>"
+	Revision = ""
 )
+
+const unknown = "<unknown>"
+
+func GetVersion() string {
+	if Version != "" {
+		return Version
+	}
+	/*
+	 * go install example.com/cmd/foo@vX.Y.Z: bi.Main.Version="vX.Y.Z",                               vcs.revision is unset
+	 * go install example.com/cmd/foo@latest: bi.Main.Version="vX.Y.Z",                               vcs.revision is unset
+	 * go install example.com/cmd/foo@master: bi.Main.Version="vX.Y.Z-N.yyyyMMddhhmmss-gggggggggggg", vcs.revision is unset
+	 * go install ./cmd/foo:                  bi.Main.Version="(devel)", vcs.revision="gggggggggggggggggggggggggggggggggggggggg"
+	 *                                        vcs.time="yyyy-MM-ddThh:mm:ssZ", vcs.modified=("false"|"true")
+	 */
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+			return bi.Main.Version
+		}
+	}
+	return unknown
+}
+
+func GetRevision() string {
+	if Revision != "" {
+		return Revision
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		var (
+			vcsRevision string
+			vcsModified bool
+		)
+		for _, f := range bi.Settings {
+			switch f.Key {
+			case "vcs.revision":
+				vcsRevision = f.Value
+			case "vcs.modified":
+				vcsModified, _ = strconv.ParseBool(f.Value)
+			}
+		}
+		if vcsRevision == "" {
+			return unknown
+		}
+		rev := vcsRevision
+		if vcsModified {
+			rev += ".m"
+		}
+		return rev
+	}
+	return unknown
+}


### PR DESCRIPTION
Fulfill `version.Version` and `version.Revision` from `debug/buildinfo` when the build info is available so that the version can be still printed when nerdctl is installed from `go install`.

The values from Makefile is still prioritized over `debug/buildinfo` values.