### PR TITLE
nerdctl compose cp: support rootless

### DIFF
--- a/cmd/nerdctl/compose_cp.go
+++ b/cmd/nerdctl/compose_cp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/pkg/composer"
+	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +48,6 @@ func composeCopyAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	// TODO: unimplemented rootless mode
 	source := args[0]
 	if source == "" {
 		return errors.New("source can not be empty")
@@ -69,7 +69,15 @@ func composeCopyAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, globalOptions.Address)
+	address := globalOptions.Address
+	// rootless cp runs in the host namespaces, so the address is different
+	if rootlessutil.IsRootless() {
+		address, err = rootlessutil.RootlessContainredSockAddress()
+		if err != nil {
+			return err
+		}
+	}
+	client, ctx, cancel, err := clientutil.NewClient(cmd.Context(), globalOptions.Namespace, address)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/compose_cp_linux_test.go
+++ b/cmd/nerdctl/compose_cp_linux_test.go
@@ -22,15 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"gotest.tools/v3/assert"
 )
 
 func TestComposeCopy(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("Test skipped in rootless mode for compose copy")
-	}
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`

--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -39,10 +39,18 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 	switch commands[1] {
 	// completion, login, logout: false, because it shouldn't require the daemon to be running
 	// apparmor: false, because it requires the initial mount namespace to access /sys/kernel/security
-	// cp: false, because it requires the initial mount namespace to inspect file owners
+	// cp, compose cp: false, because it requires the initial mount namespace to inspect file owners
 	case "", "completion", "login", "logout", "apparmor", "cp":
 		return false
 	case "container":
+		if len(commands) < 3 {
+			return true
+		}
+		switch commands[2] {
+		case "cp":
+			return false
+		}
+	case "compose":
 		if len(commands) < 3 {
 			return true
 		}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1558,8 +1558,6 @@ Flags:
 
 Unimplemented `docker compose cp` flags: `--archive`
 
-Unimplemented rootless mode
-
 ### :whale: nerdctl compose kill
 
 Force stop service containers

--- a/pkg/rootlessutil/rootlessutil_other.go
+++ b/pkg/rootlessutil/rootlessutil_other.go
@@ -62,3 +62,7 @@ func NewRootlessKitClient() (client.Client, error) {
 func ParentMain(hostGatewayIP string) error {
 	return fmt.Errorf("cannot use RootlessKit on main entry point on non-Linux hosts")
 }
+
+func RootlessContainredSockAddress() (string, error) {
+	return "", fmt.Errorf("cannot inspect RootlessKit state on non-Linux hosts")
+}


### PR DESCRIPTION
rootless cp runs in the host namespace (for inspecting file owners)

Fix #2512