### PR TITLE
docs: read-only (RRO) bind-mount have been support by docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ Major:
 - [Image encryption and decryption using ocicrypt (imgcrypt)](./docs/ocicrypt.md): `nerdctl image (encrypt|decrypt) SRC DST`
 - [P2P image distribution using IPFS](./docs/ipfs.md): `nerdctl run ipfs://CID` .
   P2P image distribution (IPFS) is completely optional. Your host is NOT connected to any P2P network, unless you opt in to [install and run IPFS daemon](https://docs.ipfs.io/install/).
-- Recursive read-only (RRO) bind-mount: `nerdctl run -v /mnt:/mnt:rro` (make children such as `/mnt/usb` to be read-only, too).
-  Requires kernel >= 5.12, and crun >= 1.4 or runc >= 1.1 (PR [#3272](https://github.com/opencontainers/runc/pull/3272)).
 - [Cosign integration](./docs/cosign.md): `nerdctl pull --verify=cosign` and `nerdctl push --sign=cosign`, and [in Compose](./docs/cosign.md#cosign-in-compose)
 - [Accelerated rootless containers using bypass4netns](./docs/rootless.md): `nerdctl run --label nerdctl/bypass4netns=true`
 
@@ -210,6 +208,11 @@ Trivial:
 
 - Inspecting raw OCI config: `nerdctl container inspect --mode=native` .
 
+## Features implemented in `nerdctl` ahead of Docker
+
+- Recursive read-only (RRO) bind-mount: `nerdctl run -v /mnt:/mnt:rro` (make children such as `/mnt/usb` to be read-only, too).
+  Requires kernel >= 5.12.
+The same feature was later introduced in Docker v25 with a different syntax. nerdctl will support Docker v25 syntax too in the future.
 ## Similar tools
 
 - [`ctr`](https://github.com/containerd/containerd/tree/main/cmd/ctr): incompatible with Docker CLI, and not friendly to users.


### PR DESCRIPTION
Read-only (RRO) bind-mount have been support by docker by https://github.com/moby/moby/pull/45278.

It will been release in docker v25.0.0.
So remove it after the v25.0.0 be released, https://github.com/moby/moby/milestone/119
