### PR TITLE
dockerconfigresolver: nullify DefaultTLS when DefaultScheme == "http" ; go.mod: github.com/containerd/containerd v1.7.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/containerd/accelerated-container-image v0.6.7
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.7.6
+	github.com/containerd/containerd v1.7.7
 	github.com/containerd/continuity v0.4.2
 	github.com/containerd/go-cni v1.1.9
 	github.com/containerd/imgcrypt v1.1.8

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKk
 github.com/containerd/cgroups/v3 v3.0.2/go.mod h1:JUgITrzdFqp42uI2ryGA+ge0ap/nxzYgkGmIcetmErE=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
-github.com/containerd/containerd v1.7.6 h1:oNAVsnhPoy4BTPQivLgTzI9Oleml9l/+eYIDYXRCYo8=
-github.com/containerd/containerd v1.7.6/go.mod h1:SY6lrkkuJT40BVNO37tlYTSnKJnP5AXBc0fhx0q+TJ4=
+github.com/containerd/containerd v1.7.7 h1:QOC2K4A42RQpcrZyptP6z9EJZnlHfHJUfZrAAHe15q4=
+github.com/containerd/containerd v1.7.7/go.mod h1:3c4XZv6VeT9qgf9GMTxNTMFxGJrGpI2vz1yk4ye+YY8=
 github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=

--- a/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
@@ -136,6 +136,10 @@ func NewHostOptions(ctx context.Context, refHostname string, optFuncs ...Opt) (*
 			ho.DefaultScheme = "http"
 		}
 	}
+	if ho.DefaultScheme == "http" {
+		// https://github.com/containerd/containerd/issues/9208
+		ho.DefaultTLS = nil
+	}
 	return &ho, nil
 }
 


### PR DESCRIPTION
Workaround for:
- containerd/containerd#9208