### PR TITLE
feat: support push with soci

### DIFF
--- a/cmd/nerdctl/flagutil.go
+++ b/cmd/nerdctl/flagutil.go
@@ -56,6 +56,16 @@ func processImageVerifyOptions(cmd *cobra.Command) (opt types.ImageVerifyOptions
 	return
 }
 
+func processSociOptions(cmd *cobra.Command) (opt types.SociOptions, err error) {
+	if opt.SpanSize, err = cmd.Flags().GetInt64("soci-span-size"); err != nil {
+		return
+	}
+	if opt.MinLayerSize, err = cmd.Flags().GetInt64("soci-min-layer-size"); err != nil {
+		return
+	}
+	return
+}
+
 func processRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error) {
 	debug, err := cmd.Flags().GetBool("debug")
 	if err != nil {

--- a/cmd/nerdctl/image_push.go
+++ b/cmd/nerdctl/image_push.go
@@ -57,6 +57,11 @@ func newPushCommand() *cobra.Command {
 	pushCommand.Flags().String("notation-key-name", "", "Signing key name for a key previously added to notation's key list for --sign=notation")
 	// #endregion
 
+	// #region soci flags
+	pushCommand.Flags().Int64("soci-span-size", -1, "Span size that soci index uses to segment layer data. Default is 4 MiB.")
+	pushCommand.Flags().Int64("soci-min-layer-size", -1, "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.")
+	// #endregion
+
 	pushCommand.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
 
 	pushCommand.Flags().Bool(allowNonDistFlag, false, "Allow pushing images with non-distributable blobs")
@@ -101,9 +106,14 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
+	sociOptions, err := processSociOptions(cmd)
+	if err != nil {
+		return types.ImagePushOptions{}, err
+	}
 	return types.ImagePushOptions{
 		GOptions:                       globalOptions,
 		SignOptions:                    signOptions,
+		SociOptions:                    sociOptions,
 		Platforms:                      platform,
 		AllPlatforms:                   allPlatforms,
 		Estargz:                        estargz,

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -769,6 +769,8 @@ Flags:
 - :nerd_face: `--allow-nondistributable-artifacts`: Allow pushing images with non-distributable blobs
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 - :whale: `-q, --quiet`: Suppress verbose output
+- :nerd_face: `--soci-span-size`: Span size in bytes that soci index uses to segment layer data. Default is 4 MiB.
+- :nerd_face: `--soci-min-layer-size`: Minimum layer size in bytes to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.
 
 Unimplemented `docker push` flags: `--all-tags`, `--disable-content-trust` (default true)
 

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -152,6 +152,7 @@ type ImagePushOptions struct {
 	Stdout      io.Writer
 	GOptions    GlobalCommandOptions
 	SignOptions ImageSignOptions
+	SociOptions SociOptions
 	// Platforms convert content for a specific platform
 	Platforms []string
 	// AllPlatforms convert content for all platforms
@@ -255,4 +256,12 @@ type ImageVerifyOptions struct {
 	CosignCertificateOidcIssuer string
 	// CosignCertificateOidcIssuerRegexp A regular expression alternative to --certificate-oidc-issuer for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows
 	CosignCertificateOidcIssuerRegexp string
+}
+
+// SociOptions contains options for SOCI.
+type SociOptions struct {
+	// Span size that soci index uses to segment layer data. Default is 4 MiB.
+	SpanSize int64
+	// Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.
+	MinLayerSize int64
 }

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
 	"github.com/containerd/nerdctl/pkg/signutil"
+	"github.com/containerd/nerdctl/pkg/snapshotterutil"
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/estargz/zstdchunked"
 	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
@@ -180,6 +181,14 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		options.GOptions.Experimental,
 		options.SignOptions); err != nil {
 		return err
+	}
+	if options.GOptions.Snapshotter == "soci" {
+		if err = snapshotterutil.CreateSoci(ref, options.GOptions, options.AllPlatforms, options.Platforms, options.SociOptions); err != nil {
+			return err
+		}
+		if err = snapshotterutil.PushSoci(ref, options.GOptions, options.AllPlatforms, options.Platforms); err != nil {
+			return err
+		}
 	}
 	if options.Quiet {
 		fmt.Fprintln(options.Stdout, ref)

--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -1,0 +1,166 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package snapshotterutil
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/sirupsen/logrus"
+)
+
+// CreateSoci creates a SOCI index(`rawRef`)
+func CreateSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool, platforms []string, sOpts types.SociOptions) error {
+	sociExecutable, err := exec.LookPath("soci")
+	if err != nil {
+		logrus.WithError(err).Error("soci executable not found in path $PATH")
+		logrus.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
+		return err
+	}
+
+	sociCmd := exec.Command(sociExecutable)
+	sociCmd.Env = os.Environ()
+
+	// #region for global flags.
+	if gOpts.Address != "" {
+		sociCmd.Args = append(sociCmd.Args, "--address", gOpts.Address)
+	}
+	if gOpts.Namespace != "" {
+		sociCmd.Args = append(sociCmd.Args, "--namespace", gOpts.Namespace)
+	}
+	// #endregion
+
+	// Global flags have to be put before subcommand before soci upgrades to urfave v3.
+	// https://github.com/urfave/cli/issues/1113
+	sociCmd.Args = append(sociCmd.Args, "create")
+
+	if allPlatform {
+		sociCmd.Args = append(sociCmd.Args, "--all-platforms", strconv.FormatBool(allPlatform))
+	}
+	if len(platforms) > 0 {
+		sociCmd.Args = append(sociCmd.Args, "--platform")
+		sociCmd.Args = append(sociCmd.Args, strings.Join(platforms, ","))
+	}
+	if sOpts.SpanSize != -1 {
+		sociCmd.Args = append(sociCmd.Args, "--span-size", strconv.FormatInt(sOpts.SpanSize, 10))
+	}
+	if sOpts.MinLayerSize != -1 {
+		sociCmd.Args = append(sociCmd.Args, "--min-layer-size", strconv.FormatInt(sOpts.MinLayerSize, 10))
+	}
+	// --timeout, --debug, --content-store
+	sociCmd.Args = append(sociCmd.Args, rawRef)
+
+	logrus.Debugf("running %s %v", sociExecutable, sociCmd.Args)
+
+	err = processSociIO(sociCmd)
+	if err != nil {
+		return err
+	}
+
+	return sociCmd.Wait()
+}
+
+// PushSoci pushes a SOCI index(`rawRef`)
+// `hostsDirs` are used to resolve image `rawRef`
+func PushSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool, platforms []string) error {
+	logrus.Debugf("pushing SOCI index: %s", rawRef)
+
+	sociExecutable, err := exec.LookPath("soci")
+	if err != nil {
+		logrus.WithError(err).Error("soci executable not found in path $PATH")
+		logrus.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
+		return err
+	}
+
+	sociCmd := exec.Command(sociExecutable)
+	sociCmd.Env = os.Environ()
+
+	// #region for global flags.
+	if gOpts.Address != "" {
+		sociCmd.Args = append(sociCmd.Args, "--address", gOpts.Address)
+	}
+	if gOpts.Namespace != "" {
+		sociCmd.Args = append(sociCmd.Args, "--namespace", gOpts.Namespace)
+	}
+	// #endregion
+
+	// Global flags have to be put before subcommand before soci upgrades to urfave v3.
+	// https://github.com/urfave/cli/issues/1113
+	sociCmd.Args = append(sociCmd.Args, "push")
+
+	if allPlatform {
+		sociCmd.Args = append(sociCmd.Args, "--all-platforms", strconv.FormatBool(allPlatform))
+	}
+	if len(platforms) > 0 {
+		sociCmd.Args = append(sociCmd.Args, "--platform")
+		sociCmd.Args = append(sociCmd.Args, strings.Join(platforms, ","))
+	}
+	if gOpts.InsecureRegistry {
+		sociCmd.Args = append(sociCmd.Args, "--skip-verify")
+		sociCmd.Args = append(sociCmd.Args, "--plain-http")
+	}
+	if len(gOpts.HostsDir) > 0 {
+		sociCmd.Args = append(sociCmd.Args, "--hosts-dir")
+		sociCmd.Args = append(sociCmd.Args, strings.Join(gOpts.HostsDir, ","))
+	}
+	sociCmd.Args = append(sociCmd.Args, rawRef)
+
+	logrus.Debugf("running %s %v", sociExecutable, sociCmd.Args)
+
+	err = processSociIO(sociCmd)
+	if err != nil {
+		return err
+	}
+	return sociCmd.Wait()
+}
+
+func processSociIO(sociCmd *exec.Cmd) error {
+	stdout, err := sociCmd.StdoutPipe()
+	if err != nil {
+		logrus.Warn("soci: " + err.Error())
+	}
+	stderr, err := sociCmd.StderrPipe()
+	if err != nil {
+		logrus.Warn("soci: " + err.Error())
+	}
+	if err := sociCmd.Start(); err != nil {
+		// only return err if it's critical (soci command failed to start.)
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		logrus.Info("soci: " + scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		logrus.Warn("soci: " + err.Error())
+	}
+
+	errScanner := bufio.NewScanner(stderr)
+	for errScanner.Scan() {
+		logrus.Info("soci: " + errScanner.Text())
+	}
+	if err := errScanner.Err(); err != nil {
+		logrus.Warn("soci: " + err.Error())
+	}
+
+	return nil
+}

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -60,6 +60,7 @@ var (
 const (
 	FedoraESGZImage = "ghcr.io/stargz-containers/fedora:30-esgz"            // eStargz
 	FfmpegSociImage = "public.ecr.aws/soci-workshop-examples/ffmpeg:latest" // SOCI
+	UbuntuImage     = "public.ecr.aws/docker/library/ubuntu:23.10"          // Large enough for testing soci index creation
 )
 
 type delayOnceReader struct {


### PR DESCRIPTION
## High level approach

The current approach integrates both `soci create` and `soci push` to `nerdctl push` when soci is specified in `nerdctl push`. The change is based on the assumption that we want to integrate whole soci workflow to nerdctl seamlessly without letting users run any soci commands by themselves.

One alternative is to integrate `soci create` to `nerdctl build` and `soci push` to `nerdctl push`. `nerdctl build` makes sense to be independent with `nerdctl push` because the image can ran or exported locally without pushing later, but soci index is for lazy pull, which doesn't make sense without pushing to a registry later. The soci getting-started [guide](https://github.com/awslabs/soci-snapshotter/blob/main/docs/getting-started.md) also puts `soci create` after pushing image to registry. So didn't choose this approach.

## SOCI flags

When calling `soci` commands in `nerdctl push`. There are many flags in `soci create` and `soci push` to be set properly. There are several possible ways of setting them:

- If Nerdctl has the same flag and it is reasonable to pass through, pass throught the flags from Nerdctl input to soci.
- If the flag is reasonable to expose to Nerdctl users but not available in Nerdctl, add new flags to Nerdctl prefixed with `soci`. (Similar to the [style](https://github.com/containerd/nerdctl/blob/593b94f977d802db43801baccc148e7bed499e95/docs/command-reference.md?plain=1#L365) in Cosign)
- Hardcode to specific values in soci commands.
- Keep the flags as default in soci commands if we don't see obvious benefit of exposing them to Nerdctl users. It is a two-way-door to expose them later.

|  SOCI flag             |  SOCI command      | Recommended Value |
|--------------------------|-----------------|-------------------|
| **--address**                | global          | Pass through from Nerdctl global flag --address                  |
| **--namespace**              | global          | Pass through from Nerdctl global flag --namespace        |
| --timeout                | global          |  Keep default as no timeout          |
| --debug                  | global          |    Keep default as false, which is consistent with the pattern of other dependencies such as Cosign               |
| --content-store          | global          |   Keep default. The content store is anyways managed by SOCI. [Discussion](https://github.com/awslabs/soci-snapshotter/issues/423#issuecomment-1720368676)                |
| **--all-platforms**          | create and push | Pass through from Nerdctl push flag --all-platforms                  |
| **--platform**               | create and push | Pass through from Nerdctl push flag --platform                  |
| **--span-size**              | create          |  Add new Nerdctl push flag --soci-span-size to expose it                 |
| **--min-layer-size**         | create          | Add new Nerdctl push flag --soci-min-layer-size to expose it                  |
| **--skip-verify**       | push            |        Pass through from Nerdctl push flag --insecure-registry           |
| **--plain-http**       | push            |         Pass through from Nerdctl push flag --insecure-registry (from this [discussion](https://github.com/containerd/containerd/issues/4826#issuecomment-742280578), both are needed)          |
| --user      | push            |    Keep default as empty. Soci could and should share nerdctl's credentials               |
| --refresh     | push            |   Keep default as empty. Soci could and should share nerdctl's credentials                |
| **--hosts-dir**    | push            |   Pass through from Nerdctl config "hosts_dir" (TBD. Seems unsupported. To be confirmed. https://github.com/awslabs/soci-snapshotter/discussions/839)             |
| --tlscacert    | push            |  Keep default. The config has too low level to be exposed in Nerdctl                      |
| --tlscert      | push            |    Keep default. The config has too low level to be exposed in Nerdctl                    |
| --tlskey       | push            |    Keep default. The config has too low level to be exposed in Nerdctl                     |
| --http-dump      | push            |  Keep default. The config has too low level to be exposed in Nerdctl                        |
| --http-trace       | push            |   Keep default. The config has too low level to be exposed in Nerdctl                     |
| --label          | push            | Keep default. SOCI index should not need special labels and any labels in Nerdctl should not apply to index                  |
| --snapshotter     | push            |  Keep default. The user input snapshotter in Nerdctl is soci. SOCI index should use the default one instead of using SOCI snapshotter again                 |
| --existing-index         | push            |  Keep default as "warn". Can expose later if needed.                |
| --max-concurrent-uploads | push            | Keep default as "10". Can expose later if needed.                   |
| --quiet                  | push            |  Keep default as false. No matter whether `quiet` is true in soci, Nerdctl quiet should already suppress anything |

