### PR TITLE
Fix --add-host overwritten

### DIFF
--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -133,7 +133,7 @@ func (x *store) Acquire(meta Meta) error {
 		if err := os.WriteFile(metaPath, metaB, 0644); err != nil {
 			return err
 		}
-		return newUpdater(meta.ID, x.hostsD, meta.ExtraHosts).update()
+		return newUpdater(meta.ID, x.hostsD).update()
 	}
 	return lockutil.WithDirLock(x.hostsD, fn)
 }
@@ -153,7 +153,7 @@ func (x *store) Release(ns, id string) error {
 		if err := os.RemoveAll(metaPath); err != nil {
 			return err
 		}
-		return newUpdater(id, x.hostsD, nil).update()
+		return newUpdater(id, x.hostsD).update()
 	}
 	return lockutil.WithDirLock(x.hostsD, fn)
 }
@@ -177,7 +177,7 @@ func (x *store) Update(ns, id, newName string) error {
 		if err := os.WriteFile(metaPath, metaB, 0644); err != nil {
 			return err
 		}
-		return newUpdater(meta.ID, x.hostsD, meta.ExtraHosts).update()
+		return newUpdater(meta.ID, x.hostsD).update()
 	}
 	return lockutil.WithDirLock(x.hostsD, fn)
 }

--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -30,14 +30,13 @@ import (
 )
 
 // newUpdater creates an updater for hostsD (/var/lib/nerdctl/<ADDRHASH>/etchosts)
-func newUpdater(id, hostsD string, extraHosts map[string]string) *updater {
+func newUpdater(id, hostsD string) *updater {
 	u := &updater{
 		id:            id,
 		hostsD:        hostsD,
 		metaByIPStr:   make(map[string]*Meta),
 		nwNameByIPStr: make(map[string]string),
 		metaByDir:     make(map[string]*Meta),
-		extraHosts:    extraHosts,
 	}
 	return u
 }
@@ -49,7 +48,6 @@ type updater struct {
 	metaByIPStr   map[string]*Meta  // key: IP string
 	nwNameByIPStr map[string]string // key: IP string, value: key of Meta.Networks
 	metaByDir     map[string]*Meta  // key: "/var/lib/nerdctl/<ADDRHASH>/etchosts/<NS>/<ID>"
-	extraHosts    map[string]string // key: host value: IP string
 }
 
 // update updates the hostsD tree.
@@ -136,10 +134,8 @@ func (u *updater) phase2() error {
 		buf.WriteString("::1		localhost localhost.localdomain\n")
 
 		// keep extra hosts first
-		if u.id == myMeta.ID {
-			for host, ip := range u.extraHosts {
-				buf.WriteString(fmt.Sprintf("%-15s %s\n", ip, host))
-			}
+		for host, ip := range myMeta.ExtraHosts {
+			buf.WriteString(fmt.Sprintf("%-15s %s\n", ip, host))
 		}
 
 		for ip, nwName := range u.nwNameByIPStr {


### PR DESCRIPTION
https://github.com/containerd/nerdctl/issues/2560 
I fixed a problem that the `--add-host` items disappear when the another container created. The problem is called "first bug" in the issue above.

During the oci-hook, the `hosts` files for all containers are overwritten.
The main cause was that for containers other than the one involved in the oci-hook, the output of the ExtraHosts entries was skipped. I've made a correction to ensure it doesn't get skipped.

I would appreciate it if you could take a look.

## Repro Steps
A simpler way to reproduce the bug.

Run a contianer
```
cid=$(nerdctl run -d --add-host host.docker.internal:host-gateway nginx)
nerdctl exec -it "$cid" cat /etc/hosts
```

Run another container
```
nerdctl run --rm alpine
```

The ExtraHosts entry of the first container disappears
```
nerdctl exec -it "$cid" cat /etc/hosts
```