### PR TITLE
seccomp: rename "default" to "builtin" to follow Docker 23

### DIFF
--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -172,7 +172,11 @@ func setCreateFlags(cmd *cobra.Command) {
 	// #region security flags
 	cmd.Flags().StringArray("security-opt", []string{}, "Security options")
 	cmd.RegisterFlagCompletionFunc("security-opt", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"seccomp=", "seccomp=unconfined", "apparmor=", "apparmor=" + defaults.AppArmorProfileName, "apparmor=unconfined", "no-new-privileges", "privileged-without-host-devices"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{
+			"seccomp=", "seccomp=" + defaults.SeccompProfileName, "seccomp=unconfined",
+			"apparmor=", "apparmor=" + defaults.AppArmorProfileName, "apparmor=unconfined",
+			"no-new-privileges",
+			"privileged-without-host-devices"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	// cap-add and cap-drop are defined as StringSlice, not StringArray, to allow specifying "--cap-add=CAP_SYS_ADMIN,CAP_NET_ADMIN" (compatible with Podman)
 	cmd.Flags().StringSlice("cap-add", []string{}, "Add Linux capabilities")

--- a/pkg/cmd/container/run_security_linux.go
+++ b/pkg/cmd/container/run_security_linux.go
@@ -53,7 +53,7 @@ func generateSecurityOpts(privileged bool, securityOptsMap map[string]string) ([
 		}
 	}
 	var opts []oci.SpecOpts
-	if seccompProfile, ok := securityOptsMap["seccomp"]; ok {
+	if seccompProfile, ok := securityOptsMap["seccomp"]; ok && seccompProfile != defaults.SeccompProfileName {
 		if seccompProfile == "" {
 			return nil, errors.New("invalid security-opt \"seccomp\"")
 		}

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -20,8 +20,11 @@ import (
 	gocni "github.com/containerd/go-cni"
 )
 
-const AppArmorProfileName = ""
-const Runtime = "wtf.sbk.runj.v1"
+const (
+	AppArmorProfileName = ""
+	SeccompProfileName  = ""
+	Runtime             = "wtf.sbk.runj.v1"
+)
 
 func DataRoot() string {
 	return "/var/lib/nerdctl"

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -28,8 +28,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const AppArmorProfileName = "nerdctl-default"
-const Runtime = plugin.RuntimeRuncV2
+const (
+	AppArmorProfileName = "nerdctl-default"
+	SeccompProfileName  = "builtin"
+	Runtime             = plugin.RuntimeRuncV2
+)
 
 func DataRoot() string {
 	if !rootlessutil.IsRootless() {

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -22,8 +22,11 @@ import (
 	"path/filepath"
 )
 
-const AppArmorProfileName = ""
-const Runtime = "io.containerd.runhcs.v1"
+const (
+	AppArmorProfileName = ""
+	SeccompProfileName  = ""
+	Runtime             = "io.containerd.runhcs.v1"
+)
 
 func DataRoot() string {
 	return filepath.Join(os.Getenv("ProgramData"), "nerdctl")

--- a/pkg/infoutil/infoutil_linux.go
+++ b/pkg/infoutil/infoutil_linux.go
@@ -49,7 +49,7 @@ WARNING: AppArmor profile %q is not loaded.
          This warning is negligible if you do not intend to use AppArmor.`), defaults.AppArmorProfileName))
 		}
 	}
-	info.SecurityOptions = append(info.SecurityOptions, "name=seccomp,profile=default")
+	info.SecurityOptions = append(info.SecurityOptions, "name=seccomp,profile="+defaults.SeccompProfileName)
 	if defaults.CgroupnsMode() == "private" {
 		info.SecurityOptions = append(info.SecurityOptions, "name=cgroupns")
 	}


### PR DESCRIPTION
Docker 23 renamed the "default" profile to "builtin"
- https://github.com/moby/moby/commit/ac449d6b5ad29a5086824729ce54eec6b0cc8545
- https://github.com/moby/moby/commit/f8795ed364586acd93f72e206a409e7e0e27edcc