### PR TITLE
bump up stargz snapshotter to v0.15.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG CNI_PLUGINS_VERSION=v1.3.0
 # Extra deps: Build
 ARG BUILDKIT_VERSION=v0.12.2
 # Extra deps: Lazy-pulling
-ARG STARGZ_SNAPSHOTTER_VERSION=v0.14.3
+ARG STARGZ_SNAPSHOTTER_VERSION=v0.15.1
 # Extra deps: Encryption
 ARG IMGCRYPT_VERSION=v1.1.8
 # Extra deps: Rootless

--- a/Dockerfile.d/SHA256SUMS.d/stargz-snapshotter-v0.14.3
+++ b/Dockerfile.d/SHA256SUMS.d/stargz-snapshotter-v0.14.3
@@ -1,3 +1,0 @@
-3f5c268eac6c68f1caeb433321a07e6332ed304e9b3ae428f183982ce6df91d6  stargz-snapshotter-v0.14.3-linux-amd64.tar.gz
-5788407890786210ea9552a62fd653cea3acc48ffd354f66e5821967128d06d9  stargz-snapshotter-v0.14.3-linux-arm64.tar.gz
-f1cf855870af16a653d8acb9daa3edf84687c2c05323cb958f078fb148af3eec  stargz-snapshotter.service

--- a/Dockerfile.d/SHA256SUMS.d/stargz-snapshotter-v0.15.1
+++ b/Dockerfile.d/SHA256SUMS.d/stargz-snapshotter-v0.15.1
@@ -1,0 +1,3 @@
+7f25b570f5e954a33df695d41fdf60d060a3096066f1668236fb5e1b4c7b7753  stargz-snapshotter-v0.15.1-linux-amd64.tar.gz
+4bd1ac3331501e14d87f5f8c3cde82cb08971d9b55643eb80155f74261e82a5a  stargz-snapshotter-v0.15.1-linux-arm64.tar.gz
+f1cf855870af16a653d8acb9daa3edf84687c2c05323cb958f078fb148af3eec  stargz-snapshotter.service


### PR DESCRIPTION
Following-up: #2610

Release note: https://github.com/containerd/stargz-snapshotter/releases/tag/v0.15.1

v0.15.1 starts providing statically built binaries.