### PR TITLE
Add SOCI index digest flag

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -757,6 +757,7 @@ Flags:
 - :nerd_face: `--cosign-certificate-oidc-issuer`: The OIDC issuer expected in a valid Fulcio certificate for --verify=cosign,, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows
 - :nerd_face: `--cosign-certificate-oidc-issuer-regexp`: A regular expression alternative to --certificate-oidc-issuer for --verify=cosign,. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
+- :nerd_face: `--soci-index-digest`: Specify a particular index digest for SOCI. If left empty, SOCI will automatically use the index determined by the selection policy.
 
 Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true)
 

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -16,7 +16,11 @@
 
 package types
 
-import "io"
+import (
+	"io"
+
+	"github.com/containerd/nerdctl/pkg/imgutil"
+)
 
 // ImageListOptions specifies options for `nerdctl image list`.
 type ImageListOptions struct {
@@ -193,6 +197,8 @@ type ImagePullOptions struct {
 	Quiet bool
 	// multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)
 	IPFSAddress string
+	// Flags to pass into remote snapshotters
+	RFlags imgutil.RemoteSnapshotterFlags
 }
 
 // ImageTagOptions specifies options for `nerdctl (image) tag`.

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -125,7 +125,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 				ipfsPath = dir
 			}
 			_, err = ipfs.EnsureImage(ctx, client, stdout, stderr, globalOptions.Snapshotter, scheme, ref,
-				pullMode, ocispecPlatforms, nil, quiet, ipfsPath)
+				pullMode, ocispecPlatforms, nil, quiet, ipfsPath, imgutil.RemoteSnapshotterFlags{})
 			return err
 		}
 
@@ -136,7 +136,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 		}
 
 		_, err = imgutil.EnsureImage(ctx, client, stdout, stderr, globalOptions.Snapshotter, ref,
-			pullMode, globalOptions.InsecureRegistry, globalOptions.HostsDir, ocispecPlatforms, nil, quiet)
+			pullMode, globalOptions.InsecureRegistry, globalOptions.HostsDir, ocispecPlatforms, nil, quiet, imgutil.RemoteSnapshotterFlags{})
 		return err
 	}
 

--- a/pkg/cmd/image/pull.go
+++ b/pkg/cmd/image/pull.go
@@ -76,7 +76,7 @@ func EnsureImage(ctx context.Context, client *containerd.Client, rawRef string, 
 		}
 
 		ensured, err = ipfs.EnsureImage(ctx, client, options.Stdout, options.Stderr, options.GOptions.Snapshotter, scheme, ref,
-			pull, ocispecPlatforms, unpack, quiet, ipfsPath)
+			pull, ocispecPlatforms, unpack, quiet, ipfsPath, options.RFlags)
 		if err != nil {
 			return nil, err
 		}
@@ -89,7 +89,7 @@ func EnsureImage(ctx context.Context, client *containerd.Client, rawRef string, 
 	}
 
 	ensured, err = imgutil.EnsureImage(ctx, client, options.Stdout, options.Stderr, options.GOptions.Snapshotter, ref,
-		pull, options.GOptions.InsecureRegistry, options.GOptions.HostsDir, ocispecPlatforms, unpack, quiet)
+		pull, options.GOptions.InsecureRegistry, options.GOptions.HostsDir, ocispecPlatforms, unpack, quiet, options.RFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/imgutil/snapshotter.go
+++ b/pkg/imgutil/snapshotter.go
@@ -48,10 +48,14 @@ var builtinRemoteSnapshotterOpts = map[string]snapshotterOpts{
 	snapshotterNameCvmfs:     &remoteSnapshotterOpts{snapshotter: "cvmfs-snapshotter"},
 }
 
+type RemoteSnapshotterFlags struct {
+	SociIndexDigest string
+}
+
 // snapshotterOpts is used to update pull config
 // for different snapshotters
 type snapshotterOpts interface {
-	apply(config *pull.Config, ref string)
+	apply(config *pull.Config, ref string, rFlags RemoteSnapshotterFlags)
 	isRemote() bool
 }
 
