### PR TITLE
[build][iidfile] Set the same permissions as docker

### DIFF
--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -91,7 +91,7 @@ func Build(ctx context.Context, client *containerd.Client, options types.Builder
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(options.IidFile, []byte(id), 0600); err != nil {
+		if err := os.WriteFile(options.IidFile, []byte(id), 0644); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Docker makes the file readable by other users, nerdctl makes only readable by the user created the file, which breaks compatibility.

See https://github.com/docker/buildx/blob/ff8bca206b389bc09e8e0a9afb5bf21f3d51686d/commands/build.go#L297C1-L298C1