### PR TITLE
fix: fix nerdctl run -v when host folder does not exist for bind mounts

### DIFF
--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -93,7 +93,8 @@ func withMounts(mounts []specs.Mount) oci.SpecOpts {
 func parseMountFlags(volStore volumestore.VolumeStore, options types.ContainerCreateOptions) ([]*mountutil.Processed, error) {
 	var parsed []*mountutil.Processed //nolint:prealloc
 	for _, v := range strutil.DedupeStrSlice(options.Volume) {
-		x, err := mountutil.ProcessFlagV(v, volStore)
+		// createDir=true for -v option to allow creation of directory on host if not found.
+		x, err := mountutil.ProcessFlagV(v, volStore, true)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -424,7 +424,8 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 	case Tmpfs:
 		return ProcessFlagTmpfs(fieldsStr)
 	case Volume, Bind:
-		return ProcessFlagV(fieldsStr, volStore)
+		// createDir=false for --mount option to disallow creating directories on host if not found
+		return ProcessFlagV(fieldsStr, volStore, false)
 	}
 	return nil, fmt.Errorf("invalid mount type '%s' must be a volume/bind/tmpfs", mountType)
 }


### PR DESCRIPTION
Fixes: https://github.com/containerd/nerdctl/issues/1945 and improves [compatibility](https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior) with docker.