@@ -73,17 +77,17 @@ func getSnapshotterOpts(snapshotter string) snapshotterOpts {
 // interface `snapshotterOpts.isRemote()` function
 type remoteSnapshotterOpts struct {
 	snapshotter string
-	extraLabels func(func(images.Handler) images.Handler) func(images.Handler) images.Handler
+	extraLabels func(func(images.Handler) images.Handler, RemoteSnapshotterFlags) func(images.Handler) images.Handler
 }
 
 func (rs *remoteSnapshotterOpts) isRemote() bool {
 	return true
 }
 
-func (rs *remoteSnapshotterOpts) apply(config *pull.Config, ref string) {
+func (rs *remoteSnapshotterOpts) apply(config *pull.Config, ref string, rFlags RemoteSnapshotterFlags) {
 	h := ctdsnapshotters.AppendInfoHandlerWrapper(ref)
 	if rs.extraLabels != nil {
-		h = rs.extraLabels(h)
+		h = rs.extraLabels(h, rFlags)
 	}
 	config.RemoteOpts = append(
 		config.RemoteOpts,
@@ -98,7 +102,7 @@ type defaultSnapshotterOpts struct {
 	snapshotter string
 }
 
-func (dsn *defaultSnapshotterOpts) apply(config *pull.Config, _ref string) {
+func (dsn *defaultSnapshotterOpts) apply(config *pull.Config, _ref string, rFlags RemoteSnapshotterFlags) {
 	config.RemoteOpts = append(
 		config.RemoteOpts,
 		containerd.WithPullSnapshotter(dsn.snapshotter))
@@ -109,10 +113,10 @@ func (dsn *defaultSnapshotterOpts) isRemote() bool {
 	return false
 }
 
-func stargzExtraLabels(f func(images.Handler) images.Handler) func(images.Handler) images.Handler {
+func stargzExtraLabels(f func(images.Handler) images.Handler, rFlags RemoteSnapshotterFlags) func(images.Handler) images.Handler {
 	return source.AppendExtraLabelsHandler(prefetchSize, f)
 }
 
-func sociExtraLabels(f func(images.Handler) images.Handler) func(images.Handler) images.Handler {
-	return socisource.AppendDefaultLabelsHandlerWrapper("", f)
+func sociExtraLabels(f func(images.Handler) images.Handler, rFlags RemoteSnapshotterFlags) func(images.Handler) images.Handler {
+	return socisource.AppendDefaultLabelsHandlerWrapper(rFlags.SociIndexDigest, f)
 }

--- a/pkg/imgutil/snapshotter_test.go
+++ b/pkg/imgutil/snapshotter_test.go
@@ -93,7 +93,8 @@ func sameOpts(want snapshotterOpts) func(*testing.T, snapshotterOpts) {
 func getAndApplyRemoteOpts(t *testing.T, sn string) *containerd.RemoteContext {
 	config := &pull.Config{}
 	snOpts := getSnapshotterOpts(sn)
-	snOpts.apply(config, testRef)
+	rFlags := RemoteSnapshotterFlags{}
+	snOpts.apply(config, testRef, rFlags)
 
 	rc := &containerd.RemoteContext{}
 	for _, o := range config.RemoteOpts {

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -40,7 +40,7 @@ import (
 const ipfsPathEnv = "IPFS_PATH"
 
 // EnsureImage pull the specified image from IPFS.
-func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr io.Writer, snapshotter string, scheme string, ref string, mode imgutil.PullMode, ocispecPlatforms []ocispec.Platform, unpack *bool, quiet bool, ipfsPath string) (*imgutil.EnsuredImage, error) {
+func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr io.Writer, snapshotter string, scheme string, ref string, mode imgutil.PullMode, ocispecPlatforms []ocispec.Platform, unpack *bool, quiet bool, ipfsPath string, rFlags imgutil.RemoteSnapshotterFlags) (*imgutil.EnsuredImage, error) {
 	switch mode {
 	case "always", "missing", "never":
 		// NOP
@@ -73,7 +73,7 @@ func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr 
 	if err != nil {
 		return nil, err
 	}
-	return imgutil.PullImage(ctx, client, stdout, stderr, snapshotter, r, ref, ocispecPlatforms, unpack, quiet)
+	return imgutil.PullImage(ctx, client, stdout, stderr, snapshotter, r, ref, ocispecPlatforms, unpack, quiet, rFlags)
 }
 
 // Push pushes the specified image to IPFS.


### PR DESCRIPTION
Addresses #2637.

`soci image rpull` and the SOCI library both allow for a particular SOCI index to be specified, so this change adds support for passing this in.

Since no existing structure was in place to pass flags to remote snapshotters, this change also introduces the structures needed to support such future changes. I did my best to ensure that, should any supported remote snapshotters need any additional flags, the changes needed to support such changes would be minimal, but please let me know if this does not scale properly.

I also added another test case to TestPullSoci with a garbage SOCI index to ensure it behaves the same as `soci image rpull`. I attempted to make the testing suite run on my machine, but couldn't get it to work, so apologies if that test case fails.