### PR TITLE
[Chore] 2523: Use https://github.com/containerd/log for logging

### DIFF
--- a/cmd/nerdctl/builder.go
+++ b/cmd/nerdctl/builder.go
@@ -22,9 +22,9 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -75,7 +75,7 @@ func builderPruneAction(cmd *cobra.Command, _ []string) error {
 	}
 	buildctlArgs := buildkitutil.BuildctlBaseArgs(buildkitHost)
 	buildctlArgs = append(buildctlArgs, "prune")
-	logrus.Debugf("running %s %v", buildctlBinary, buildctlArgs)
+	log.L.Debugf("running %s %v", buildctlBinary, buildctlArgs)
 	buildctlCmd := exec.Command(buildctlBinary, buildctlArgs...)
 	buildctlCmd.Env = os.Environ()
 	buildctlCmd.Stdout = cmd.OutOrStdout()

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -27,13 +27,13 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/restart"
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/portutil"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -335,7 +335,7 @@ func formatPublishers(labelMap map[string]string) []PortPublisher {
 			dockerPorts = append(dockerPorts, mapper(p))
 		}
 	} else {
-		logrus.Error(err.Error())
+		log.L.Error(err.Error())
 	}
 	return dockerPorts
 }

--- a/cmd/nerdctl/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose_run_linux_test.go
@@ -23,10 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"github.com/containerd/nerdctl/pkg/testutil/nettestutil"
 	"github.com/containerd/nerdctl/pkg/testutil/testregistry"
-	"github.com/sirupsen/logrus"
 	"gotest.tools/v3/assert"
 )
 
@@ -94,7 +94,7 @@ services:
 	stdoutContent := result.Stdout() + result.Stderr()
 	assert.Assert(psCmd.Base.T, result.ExitCode == 0, stdoutContent)
 	if strings.Contains(stdoutContent, containerName) {
-		logrus.Errorf("test failed, the container %s is not removed", stdoutContent)
+		log.L.Errorf("test failed, the container %s is not removed", stdoutContent)
 		t.Fail()
 		return
 	}
@@ -316,7 +316,7 @@ services:
 
 	container := base.InspectContainer(containerName)
 	if container.Config == nil {
-		logrus.Errorf("test failed, cannot fetch container config")
+		log.L.Errorf("test failed, cannot fetch container config")
 		t.Fail()
 	}
 	assert.Equal(t, container.Config.Labels["foo"], "rab")

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 
 	"github.com/containerd/nerdctl/pkg/testutil"
 	"github.com/containerd/nerdctl/pkg/testutil/nettestutil"
@@ -194,7 +194,7 @@ networks:
 	stdoutContent := result.Stdout() + result.Stderr()
 	assert.Assert(inspectCmd.Base.T, result.ExitCode == 0, stdoutContent)
 	if !strings.Contains(stdoutContent, staticIP) {
-		logrus.Errorf("test failed, the actual container ip is %s", stdoutContent)
+		log.L.Errorf("test failed, the actual container ip is %s", stdoutContent)
 		t.Fail()
 		return
 	}

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 
 	"github.com/containerd/console"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/container"
@@ -34,7 +35,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/signalutil"
 	"github.com/containerd/nerdctl/pkg/taskutil"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -348,11 +348,11 @@ func runAction(cmd *cobra.Command, args []string) error {
 			// network setup/cleanup from the main nerdctl executable.
 			if runtime.GOOS == "windows" {
 				if err := netManager.CleanupNetworking(ctx, c); err != nil {
-					logrus.Warnf("failed to clean up container networking: %s", err)
+					log.L.Warnf("failed to clean up container networking: %s", err)
 				}
 			}
 			if err := container.RemoveContainer(ctx, c, createOpt.GOptions, true, true, client); err != nil {
-				logrus.WithError(err).Warnf("failed to remove container %s", id)
+				log.L.WithError(err).Warnf("failed to remove container %s", id)
 			}
 		}()
 	}
