### PR TITLE
compose: silence "build.config should be relative path" warning

### DIFF
--- a/pkg/composer/serviceparser/build.go
+++ b/pkg/composer/serviceparser/build.go
@@ -44,9 +44,6 @@ func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName st
 	if strings.Contains(c.Context, "://") {
 		return nil, fmt.Errorf("build: URL-style context (%q) is not supported yet: %w", c.Context, errdefs.ErrNotImplemented)
 	}
-	if filepath.IsAbs(c.Context) {
-		logrus.Warnf("build.config should be relative path, got %q", c.Context)
-	}
 	ctxDir := project.RelativePath(c.Context)
 
 	var b Build


### PR DESCRIPTION
This warning was always printed with a compose yaml that contains a build, as `compose-go/loader.ResolveServiceRelativePaths` automatically expands a relative context path to an abstract path: https://github.com/compose-spec/compose-go/blob/v1.18.4/loader/paths.go#L91-L93

("build.config" was a typo of "build.context")

Fix #2508