### PR TITLE
[WIP]Workaround to vagrant up for freebsd

### DIFF
--- a/Vagrantfile.freebsd
+++ b/Vagrantfile.freebsd
@@ -18,7 +18,9 @@
 # Vagrantfile for FreeBSD
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/freebsd13"
-
+  # workaround for https://github.com/containerd/nerdctl/issues/2596
+  config.vm.box_version = "4.3.2"
+  
   memory = 2048
   cpus = 1
   config.vm.provider :virtualbox do |v, o|


### PR DESCRIPTION
The vargrant version 4.3.4 updated 3 days ago is error. https://app.vagrantup.com/generic/boxes/freebsd13/versions/4.3.4
So roll the version back to 4.3.2 .

fix: https://github.com/containerd/nerdctl/issues/2596