### PR TITLE
Fix  `nerdctl ps --format {{.Names}} ` behaviour

### DIFF
--- a/cmd/nerdctl/container_list.go
+++ b/cmd/nerdctl/container_list.go
@@ -202,10 +202,6 @@ func formatAndPrintContainerInfo(containers []container.ListItem, options Format
 				return err
 			}
 		} else {
-			var name string
-			if len(c.Names) > 0 {
-				name = c.Names[0]
-			}
 			format := "%s\t%s\t%s\t%s\t%s\t%s\t%s"
 			args := []interface{}{
 				c.ID,
@@ -214,7 +210,7 @@ func formatAndPrintContainerInfo(containers []container.ListItem, options Format
 				formatter.TimeSinceInHuman(c.CreatedAt),
 				c.Status,
 				c.Ports,
-				name,
+				c.Names,
 			}
 			if wide {
 				format += "\t%s\t%s\t%s\n"

--- a/cmd/nerdctl/container_list_linux_test.go
+++ b/cmd/nerdctl/container_list_linux_test.go
@@ -223,6 +223,24 @@ func TestContainerListWithLabels(t *testing.T) {
 	})
 }
 
+func TestContainerListWithNames(t *testing.T) {
+	base, testContainer := preparePsTestContainer(t, "listWithNames", true)
+
+	// hope there are no tests running parallel
+	base.Cmd("ps", "-n", "1", "--format", "{{.Names}}").AssertOutWithFunc(func(stdout string) error {
+
+		// An example of nerdctl ps --format "{{.Names}}"
+		lines := strings.Split(strings.TrimSpace(stdout), "\n")
+		if len(lines) != 1 {
+			return fmt.Errorf("expected 1 line, got %d", len(lines))
+		}
+
+		assert.Equal(t, lines[0], testContainer.name)
+
+		return nil
+	})
+}
+
 func TestContainerListWithFilter(t *testing.T) {
 	base, testContainerA := preparePsTestContainer(t, "listWithFilterA", true)
 	_, testContainerB := preparePsTestContainer(t, "listWithFilterB", true)

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -92,7 +92,7 @@ type ListItem struct {
 	ID        string
 	Image     string
 	Platform  string // nerdctl extension
-	Names     []string
+	Names     string
 	Ports     string
 	Status    string
 	Runtime   string // nerdctl extension
@@ -130,7 +130,7 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 			ID:        id,
 			Image:     info.Image,
 			Platform:  info.Labels[labels.Platform],
-			Names:     []string{getContainerName(info.Labels)},
+			Names:     getContainerName(info.Labels),
 			Ports:     formatter.FormatPorts(info.Labels),
 			Status:    formatter.ContainerStatus(ctx, c),
 			Runtime:   info.Runtime.Name,


### PR DESCRIPTION
The `docker ps --format`  is inconsistent with docker , the brackets is not appeared in the docker.

fix: https://github.com/containerd/nerdctl/issues/2593