### PR TITLE
nerdctl version: skip inspecting rootless daemon if the daemon is not running

### DIFF
--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -37,10 +37,10 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 		return true
 	}
 	switch commands[1] {
-	// completion, login, logout: false, because it shouldn't require the daemon to be running
+	// completion, login, logout, version: false, because it shouldn't require the daemon to be running
 	// apparmor: false, because it requires the initial mount namespace to access /sys/kernel/security
 	// cp, compose cp: false, because it requires the initial mount namespace to inspect file owners
-	case "", "completion", "login", "logout", "apparmor", "cp":
+	case "", "completion", "login", "logout", "apparmor", "cp", "version":
 		return false
 	case "container":
 		if len(commands) < 3 {


### PR DESCRIPTION
Fix #2455