### PR TITLE
Support zstd (non-chunked) conversion

### DIFF
--- a/cmd/nerdctl/image_convert.go
+++ b/cmd/nerdctl/image_convert.go
@@ -60,6 +60,11 @@ func newImageConvertCommand() *cobra.Command {
 	imageConvertCommand.Flags().Bool("estargz-keep-diff-id", false, "Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')")
 	// #endregion
 
+	// #region zstd flags
+	imageConvertCommand.Flags().Bool("zstd", false, "Convert legacy tar(.gz) layers to zstd. Should be used in conjunction with '--oci'")
+	imageConvertCommand.Flags().Int("zstd-compression-level", 3, "zstd compression level")
+	// #endregion
+
 	// #region zstd:chunked flags
 	imageConvertCommand.Flags().Bool("zstdchunked", false, "Convert legacy tar(.gz) layers to zstd:chunked for lazy pulling. Should be used in conjunction with '--oci'")
 	imageConvertCommand.Flags().String("zstdchunked-record-in", "", "Read 'ctr-remote optimize --record-out=<FILE>' record file (EXPERIMENTAL)")
@@ -132,6 +137,17 @@ func processImageConvertOptions(cmd *cobra.Command) (types.ImageConvertOptions, 
 		return types.ImageConvertOptions{}, err
 	}
 	estargzKeepDiffID, err := cmd.Flags().GetBool("estargz-keep-diff-id")
+	if err != nil {
+		return types.ImageConvertOptions{}, err
+	}
+	// #endregion
+
+	// #region zstd flags
+	zstd, err := cmd.Flags().GetBool("zstd")
+	if err != nil {
+		return types.ImageConvertOptions{}, err
+	}
+	zstdCompressionLevel, err := cmd.Flags().GetInt("zstd-compression-level")
 	if err != nil {
 		return types.ImageConvertOptions{}, err
 	}
@@ -226,6 +242,10 @@ func processImageConvertOptions(cmd *cobra.Command) (types.ImageConvertOptions, 
 		EstargzMinChunkSize:     estargzMinChunkSize,
 		EstargzExternalToc:      estargzExternalTOC,
 		EstargzKeepDiffID:       estargzKeepDiffID,
+		// #endregion
+		// #region zstd flags
+		Zstd:                 zstd,
+		ZstdCompressionLevel: zstdCompressionLevel,
 		// #endregion
 		// #region zstd:chunked flags
 		ZstdChunked:                 zstdchunked,

--- a/cmd/nerdctl/image_convert_test.go
+++ b/cmd/nerdctl/image_convert_test.go
@@ -38,6 +38,20 @@ func TestImageConvertEStargz(t *testing.T) {
 		testutil.CommonImage, convertedImage).AssertOK()
 }
 
+func TestImageConvertZstd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no windows support yet")
+	}
+	testutil.DockerIncompatible(t)
+	base := testutil.NewBase(t)
+	convertedImage := testutil.Identifier(t) + ":zstd"
+	base.Cmd("rmi", convertedImage).Run()
+	defer base.Cmd("rmi", convertedImage).Run()
+	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	base.Cmd("image", "convert", "--zstd", "--oci", "--zstd-compression-level", "3",
+		testutil.CommonImage, convertedImage).AssertOK()
+}
+
 func TestImageConvertZstdChunked(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("no windows support yet")

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -878,6 +878,8 @@ Flags:
 - `--estargz-min-chunk-size=<SIZE>` : The minimal number of bytes of data must be written in one gzip stream (requires stargz-snapshotter >= v0.13.0). Useful for creating a smaller eStargz image (refer to [`./stargz.md`](./stargz.md) for details).
 - `--estargz-external-toc` : Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. (requires stargz-snapshotter >= v0.13.0) Useful for creating a smaller eStargz image (refer to [`./stargz.md`](./stargz.md) for details). :warning: This flag is experimental and subject to change.
 - `--estargz-keep-diff-id`: Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')
+- `--zstd`                             : Use zstd compression instead of gzip. Should be used in conjunction with '--oci'
+- `--zstd-compression-level=<LEVEL>`   : zstd compression level (default: 3)
 - `--zstdchunked`                      : Use zstd compression instead of gzip (a.k.a zstd:chunked). Should be used in conjunction with '--oci'
 - `--zstdchunked-record-in=<FILE>` : read `ctr-remote optimize --record-out=<FILE>` record file. :warning: This flag is experimental and subject to change.
 - `--zstdchunked-compression-level=<LEVEL>`: zstd:chunked compression level (default: 3)

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -80,6 +80,13 @@ type ImageConvertOptions struct {
 	EstargzKeepDiffID bool
 	// #endregion
 
+	// #region zstd flags
+	// Zstd convert legacy tar(.gz) layers to zstd. Should be used in conjunction with '--oci'
+	Zstd bool
+	// ZstdCompressionLevel zstd compression level
+	ZstdCompressionLevel int
+	// #endregion
+
 	// #region zstd:chunked flags
 	// ZstdChunked convert legacy tar(.gz) layers to zstd:chunked for lazy pulling. Should be used in conjunction with '--oci'
 	ZstdChunked bool

--- a/pkg/imgutil/converter/zstd.go
+++ b/pkg/imgutil/converter/zstd.go
@@ -1,0 +1,122 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package converter
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/images/converter"
+	"github.com/containerd/containerd/images/converter/uncompress"
+	"github.com/containerd/nerdctl/pkg/api/types"
+	"github.com/klauspost/compress/zstd"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// ZstdLayerConvertFunc converts legacy tar.gz layers into zstd layers with
+// the specified compression level.
+func ZstdLayerConvertFunc(options types.ImageConvertOptions) (converter.ConvertFunc, error) {
+	return func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
+		if !images.IsLayerType(desc.MediaType) {
+			// No conversion. No need to return an error here.
+			return nil, nil
+		}
+		uncompressedDesc := &desc
+		if !uncompress.IsUncompressedType(desc.MediaType) {
+			var err error
+			uncompressedDesc, err = uncompress.LayerConvertFunc(ctx, cs, desc)
+			if err != nil {
+				return nil, err
+			}
+			if uncompressedDesc == nil {
+				return nil, fmt.Errorf("unexpectedly got the same blob after compression (%s, %q)", desc.Digest, desc.MediaType)
+			}
+			defer func() {
+				if err := cs.Delete(ctx, uncompressedDesc.Digest); err != nil {
+					logrus.WithError(err).WithField("uncompressedDesc", uncompressedDesc).Warn("failed to remove tmp uncompressed layer")
+				}
+			}()
+			logrus.Debugf("zstd: uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
+		}
+
+		info, err := cs.Info(ctx, desc.Digest)
+		if err != nil {
+			return nil, err
+		}
+		readerAt, err := cs.ReaderAt(ctx, *uncompressedDesc)
+		if err != nil {
+			return nil, err
+		}
+		defer readerAt.Close()
+		sr := io.NewSectionReader(readerAt, 0, uncompressedDesc.Size)
+		ref := fmt.Sprintf("convert-zstd-from-%s", desc.Digest)
+		w, err := content.OpenWriter(ctx, cs, content.WithRef(ref))
+		if err != nil {
+			return nil, err
+		}
+		defer w.Close()
+
+		// Reset the writing position
+		// Old writer possibly remains without aborted
+		// (e.g. conversion interrupted by a signal)
+		if err := w.Truncate(0); err != nil {
+			return nil, err
+		}
+
+		pr, pw := io.Pipe()
+		enc, err := zstd.NewWriter(pw, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(options.ZstdCompressionLevel)))
+		if err != nil {
+			return nil, err
+		}
+		go func() {
+			if _, err := io.Copy(enc, sr); err != nil {
+				pr.CloseWithError(err)
+				return
+			}
+			if err = enc.Close(); err != nil {
+				pr.CloseWithError(err)
+				return
+			}
+			if err = pw.Close(); err != nil {
+				pr.CloseWithError(err)
+				return
+			}
+		}()
+
+		n, err := io.Copy(w, pr)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = w.Commit(ctx, 0, "", content.WithLabels(info.Labels)); err != nil && !errdefs.IsAlreadyExists(err) {
+			return nil, err
+		}
+		if err := w.Close(); err != nil {
+			return nil, err
+		}
+		newDesc := desc
+		newDesc.Digest = w.Digest()
+		newDesc.Size = n
+		newDesc.MediaType = ocispec.MediaTypeImageLayerZstd
+		return &newDesc, nil
+	}, nil
+}


### PR DESCRIPTION
This PR adds non-chunked zstd image conversion to `nerdctl`.

`nerdctl` today already supports converting images to `zstdchunked` format for lazy-loading. Traditional non-chunked `zstd` format is usually smaller than the chunked equivalent, and faster to convert. This is desirable for the non lazy-loading scenarios.

The following is the image size comparison between gzip, zstd and ztdchunked formats. Both `zstd` and `zstdchunked` used the default level 3 compression level.

```
// Gzip
REPOSITORY    TAG       IMAGE ID        CREATED          PLATFORM       SIZE        BLOB SIZE
ubuntu        latest    aabed3296a3d    2 seconds ago    linux/amd64    83.4 MiB    28.2 MiB

// zstd
REPOSITORY     TAG       IMAGE ID        CREATED          PLATFORM       SIZE        BLOB SIZE
ubuntu:zstd    latest    fdda97ba5d76    5 minutes ago    linux/amd64    83.4 MiB    24.5 MiB

// Zstdchunked
REPOSITORY    TAG       IMAGE ID        CREATED          PLATFORM       SIZE        BLOB SIZE
ubuntu        zstdchunked      3fc7ec4a3a95    3 seconds ago         linux/amd64    0.0 B       31.3 MiB
```