### PR TITLE
nerdctl-full: build containerd and ipfs as static binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,10 +73,7 @@ WORKDIR /go/src/github.com/containerd/containerd
 RUN git checkout ${CONTAINERD_VERSION} && \
   mkdir -p /out /out/$TARGETARCH && \
   cp -a containerd.service /out
-ENV CGO_ENABLED=1
-ENV GO111MODULE=off
-# TODO: how to build containerd as static binaries? https://github.com/containerd/containerd/issues/6158
-RUN GO=xx-go make && \
+RUN GO=xx-go make STATIC=1 && \
   cp -a bin/containerd bin/containerd-shim-runc-v2 bin/ctr /out/$TARGETARCH
 
 FROM build-base-debian AS build-runc

--- a/Dockerfile.d/SHA256SUMS.d/kubo-v0.23.0
+++ b/Dockerfile.d/SHA256SUMS.d/kubo-v0.23.0
@@ -1,3 +1,0 @@
-# From https://github.com/ipfs/kubo/releases
-b78d209ce9b5797534348c6939d305b8758b0e4bc3abae532b63d15d9cddb9c6  kubo_v0.23.0_linux-amd64.tar.gz
-0de1bf8564f563b77e7bef620f357c0787b2fad37378c8cdb789a55959e5b543  kubo_v0.23.0_linux-arm64.tar.gz


### PR DESCRIPTION
Fix #266


stargz-snapshotter is still build as dynamic binaries, until the following PR gets merged:
- https://github.com/containerd/stargz-snapshotter/pull/1447