@@ -387,7 +387,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 	}
 	if createOpt.TTY {
 		if err := consoleutil.HandleConsoleResize(ctx, task, con); err != nil {
-			logrus.WithError(err).Error("console resize")
+			log.L.WithError(err).Error("console resize")
 		}
 	} else {
 		sigC := signalutil.ForwardAllSignals(ctx, task)
@@ -415,7 +415,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 	case status := <-statusC:
 		if createOpt.Rm {
 			if _, taskDeleteErr := task.Delete(ctx); taskDeleteErr != nil {
-				logrus.Error(taskDeleteErr)
+				log.L.Error(taskDeleteErr)
 			}
 		}
 		code, _, err := status.Result()

--- a/cmd/nerdctl/container_update.go
+++ b/cmd/nerdctl/container_update.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containerd/typeurl/v2"
 	"github.com/docker/go-units"
 	runtimespec "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -196,7 +195,7 @@ func getUpdateOption(cmd *cobra.Command, globalOptions types.GlobalCommandOption
 		return options, err
 	}
 	if kernelMemStr != "" && cmd.Flag("kernel-memory").Changed {
-		logrus.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
+		log.L.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
 	}
 	cpuset, err := cmd.Flags().GetString("cpuset-cpus")
 	if err != nil {

--- a/cmd/nerdctl/image_history.go
+++ b/cmd/nerdctl/image_history.go
@@ -29,12 +29,12 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/pkg/progress"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/opencontainers/image-spec/identity"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -198,7 +198,7 @@ func printHistory(cmd *cobra.Command, historys []historyPrintable) error {
 
 	for index := len(historys) - 1; index >= 0; index-- {
 		if err := printer.printHistory(historys[index]); err != nil {
-			logrus.Warn(err)
+			log.L.Warn(err)
 		}
 	}
 

--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -21,10 +21,10 @@ import (
 	"io"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/cmd/login"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -76,7 +76,7 @@ func loginAction(cmd *cobra.Command, args []string) error {
 // copied from github.com/docker/cli/cli/command/registry/login.go (v20.10.3)
 func verifyLoginOptions(cmd *cobra.Command, options *loginOptions) error {
 	if options.password != "" {
-		logrus.Warn("WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
+		log.L.Warn("WARNING! Using --password via the CLI is insecure. Use --password-stdin.")
 		if options.passwordStdin {
 			return errors.New("--password and --password-stdin are mutually exclusive")
 		}

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/config"
 	ncdefaults "github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/errutil"
@@ -34,7 +35,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/pelletier/go-toml/v2"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -118,7 +118,7 @@ func usage(c *cobra.Command) error {
 func main() {
 	if err := xmain(); err != nil {
 		errutil.HandleExitCoder(err)
-		logrus.Fatal(err)
+		log.L.Fatal(err)
 	}
 }
 
@@ -139,15 +139,15 @@ func xmain() error {
 func initRootCmdFlags(rootCmd *cobra.Command, tomlPath string) (*pflag.FlagSet, error) {
 	cfg := config.New()
 	if r, err := os.Open(tomlPath); err == nil {
-		logrus.Debugf("Loading config from %q", tomlPath)
+		log.L.Debugf("Loading config from %q", tomlPath)
 		defer r.Close()
 		dec := toml.NewDecoder(r).DisallowUnknownFields() // set Strict to detect typo
 		if err := dec.Decode(cfg); err != nil {
 			return nil, fmt.Errorf("failed to load nerdctl config (not daemon config) from %q (Hint: don't mix up daemon's `config.toml` with `nerdctl.toml`): %w", tomlPath, err)
 		}
-		logrus.Debugf("Loaded config %+v", cfg)
+		log.L.Debugf("Loaded config %+v", cfg)
 	} else {
-		logrus.WithError(err).Debugf("Not loading config from %q", tomlPath)
+		log.L.WithError(err).Debugf("Not loading config from %q", tomlPath)
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
@@ -216,7 +216,7 @@ Config file ($NERDCTL_TOML): %s
 			debug = globalOptions.Debug
 		}
 		if debug {
-			logrus.SetLevel(logrus.DebugLevel)
+			log.SetLevel(log.DebugLevel.String())
 		}
 		address := globalOptions.Address
 		if strings.Contains(address, "://") && !strings.HasPrefix(address, "unix://") {
@@ -327,7 +327,7 @@ Config file ($NERDCTL_TOML): %s
 func globalFlags(cmd *cobra.Command) (string, []string) {
 	args0, err := os.Executable()
 	if err != nil {
-		logrus.WithError(err).Warnf("cannot call os.Executable(), assuming the executable to be %q", os.Args[0])
+		log.L.WithError(err).Warnf("cannot call os.Executable(), assuming the executable to be %q", os.Args[0])
 		args0 = os.Args[0]
 	}
 	if len(os.Args) < 2 {
@@ -396,7 +396,7 @@ func AddIntFlag(cmd *cobra.Command, name string, aliases []string, value int, en
 	if envV, ok := os.LookupEnv(env); ok {
 		v, err := strconv.ParseInt(envV, 10, 64)
 		if err != nil {
-			logrus.WithError(err).Warnf("Invalid int value for `%s`", env)
+			log.L.WithError(err).Warnf("Invalid int value for `%s`", env)
 		}
 		value = int(v)
 	}
@@ -423,7 +423,7 @@ func AddDurationFlag(cmd *cobra.Command, name string, aliases []string, value ti
 		var err error
 		value, err = time.ParseDuration(envV)
 		if err != nil {
-			logrus.WithError(err).Warnf("Invalid duration value for `%s`", env)
+			log.L.WithError(err).Warnf("Invalid duration value for `%s`", env)
 		}
 	}
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
@@ -501,7 +501,7 @@ func AddPersistentBoolFlag(cmd *cobra.Command, name string, aliases, nonPersiste
 		var err error
 		value, err = strconv.ParseBool(envV)
 		if err != nil {
-			logrus.WithError(err).Warnf("Invalid boolean value for `%s`", env)
+			log.L.WithError(err).Warnf("Invalid boolean value for `%s`", env)
 		}
 	}
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)

--- a/cmd/nerdctl/main_unix.go
+++ b/cmd/nerdctl/main_unix.go
@@ -19,10 +19,10 @@
 package main
 
 import (
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/infoutil"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func shellCompleteNamespaceNames(cmd *cobra.Command, args []string, toComplete s
 	nsService := client.NamespaceService()
 	nsList, err := nsService.List(ctx)
 	if err != nil {
-		logrus.Warn(err)
+		log.L.Warn(err)
 		return nil, cobra.ShellCompDirectiveError
 	}
 	var candidates []string

--- a/cmd/nerdctl/namespace.go
+++ b/cmd/nerdctl/namespace.go
@@ -24,9 +24,9 @@ import (
 	"text/tabwriter"
 
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -103,24 +103,24 @@ func namespaceLsAction(cmd *cobra.Command, args []string) error {
 
 		containers, err := client.Containers(ctx)
 		if err != nil {
-			logrus.Warn(err)
+			log.L.Warn(err)
 		}
 		numContainers = len(containers)
 
 		images, err := client.ImageService().List(ctx)
 		if err != nil {
-			logrus.Warn(err)
+			log.L.Warn(err)
 		}
 		numImages = len(images)
 
 		volStore, err := volumestore.Path(dataStore, ns)
 		if err != nil {
-			logrus.Warn(err)
+			log.L.Warn(err)
 		} else {
 			volEnts, err := os.ReadDir(volStore)
 			if err != nil {
 				if !os.IsNotExist(err) {
-					logrus.Warn(err)
+					log.L.Warn(err)
 				}
 			}
 			numVolumes = len(volEnts)

--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/cmd/system"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +60,7 @@ func processSystemPruneOptions(cmd *cobra.Command) (types.SystemPruneOptions, er
 
 	buildkitHost, err := getBuildkitHost(cmd, globalOptions.Namespace)
 	if err != nil {
-		logrus.WithError(err).Warn("BuildKit is not running. Build caches will not be pruned.")
+		log.L.WithError(err).Warn("BuildKit is not running. Build caches will not be pruned.")
 		buildkitHost = ""
 	}
 

--- a/cmd/nerdctl/system_prune_linux_test.go
+++ b/cmd/nerdctl/system_prune_linux_test.go
@@ -25,9 +25,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/pkg/testutil"
-	"github.com/sirupsen/logrus"
 )
 
 func TestSystemPrune(t *testing.T) {
@@ -79,7 +79,7 @@ func TestSystemPrune(t *testing.T) {
 
 	buildctlArgs := buildkitutil.BuildctlBaseArgs(host)
 	buildctlArgs = append(buildctlArgs, "du")
-	logrus.Debugf("running %s %v", buildctlBinary, buildctlArgs)
+	log.L.Debugf("running %s %v", buildctlBinary, buildctlArgs)
 	buildctlCmd := exec.Command(buildctlBinary, buildctlArgs...)
 	buildctlCmd.Env = os.Environ()
 	stdout := bytes.NewBuffer(nil)

--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -23,12 +23,12 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/infoutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -72,7 +72,7 @@ func versionAction(cmd *cobra.Command, args []string) error {
 	if rootlessutil.IsRootless() {
 		address, err = rootlessutil.RootlessContainredSockAddress()
 		if err != nil {
-			logrus.WithError(err).Warning("failed to inspect the rootless containerd socket address")
+			log.L.WithError(err).Warning("failed to inspect the rootless containerd socket address")
 			address = ""
 		}
 	}

--- a/pkg/apparmorutil/apparmorutil_linux.go
+++ b/pkg/apparmorutil/apparmorutil_linux.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/containerd/containerd/pkg/apparmor"
 	"github.com/containerd/containerd/pkg/userns"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 // CanLoadNewProfile returns whether the current process can load a new AppArmor profile.
@@ -73,7 +73,7 @@ func CanApplySpecificExistingProfile(profileName string) bool {
 	cmd := exec.Command("aa-exec", "-p", profileName, "--", "true")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logrus.WithError(err).Debugf("failed to run %v: %q", cmd.Args, string(out))
+		log.L.WithError(err).Debugf("failed to run %v: %q", cmd.Args, string(out))
 		return false
 	}
 	return true
@@ -101,7 +101,7 @@ func Profiles() ([]Profile, error) {
 		namePath := filepath.Join(profilesPath, ent.Name(), "name")
 		b, err := os.ReadFile(namePath)
 		if err != nil {
-			logrus.WithError(err).Warnf("failed to read %q", namePath)
+			log.L.WithError(err).Warnf("failed to read %q", namePath)
 			continue
 		}
 		profile := Profile{
@@ -110,7 +110,7 @@ func Profiles() ([]Profile, error) {
 		modePath := filepath.Join(profilesPath, ent.Name(), "mode")
 		b, err = os.ReadFile(modePath)
 		if err != nil {
-			logrus.WithError(err).Warnf("failed to read %q", namePath)
+			log.L.WithError(err).Warnf("failed to read %q", namePath)
 		} else {
 			profile.Mode = strings.TrimSpace(string(b))
 		}

--- a/pkg/clientutil/client.go
+++ b/pkg/clientutil/client.go
@@ -27,10 +27,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/platformutil"
 	"github.com/containerd/nerdctl/pkg/systemutil"
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 )
 
 func NewClient(ctx context.Context, namespace, address string, opts ...containerd.ClientOpt) (*containerd.Client, context.Context, context.CancelFunc, error) {
@@ -62,9 +62,9 @@ func NewClientWithPlatform(ctx context.Context, namespace, address, platform str
 			warn := fmt.Sprintf("Platform %q seems incompatible with the host platform %q. If you see \"exec format error\", see https://github.com/containerd/nerdctl/blob/main/docs/multi-platform.md",
 				platform, platforms.DefaultString())
 			if canExecErr != nil {
-				logrus.WithError(canExecErr).Warn(warn)
+				log.L.WithError(canExecErr).Warn(warn)
 			} else {
-				logrus.Warn(warn)
+				log.L.Warn(warn)
 			}
 		}
 		platformParsed, err := platforms.Parse(platform)

--- a/pkg/cmd/apparmor/load_linux.go
+++ b/pkg/cmd/apparmor/load_linux.go
@@ -18,11 +18,11 @@ package apparmor
 
 import (
 	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/defaults"
-	"github.com/sirupsen/logrus"
 )
 
 func Load() error {
-	logrus.Infof("Loading profile %q", defaults.AppArmorProfileName)
+	log.L.Infof("Loading profile %q", defaults.AppArmorProfileName)
 	return apparmor.LoadDefaultProfile(defaults.AppArmorProfileName)
 }

--- a/pkg/cmd/apparmor/unload_linux.go
+++ b/pkg/cmd/apparmor/unload_linux.go
@@ -17,11 +17,11 @@
 package apparmor
 
 import (
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/apparmorutil"
-	"github.com/sirupsen/logrus"
 )
 
 func Unload(target string) error {
-	logrus.Infof("Unloading profile %q", target)
+	log.L.Infof("Unloading profile %q", target)
 	return apparmorutil.Unload(target)
 }

--- a/pkg/cmd/builder/prune.go
+++ b/pkg/cmd/builder/prune.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Prune will prune all build cache.
@@ -40,7 +40,7 @@ func Prune(ctx context.Context, options types.BuilderPruneOptions) ([]buildkitut
 		buildctlArgs = append(buildctlArgs, "--all")
 	}
 	buildctlCmd := exec.Command(buildctlBinary, buildctlArgs...)
-	logrus.Debugf("running %v", buildctlCmd.Args)
+	log.G(ctx).Debugf("running %v", buildctlCmd.Args)
 	buildctlCmd.Stderr = options.Stderr
 	stdout, err := buildctlCmd.StdoutPipe()
 	if err != nil {

--- a/pkg/cmd/container/attach.go
+++ b/pkg/cmd/container/attach.go
@@ -24,12 +24,12 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/consoleutil"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/signalutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Attach attaches stdin, stdout, and stderr to a running container.
@@ -80,7 +80,7 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 			// [1] https://github.com/containerd/containerd/blob/8f756bc8c26465bd93e78d9cd42082b66f276e10/cio/io.go#L358-L359
 			io := task.IO()
 			if io == nil {
-				logrus.Errorf("got a nil io")
+				log.G(ctx).Errorf("got a nil io")
 				return
 			}
 			io.Cancel()
@@ -99,7 +99,7 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 	}
 	if spec.Process.Terminal {
 		if err := consoleutil.HandleConsoleResize(ctx, task, con); err != nil {
-			logrus.WithError(err).Error("console resize")
+			log.G(ctx).WithError(err).Error("console resize")
 		}
 	}
 	sigC := signalutil.ForwardAllSignals(ctx, task)

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/imgutil/commit"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Commit will commit a container’s file changes or settings into a new image.
@@ -96,7 +96,7 @@ func parseChanges(userChanges []string) (commit.Changes, error) {
 				return commit.Changes{}, fmt.Errorf("malformed json in change flag value %q", change)
 			}
 			if changes.CMD != nil {
-				logrus.Warn("multiple change flags supplied for the CMD directive, overriding with last supplied")
+				log.L.Warn("multiple change flags supplied for the CMD directive, overriding with last supplied")
 			}
 			changes.CMD = overrideCMD
 		case entrypointDirective:
@@ -105,7 +105,7 @@ func parseChanges(userChanges []string) (commit.Changes, error) {
 				return commit.Changes{}, fmt.Errorf("malformed json in change flag value %q", change)
 			}
 			if changes.Entrypoint != nil {
-				logrus.Warnf("multiple change flags supplied for the Entrypoint directive, overriding with last supplied")
+				log.L.Warnf("multiple change flags supplied for the Entrypoint directive, overriding with last supplied")
 			}
 			changes.Entrypoint = overrideEntrypoint
 		default: // TODO: Support the rest of the change directives

--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/console"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/consoleutil"
 	"github.com/containerd/nerdctl/pkg/flagutil"
@@ -33,7 +34,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/signalutil"
 	"github.com/containerd/nerdctl/pkg/taskutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // Exec will find the right running container to run a new command.
@@ -113,7 +113,7 @@ func execActionWithContainer(ctx context.Context, client *containerd.Client, con
 	if !options.Detach {
 		if options.TTY {
 			if err := consoleutil.HandleConsoleResize(ctx, process, con); err != nil {
-				logrus.WithError(err).Error("console resize")
+				log.G(ctx).WithError(err).Error("console resize")
 			}
 		} else {
 			sigc := signalutil.ForwardAllSignals(ctx, process)

--- a/pkg/cmd/container/inspect.go
+++ b/pkg/cmd/container/inspect.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerinspector"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
-	"github.com/sirupsen/logrus"
 )
 
 // Inspect prints detailed information for each container in `containers`.
@@ -44,7 +44,7 @@ func Inspect(ctx context.Context, client *containerd.Client, containers []string
 	err := walker.WalkAll(ctx, containers, true)
 	if len(f.entries) > 0 {
 		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, f.entries); formatErr != nil {
-			logrus.Error(formatErr)
+			log.L.Error(formatErr)
 		}
 	}
 	return err

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -26,11 +26,11 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/idutil/containerwalker"
 	"github.com/moby/sys/signal"
-	"github.com/sirupsen/logrus"
 )
 
 // Kill kills a list of containers
@@ -101,7 +101,7 @@ func killContainer(ctx context.Context, container containerd.Container, signal s
 	// signal will be sent once resume is finished
 	if paused {
 		if err := task.Resume(ctx); err != nil {
-			logrus.Warnf("cannot unpause container %s: %s", container.ID(), err)
+			log.G(ctx).Warnf("cannot unpause container %s: %s", container.ID(), err)
 		}
 	}
 	return nil

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/pkg/progress"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/labels/k8slabels"
-	"github.com/sirupsen/logrus"
 )
 
 // List prints containers according to `options`.
@@ -107,7 +107,7 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 		info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 				continue
 			}
 			return nil, err
@@ -115,7 +115,7 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 		spec, err := c.Spec(ctx)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 				continue
 			}
 			return nil, err
@@ -170,7 +170,7 @@ func getContainerNetworks(containerLables map[string]string) []string {
 	var networks []string
 	if names, ok := containerLables[labels.Networks]; ok {
 		if err := json.Unmarshal([]byte(names), &networks); err != nil {
-			logrus.Warn(err)
+			log.L.Warn(err)
 		}
 	}
 	return networks

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/containerutil"
-	"github.com/sirupsen/logrus"
 )
 
 func foldContainerFilters(ctx context.Context, containers []containerd.Container, filters []string) (*containerFilterContext, error) {
@@ -121,7 +121,7 @@ func (cl *containerFilterContext) foldStatusFilter(_ context.Context, filter, va
 			return containerd.Stopped == stats
 		})
 	case containerd.ProcessStatus("restarting"), containerd.ProcessStatus("removing"), containerd.ProcessStatus("dead"):
-		logrus.Warnf("%s is not supported and is ignored", filter)
+		log.L.Warnf("%s is not supported and is ignored", filter)
 	default:
 		return fmt.Errorf("invalid filter '%s'", filter)
 	}
@@ -232,12 +232,12 @@ func (cl *containerFilterContext) matchesTaskFilters(ctx context.Context, contai
 	defer cancel()
 	task, err := container.Task(ctx, nil)
 	if err != nil {
-		logrus.Warn(err)
+		log.G(ctx).Warn(err)
 		return false
 	}
 	status, err := task.Status(ctx)
 	if err != nil {
-		logrus.Warn(err)
+		log.G(ctx).Warn(err)
 		return false
 	}
 	return cl.matchesExitedFilter(status) && cl.matchesStatusFilter(status)

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/api/types/cri"
 	"github.com/containerd/nerdctl/pkg/clientutil"
@@ -32,7 +33,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/labels/k8slabels"
 	"github.com/containerd/nerdctl/pkg/logging"
-	"github.com/sirupsen/logrus"
 )
 
 func Logs(ctx context.Context, client *containerd.Client, container string, options types.ContainerLogsOptions) error {
@@ -43,7 +43,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 
 	switch options.GOptions.Namespace {
 	case "moby":
-		logrus.Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d` or CRI")
+		log.G(ctx).Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d` or CRI")
 	}
 
 	stopChannel := make(chan os.Signal, 1)
@@ -90,7 +90,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 						// Setup goroutine to send stop event if container task finishes:
 						go func() {
 							<-waitCh
-							logrus.Debugf("container task has finished, sending kill signal to log viewer")
+							log.G(ctx).Debugf("container task has finished, sending kill signal to log viewer")
 							stopChannel <- os.Interrupt
 						}()
 					}

--- a/pkg/cmd/container/prune.go
+++ b/pkg/cmd/container/prune.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/sirupsen/logrus"
 )
 
 // Prune remove all stopped containers
@@ -43,7 +43,7 @@ func Prune(ctx context.Context, client *containerd.Client, options types.Contain
 		if errors.As(err, &ErrContainerStatus{}) {
 			continue
 		}
-		logrus.WithError(err).Warnf("failed to remove container %s", c.ID())
+		log.G(ctx).WithError(err).Warnf("failed to remove container %s", c.ID())
 	}
 
 	if len(deleted) > 0 {

--- a/pkg/cmd/container/run_cgroup_linux.go
+++ b/pkg/cmd/container/run_cgroup_linux.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/infoutil"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 type customMemoryOptions struct {
@@ -41,11 +41,11 @@ type customMemoryOptions struct {
 
 func generateCgroupOpts(id string, options types.ContainerCreateOptions) ([]oci.SpecOpts, error) {
 	if options.KernelMemory != "" {
-		logrus.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
+		log.L.Warnf("The --kernel-memory flag is no longer supported. This flag is a noop.")
 	}
 
 	if options.Memory == "" && options.OomKillDisable {
-		logrus.Warn("Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.")
+		log.L.Warn("Disabling the OOM killer on containers without setting a '-m/--memory' limit may be dangerous.")
 	}
 
 	if options.GOptions.CgroupManager == "none" {
@@ -54,11 +54,11 @@ func generateCgroupOpts(id string, options types.ContainerCreateOptions) ([]oci.
 		}
 
 		if options.CPUs > 0.0 || options.Memory != "" || options.MemorySwap != "" || options.PidsLimit > 0 {
-			logrus.Warn(`cgroup manager is set to "none", discarding resource limit requests. ` +
+			log.L.Warn(`cgroup manager is set to "none", discarding resource limit requests. ` +
 				"(Hint: enable cgroup v2 with systemd: https://rootlesscontaine.rs/getting-started/common/cgroup2/)")
 		}
 		if options.CgroupParent != "" {
-			logrus.Warnf(`cgroup manager is set to "none", ignoring cgroup parent %q`+
+			log.L.Warnf(`cgroup manager is set to "none", ignoring cgroup parent %q`+
 				"(Hint: enable cgroup v2 with systemd: https://rootlesscontaine.rs/getting-started/common/cgroup2/)", options.CgroupParent)
 		}
 		return []oci.SpecOpts{oci.WithCgroup("")}, nil
@@ -178,7 +178,7 @@ func generateCgroupOpts(id string, options types.ContainerCreateOptions) ([]oci.
 	opts = append(opts, withUnified(unifieds))
 
 	if options.BlkioWeight != 0 && !infoutil.BlockIOWeight(options.GOptions.CgroupManager) {
-		logrus.Warn("kernel support for cgroup blkio weight missing, weight discarded")
+		log.L.Warn("kernel support for cgroup blkio weight missing, weight discarded")
 		options.BlkioWeight = 0
 	}
 	if options.BlkioWeight > 0 && options.BlkioWeight < 10 || options.BlkioWeight > 1000 {

--- a/pkg/cmd/container/run_linux.go
+++ b/pkg/cmd/container/run_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/userns"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/bypass4netnsutil"
 	"github.com/containerd/nerdctl/pkg/containerutil"
@@ -33,7 +34,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // WithoutRunMount returns a SpecOpts that unmounts the default tmpfs on "/run"
@@ -229,7 +229,7 @@ func setOOMScoreAdj(opts []oci.SpecOpts, oomScoreAdjChanged bool, oomScoreAdj in
 		// (FIXME: find a more robust way to get the current minimum value)
 		const minimum = 100
 		if oomScoreAdj < minimum {
-			logrus.Warnf("Limiting oom_score_adj (%d -> %d)", oomScoreAdj, minimum)
+			log.L.Warnf("Limiting oom_score_adj (%d -> %d)", oomScoreAdj, minimum)
 			oomScoreAdj = minimum
 		}
 	}

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/userns"
 	"github.com/containerd/continuity/fs"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/pkg/idgen"
@@ -47,7 +48,6 @@ import (
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/image-spec/identity"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 // copy from https://github.com/containerd/containerd/blob/v1.6.0-rc.1/pkg/cri/opts/spec_linux.go#L129-L151
@@ -180,7 +180,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 		// https://github.com/containerd/containerd/commit/791e175c79930a34cfbb2048fbcaa8493fd2c86b
 		unmounter := func(mountPath string) {
 			if uerr := mount.Unmount(mountPath, 0); uerr != nil {
-				logrus.Debugf("Failed to unmount snapshot %q", tempDir)
+				log.G(ctx).Debugf("Failed to unmount snapshot %q", tempDir)
 				if err == nil {
 					err = uerr
 				}
@@ -259,7 +259,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 		}
 		anonVolName := idgen.GenerateID()
 
-		logrus.Debugf("creating anonymous volume %q, for \"VOLUME %s\"",
+		log.G(ctx).Debugf("creating anonymous volume %q, for \"VOLUME %s\"",
 			anonVolName, imgVolRaw)
 		anonVol, err := volStore.Create(anonVolName, []string{})
 		if err != nil {
@@ -354,7 +354,7 @@ func copyExistingContents(source, destination string) error {
 		return err
 	}
 	if len(dstList) != 0 {
-		logrus.Debugf("volume at %q is not initially empty, skipping copying", destination)
+		log.L.Debugf("volume at %q is not initially empty, skipping copying", destination)
 		return nil
 	}
 	return fs.CopyDir(destination, source)

--- a/pkg/cmd/container/run_runtime.go
+++ b/pkg/cmd/container/run_runtime.go
@@ -25,8 +25,8 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/plugin"
 	runcoptions "github.com/containerd/containerd/runtime/v2/runc/options"
+	"github.com/containerd/log"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 )
 
 func generateRuntimeCOpts(cgroupManager, runtimeStr string) ([]containerd.NewContainerOpts, error) {
@@ -43,7 +43,7 @@ func generateRuntimeCOpts(cgroupManager, runtimeStr string) ([]containerd.NewCon
 			runtime = runtimeStr
 			if !strings.HasPrefix(runtimeStr, "io.containerd.runc.") {
 				if cgroupManager == "systemd" {
-					logrus.Warnf("cannot set cgroup manager to %q for runtime %q", cgroupManager, runtimeStr)
+					log.L.Warnf("cannot set cgroup manager to %q for runtime %q", cgroupManager, runtimeStr)
 				}
 				runtimeOpts = nil
 			}

--- a/pkg/cmd/container/run_security_linux.go
+++ b/pkg/cmd/container/run_security_linux.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/cap"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/pkg/defaults"
 	"github.com/containerd/nerdctl/pkg/maputil"
 	"github.com/containerd/nerdctl/pkg/strutil"
-	"github.com/sirupsen/logrus"
 )
 
 var privilegedOpts = []oci.SpecOpts{
@@ -49,7 +49,7 @@ func generateSecurityOpts(privileged bool, securityOptsMap map[string]string) ([
 		switch k {
 		case "seccomp", "apparmor", "no-new-privileges", "privileged-without-host-devices":
 		default:
-			logrus.Warnf("unknown security-opt: %q", k)
+			log.L.Warnf("unknown security-opt: %q", k)
 		}
 	}
 	var opts []oci.SpecOpts
@@ -73,7 +73,7 @@ func generateSecurityOpts(privileged bool, securityOptsMap map[string]string) ([
 		}
 		if aaProfile != "unconfined" {
 			if !canApplyExistingProfile {
-				logrus.Warnf("the host does not support AppArmor. Ignoring profile %q", aaProfile)
+				log.L.Warnf("the host does not support AppArmor. Ignoring profile %q", aaProfile)
 			} else {
 				opts = append(opts, apparmor.WithProfile(aaProfile))
 			}
@@ -127,7 +127,7 @@ func canonicalizeCapName(s string) string {
 		s = "CAP_" + s
 	}
 	if !isKnownCapName(s) {
-		logrus.Warnf("unknown capability name %q", s)
+		log.L.Warnf("unknown capability name %q", s)
 		// Not a fatal error, because runtime might be aware of this cap
 	}
 	return s

--- a/pkg/cmd/container/stats.go
+++ b/pkg/cmd/container/stats.go
@@ -31,6 +31,7 @@ import (
 	eventstypes "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/events"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/containerinspector"
@@ -42,7 +43,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/statsutil"
 	"github.com/containerd/typeurl/v2"
-	"github.com/sirupsen/logrus"
 )
 
 type stats struct {
@@ -325,7 +325,7 @@ func Stats(ctx context.Context, client *containerd.Client, containerIds []string
 }
 
 func collect(ctx context.Context, globalOptions types.GlobalCommandOptions, s *statsutil.Stats, waitFirst *sync.WaitGroup, id string, noStream bool) {
-	logrus.Debugf("collecting stats for %s", s.Container)
+	log.G(ctx).Debugf("collecting stats for %s", s.Container)
 	var (
 		getFirst = true
 		u        = make(chan error, 1)

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/images/converter/uncompress"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	converterutil "github.com/containerd/nerdctl/pkg/imgutil/converter"
@@ -44,7 +45,6 @@ import (
 	"github.com/containerd/stargz-snapshotter/recorder"
 	"github.com/klauspost/compress/zstd"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, options types.ImageConvertOptions) error {
@@ -163,9 +163,9 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 		}
 		if !options.Oci {
 			if nydus || overlaybd {
-				logrus.Warnf("option --%s should be used in conjunction with --oci, forcibly enabling on oci mediatype for %s conversion", convertType, convertType)
+				log.G(ctx).Warnf("option --%s should be used in conjunction with --oci, forcibly enabling on oci mediatype for %s conversion", convertType, convertType)
 			} else {
-				logrus.Warnf("option --%s should be used in conjunction with --oci", convertType)
+				log.G(ctx).Warnf("option --%s should be used in conjunction with --oci", convertType)
 			}
 		}
 		if options.Uncompress {
@@ -254,7 +254,7 @@ func getESGZConvertOpts(options types.ImageConvertOptions) ([]estargz.Option, er
 			return nil, fmt.Errorf("estargz-record-in requires experimental mode to be enabled")
 		}
 
-		logrus.Warn("--estargz-record-in flag is experimental and subject to change")
+		log.L.Warn("--estargz-record-in flag is experimental and subject to change")
 		paths, err := readPathsFromRecordFile(options.EstargzRecordIn)
 		if err != nil {
 			return nil, err
@@ -281,7 +281,7 @@ func getZstdchunkedConverter(options types.ImageConvertOptions) (converter.Conve
 			return nil, fmt.Errorf("zstdchunked-record-in requires experimental mode to be enabled")
 		}
 
-		logrus.Warn("--zstdchunked-record-in flag is experimental and subject to change")
+		log.L.Warn("--zstdchunked-record-in flag is experimental and subject to change")
 		paths, err := readPathsFromRecordFile(options.ZstdChunkedRecordIn)
 		if err != nil {
 			return nil, err
@@ -356,14 +356,14 @@ func printConvertedImage(stdout io.Writer, options types.ImageConvertOptions, im
 		for i, e := range img.ExtraImages {
 			elems := strings.SplitN(e, "@", 2)
 			if len(elems) < 2 {
-				logrus.Errorf("extra reference %q doesn't contain digest", e)
+				log.L.Errorf("extra reference %q doesn't contain digest", e)
 			} else {
-				logrus.Infof("Extra image(%d) %s", i, elems[0])
+				log.L.Infof("Extra image(%d) %s", i, elems[0])
 			}
 		}
 		elems := strings.SplitN(img.Image, "@", 2)
 		if len(elems) < 2 {
-			logrus.Errorf("reference %q doesn't contain digest", img.Image)
+			log.L.Errorf("reference %q doesn't contain digest", img.Image)
 		} else {
 			fmt.Fprintln(stdout, elems[1])
 		}

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/pkg/imageinspector"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
-	"github.com/sirupsen/logrus"
 )
 
 // Inspect prints detailed information of each image in `images`.
@@ -64,7 +64,7 @@ func Inspect(ctx context.Context, client *containerd.Client, images []string, op
 	err := walker.WalkAll(ctx, images, true)
 	if len(f.entries) > 0 {
 		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, f.entries); formatErr != nil {
-			logrus.Error(formatErr)
+			log.G(ctx).Error(formatErr)
 		}
 	}
 	return err

--- a/pkg/cmd/image/prune.go
+++ b/pkg/cmd/image/prune.go
@@ -23,10 +23,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/opencontainers/go-digest"
-	"github.com/sirupsen/logrus"
 )
 
 // Prune will remove all dangling images. If all is specified, will also remove all images not referenced by any container.
@@ -70,10 +70,10 @@ func Prune(ctx context.Context, client *containerd.Client, options types.ImagePr
 	for _, image := range filteredImages {
 		digests, err := image.RootFS(ctx, contentStore, platforms.DefaultStrict())
 		if err != nil {
-			logrus.WithError(err).Warnf("failed to enumerate rootfs")
+			log.G(ctx).WithError(err).Warnf("failed to enumerate rootfs")
 		}
 		if err := imageStore.Delete(ctx, image.Name, delOpts...); err != nil {
-			logrus.WithError(err).Warnf("failed to delete image %s", image.Name)
+			log.G(ctx).WithError(err).Warnf("failed to delete image %s", image.Name)
 			continue
 		}
 		removedImages[image.Name] = digests

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	dockerconfig "github.com/containerd/containerd/remotes/docker/config"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/imgutil/dockerconfigresolver"
@@ -46,7 +47,6 @@ import (
 	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 // Push pushes an image specified by `rawRef`.
@@ -55,7 +55,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		if scheme != "ipfs" {
 			return fmt.Errorf("ipfs scheme is only supported but got %q", scheme)
 		}
-		logrus.Infof("pushing image %q to IPFS", ref)
+		log.G(ctx).Infof("pushing image %q to IPFS", ref)
 
 		var ipfsPath string
 		if options.IpfsAddress != "" {
@@ -76,7 +76,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		}
 		c, err := ipfs.Push(ctx, client, ref, layerConvert, options.AllPlatforms, options.Platforms, options.IpfsEnsureImage, ipfsPath)
 		if err != nil {
-			logrus.WithError(err).Warnf("ipfs push failed")
+			log.G(ctx).WithError(err).Warnf("ipfs push failed")
 			return err
 		}
 		fmt.Fprintln(options.Stdout, c)
@@ -107,7 +107,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 			return fmt.Errorf("failed to create a tmp reduced-platform image %q (platform=%v): %w", pushRef, options.Platforms, err)
 		}
 		defer client.ImageService().Delete(ctx, platImg.Name, images.SynchronousDelete())
-		logrus.Infof("pushing as a reduced-platform image (%s, %s)", platImg.Target.MediaType, platImg.Target.Digest)
+		log.G(ctx).Infof("pushing as a reduced-platform image (%s, %s)", platImg.Target.MediaType, platImg.Target.Digest)
 	}
 
 	if options.Estargz {
@@ -117,7 +117,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 			return fmt.Errorf("failed to convert to eStargz: %v", err)
 		}
 		defer client.ImageService().Delete(ctx, esgzImg.Name, images.SynchronousDelete())
-		logrus.Infof("pushing as an eStargz image (%s, %s)", esgzImg.Target.MediaType, esgzImg.Target.Digest)
+		log.G(ctx).Infof("pushing as an eStargz image (%s, %s)", esgzImg.Target.MediaType, esgzImg.Target.Digest)
 	}
 
 	// In order to push images where most layers are the same but the
@@ -133,7 +133,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 
 	var dOpts []dockerconfigresolver.Opt
 	if options.GOptions.InsecureRegistry {
-		logrus.Warnf("skipping verifying HTTPS certs for %q", refDomain)
+		log.G(ctx).Warnf("skipping verifying HTTPS certs for %q", refDomain)
 		dOpts = append(dOpts, dockerconfigresolver.WithSkipVerifyCerts(true))
 	}
 	dOpts = append(dOpts, dockerconfigresolver.WithHostsDirs(options.GOptions.HostsDir))
@@ -155,7 +155,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 			return err
 		}
 		if options.GOptions.InsecureRegistry {
-			logrus.WithError(err).Warnf("server %q does not seem to support HTTPS, falling back to plain HTTP", refDomain)
+			log.G(ctx).WithError(err).Warnf("server %q does not seem to support HTTPS, falling back to plain HTTP", refDomain)
 			dOpts = append(dOpts, dockerconfigresolver.WithPlainHTTP(true))
 			resolver, err = dockerconfigresolver.New(ctx, refDomain, dOpts...)
 			if err != nil {
@@ -163,8 +163,8 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 			}
 			return pushFunc(resolver)
 		}
-		logrus.WithError(err).Errorf("server %q does not seem to support HTTPS", refDomain)
-		logrus.Info("Hint: you may want to try --insecure-registry to allow plain HTTP (if you are in a trusted network)")
+		log.G(ctx).WithError(err).Errorf("server %q does not seem to support HTTPS", refDomain)
+		log.G(ctx).Info("Hint: you may want to try --insecure-registry to allow plain HTTP (if you are in a trusted network)")
 		return err
 	}
 
@@ -200,14 +200,14 @@ func eStargzConvertFunc() converter.ConvertFunc {
 	convertToESGZ := estargzconvert.LayerConvertFunc()
 	return func(ctx context.Context, cs content.Store, desc ocispec.Descriptor) (*ocispec.Descriptor, error) {
 		if isReusableESGZ(ctx, cs, desc) {
-			logrus.Infof("reusing estargz %s without conversion", desc.Digest)
+			log.L.Infof("reusing estargz %s without conversion", desc.Digest)
 			return nil, nil
 		}
 		newDesc, err := convertToESGZ(ctx, cs, desc)
 		if err != nil {
 			return nil, err
 		}
-		logrus.Infof("converted %q to %s", desc.MediaType, newDesc.Digest)
+		log.L.Infof("converted %q to %s", desc.MediaType, newDesc.Digest)
 		return newDesc, err
 	}
 

--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -25,10 +25,10 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/containerutil"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
-	"github.com/sirupsen/logrus"
 )
 
 // Remove removes a list of `images`.
@@ -78,7 +78,7 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 			// digests is used only for emulating human-readable output of `docker rmi`
 			digests, err := found.Image.RootFS(ctx, cs, platforms.DefaultStrict())
 			if err != nil {
-				logrus.WithError(err).Warning("failed to enumerate rootfs")
+				log.G(ctx).WithError(err).Warning("failed to enumerate rootfs")
 			}
 
 			if err := is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
@@ -112,7 +112,7 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 		if !options.Force || fatalErr {
 			return errors.New(msg)
 		}
-		logrus.Error(msg)
+		log.G(ctx).Error(msg)
 	}
 	return nil
 }

--- a/pkg/cmd/ipfs/registry_serve.go
+++ b/pkg/cmd/ipfs/registry_serve.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/ipfs"
-	"github.com/sirupsen/logrus"
 )
 
 func RegistryServe(options types.IPFSRegistryServeOptions) error {
@@ -47,7 +47,7 @@ func RegistryServe(options types.IPFSRegistryServeOptions) error {
 	if err != nil {
 		return err
 	}
-	logrus.Infof("serving on %v", options.ListenRegistry)
+	log.L.Infof("serving on %v", options.ListenRegistry)
 	http.Handle("/", h)
 	return http.ListenAndServe(options.ListenRegistry, nil)
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/containerd/containerd/remotes/docker/config"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/errutil"
 	"github.com/containerd/nerdctl/pkg/imgutil/dockerconfigresolver"
@@ -36,7 +37,6 @@ import (
 	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/errdefs"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
 	"golang.org/x/term"
 )
@@ -148,7 +148,7 @@ func loginClientSide(ctx context.Context, globalOptions types.GlobalCommandOptio
 	}
 	var dOpts []dockerconfigresolver.Opt
 	if globalOptions.InsecureRegistry {
-		logrus.Warnf("skipping verifying HTTPS certs for %q", host)
+		log.G(ctx).Warnf("skipping verifying HTTPS certs for %q", host)
 		dOpts = append(dOpts, dockerconfigresolver.WithSkipVerifyCerts(true))
 	}
 	dOpts = append(dOpts, dockerconfigresolver.WithHostsDirs(globalOptions.HostsDir))
@@ -158,7 +158,7 @@ func loginClientSide(ctx context.Context, globalOptions types.GlobalCommandOptio
 			if auth.RegistryToken != "" {
 				// Even containerd/CRI does not support RegistryToken as of v1.4.3,
 				// so, nobody is actually using RegistryToken?
-				logrus.Warnf("RegistryToken (for %q) is not supported yet (FIXME)", host)
+				log.G(ctx).Warnf("RegistryToken (for %q) is not supported yet (FIXME)", host)
 			}
 			return auth.Username, auth.Password, nil
 		}
@@ -180,7 +180,7 @@ func loginClientSide(ctx context.Context, globalOptions types.GlobalCommandOptio
 	if err != nil {
 		return "", err
 	}
-	logrus.Debugf("len(regHosts)=%d", len(regHosts))
+	log.G(ctx).Debugf("len(regHosts)=%d", len(regHosts))
 	if len(regHosts) == 0 {
 		return "", fmt.Errorf("got empty []docker.RegistryHost for %q", host)
 	}
@@ -194,7 +194,7 @@ func loginClientSide(ctx context.Context, globalOptions types.GlobalCommandOptio
 		if err == nil {
 			return identityToken, nil
 		}
-		logrus.WithError(err).WithField("i", i).Error("failed to call tryLoginWithRegHost")
+		log.G(ctx).WithError(err).WithField("i", i).Error("failed to call tryLoginWithRegHost")
 	}
 	return "", err
 }

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/idutil/netwalker"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/netutil"
-	"github.com/sirupsen/logrus"
 )
 
 func Inspect(ctx context.Context, options types.NetworkInspectOptions) error {
@@ -72,7 +72,7 @@ func Inspect(ctx context.Context, options types.NetworkInspectOptions) error {
 	err = walker.WalkAll(ctx, options.Networks, true, false)
 	if len(result) > 0 {
 		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, result); formatErr != nil {
-			logrus.Error(formatErr)
+			log.G(ctx).Error(formatErr)
 		}
 	}
 	return err

--- a/pkg/cmd/network/prune.go
+++ b/pkg/cmd/network/prune.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
-	"github.com/sirupsen/logrus"
 )
 
 func Prune(ctx context.Context, client *containerd.Client, options types.NetworkPruneOptions) error {
@@ -55,7 +55,7 @@ func Prune(ctx context.Context, client *containerd.Client, options types.Network
 			continue
 		}
 		if err := e.RemoveNetwork(net); err != nil {
-			logrus.WithError(err).Errorf("failed to remove network %s", net.Name)
+			log.G(ctx).WithError(err).Errorf("failed to remove network %s", net.Name)
 			continue
 		}
 		removedNetworks = append(removedNetworks, net.Name)

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -25,6 +25,7 @@ import (
 	"text/template"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -37,7 +38,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/docker/go-units"
-	"github.com/sirupsen/logrus"
 )
 
 func Info(ctx context.Context, client *containerd.Client, options types.SystemInfoOptions) error {
@@ -162,12 +162,12 @@ func prettyPrintInfoDockerCompat(stdout io.Writer, stderr io.Writer, info *docke
 	for _, s := range info.SecurityOptions {
 		m, err := strutil.ParseCSVMap(s)
 		if err != nil {
-			logrus.WithError(err).Warnf("unparsable security option %q", s)
+			log.L.WithError(err).Warnf("unparsable security option %q", s)
 			continue
 		}
 		name := m["name"]
 		if name == "" {
-			logrus.Warnf("unparsable security option %q", s)
+			log.L.Warnf("unparsable security option %q", s)
 			continue
 		}
 		fmt.Fprintf(w, "  %s\n", name)

--- a/pkg/cmd/volume/list.go
+++ b/pkg/cmd/volume/list.go
@@ -26,10 +26,10 @@ import (
 	"text/template"
 
 	"github.com/containerd/containerd/pkg/progress"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
-	"github.com/sirupsen/logrus"
 )
 
 type volumePrintable struct {
@@ -44,16 +44,16 @@ type volumePrintable struct {
 
 func List(options types.VolumeListOptions) error {
 	if options.Quiet && options.Size {
-		logrus.Warn("cannot use --size and --quiet together, ignoring --size")
+		log.L.Warn("cannot use --size and --quiet together, ignoring --size")
 		options.Size = false
 	}
 	sizeFilter := hasSizeFilter(options.Filters)
 	if sizeFilter && options.Quiet {
-		logrus.Warn("cannot use --filter=size and --quiet together, ignoring --filter=size")
+		log.L.Warn("cannot use --filter=size and --quiet together, ignoring --filter=size")
 		options.Filters = removeSizeFilters(options.Filters)
 	}
 	if sizeFilter && !options.Size {
-		logrus.Warn("should use --filter=size and --size together")
+		log.L.Warn("should use --filter=size and --size together")
 		options.Size = true
 	}
 

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -22,9 +22,8 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
-
-	"github.com/sirupsen/logrus"
 )
 
 type BuildOptions struct {
@@ -47,7 +46,7 @@ func (c *Composer) Build(ctx context.Context, bo BuildOptions, services []string
 }
 
 func (c *Composer) buildServiceImage(ctx context.Context, image string, b *serviceparser.Build, platform string, bo BuildOptions) error {
-	logrus.Infof("Building image %s", image)
+	log.G(ctx).Infof("Building image %s", image)
 
 	var args []string // nolint: prealloc
 	if platform != "" {
@@ -66,7 +65,7 @@ func (c *Composer) buildServiceImage(ctx context.Context, image string, b *servi
 
 	cmd := c.createNerdctlCmd(ctx, append([]string{"build"}, args...)...)
 	if c.DebugPrintFull {
-		logrus.Debugf("Running %v", cmd.Args)
+		log.G(ctx).Debugf("Running %v", cmd.Args)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -27,9 +27,9 @@ import (
 	compose "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Options groups the command line options recommended for a Compose implementation (ProjectOptions) and extra options for nerdctl
@@ -103,8 +103,8 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 
 	if o.DebugPrintFull {
 		projectJSON, _ := json.MarshalIndent(project, "", "    ")
-		logrus.Debug("printing project JSON")
-		logrus.Debugf("%s", projectJSON)
+		log.L.Debug("printing project JSON")
+		log.L.Debugf("%s", projectJSON)
 	}
 
 	if unknown := reflectutil.UnknownNonEmptyFields(project,
@@ -117,7 +117,7 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 		"Secrets",
 		"Configs",
 		"ComposeFiles"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: %+v", unknown)
+		log.L.Warnf("Ignoring: %+v", unknown)
 	}
 
 	c := &Composer{
@@ -142,7 +142,7 @@ func (c *Composer) createNerdctlCmd(ctx context.Context, args ...string) *exec.C
 func (c *Composer) runNerdctlCmd(ctx context.Context, args ...string) error {
 	cmd := c.createNerdctlCmd(ctx, args...)
 	if c.DebugPrintFull {
-		logrus.Debugf("Running %v", cmd.Args)
+		log.G(ctx).Debugf("Running %v", cmd.Args)
 	}
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("error while executing %v: %q: %w", cmd.Args, string(out), err)

--- a/pkg/composer/container.go
+++ b/pkg/composer/container.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
-	"github.com/sirupsen/logrus"
 )
 
 func (c *Composer) Containers(ctx context.Context, services ...string) ([]containerd.Container, error) {
@@ -34,7 +34,7 @@ func (c *Composer) Containers(ctx context.Context, services ...string) ([]contai
 	if len(services) == 0 {
 		filters = append(filters, projectLabel)
 	}
-	logrus.Debugf("filters: %v", filters)
+	log.G(ctx).Debugf("filters: %v", filters)
 	containers, err := c.client.Containers(ctx, filters...)
 	if err != nil {
 		return nil, err

--- a/pkg/composer/copy.go
+++ b/pkg/composer/copy.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/docker/docker/pkg/system"
-	"github.com/sirupsen/logrus"
 )
 
 type CopyOptions struct {
@@ -110,7 +110,7 @@ func (c *Composer) logCopyMsg(ctx context.Context, container containerd.Containe
 	if direction == toService {
 		msg = msg + fmt.Sprintf("copy %s to %s:%s", srcPath, containerName, dstPath)
 	}
-	logrus.Info(msg)
+	log.G(ctx).Info(msg)
 	return nil
 }
 

--- a/pkg/composer/create.go
+++ b/pkg/composer/create.go
@@ -24,9 +24,9 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/labels"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -163,18 +163,18 @@ func (c *Composer) createServiceContainer(ctx context.Context, service *servicep
 	// delete container if it already exists and force-recreate is enabled
 	if exists {
 		if recreate != RecreateForce {
-			logrus.Infof("Container %s exists, skipping", container.Name)
+			log.G(ctx).Infof("Container %s exists, skipping", container.Name)
 			return "", nil
 		}
 
-		logrus.Debugf("Container %q already exists and force-created is enabled, deleting", container.Name)
+		log.G(ctx).Debugf("Container %q already exists and force-created is enabled, deleting", container.Name)
 		delCmd := c.createNerdctlCmd(ctx, "rm", "-f", container.Name)
 		if err = delCmd.Run(); err != nil {
 			return "", fmt.Errorf("could not delete container %q: %s", container.Name, err)
 		}
-		logrus.Infof("Re-creating container %s", container.Name)
+		log.G(ctx).Infof("Re-creating container %s", container.Name)
 	} else {
-		logrus.Infof("Creating container %s", container.Name)
+		log.G(ctx).Infof("Creating container %s", container.Name)
 	}
 
 	tempDir, err := os.MkdirTemp(os.TempDir(), "compose-")
@@ -193,7 +193,7 @@ func (c *Composer) createServiceContainer(ctx context.Context, service *servicep
 
 	cmd := c.createNerdctlCmd(ctx, append([]string{"create"}, container.RunArgs...)...)
 	if c.DebugPrintFull {
-		logrus.Debugf("Running %v", cmd.Args)
+		log.G(ctx).Debugf("Running %v", cmd.Args)
 	}
 
 	// FIXME

--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -20,9 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/strutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 type DownOptions struct {
@@ -61,7 +60,7 @@ func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
 				return fmt.Errorf("error removeing orphaned containers: %s", err)
 			}
 		} else {
-			logrus.Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
 		}
 	}
 
@@ -105,9 +104,9 @@ func (c *Composer) downNetwork(ctx context.Context, shortName string) error {
 			return fmt.Errorf("network %s is in use", fullName)
 		}
 
-		logrus.Infof("Removing network %s", fullName)
+		log.G(ctx).Infof("Removing network %s", fullName)
 		if err := c.runNerdctlCmd(ctx, "network", "rm", fullName); err != nil {
-			logrus.Warn(err)
+			log.G(ctx).Warn(err)
 		}
 	}
 	return nil
@@ -128,9 +127,9 @@ func (c *Composer) downVolume(ctx context.Context, shortName string) error {
 	if err != nil {
 		return err
 	} else if volExists {
-		logrus.Infof("Removing volume %s", fullName)
+		log.G(ctx).Infof("Removing volume %s", fullName)
 		if err := c.runNerdctlCmd(ctx, "volume", "rm", "-f", fullName); err != nil {
-			logrus.Warn(err)
+			log.G(ctx).Warn(err)
 		}
 	}
 	return nil

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"github.com/containerd/containerd"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 // ExecOptions stores options passed from users as flags and args.
@@ -90,7 +90,7 @@ func (c *Composer) exec(ctx context.Context, container containerd.Container, eo 
 	}
 
 	if c.DebugPrintFull {
-		logrus.Debugf("Executing %v", cmd.Args)
+		log.G(ctx).Debugf("Executing %v", cmd.Args)
 	}
 	return cmd.Run()
 }

--- a/pkg/composer/kill.go
+++ b/pkg/composer/kill.go
@@ -19,7 +19,7 @@ package composer
 import (
 	"context"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -42,7 +42,7 @@ func (c *Composer) Kill(ctx context.Context, opts KillOptions, services []string
 		eg.Go(func() error {
 			args := []string{"kill", "-s", opts.Signal, container.ID()}
 			if err := c.runNerdctlCmd(ctx, args...); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 				return err
 			}
 			return nil

--- a/pkg/composer/pull.go
+++ b/pkg/composer/pull.go
@@ -22,9 +22,8 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
-
-	"github.com/sirupsen/logrus"
 )
 
 type PullOptions struct {
@@ -42,7 +41,7 @@ func (c *Composer) Pull(ctx context.Context, po PullOptions, services []string) 
 }
 
 func (c *Composer) pullServiceImage(ctx context.Context, image string, platform string, ps *serviceparser.Service, po PullOptions) error {
-	logrus.Infof("Pulling image %s", image)
+	log.G(ctx).Infof("Pulling image %s", image)
 
 	var args []string // nolint: prealloc
 	if platform != "" {
@@ -78,7 +77,7 @@ func (c *Composer) pullServiceImage(ctx context.Context, image string, platform 
 
 	cmd := c.createNerdctlCmd(ctx, append([]string{"pull"}, args...)...)
 	if c.DebugPrintFull {
-		logrus.Debugf("Running %v", cmd.Args)
+		log.G(ctx).Debugf("Running %v", cmd.Args)
 	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/composer/push.go
+++ b/pkg/composer/push.go
@@ -22,9 +22,8 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
-
-	"github.com/sirupsen/logrus"
 )
 
 type PushOptions struct {
@@ -41,7 +40,7 @@ func (c *Composer) Push(ctx context.Context, po PushOptions, services []string) 
 }
 
 func (c *Composer) pushServiceImage(ctx context.Context, image string, platform string, ps *serviceparser.Service, po PushOptions) error {
-	logrus.Infof("Pushing image %s", image)
+	log.G(ctx).Infof("Pushing image %s", image)
 
 	var args []string // nolint: prealloc
 	if platform != "" {
@@ -61,7 +60,7 @@ func (c *Composer) pushServiceImage(ctx context.Context, image string, platform 
 
 	cmd := c.createNerdctlCmd(ctx, append([]string{"push"}, args...)...)
 	if c.DebugPrintFull {
-		logrus.Debugf("Running %v", cmd.Args)
+		log.G(ctx).Debugf("Running %v", cmd.Args)
 	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/pkg/composer/restart.go
+++ b/pkg/composer/restart.go
@@ -23,9 +23,8 @@ import (
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
-
-	"github.com/sirupsen/logrus"
 )
 
 // RestartOptions stores all option input from `nerdctl compose restart`
@@ -61,14 +60,14 @@ func (c *Composer) restartContainers(ctx context.Context, containers []container
 		go func() {
 			defer rsWG.Done()
 			info, _ := container.Info(ctx, containerd.WithoutRefreshedMetadata)
-			logrus.Infof("Restarting container %s", info.Labels[labels.Name])
+			log.G(ctx).Infof("Restarting container %s", info.Labels[labels.Name])
 			args := []string{"restart"}
 			if opt.Timeout != nil {
 				args = append(args, timeoutArg)
 			}
 			args = append(args, container.ID())
 			if err := c.runNerdctlCmd(ctx, args...); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 			}
 		}()
 	}

--- a/pkg/composer/rm.go
+++ b/pkg/composer/rm.go
@@ -22,12 +22,11 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/formatter"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/strutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 // RemoveOptions stores all options when removing compose containers:
@@ -80,14 +79,14 @@ func (c *Composer) removeContainers(ctx context.Context, containers []containerd
 			if !opt.Stop {
 				cStatus := formatter.ContainerStatus(ctx, container)
 				if strings.HasPrefix(cStatus, "Up") {
-					logrus.Warnf("Removing container %s failed: container still running.", info.Labels[labels.Name])
+					log.G(ctx).Warnf("Removing container %s failed: container still running.", info.Labels[labels.Name])
 					return
 				}
 			}
 
-			logrus.Infof("Removing container %s", info.Labels[labels.Name])
+			log.G(ctx).Infof("Removing container %s", info.Labels[labels.Name])
 			if err := c.runNerdctlCmd(ctx, append(args, container.ID())...); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 			}
 		}()
 	}
@@ -104,9 +103,9 @@ func (c *Composer) removeContainersFromParsedServices(ctx context.Context, conta
 		rmWG.Add(1)
 		go func() {
 			defer rmWG.Done()
-			logrus.Infof("Removing container %s", container.Name)
+			log.G(ctx).Infof("Removing container %s", container.Name)
 			if err := c.runNerdctlCmd(ctx, "rm", "-f", id); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 			}
 		}()
 	}

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -24,9 +24,9 @@ import (
 
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/idgen"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -198,7 +198,7 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 				return fmt.Errorf("error removing orphaned containers: %s", err)
 			}
 		} else {
-			logrus.Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
 		}
 	}
 
@@ -230,7 +230,7 @@ func (c *Composer) runServices(ctx context.Context, parsedServices []*servicepar
 		services = append(services, ps.Unparsed.Name)
 
 		if len(ps.Containers) != 1 {
-			logrus.Warnf("compose run does not support scale but %s is currently %v, automatically it will configure 1", ps.Unparsed.Name, len(ps.Containers))
+			log.G(ctx).Warnf("compose run does not support scale but %s is currently %v, automatically it will configure 1", ps.Unparsed.Name, len(ps.Containers))
 		}
 
 		if len(ps.Containers) == 0 {
@@ -257,14 +257,14 @@ func (c *Composer) runServices(ctx context.Context, parsedServices []*servicepar
 	}
 
 	if ro.Detach {
-		logrus.Printf("%s\n", cid)
+		log.G(ctx).Printf("%s\n", cid)
 		return nil
 	}
 
 	// TODO: fix it when `nerdctl logs` supports `nerdctl run` without detach
 	// https://github.com/containerd/nerdctl/blob/v0.22.2/pkg/taskutil/taskutil.go#L55
 	if !ro.Interactive && !ro.Tty {
-		logrus.Info("Attaching to logs")
+		log.G(ctx).Info("Attaching to logs")
 		lo := LogsOptions{
 			Follow:      true,
 			NoColor:     ro.NoColor,
@@ -276,7 +276,7 @@ func (c *Composer) runServices(ctx context.Context, parsedServices []*servicepar
 		}
 	}
 
-	logrus.Infof("Stopping containers (forcibly)") // TODO: support gracefully stopping
+	log.G(ctx).Infof("Stopping containers (forcibly)") // TODO: support gracefully stopping
 	c.stopContainersFromParsedServices(ctx, containers)
 
 	if ro.Rm {

--- a/pkg/composer/serviceparser/build.go
+++ b/pkg/composer/serviceparser/build.go
@@ -25,17 +25,17 @@ import (
 	"github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/identifiers"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
 
 	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/sirupsen/logrus"
 )
 
 func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName string) (*Build, error) {
 	if unknown := reflectutil.UnknownNonEmptyFields(c,
 		"Context", "Dockerfile", "Args", "CacheFrom", "Target", "Labels", "Secrets",
 	); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: build: %+v", unknown)
+		log.L.Warnf("Ignoring: build: %+v", unknown)
 	}
 
 	if c.Context == "" {
@@ -50,7 +50,7 @@ func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName st
 	b.BuildArgs = append(b.BuildArgs, "-t="+imageName)
 	if c.Dockerfile != "" {
 		if filepath.IsAbs(c.Dockerfile) {
-			logrus.Warnf("build.dockerfile should be relative path, got %q", c.Dockerfile)
+			log.L.Warnf("build.dockerfile should be relative path, got %q", c.Dockerfile)
 			b.BuildArgs = append(b.BuildArgs, "-f="+c.Dockerfile)
 		} else {
 			// no need to use securejoin
@@ -92,7 +92,7 @@ func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName st
 		}
 		var src string
 		if filepath.IsAbs(projectSecret.File) {
-			logrus.Warnf("build.secrets should be relative path, got %q", projectSecret.File)
+			log.L.Warnf("build.secrets should be relative path, got %q", projectSecret.File)
 			src = projectSecret.File
 		} else {
 			var err error

--- a/pkg/composer/stop.go
+++ b/pkg/composer/stop.go
@@ -22,11 +22,10 @@ import (
 	"sync"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/strutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 // StopOptions stores all option input from `nerdctl compose stop`
@@ -68,14 +67,14 @@ func (c *Composer) stopContainers(ctx context.Context, containers []containerd.C
 		go func() {
 			defer rmWG.Done()
 			info, _ := container.Info(ctx, containerd.WithoutRefreshedMetadata)
-			logrus.Infof("Stopping container %s", info.Labels[labels.Name])
+			log.G(ctx).Infof("Stopping container %s", info.Labels[labels.Name])
 			args := []string{"stop"}
 			if opt.Timeout != nil {
 				args = append(args, timeoutArg)
 			}
 			args = append(args, container.ID())
 			if err := c.runNerdctlCmd(ctx, args...); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 			}
 		}()
 	}
@@ -92,9 +91,9 @@ func (c *Composer) stopContainersFromParsedServices(ctx context.Context, contain
 		rmWG.Add(1)
 		go func() {
 			defer rmWG.Done()
-			logrus.Infof("Stopping container %s", container.Name)
+			log.G(ctx).Infof("Stopping container %s", container.Name)
 			if err := c.runNerdctlCmd(ctx, "stop", id); err != nil {
-				logrus.Warn(err)
+				log.G(ctx).Warn(err)
 			}
 		}()
 	}

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -22,10 +22,9 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 type UpOptions struct {
@@ -98,7 +97,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 				return fmt.Errorf("error removing orphaned containers: %s", err)
 			}
 		} else {
-			logrus.Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
 		}
 	}
 
@@ -107,7 +106,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 
 func validateFileObjectConfig(obj types.FileObjectConfig, shortName, objType string, project *types.Project) error {
 	if unknown := reflectutil.UnknownNonEmptyFields(&obj, "Name", "External", "File"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: %s %s: %+v", objType, shortName, unknown)
+		log.L.Warnf("Ignoring: %s %s: %+v", objType, shortName, unknown)
 	}
 	if obj.External.External || obj.External.Name != "" {
 		return fmt.Errorf("%s %q: external object is not supported", objType, shortName)

--- a/pkg/composer/up_network.go
+++ b/pkg/composer/up_network.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 func (c *Composer) upNetwork(ctx context.Context, shortName string) error {
@@ -37,7 +36,7 @@ func (c *Composer) upNetwork(ctx context.Context, shortName string) error {
 	}
 
 	if unknown := reflectutil.UnknownNonEmptyFields(&net, "Name", "Ipam", "Driver", "DriverOpts"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: network %s: %+v", shortName, unknown)
+		log.G(ctx).Warnf("Ignoring: network %s: %+v", shortName, unknown)
 	}
 
 	// shortName is like "default", fullName is like "compose-wordpress_default"
@@ -46,7 +45,7 @@ func (c *Composer) upNetwork(ctx context.Context, shortName string) error {
 	if err != nil {
 		return err
 	} else if !netExists {
-		logrus.Infof("Creating network %s", fullName)
+		log.G(ctx).Infof("Creating network %s", fullName)
 		//add metadata labels to network https://github.com/compose-spec/compose-spec/blob/master/spec.md#labels-1
 		createArgs := []string{
 			fmt.Sprintf("--label=%s=%s", labels.ComposeProject, c.project.Name),
@@ -65,12 +64,12 @@ func (c *Composer) upNetwork(ctx context.Context, shortName string) error {
 
 		if net.Ipam.Config != nil {
 			if len(net.Ipam.Config) > 1 {
-				logrus.Warnf("Ignoring: network %s: imam.config %+v", shortName, net.Ipam.Config[1:])
+				log.G(ctx).Warnf("Ignoring: network %s: imam.config %+v", shortName, net.Ipam.Config[1:])
 			}
 
 			ipamConfig := net.Ipam.Config[0]
 			if unknown := reflectutil.UnknownNonEmptyFields(ipamConfig, "Subnet", "Gateway", "IPRange"); len(unknown) > 0 {
-				logrus.Warnf("Ignoring: network %s: ipam.config[0]: %+v", shortName, unknown)
+				log.G(ctx).Warnf("Ignoring: network %s: ipam.config[0]: %+v", shortName, unknown)
 			}
 			if ipamConfig.Subnet != "" {
 				createArgs = append(createArgs, fmt.Sprintf("--subnet=%s", ipamConfig.Subnet))
@@ -86,7 +85,7 @@ func (c *Composer) upNetwork(ctx context.Context, shortName string) error {
 		createArgs = append(createArgs, fullName)
 
 		if c.DebugPrintFull {
-			logrus.Debugf("Creating network args: %s", createArgs)
+			log.G(ctx).Debugf("Creating network args: %s", createArgs)
 		}
 
 		if err := c.runNerdctlCmd(ctx, append([]string{"network", "create"}, createArgs...)...); err != nil {

--- a/pkg/composer/up_volume.go
+++ b/pkg/composer/up_volume.go
@@ -20,10 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/reflectutil"
-
-	"github.com/sirupsen/logrus"
 )
 
 func (c *Composer) upVolume(ctx context.Context, shortName string) error {
@@ -37,7 +36,7 @@ func (c *Composer) upVolume(ctx context.Context, shortName string) error {
 	}
 
 	if unknown := reflectutil.UnknownNonEmptyFields(&vol, "Name"); len(unknown) > 0 {
-		logrus.Warnf("Ignoring: volume %s: %+v", shortName, unknown)
+		log.G(ctx).Warnf("Ignoring: volume %s: %+v", shortName, unknown)
 	}
 
 	// shortName is like "db_data", fullName is like "compose-wordpress_db_data"
@@ -46,7 +45,7 @@ func (c *Composer) upVolume(ctx context.Context, shortName string) error {
 	if err != nil {
 		return err
 	} else if !volExists {
-		logrus.Infof("Creating volume %s", fullName)
+		log.G(ctx).Infof("Creating volume %s", fullName)
 		//add metadata labels to volume https://github.com/compose-spec/compose-spec/blob/master/spec.md#labels-2
 		createArgs := []string{
 			fmt.Sprintf("--label=%s=%s", labels.ComposeProject, c.project.Name),

--- a/pkg/consoleutil/detach.go
+++ b/pkg/consoleutil/detach.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/containerd/log"
 	"github.com/moby/term"
-	"github.com/sirupsen/logrus"
 )
 
 const DefaultDetachKeys = "ctrl-p,ctrl-q"
@@ -53,7 +53,7 @@ func (ds *detachableStdin) Read(p []byte) (int, error) {
 	n, err := ds.stdin.Read(p)
 	var eerr term.EscapeError
 	if errors.As(err, &eerr) {
-		logrus.Info("read detach keys")
+		log.L.Info("read detach keys")
 		if ds.closer != nil {
 			ds.closer()
 		}

--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/typeurl/v2"
-	"github.com/sirupsen/logrus"
 )
 
 func Inspect(ctx context.Context, container containerd.Container) (*native.Container, error) {
@@ -38,13 +38,13 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 
 	n.Spec, err = typeurl.UnmarshalAny(info.Spec)
 	if err != nil {
-		logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Spec")
+		log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect Spec")
 		return n, nil
 	}
 	task, err := container.Task(ctx, nil)
 	if err != nil {
 		if !errdefs.IsNotFound(err) {
-			logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Task")
+			log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect Task")
 		}
 		return n, nil
 	}
@@ -53,13 +53,13 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 	}
 	st, err := task.Status(ctx)
 	if err != nil {
-		logrus.WithError(err).WithField("id", id).Warnf("failed to inspect Status")
+		log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect Status")
 		return n, nil
 	}
 	n.Process.Status = st
 	netNS, err := InspectNetNS(ctx, n.Process.Pid)
 	if err != nil {
-		logrus.WithError(err).WithField("id", id).Warnf("failed to inspect NetNS")
+		log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect NetNS")
 		return n, nil
 	}
 	n.Process.NetNS = netNS

--- a/pkg/containerutil/container_network_manager_linux.go
+++ b/pkg/containerutil/container_network_manager_linux.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/containerd/nerdctl/pkg/clientutil"
 	"github.com/containerd/nerdctl/pkg/dnsutil"
@@ -31,7 +32,6 @@ import (
 	"github.com/containerd/nerdctl/pkg/netutil"
 	"github.com/containerd/nerdctl/pkg/resolvconf"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Verifies that the internal network settings are correct.
@@ -149,7 +149,7 @@ func (m *cniNetworkManager) buildResolvConf(resolvConfPath string) error {
 			}
 			// if resolvConf file does't exist, using default resolvers
 			conf = &resolvconf.File{}
-			logrus.WithError(err).Debugf("resolvConf file doesn't exist on host")
+			log.L.WithError(err).Debugf("resolvConf file doesn't exist on host")
 		}
 		conf, err = resolvconf.FilterResolvDNS(conf.Content, true)
 		if err != nil {

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/containerd/containerd/plugin"
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -93,7 +93,7 @@ func CNIRuntimeDir() string {
 	}
 	xdr, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
-		logrus.Warn(err)
+		log.L.Warn(err)
 		xdr = fmt.Sprintf("/run/user/%d", rootlessutil.ParentEUID())
 	}
 	return fmt.Sprintf("%s/cni", xdr)
@@ -105,7 +105,7 @@ func BuildKitHost() string {
 	}
 	xdr, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
-		logrus.Warn(err)
+		log.L.Warn(err)
 		xdr = fmt.Sprintf("/run/user/%d", rootlessutil.ParentEUID())
 	}
 	return fmt.Sprintf("unix://%s/buildkit/buildkitd.sock", xdr)

--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/netutil"
-	"github.com/sirupsen/logrus"
 )
 
 // newUpdater creates an updater for hostsD (/var/lib/nerdctl/<ADDRHASH>/etchosts)
@@ -110,7 +110,7 @@ func (u *updater) phase2() error {
 		dir := filepath.Dir(path)
 		myMeta, ok := u.metaByDir[dir]
 		if !ok {
-			logrus.WithError(errdefs.ErrNotFound).Debugf("hostsstore metadata %q not found in %q?", metaJSON, dir)
+			log.L.WithError(errdefs.ErrNotFound).Debugf("hostsstore metadata %q not found in %q?", metaJSON, dir)
 			return nil
 		}
 		myNetworks := make(map[string]struct{})
@@ -127,7 +127,7 @@ func (u *updater) phase2() error {
 		var buf bytes.Buffer
 		if r != nil {
 			if err := parseHostsButSkipMarkedRegion(&buf, r); err != nil {
-				logrus.WithError(err).Warn("failed to read hosts file")
+				log.L.WithError(err).Warn("failed to read hosts file")
 			}
 		}
 

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -32,9 +32,9 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/runtime/restart"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/portutil"
 	"github.com/docker/go-units"
-	"github.com/sirupsen/logrus"
 )
 
 func ContainerStatus(ctx context.Context, c containerd.Container) string {
@@ -118,7 +118,7 @@ func Ellipsis(str string, maxDisplayWidth int) string {
 func FormatPorts(labelMap map[string]string) string {
 	ports, err := portutil.ParsePortsLabel(labelMap)
 	if err != nil {
-		logrus.Error(err.Error())
+		log.L.Error(err.Error())
 	}
 	if len(ports) == 0 {
 		return ""

--- a/pkg/imageinspector/imageinspector.go
+++ b/pkg/imageinspector/imageinspector.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/log"
 	imgutil "github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
-	"github.com/sirupsen/logrus"
 )
 
 // Inspect inspects the image, for the platform specified in image.platform.
@@ -34,7 +34,7 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 	img := containerd.NewImage(client, image)
 	idx, idxDesc, err := imgutil.ReadIndex(ctx, img)
 	if err != nil {
-		logrus.WithError(err).WithField("id", image.Name).Warnf("failed to inspect index")
+		log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to inspect index")
 	} else {
 		n.IndexDesc = idxDesc
 		n.Index = idx
@@ -42,7 +42,7 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 
 	mani, maniDesc, err := imgutil.ReadManifest(ctx, img)
 	if err != nil {
-		logrus.WithError(err).WithField("id", image.Name).Warnf("failed to inspect manifest")
+		log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to inspect manifest")
 	} else {
 		n.ManifestDesc = maniDesc
 		n.Manifest = mani
@@ -50,7 +50,7 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 
 	imageConfig, imageConfigDesc, err := imgutil.ReadImageConfig(ctx, img)
 	if err != nil {
-		logrus.WithError(err).WithField("id", image.Name).Warnf("failed to inspect image config")
+		log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to inspect image config")
 	} else {
 		n.ImageConfigDesc = imageConfigDesc
 		n.ImageConfig = imageConfig
@@ -58,7 +58,7 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 	snapSvc := client.SnapshotService(snapshotter)
 	n.Size, err = imgutil.UnpackedImageSize(ctx, snapSvc, img)
 	if err != nil {
-		logrus.WithError(err).WithField("id", image.Name).Warnf("failed to inspect calculate size")
+		log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to inspect calculate size")
 	}
 	n.Image = image
 

--- a/pkg/imgutil/converter/zstd.go
+++ b/pkg/imgutil/converter/zstd.go
@@ -26,10 +26,10 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/images/converter/uncompress"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
 	"github.com/klauspost/compress/zstd"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 // ZstdLayerConvertFunc converts legacy tar.gz layers into zstd layers with
@@ -52,10 +52,10 @@ func ZstdLayerConvertFunc(options types.ImageConvertOptions) (converter.ConvertF
 			}
 			defer func() {
 				if err := cs.Delete(ctx, uncompressedDesc.Digest); err != nil {
-					logrus.WithError(err).WithField("uncompressedDesc", uncompressedDesc).Warn("failed to remove tmp uncompressed layer")
+					log.L.WithError(err).WithField("uncompressedDesc", uncompressedDesc).Warn("failed to remove tmp uncompressed layer")
 				}
 			}()
-			logrus.Debugf("zstd: uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
+			log.L.Debugf("zstd: uncompressed %s into %s", desc.Digest, uncompressedDesc.Digest)
 		}
 
 		info, err := cs.Info(ctx, desc.Digest)

--- a/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
@@ -26,11 +26,11 @@ import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	dockerconfig "github.com/containerd/containerd/remotes/docker/config"
+	"github.com/containerd/log"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/credentials"
 	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/errdefs"
-	"github.com/sirupsen/logrus"
 )
 
 var PushTracker = docker.NewInMemoryTracker()
@@ -63,17 +63,17 @@ func WithSkipVerifyCerts(b bool) Opt {
 func WithHostsDirs(orig []string) Opt {
 	var ss []string
 	if len(orig) == 0 {
-		logrus.Debug("no hosts dir was specified")
+		log.L.Debug("no hosts dir was specified")
 	}
 	for _, v := range orig {
 		if _, err := os.Stat(v); err == nil {
-			logrus.Debugf("Found hosts dir %q", v)
+			log.L.Debugf("Found hosts dir %q", v)
 			ss = append(ss, v)
 		} else {
 			if errors.Is(err, os.ErrNotExist) {
-				logrus.WithError(err).Debugf("Ignoring hosts dir %q", v)
+				log.L.WithError(err).Debugf("Ignoring hosts dir %q", v)
 			} else {
-				logrus.WithError(err).Warnf("Ignoring hosts dir %q", v)
+				log.L.WithError(err).Warnf("Ignoring hosts dir %q", v)
 			}
 		}
 	}
@@ -195,7 +195,7 @@ func NewAuthCreds(refHostname string) (AuthCreds, error) {
 		// GetAuthConfig does not raise an error on ENOENT
 		ac, err := dockerConfigFile.GetAuthConfig(authConfigHostname)
 		if err != nil {
-			logrus.WithError(err).Warnf("cannot get auth config for authConfigHostname=%q (refHostname=%q)",
+			log.L.WithError(err).Warnf("cannot get auth config for authConfigHostname=%q (refHostname=%q)",
 				authConfigHostname, refHostname)
 		} else {
 			// When refHostname is "docker.io":
@@ -206,7 +206,7 @@ func NewAuthCreds(refHostname string) (AuthCreds, error) {
 			if !isAuthConfigEmpty(ac) {
 				if ac.ServerAddress == "" {
 					// This can happen with Amazon ECR: https://github.com/containerd/nerdctl/issues/733
-					logrus.Debugf("failed to get ac.ServerAddress for authConfigHostname=%q (refHostname=%q)",
+					log.L.Debugf("failed to get ac.ServerAddress for authConfigHostname=%q (refHostname=%q)",
 						authConfigHostname, refHostname)
 				} else if authConfigHostname == IndexServer {
 					if ac.ServerAddress != IndexServer {
@@ -223,7 +223,7 @@ func NewAuthCreds(refHostname string) (AuthCreds, error) {
 				if ac.RegistryToken != "" {
 					// Even containerd/CRI does not support RegistryToken as of v1.4.3,
 					// so, nobody is actually using RegistryToken?
-					logrus.Warnf("ac.RegistryToken (for %q) is not supported yet (FIXME)", authConfigHostname)
+					log.L.Warnf("ac.RegistryToken (for %q) is not supported yet (FIXME)", authConfigHostname)
 				}
 
 				credFunc = func(credFuncArg string) (string, string, error) {

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -26,8 +26,8 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	dockerreference "github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/referenceutil"
-	"github.com/sirupsen/logrus"
 )
 
 // Filter types supported to filter images.
@@ -136,9 +136,9 @@ func FilterImages(labelImages []images.Image, beforeImages []images.Image, since
 // FilterByReference filters images using references given in `filters`.
 func FilterByReference(imageList []images.Image, filters []string) ([]images.Image, error) {
 	var filteredImageList []images.Image
-	logrus.Debug(filters)
+	log.L.Debug(filters)
 	for _, image := range imageList {
-		logrus.Debug(image.Name)
+		log.L.Debug(image.Name)
 		var matches int
 		for _, f := range filters {
 			var ref dockerreference.Reference

--- a/pkg/imgutil/snapshotter.go
+++ b/pkg/imgutil/snapshotter.go
@@ -23,9 +23,9 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
 	ctdsnapshotters "github.com/containerd/containerd/pkg/snapshotters"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/imgutil/pull"
 	"github.com/containerd/stargz-snapshotter/fs/source"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -58,7 +58,7 @@ func getSnapshotterOpts(snapshotter string) snapshotterOpts {
 	for sn, sno := range builtinRemoteSnapshotterOpts {
 		if strings.Contains(snapshotter, sn) {
 			if snapshotter != sn {
-				logrus.Debugf("assuming %s to be a %s-compatible snapshotter", snapshotter, sn)
+				log.L.Debugf("assuming %s to be a %s-compatible snapshotter", snapshotter, sn)
 			}
 			return sno
 		}

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -29,12 +29,12 @@ import (
 	"github.com/containerd/containerd"
 	ptypes "github.com/containerd/containerd/protobuf/types"
 	"github.com/containerd/containerd/services/introspection"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/logging"
 	"github.com/containerd/nerdctl/pkg/version"
-	"github.com/sirupsen/logrus"
 )
 
 func NativeDaemonInfo(ctx context.Context, client *containerd.Client) (*native.DaemonInfo, error) {
@@ -160,19 +160,19 @@ func ServerSemVer(ctx context.Context, client *containerd.Client) (*semver.Versi
 func buildctlVersion() dockercompat.ComponentVersion {
 	buildctlBinary, err := buildkitutil.BuildctlBinary()
 	if err != nil {
-		logrus.Warnf("unable to determine buildctl version: %s", err.Error())
+		log.L.Warnf("unable to determine buildctl version: %s", err.Error())
 		return dockercompat.ComponentVersion{Name: "buildctl"}
 	}
 
 	stdout, err := exec.Command(buildctlBinary, "--version").Output()
 	if err != nil {
-		logrus.Warnf("unable to determine buildctl version: %s", err.Error())
+		log.L.Warnf("unable to determine buildctl version: %s", err.Error())
 		return dockercompat.ComponentVersion{Name: "buildctl"}
 	}
 
 	v, err := parseBuildctlVersion(stdout)
 	if err != nil {
-		logrus.Warn(err)
+		log.L.Warn(err)
 		return dockercompat.ComponentVersion{Name: "buildctl"}
 	}
 	return *v
@@ -205,12 +205,12 @@ func parseBuildctlVersion(buildctlVersionStdout []byte) (*dockercompat.Component
 func runcVersion() dockercompat.ComponentVersion {
 	stdout, err := exec.Command("runc", "--version").Output()
 	if err != nil {
-		logrus.Warnf("unable to determine runc version: %s", err.Error())
+		log.L.Warnf("unable to determine runc version: %s", err.Error())
 		return dockercompat.ComponentVersion{Name: "runc"}
 	}
 	v, err := parseRuncVersion(stdout)
 	if err != nil {
-		logrus.Warn(err)
+		log.L.Warn(err)
 		return dockercompat.ComponentVersion{Name: "runc"}
 	}
 	return *v
@@ -228,7 +228,7 @@ func parseRuncVersion(runcVersionStdout []byte) (*dockercompat.ComponentVersion,
 	for _, detailsLine := range versionList[1:] {
 		detail := strings.SplitN(detailsLine, ":", 2)
 		if len(detail) != 2 {
-			logrus.Warnf("unable to determine one of runc details, got: %s, %d", detail, len(detail))
+			log.L.Warnf("unable to determine one of runc details, got: %s, %d", detail, len(detail))
 			continue
 		}
 		switch strings.TrimSpace(detail[0]) {

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -38,12 +38,12 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/runtime/restart"
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/docker/go-connections/nat"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 
@@ -357,7 +357,7 @@ func networkSettingsFromNative(n *native.NetNS, sp *specs.Spec) (*NetworkSetting
 		for _, a := range x.Addrs {
 			ip, ipnet, err := net.ParseCIDR(a)
 			if err != nil {
-				logrus.WithError(err).WithField("name", x.Name).Warnf("failed to parse %q", a)
+				log.L.WithError(err).WithField("name", x.Name).Warnf("failed to parse %q", a)
 				continue
 			}
 			if ip.IsLoopback() || ip.IsLinkLocalUnicast() {

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/pkg/imgutil"
 	"github.com/containerd/nerdctl/pkg/platformutil"
@@ -34,7 +35,6 @@ import (
 	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
 	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 const ipfsPathEnv = "IPFS_PATH"
@@ -85,9 +85,9 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, layerCo
 	ipath := lookupIPFSPath(ipfsPath)
 	if ensureImage {
 		// Ensure image contents are fully downloaded
-		logrus.Infof("ensuring image contents")
+		log.G(ctx).Infof("ensuring image contents")
 		if err := ensureContentsOfIPFSImage(ctx, client, rawRef, allPlatforms, platform, ipath); err != nil {
-			logrus.WithError(err).Warnf("failed to ensure the existence of image %q", rawRef)
+			log.G(ctx).WithError(err).Warnf("failed to ensure the existence of image %q", rawRef)
 		}
 	}
 	ref, err := referenceutil.ParseAny(rawRef)

--- a/pkg/ipfs/registry.go
+++ b/pkg/ipfs/registry.go
@@ -31,10 +31,10 @@ import (
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/log"
 	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/sirupsen/logrus"
 )
 
 // RegistryOptions represents options to configure the registry.
@@ -72,14 +72,14 @@ var blobsRegexp = regexp.MustCompile(`/v2/ipfs/([a-z0-9]+)/blobs/(.*)`)
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	cid, content, mediaType, size, err := s.serve(r)
 	if err != nil {
-		logrus.WithError(err).Warnf("failed to serve %q %q", r.Method, r.URL.Path)
+		log.L.WithError(err).Warnf("failed to serve %q %q", r.Method, r.URL.Path)
 		// TODO: support response body following OCI Distribution Spec's error response format spec:
 		// https://github.com/opencontainers/distribution-spec/blob/v1.0/spec.md#error-codes
 		http.Error(w, "", http.StatusNotFound)
 		return
 	}
 	if content == nil {
-		logrus.Debugf("returning without contents")
+		log.L.Debugf("returning without contents")
 		w.WriteHeader(200)
 		return
 	}
@@ -87,7 +87,7 @@ func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
 	if r.Method == "GET" {
 		http.ServeContent(w, r, "", time.Now(), content)
-		logrus.WithField("CID", cid).Debugf("served file")
+		log.L.WithField("CID", cid).Debugf("served file")
 	}
 }
 
@@ -97,7 +97,7 @@ func (s *server) serve(r *http.Request) (string, io.ReadSeeker, string, int64, e
 	}
 
 	if r.URL.Path == "/v2/" {
-		logrus.Debugf("requested /v2/")
+		log.L.Debugf("requested /v2/")
 		return "", nil, "", 0, nil
 	}
 
@@ -108,7 +108,7 @@ func (s *server) serve(r *http.Request) (string, io.ReadSeeker, string, int64, e
 			if !images.IsManifestType(mediaType) && !images.IsIndexType(mediaType) {
 				return "", nil, "", 0, fmt.Errorf("cannot serve non-manifest from manifest API: %q", mediaType)
 			}
-			logrus.WithField("root CID", cidStr).WithField("digest", ref).WithField("resolved CID", resolvedCID).Debugf("resolved manifest by digest")
+			log.L.WithField("root CID", cidStr).WithField("digest", ref).WithField("resolved CID", resolvedCID).Debugf("resolved manifest by digest")
 			return resolvedCID, content, mediaType, size, err
 		}
 		if ref != "latest" {
@@ -118,7 +118,7 @@ func (s *server) serve(r *http.Request) (string, io.ReadSeeker, string, int64, e
 		if err != nil {
 			return "", nil, "", 0, err
 		}
-		logrus.WithField("root CID", cidStr).WithField("resolved CID", resolvedCID).Debugf("resolved manifest by cid")
+		log.L.WithField("root CID", cidStr).WithField("resolved CID", resolvedCID).Debugf("resolved manifest by cid")
 		return resolvedCID, content, mediaType, size, nil
 	}
 
@@ -128,7 +128,7 @@ func (s *server) serve(r *http.Request) (string, io.ReadSeeker, string, int64, e
 		if err != nil {
 			return "", nil, "", 0, err
 		}
-		logrus.WithField("root CID", rootCIDStr).WithField("digest", dgstStr).WithField("resolved CID", resolvedCID).Debugf("resolved blob by digest")
+		log.L.WithField("root CID", rootCIDStr).WithField("digest", dgstStr).WithField("resolved CID", resolvedCID).Debugf("resolved blob by digest")
 		return resolvedCID, content, mediaType, size, nil
 	}
 

--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 	"golang.org/x/sys/unix"
 )
 
@@ -37,7 +37,7 @@ func WithDirLock(dir string, fn func() error) error {
 	}
 	defer func() {
 		if err := Flock(dirFile, unix.LOCK_UN); err != nil {
-			logrus.WithError(err).Errorf("failed to unlock %q", dir)
+			log.L.WithError(err).Errorf("failed to unlock %q", dir)
 		}
 	}()
 	return fn()

--- a/pkg/lockutil/lockutil_windows.go
+++ b/pkg/lockutil/lockutil_windows.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 	"golang.org/x/sys/windows"
 )
 
@@ -38,7 +38,7 @@ func WithDirLock(dir string, fn func() error) error {
 
 	defer func() {
 		if err := windows.UnlockFileEx(windows.Handle(dirFile.Fd()), 0, 1, 0, &windows.Overlapped{}); err != nil {
-			logrus.WithError(err).Errorf("failed to unlock %q", dir)
+			log.L.WithError(err).Errorf("failed to unlock %q", dir)
 		}
 	}()
 	return fn()

--- a/pkg/logging/cri_logger.go
+++ b/pkg/logging/cri_logger.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/logging/tail"
-	"github.com/sirupsen/logrus"
 )
 
 // LogStreamType is the type of the stream in CRI container log.
@@ -114,11 +113,11 @@ func ReadLogs(opts *LogViewOptions, stdout, stderr io.Writer, stopChannel chan o
 	for {
 		select {
 		case <-stopChannel:
-			logrus.Debugf("received stop signal while reading cri logfile, returning")
+			log.L.Debugf("received stop signal while reading cri logfile, returning")
 			return nil
 		default:
 			if stop || (limitedMode && limitedNum == 0) {
-				logrus.Debugf("finished parsing log file, path: %s", logPath)
+				log.L.Debugf("finished parsing log file, path: %s", logPath)
 				return nil
 			}
 			l, err := r.ReadBytes(eol[0])
@@ -142,22 +141,22 @@ func ReadLogs(opts *LogViewOptions, stdout, stderr io.Writer, stopChannel chan o
 				if len(l) == 0 {
 					continue
 				}
-				logrus.Debugf("incomplete line in log file, path: %s, line: %s", logPath, l)
+				log.L.Debugf("incomplete line in log file, path: %s, line: %s", logPath, l)
 			}
 
 			// Parse the log line.
 			msg.reset()
 			if err := ParseCRILog(l, msg); err != nil {
-				logrus.WithError(err).Errorf("failed when parsing line in log file, path: %s, line: %s", logPath, l)
+				log.L.WithError(err).Errorf("failed when parsing line in log file, path: %s, line: %s", logPath, l)
 				continue
 			}
 			// Write the log line into the stream.
 			if err := writer.write(msg, isNewLine); err != nil {
 				if err == errMaximumWrite {
-					logrus.Debugf("finished parsing log file, hit bytes limit path: %s", logPath)
+					log.L.Debugf("finished parsing log file, hit bytes limit path: %s", logPath)
 					return nil
 				}
-				logrus.WithError(err).Errorf("failed when writing line to log file, path: %s, line: %s", logPath, l)
+				log.L.WithError(err).Errorf("failed when writing line to log file, path: %s, line: %s", logPath, l)
 				return err
 			}
 			if limitedMode {

--- a/pkg/logging/fluentd_logger.go
+++ b/pkg/logging/fluentd_logger.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/fluent/fluent-logger-golang/fluent"
-	"github.com/sirupsen/logrus"
 )
 
 type FluentdLogger struct {
@@ -77,11 +77,11 @@ const (
 func FluentdLogOptsValidate(logOptMap map[string]string) error {
 	for key := range logOptMap {
 		if !strutil.InStringSlice(FluentdLogOpts, key) {
-			logrus.Warnf("log-opt %s is ignored for fluentd log driver", key)
+			log.L.Warnf("log-opt %s is ignored for fluentd log driver", key)
 		}
 	}
 	if _, ok := logOptMap[fluentAddress]; !ok {
-		logrus.Warnf("%s is missing for fluentd log driver, the default value %s:%d will be used", fluentAddress, defaultHost, defaultPort)
+		log.L.Warnf("%s is missing for fluentd log driver, the default value %s:%d will be used", fluentAddress, defaultHost, defaultPort)
 	}
 	return nil
 }

--- a/pkg/logging/journald_logger.go
+++ b/pkg/logging/journald_logger.go
@@ -29,11 +29,11 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/docker/cli/templates"
 	timetypes "github.com/docker/docker/api/types/time"
-	"github.com/sirupsen/logrus"
 )
 
 var JournalDriverLogOpts = []string{
@@ -43,7 +43,7 @@ var JournalDriverLogOpts = []string{
 func JournalLogOptsValidate(logOptMap map[string]string) error {
 	for key := range logOptMap {
 		if !strutil.InStringSlice(JournalDriverLogOpts, key) {
-			logrus.Warnf("log-opt %s is ignored for journald log driver", key)
+			log.L.Warnf("log-opt %s is ignored for journald log driver", key)
 		}
 	}
 	return nil
@@ -141,7 +141,7 @@ func FetchLogs(stdout, stderr io.Writer, journalctlArgs []string, stopChannel ch
 	// Setup killing goroutine:
 	go func() {
 		<-stopChannel
-		logrus.Debugf("killing journalctl logs process with PID: %#v", cmd.Process.Pid)
+		log.L.Debugf("killing journalctl logs process with PID: %#v", cmd.Process.Pid)
 		cmd.Process.Kill()
 	}()
 
@@ -172,7 +172,7 @@ func viewLogsJournald(lvopts LogViewOptions, stdout, stderr io.Writer, stopChann
 		journalctlArgs = append(journalctlArgs, "--since", date)
 	}
 	if lvopts.Timestamps {
-		logrus.Warnf("unsupported Timestamps option for journald driver")
+		log.L.Warnf("unsupported Timestamps option for journald driver")
 	}
 	if lvopts.Until != "" {
 		// using GetTimestamp from moby to keep time format consistency

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -27,11 +27,11 @@ import (
 	"time"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/logging/jsonfile"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/docker/go-units"
 	"github.com/fahedouch/go-logrotate"
-	"github.com/sirupsen/logrus"
 )
 
 var JSONDriverLogOpts = []string{
@@ -48,7 +48,7 @@ type JSONLogger struct {
 func JSONFileLogOptsValidate(logOptMap map[string]string) error {
 	for key := range logOptMap {
 		if !strutil.InStringSlice(JSONDriverLogOpts, key) {
-			logrus.Warnf("log-opt %s is ignored for json-file log driver", key)
+			log.L.Warnf("log-opt %s is ignored for json-file log driver", key)
 		}
 	}
 	return nil
@@ -160,7 +160,7 @@ func viewLogsJSONFileDirect(lvopts LogViewOptions, jsonLogFilePath string, stdou
 		for {
 			select {
 			case <-stopChannel:
-				logrus.Debugf("received stop signal while re-reading JSON logfile, returning")
+				log.L.Debugf("received stop signal while re-reading JSON logfile, returning")
 				return nil
 			default:
 				// Re-open the file and seek to the last-consumed offset.
@@ -224,7 +224,7 @@ func viewLogsJSONFileThroughTailExec(lvopts LogViewOptions, jsonLogFilePath stri
 	// Setup killing goroutine:
 	go func() {
 		<-stopChannel
-		logrus.Debugf("killing tail logs process with PID: %d", cmd.Process.Pid)
+		log.L.Debugf("killing tail logs process with PID: %d", cmd.Process.Pid)
 		cmd.Process.Kill()
 	}()
 

--- a/pkg/logging/log_viewer.go
+++ b/pkg/logging/log_viewer.go
@@ -23,8 +23,8 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels/k8slabels"
-	"github.com/sirupsen/logrus"
 )
 
 // Type alias for functions which write out logs to the provided stdout/stderr Writers.
@@ -37,7 +37,7 @@ var logViewers = make(map[string]LogViewerFunc)
 // Registers a LogViewerFunc for the
 func RegisterLogViewer(driverName string, lvfn LogViewerFunc) {
 	if v, ok := logViewers[driverName]; ok {
-		logrus.Warnf("A LogViewerFunc with name %q has already been registered: %#v, overriding with %#v either way", driverName, v, lvfn)
+		log.L.Warnf("A LogViewerFunc with name %q has already been registered: %#v, overriding with %#v either way", driverName, v, lvfn)
 	}
 	logViewers[driverName] = lvfn
 }
@@ -93,7 +93,7 @@ func (lvo *LogViewOptions) Validate() error {
 		if err != nil {
 			return err
 		}
-		logrus.Warnf("given relative datastore path %q, transformed it to absolute path: %q", lvo.DatastoreRootPath, abs)
+		log.L.Warnf("given relative datastore path %q, transformed it to absolute path: %q", lvo.DatastoreRootPath, abs)
 		lvo.DatastoreRootPath = abs
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/runtime/v2/logging"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 const (
@@ -154,7 +154,7 @@ func loggingProcessAdapter(driver Driver, dataStore string, config *logging.Conf
 		scanner := bufio.NewScanner(reader)
 		for scanner.Scan() {
 			if scanner.Err() != nil {
-				logrus.Errorf("failed to read log: %v", scanner.Err())
+				log.L.Errorf("failed to read log: %v", scanner.Err())
 				return
 			}
 			dataChan <- scanner.Text()

--- a/pkg/logging/syslog_logger.go
+++ b/pkg/logging/syslog_logger.go
@@ -27,12 +27,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/containerd/log"
 	"github.com/docker/go-connections/tlsconfig"
 	syslog "github.com/yuchanns/srslog"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
 	"github.com/containerd/nerdctl/pkg/strutil"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -91,7 +91,7 @@ const (
 func SyslogOptsValidate(logOptMap map[string]string) error {
 	for key := range logOptMap {
 		if !strutil.InStringSlice(syslogOpts, key) {
-			logrus.Warnf("log-opt %s is ignored for syslog log driver", key)
+			log.L.Warnf("log-opt %s is ignored for syslog log driver", key)
 		}
 	}
 	proto, _, err := parseSyslogAddress(logOptMap[syslogAddress])

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -27,12 +27,11 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/userns"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/idgen"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/opencontainers/runtime-spec/specs-go"
-
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -63,7 +62,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore, createDir bool) (*
 	case 1:
 		dst = s
 		res.AnonymousVolume = idgen.GenerateID()
-		logrus.Debugf("creating anonymous volume %q, for %q", res.AnonymousVolume, s)
+		log.L.Debugf("creating anonymous volume %q, for %q", res.AnonymousVolume, s)
 		anonVol, err := volStore.Create(res.AnonymousVolume, []string{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create an anonymous volume %q: %w", res.AnonymousVolume, err)
@@ -92,7 +91,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore, createDir bool) (*
 			res.Type = Volume
 		}
 		if !filepath.IsAbs(src) {
-			logrus.Warnf("expected an absolute path, got a relative path %q (allowed for nerdctl, but disallowed for Docker, so unrecommended)", src)
+			log.L.Warnf("expected an absolute path, got a relative path %q (allowed for nerdctl, but disallowed for Docker, so unrecommended)", src)
 			var err error
 			src, err = filepath.Abs(src)
 			if err != nil {

--- a/pkg/mountutil/mountutil_freebsd.go
+++ b/pkg/mountutil/mountutil_freebsd.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
-	"github.com/sirupsen/logrus"
 )
 
 func UnprivilegedMountFlags(path string) ([]string, error) {
@@ -47,7 +47,7 @@ func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, e
 		case "":
 			// NOP
 		default:
-			logrus.Warnf("unsupported volume option %q", opt)
+			log.L.Warnf("unsupported volume option %q", opt)
 		}
 	}
 	var opts []string

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -28,11 +28,11 @@ import (
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/mount"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 	"github.com/docker/go-units"
 	mobymount "github.com/moby/sys/mount"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -118,7 +118,7 @@ func parseVolumeOptionsWithMountInfo(vType, src, optsRaw string, getMountInfoFun
 		case "":
 			// NOP
 		default:
-			logrus.Warnf("unsupported volume option %q", opt)
+			log.L.Warnf("unsupported volume option %q", opt)
 		}
 	}
 
@@ -144,7 +144,7 @@ func parseVolumeOptionsWithMountInfo(vType, src, optsRaw string, getMountInfoFun
 			// Older version of runc just ignores "rro", so we have to add "ro" too, to our best effort.
 			opts = append(opts, "ro", "rro")
 			if len(propagationRawOpts) != 1 || propagationRawOpts[0] != "rprivate" {
-				logrus.Warn("Mount option \"rro\" should be used in conjunction with \"rprivate\"")
+				log.L.Warn("Mount option \"rro\" should be used in conjunction with \"rprivate\"")
 			}
 		case "rw":
 			// NOP
@@ -418,7 +418,7 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 	}
 	fieldsStr := strings.Join(fields, ":")
 
-	logrus.Debugf("Call legacy %s process, spec: %s ", mountType, fieldsStr)
+	log.L.Debugf("Call legacy %s process, spec: %s ", mountType, fieldsStr)
 
 	switch mountType {
 	case Tmpfs:

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/oci"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
-	"github.com/sirupsen/logrus"
 )
 
 func UnprivilegedMountFlags(path string) ([]string, error) {
@@ -49,7 +49,7 @@ func parseVolumeOptions(vType, src, optsRaw string) ([]string, []oci.SpecOpts, e
 		case "":
 			// NOP
 		default:
-			logrus.Warnf("unsupported volume option %q", opt)
+			log.L.Warnf("unsupported volume option %q", opt)
 		}
 	}
 	var opts []string

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -33,13 +33,13 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/lockutil"
 	"github.com/containerd/nerdctl/pkg/netutil/nettype"
 	subnetutil "github.com/containerd/nerdctl/pkg/netutil/subnet"
 	"github.com/containerd/nerdctl/pkg/strutil"
 	"github.com/containernetworking/cni/libcni"
-	"github.com/sirupsen/logrus"
 )
 
 type CNIEnv struct {
@@ -162,7 +162,7 @@ func (e *CNIEnv) NetworkMap() (map[string]*NetworkConfig, error) { //nolint:revi
 	m := make(map[string]*NetworkConfig, len(networks))
 	for _, n := range networks {
 		if original, exists := m[n.Name]; exists {
-			logrus.Warnf("duplicate network name %q, %#v will get superseded by %#v", n.Name, original, n)
+			log.L.Warnf("duplicate network name %q, %#v will get superseded by %#v", n.Name, original, n)
 		}
 		m[n.Name] = n
 	}
@@ -292,7 +292,7 @@ func (e *CNIEnv) GetDefaultNetworkConfig() (*NetworkConfig, error) {
 	}
 	if len(labelMatches) >= 1 {
 		if len(labelMatches) > 1 {
-			logrus.Warnf("returning the first network bearing the %q label out of the multiple found: %#v", labels.NerdctlDefaultNetwork, labelMatches)
+			log.L.Warnf("returning the first network bearing the %q label out of the multiple found: %#v", labels.NerdctlDefaultNetwork, labelMatches)
 		}
 		return labelMatches[0], nil
 	}
@@ -307,14 +307,14 @@ func (e *CNIEnv) GetDefaultNetworkConfig() (*NetworkConfig, error) {
 	}
 	if len(nameMatches) >= 1 {
 		if len(nameMatches) > 1 {
-			logrus.Warnf("returning the first network bearing the %q default network name out of the multiple found: %#v", DefaultNetworkName, nameMatches)
+			log.L.Warnf("returning the first network bearing the %q default network name out of the multiple found: %#v", DefaultNetworkName, nameMatches)
 		}
 
 		// Warn the user if the default network was not created by nerdctl.
 		match := nameMatches[0]
 		_, statErr := os.Stat(e.getConfigPathForNetworkName(DefaultNetworkName))
 		if match.NerdctlID == nil || statErr != nil {
-			logrus.Warnf("default network named %q does not have an internal nerdctl ID or nerdctl-managed config file, it was most likely NOT created by nerdctl", DefaultNetworkName)
+			log.L.Warnf("default network named %q does not have an internal nerdctl ID or nerdctl-managed config file, it was most likely NOT created by nerdctl", DefaultNetworkName)
 		}
 
 		return nameMatches[0], nil

--- a/pkg/ocihook/ocihook_linux.go
+++ b/pkg/ocihook/ocihook_linux.go
@@ -18,10 +18,9 @@ package ocihook
 
 import (
 	"github.com/containerd/containerd/contrib/apparmor"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/pkg/defaults"
-
-	"github.com/sirupsen/logrus"
 )
 
 func loadAppArmor() {
@@ -30,7 +29,7 @@ func loadAppArmor() {
 	}
 	// ensure that the default profile is loaded to the host
 	if err := apparmor.LoadDefaultProfile(defaults.AppArmorProfileName); err != nil {
-		logrus.WithError(err).Errorf("failed to load AppArmor profile %q", defaults.AppArmorProfileName)
+		log.L.WithError(err).Errorf("failed to load AppArmor profile %q", defaults.AppArmorProfileName)
 		// We do not abort here. This is by design, and not a security issue.
 		//
 		// If the container is configured to use the default AppArmor profile

--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -23,10 +23,10 @@ import (
 	"strings"
 
 	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/labels"
 	"github.com/containerd/nerdctl/pkg/rootlessutil"
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 )
 
 // return respectively ip, hostPort, containerPort
@@ -94,7 +94,7 @@ func ParseFlagP(s string) ([]gocni.PortMapping, error) {
 		if err != nil {
 			return nil, err
 		}
-		logrus.Debugf("There is no hostPort has been spec in command, the auto allocate port is from %d:%d to %d:%d", startHostPort, startPort, endHostPort, endPort)
+		log.L.Debugf("There is no hostPort has been spec in command, the auto allocate port is from %d:%d to %d:%d", startHostPort, startPort, endHostPort, endPort)
 	} else {
 		startHostPort, endHostPort, err = nat.ParsePortRange(hostPort)
 		if err != nil {

--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -35,7 +35,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 const (
@@ -78,7 +78,7 @@ func Path() string {
 		ns := GetNameservers(candidateResolvConf, IP)
 		if len(ns) == 1 && ns[0] == "127.0.0.53" {
 			pathAfterSystemdDetection = alternatePath
-			logrus.Debugf("detected 127.0.0.53 nameserver, assuming systemd-resolved, so using resolv.conf: %s", alternatePath)
+			log.L.Debugf("detected 127.0.0.53 nameserver, assuming systemd-resolved, so using resolv.conf: %s", alternatePath)
 		}
 	})
 	return pathAfterSystemdDetection
@@ -190,10 +190,10 @@ func FilterResolvDNS(resolvConf []byte, ipv6Enabled bool) (*File, error) {
 	// if the resulting resolvConf has no more nameservers defined, add appropriate
 	// default DNS servers for IPv4 and (optionally) IPv6
 	if len(GetNameservers(cleanedResolvConf, IP)) == 0 {
-		logrus.Infof("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: %v", defaultIPv4Dns)
+		log.L.Infof("No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: %v", defaultIPv4Dns)
 		dns := defaultIPv4Dns
 		if ipv6Enabled {
-			logrus.Infof("IPv6 enabled; Adding default IPv6 external servers: %v", defaultIPv6Dns)
+			log.L.Infof("IPv6 enabled; Adding default IPv6 external servers: %v", defaultIPv6Dns)
 			dns = append(dns, defaultIPv6Dns...)
 		}
 		cleanedResolvConf = append(cleanedResolvConf, []byte("\n"+strings.Join(dns, "\n"))...)

--- a/pkg/rootlessutil/parent_linux.go
+++ b/pkg/rootlessutil/parent_linux.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 func IsRootlessParent() bool {
@@ -68,7 +68,7 @@ func ParentMain(hostGatewayIP string) error {
 		return errors.New("should not be called when !IsRootlessParent()")
 	}
 	stateDir, err := RootlessKitStateDir()
-	logrus.Debugf("stateDir: %s", stateDir)
+	log.L.Debugf("stateDir: %s", stateDir)
 	if err != nil {
 		return fmt.Errorf("rootless containerd not running? (hint: use `containerd-rootless-setuptool.sh install` to start rootless containerd): %w", err)
 	}
@@ -97,7 +97,7 @@ func ParentMain(hostGatewayIP string) error {
 		"-F", // no fork
 	}
 	args = append(args, os.Args...)
-	logrus.Debugf("rootless parent main: executing %q with %v", arg0, args)
+	log.L.Debugf("rootless parent main: executing %q with %v", arg0, args)
 
 	// Env vars corresponds to RootlessKit spec:
 	// https://github.com/rootless-containers/rootlesskit/tree/v0.13.1#environment-variables

--- a/pkg/signalutil/signals.go
+++ b/pkg/signalutil/signals.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 // killer is from https://github.com/containerd/containerd/blob/v1.7.0-rc.2/cmd/ctr/commands/signals.go#L30-L32
@@ -40,16 +40,16 @@ func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
 	go func() {
 		for s := range sigc {
 			if canIgnoreSignal(s) {
-				logrus.Debugf("Ignoring signal %s", s)
+				log.G(ctx).Debugf("Ignoring signal %s", s)
 				continue
 			}
-			logrus.Debug("forwarding signal ", s)
+			log.G(ctx).Debug("forwarding signal ", s)
 			if err := task.Kill(ctx, s.(syscall.Signal)); err != nil {
 				if errdefs.IsNotFound(err) {
-					logrus.WithError(err).Debugf("Not forwarding signal %s", s)
+					log.G(ctx).WithError(err).Debugf("Not forwarding signal %s", s)
 					return
 				}
-				logrus.WithError(err).Errorf("forward signal %s", s)
+				log.G(ctx).WithError(err).Errorf("forward signal %s", s)
 			}
 		}
 	}()

--- a/pkg/signutil/cosignutil.go
+++ b/pkg/signutil/cosignutil.go
@@ -24,16 +24,16 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/imgutil"
-	"github.com/sirupsen/logrus"
 )
 
 // SignCosign signs an image(`rawRef`) using a cosign private key (`keyRef`)
 func SignCosign(rawRef string, keyRef string) error {
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
-		logrus.WithError(err).Error("cosign executable not found in path $PATH")
-		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
+		log.L.WithError(err).Error("cosign executable not found in path $PATH")
+		log.L.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
 		return err
 	}
 
@@ -50,7 +50,7 @@ func SignCosign(rawRef string, keyRef string) error {
 	cosignCmd.Args = append(cosignCmd.Args, "--yes")
 	cosignCmd.Args = append(cosignCmd.Args, rawRef)
 
-	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
+	log.L.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
 
 	err = processCosignIO(cosignCmd)
 	if err != nil {
@@ -67,7 +67,7 @@ func VerifyCosign(ctx context.Context, rawRef string, keyRef string, hostsDirs [
 	certIdentity string, certIdentityRegexp string, certOidcIssuer string, certOidcIssuerRegexp string) (string, error) {
 	digest, err := imgutil.ResolveDigest(ctx, rawRef, false, hostsDirs)
 	if err != nil {
-		logrus.WithError(err).Errorf("unable to resolve digest for an image %s: %v", rawRef, err)
+		log.G(ctx).WithError(err).Errorf("unable to resolve digest for an image %s: %v", rawRef, err)
 		return rawRef, err
 	}
 	ref := rawRef
@@ -75,12 +75,12 @@ func VerifyCosign(ctx context.Context, rawRef string, keyRef string, hostsDirs [
 		ref += "@" + digest
 	}
 
-	logrus.Debugf("verifying image: %s", ref)
+	log.G(ctx).Debugf("verifying image: %s", ref)
 
 	cosignExecutable, err := exec.LookPath("cosign")
 	if err != nil {
-		logrus.WithError(err).Error("cosign executable not found in path $PATH")
-		logrus.Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
+		log.G(ctx).WithError(err).Error("cosign executable not found in path $PATH")
+		log.G(ctx).Info("you might consider installing cosign from: https://docs.sigstore.dev/cosign/installation")
 		return ref, err
 	}
 
@@ -114,7 +114,7 @@ func VerifyCosign(ctx context.Context, rawRef string, keyRef string, hostsDirs [
 
 	cosignCmd.Args = append(cosignCmd.Args, ref)
 
-	logrus.Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
+	log.G(ctx).Debugf("running %s %v", cosignExecutable, cosignCmd.Args)
 
 	err = processCosignIO(cosignCmd)
 	if err != nil {
@@ -130,11 +130,11 @@ func VerifyCosign(ctx context.Context, rawRef string, keyRef string, hostsDirs [
 func processCosignIO(cosignCmd *exec.Cmd) error {
 	stdout, err := cosignCmd.StdoutPipe()
 	if err != nil {
-		logrus.Warn("cosign: " + err.Error())
+		log.L.Warn("cosign: " + err.Error())
 	}
 	stderr, err := cosignCmd.StderrPipe()
 	if err != nil {
-		logrus.Warn("cosign: " + err.Error())
+		log.L.Warn("cosign: " + err.Error())
 	}
 	if err := cosignCmd.Start(); err != nil {
 		// only return err if it's critical (cosign start failed.)
@@ -143,18 +143,18 @@ func processCosignIO(cosignCmd *exec.Cmd) error {
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
-		logrus.Info("cosign: " + scanner.Text())
+		log.L.Info("cosign: " + scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		logrus.Warn("cosign: " + err.Error())
+		log.L.Warn("cosign: " + err.Error())
 	}
 
 	errScanner := bufio.NewScanner(stderr)
 	for errScanner.Scan() {
-		logrus.Info("cosign: " + errScanner.Text())
+		log.L.Info("cosign: " + errScanner.Text())
 	}
 	if err := errScanner.Err(); err != nil {
-		logrus.Warn("cosign: " + err.Error())
+		log.L.Warn("cosign: " + err.Error())
 	}
 
 	return nil

--- a/pkg/signutil/signutil.go
+++ b/pkg/signutil/signutil.go
@@ -20,8 +20,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/sirupsen/logrus"
 )
 
 // Sign signs an image using a signer and options provided in options.
@@ -44,7 +44,7 @@ func Sign(rawRef string, experimental bool, options types.ImageSignOptions) erro
 			return err
 		}
 	case "", "none":
-		logrus.Debugf("signing process skipped")
+		log.L.Debugf("signing process skipped")
 	default:
 		return fmt.Errorf("no signers found: %s", options.Provider)
 	}
@@ -72,7 +72,7 @@ func Verify(ctx context.Context, rawRef string, hostsDirs []string, experimental
 		}
 	case "", "none":
 		ref = rawRef
-		logrus.Debugf("verifying process skipped")
+		log.G(ctx).Debugf("verifying process skipped")
 	default:
 		return "", fmt.Errorf("no verifiers found: %s", options.Provider)
 	}

--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -23,16 +23,16 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/pkg/api/types"
-	"github.com/sirupsen/logrus"
 )
 
 // CreateSoci creates a SOCI index(`rawRef`)
 func CreateSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool, platforms []string, sOpts types.SociOptions) error {
 	sociExecutable, err := exec.LookPath("soci")
 	if err != nil {
-		logrus.WithError(err).Error("soci executable not found in path $PATH")
-		logrus.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
+		log.L.WithError(err).Error("soci executable not found in path $PATH")
+		log.L.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
 		return err
 	}
 
@@ -68,7 +68,7 @@ func CreateSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform boo
 	// --timeout, --debug, --content-store
 	sociCmd.Args = append(sociCmd.Args, rawRef)
 
-	logrus.Debugf("running %s %v", sociExecutable, sociCmd.Args)
+	log.L.Debugf("running %s %v", sociExecutable, sociCmd.Args)
 
 	err = processSociIO(sociCmd)
 	if err != nil {
@@ -81,12 +81,12 @@ func CreateSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform boo
 // PushSoci pushes a SOCI index(`rawRef`)
 // `hostsDirs` are used to resolve image `rawRef`
 func PushSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool, platforms []string) error {
-	logrus.Debugf("pushing SOCI index: %s", rawRef)
+	log.L.Debugf("pushing SOCI index: %s", rawRef)
 
 	sociExecutable, err := exec.LookPath("soci")
 	if err != nil {
-		logrus.WithError(err).Error("soci executable not found in path $PATH")
-		logrus.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
+		log.L.WithError(err).Error("soci executable not found in path $PATH")
+		log.L.Info("you might consider installing soci from: https://github.com/awslabs/soci-snapshotter/blob/main/docs/install.md")
 		return err
 	}
 
@@ -123,7 +123,7 @@ func PushSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool,
 	}
 	sociCmd.Args = append(sociCmd.Args, rawRef)
 
-	logrus.Debugf("running %s %v", sociExecutable, sociCmd.Args)
+	log.L.Debugf("running %s %v", sociExecutable, sociCmd.Args)
 
 	err = processSociIO(sociCmd)
 	if err != nil {
@@ -135,11 +135,11 @@ func PushSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool,
 func processSociIO(sociCmd *exec.Cmd) error {
 	stdout, err := sociCmd.StdoutPipe()
 	if err != nil {
-		logrus.Warn("soci: " + err.Error())
+		log.L.Warn("soci: " + err.Error())
 	}
 	stderr, err := sociCmd.StderrPipe()
 	if err != nil {
-		logrus.Warn("soci: " + err.Error())
+		log.L.Warn("soci: " + err.Error())
 	}
 	if err := sociCmd.Start(); err != nil {
 		// only return err if it's critical (soci command failed to start.)
@@ -148,18 +148,18 @@ func processSociIO(sociCmd *exec.Cmd) error {
 
 	scanner := bufio.NewScanner(stdout)
 	for scanner.Scan() {
-		logrus.Info("soci: " + scanner.Text())
+		log.L.Info("soci: " + scanner.Text())
 	}
 	if err := scanner.Err(); err != nil {
-		logrus.Warn("soci: " + err.Error())
+		log.L.Warn("soci: " + err.Error())
 	}
 
 	errScanner := bufio.NewScanner(stderr)
 	for errScanner.Scan() {
-		logrus.Info("soci: " + errScanner.Text())
+		log.L.Info("soci: " + errScanner.Text())
 	}
 	if err := errScanner.Err(); err != nil {
-		logrus.Warn("soci: " + err.Error())
+		log.L.Warn("soci: " + err.Error())
 	}
 
 	return nil

--- a/pkg/tarutil/tarutil.go
+++ b/pkg/tarutil/tarutil.go
@@ -22,7 +22,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/containerd/log"
 )
 
 // FindTarBinary returns a path to the tar binary and whether it is GNU tar.
@@ -30,11 +30,11 @@ func FindTarBinary() (string, bool, error) {
 	isGNU := func(exe string) bool {
 		v, err := exec.Command(exe, "--version").Output()
 		if err != nil {
-			logrus.Warnf("Failed to detect whether %q is GNU tar or not", exe)
+			log.L.Warnf("Failed to detect whether %q is GNU tar or not", exe)
 			return false
 		}
 		if !strings.Contains(string(v), "GNU tar") {
-			logrus.Warnf("%q does not seem GNU tar", exe)
+			log.L.Warnf("%q does not seem GNU tar", exe)
 			return false
 		}
 		return true


### PR DESCRIPTION
# PR Description

This PR replaces direct dependencies on github.com/sirupsen/logrus and github.com/containerd/containerd/log with https://github.com/containerd/log to streamline our logging dependencies.

We continue to use logrus.SetOutput() in [ocihook.go](https://github.com/TinaMor/nerdctl/blob/replace-logrus-package/pkg/ocihook/ocihook.go) because not all Logrus APIs are provided by the new library.

Github issues #2523 