### PR TITLE
[Chore] Replace logrus.SetOutput() with log.L.Logger.SetOutput()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.1.0
 	github.com/rootless-containers/bypass4netns v0.3.0
 	github.com/rootless-containers/rootlesskit v1.1.1
-	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/gjson v1.17.0
@@ -112,6 +111,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -41,7 +41,6 @@ import (
 
 	b4nndclient "github.com/rootless-containers/bypass4netns/pkg/api/daemon/client"
 	rlkclient "github.com/rootless-containers/rootlesskit/pkg/api/client"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -80,7 +79,7 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 		return err
 	}
 	defer logFile.Close()
-	logrus.SetOutput(io.MultiWriter(stderr, logFile))
+	log.L.Logger.SetOutput(io.MultiWriter(stderr, logFile))
 
 	opts, err := newHandlerOpts(&state, dataStore, cniPath, cniNetconfPath)
 	if err != nil {


### PR DESCRIPTION
# PR Description

This is a follow up PR from PR #2543 to replace logrus package with https://github.com/containerd/log.

In PR #2543 logrus.SetOutput() was not replaced in [ocihook.go](https://github.com/TinaMor/nerdctl/blob/ff684d5a8c2bd40c459d555b395ded7c80e3f23c/pkg/ocihook/ocihook.go#L82C6-L82C6). In this PR, we replace `logrus.SetOutput()` with `log.L.Logger.SetOutput()`.

Github issues #2523  

References:
[containerd/log](https://github.com/containerd/log) 