### PR TITLE
Fix CI: `Vagrantfile.freebsd: pin generic/freebsd13 to version 4.3.2`; `compose_config_test: workaround for Docker Compose v2.23.0`

### DIFF
--- a/Vagrantfile.freebsd
+++ b/Vagrantfile.freebsd
@@ -18,6 +18,8 @@
 # Vagrantfile for FreeBSD
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/freebsd13"
+  # workaround for https://github.com/containerd/nerdctl/issues/2596
+  config.vm.box_version = "4.3.2"
 
   memory = 2048
   cpus = 1

--- a/cmd/nerdctl/compose_config_test.go
+++ b/cmd/nerdctl/compose_config_test.go
@@ -68,7 +68,11 @@ services:
 	comp := testutil.NewComposeDir(t, fmt.Sprintf(dockerComposeYAML, "3.13"))
 	defer comp.CleanUp()
 
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--hash=*").AssertOutContains("hello1")
+	// `--hash=*` is broken in Docker Compose v2.23.0: https://github.com/docker/compose/issues/11145
+	if base.Target == testutil.Nerdctl {
+		base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--hash=*").AssertOutContains("hello1")
+	}
+
 	hash := base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--hash=hello1").Out()
 
 	newComp := testutil.NewComposeDir(t, fmt.Sprintf(dockerComposeYAML, "3.14"))


### PR DESCRIPTION
## Vagrantfile.freebsd: pin generic/freebsd13 to version 4.3.2
The latest version (v4.3.4) is currently broken

Fix #2596

Carry #2597 (originally submitted by @yankay)

## `compose_config_test: workaround for Docker Compose v2.23.0`

The test for `docker compose config --hash=*` has to be temporarily skipped,
as `docker compose config --hash=*` is broken in Docker Compose v2.23.0
- docker/compose#11145

Fix #2605