### PR TITLE
release.yml: migrate from `hub` to `gh`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,8 @@ jobs:
       run: (cd _output; sha256sum SHA256SUMS)
     - name: "Prepare the release note"
       run: |
-        tag="${GITHUB_REF##*/}"
         shasha=$(sha256sum _output/SHA256SUMS | awk '{print $1}')
         cat <<-EOF | tee /tmp/release-note.txt
-        ${tag}
-
         $(hack/generate-release-note.sh)
         - - -
         The binaries were built automatically on GitHub Actions.
@@ -45,6 +42,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         tag="${GITHUB_REF##*/}"
-        asset_flags=()
-        for f in _output/*; do asset_flags+=("-a" "$f"); done
-        hub release create "${asset_flags[@]}" -F /tmp/release-note.txt --draft "${tag}"
+        gh release create -F /tmp/release-note.txt --draft --title "${tag}" "${tag}" _output/*


### PR DESCRIPTION
`hub` was deprecated and removed from GitHub Actions runners:
- https://github.com/actions/runner-images/issues/8362