### PR TITLE
Fix bash completion of volume rm

### DIFF
--- a/cmd/nerdctl/completion_linux_test.go
+++ b/cmd/nerdctl/completion_linux_test.go
@@ -54,6 +54,13 @@ func TestCompletion(t *testing.T) {
 	base.Cmd(gsc, "network", "rm", "").AssertOutContains(testNetworkName)
 	base.Cmd(gsc, "run", "--net", "").AssertOutContains(testNetworkName)
 
+	// Tests with a volume
+	testVolumekName := "nerdctl-test-completion"
+	defer base.Cmd("volume", "rm", testVolumekName).Run()
+	base.Cmd("volume", "create", testVolumekName).AssertOK()
+	base.Cmd(gsc, "volume", "inspect", "").AssertOutContains(testVolumekName)
+	base.Cmd(gsc, "volume", "rm", "").AssertOutContains(testVolumekName)
+
 	// Tests with raw base (without Args={"--namespace=nerdctl-test"})
 	rawBase := testutil.NewBase(t)
 	rawBase.Args = nil // unset "--namespace=nerdctl-test"

--- a/cmd/nerdctl/volume_list.go
+++ b/cmd/nerdctl/volume_list.go
@@ -87,7 +87,8 @@ func volumeLsAction(cmd *cobra.Command, args []string) error {
 func getVolumes(cmd *cobra.Command, globalOptions types.GlobalCommandOptions) (map[string]native.Volume, error) {
 	volumeSize, err := cmd.Flags().GetBool("size")
 	if err != nil {
-		return nil, err
+		// The `nerdctl volume rm` does not have the flag `size`, so set it to false as the default value.
+		volumeSize = false
 	}
 	return volume.Volumes(globalOptions.Namespace, globalOptions.DataRoot, globalOptions.Address, volumeSize, nil)
 }


### PR DESCRIPTION
Support the bash completion when there are not flag of `size` to fix #2474