### PR TITLE
nerdctl compose: fix `--env-file` (broken since v1.6.0)

### DIFF
--- a/cmd/nerdctl/compose_config_test.go
+++ b/cmd/nerdctl/compose_config_test.go
@@ -130,3 +130,24 @@ services:
 	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutContainsAll("hello1\n", "hello2\n")
 	base.ComposeCmd("--project-directory", comp.Dir(), "config").AssertOutContains("alpine:3.14")
 }
+
+func TestComposeConfigWithEnvFile(t *testing.T) {
+	base := testutil.NewBase(t)
+
+	const dockerComposeYAML = `
+services:
+  hello:
+    image: ${image}
+`
+
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+
+	envFile := filepath.Join(comp.Dir(), "env")
+	const envFileContent = `
+image: hello-world
+`
+	assert.NilError(t, os.WriteFile(envFile, []byte(envFileContent), 0644))
+
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "--env-file", envFile, "config").AssertOutContains("image: hello-world")
+}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -70,16 +70,18 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 	optionsFn = append(optionsFn,
 		composecli.WithOsEnv,
 		composecli.WithWorkingDirectory(o.ProjectDirectory),
-		composecli.WithConfigFileEnv,
-		composecli.WithDefaultConfigPath,
-		composecli.WithDotEnv,
-		composecli.WithName(o.Project),
 	)
 	if o.EnvFile != "" {
 		optionsFn = append(optionsFn,
 			composecli.WithEnvFiles(o.EnvFile),
 		)
 	}
+	optionsFn = append(optionsFn,
+		composecli.WithConfigFileEnv,
+		composecli.WithDefaultConfigPath,
+		composecli.WithDotEnv,
+		composecli.WithName(o.Project),
+	)
 
 	projectOptions, err := composecli.NewProjectOptions(o.ConfigPaths, optionsFn...)
 	if err != nil {


### PR DESCRIPTION
Fix #2566

This was a regression in PR #2472 (v1.6.0)