### PR TITLE
Allow for binding a named pipe on Windows

### DIFF
--- a/cmd/nerdctl/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container_run_mount_linux_test.go
@@ -85,8 +85,22 @@ func TestRunVolume(t *testing.T) {
 func TestRunAnonymousVolume(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	base.Cmd("run", "--rm", "-v", "/foo", testutil.AlpineImage,
-		"mountpoint", "-q", "/foo").AssertOK()
+	base.Cmd("run", "--rm", "-v", "/foo", testutil.AlpineImage).AssertOK()
+	base.Cmd("run", "--rm", "-v", "TestVolume2:/foo", testutil.AlpineImage).AssertOK()
+	base.Cmd("run", "--rm", "-v", "TestVolume", testutil.AlpineImage).AssertOK()
+
+	// Destination must be an absolute path not named volume
+	base.Cmd("run", "--rm", "-v", "TestVolume2:TestVolumes", testutil.AlpineImage).AssertFail()
+}
+
+func TestRunVolumeRelativePath(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", "./foo:/mnt/foo", testutil.AlpineImage).AssertOK()
+	base.Cmd("run", "--rm", "-v", "./foo", testutil.AlpineImage).AssertOK()
+
+	// Destination must be an absolute path not a relative path
+	base.Cmd("run", "--rm", "-v", "./foo:./foo", testutil.AlpineImage).AssertFail()
 }
 
 func TestRunAnonymousVolumeWithTypeMountFlag(t *testing.T) {

--- a/cmd/nerdctl/container_run_mount_windows_test.go
+++ b/cmd/nerdctl/container_run_mount_windows_test.go
@@ -1,0 +1,214 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/containerd/nerdctl/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/pkg/testutil"
+	"gotest.tools/v3/assert"
+)
+
+func TestRunMountVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+	rwDir, err := os.MkdirTemp(t.TempDir(), "rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roDir, err := os.MkdirTemp(t.TempDir(), "ro")
+	if err != nil {
+		t.Fatal(err)
+	}
+	rwVolName := tID + "-rw"
+	roVolName := tID + "-ro"
+	for _, v := range []string{rwVolName, roVolName} {
+		defer base.Cmd("volume", "rm", "-f", v).Run()
+		base.Cmd("volume", "create", v).AssertOK()
+	}
+
+	containerName := tID
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+	base.Cmd("run",
+		"-d",
+		"--name", containerName,
+		"-v", fmt.Sprintf("%s:C:/mnt1", rwDir),
+		"-v", fmt.Sprintf("%s:C:/mnt2:ro", roDir),
+		"-v", fmt.Sprintf("%s:C:/mnt3", rwVolName),
+		"-v", fmt.Sprintf("%s:C:/mnt4:ro", roVolName),
+		testutil.CommonImage,
+		"ping localhost -t",
+	).AssertOK()
+
+	base.Cmd("exec", containerName, "cmd", "/c", "echo -n str1 > C:/mnt1/file1").AssertOK()
+	base.Cmd("exec", containerName, "cmd", "/c", "echo -n str2 > C:/mnt2/file2").AssertFail()
+	base.Cmd("exec", containerName, "cmd", "/c", "echo -n str3 > C:/mnt3/file3").AssertOK()
+	base.Cmd("exec", containerName, "cmd", "/c", "echo -n str4 > C:/mnt4/file4").AssertFail()
+	base.Cmd("rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run",
+		"--rm",
+		"-v", fmt.Sprintf("%s:C:/mnt1", rwDir),
+		"-v", fmt.Sprintf("%s:C:/mnt3", rwVolName),
+		testutil.CommonImage,
+		"cat", "C:/mnt1/file1", "C:/mnt3/file3",
+	).AssertOutContainsAll("str1", "str3")
+	base.Cmd("run",
+		"--rm",
+		"-v", fmt.Sprintf("%s:C:/mnt3/mnt1", rwDir),
+		"-v", fmt.Sprintf("%s:C:/mnt3", rwVolName),
+		testutil.CommonImage,
+		"cat", "C:/mnt3/mnt1/file1", "C:/mnt3/file3",
+	).AssertOutContainsAll("str1", "str3")
+}
+
+func TestRunMountVolumeInspect(t *testing.T) {
+	base := testutil.NewBase(t)
+	testContainer := testutil.Identifier(t)
+	testVolume := testutil.Identifier(t)
+
+	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
+	base.Cmd("volume", "create", testVolume).AssertOK()
+	inspectVolume := base.InspectVolume(testVolume)
+	namedVolumeSource := inspectVolume.Mountpoint
+
+	base.Cmd(
+		"run", "-d", "--name", testContainer,
+		"-v", "C:/mnt1",
+		"-v", "C:/mnt2:C:/mnt2",
+		"-v", "\\\\.\\pipe\\containerd-containerd:\\\\.\\pipe\\containerd-containerd",
+		"-v", fmt.Sprintf("%s:C:/mnt3", testVolume),
+		testutil.CommonImage,
+	).AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+	// convert array to map to get by key of Destination
+	actual := make(map[string]dockercompat.MountPoint)
+	for i := range inspect.Mounts {
+		actual[inspect.Mounts[i].Destination] = inspect.Mounts[i]
+	}
+
+	expected := []struct {
+		dest       string
+		mountPoint dockercompat.MountPoint
+	}{
+		// anonymous volume
+		{
+			dest: "C:\\mnt1",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "volume",
+				Source:      "", // source of anonymous volume is a generated path, so here will not check it.
+				Destination: "C:\\mnt1",
+			},
+		},
+
+		// bind
+		{
+			dest: "C:\\mnt2",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "bind",
+				Source:      "C:\\mnt2",
+				Destination: "C:\\mnt2",
+			},
+		},
+
+		// named pipe
+		{
+			dest: "\\\\.\\pipe\\containerd-containerd",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "npipe",
+				Source:      "\\\\.\\pipe\\containerd-containerd",
+				Destination: "\\\\.\\pipe\\containerd-containerd",
+			},
+		},
+
+		// named volume
+		{
+			dest: "C:\\mnt3",
+			mountPoint: dockercompat.MountPoint{
+				Type:        "volume",
+				Name:        testVolume,
+				Source:      namedVolumeSource,
+				Destination: "C:\\mnt3",
+			},
+		},
+	}
+
+	for i := range expected {
+		testCase := expected[i]
+		t.Logf("test volume[dest=%q]", testCase.dest)
+
+		mountPoint, ok := actual[testCase.dest]
+		assert.Assert(base.T, ok)
+
+		assert.Equal(base.T, testCase.mountPoint.Type, mountPoint.Type)
+		assert.Equal(base.T, testCase.mountPoint.Destination, mountPoint.Destination)
+
+		if testCase.mountPoint.Source == "" {
+			// for anonymous volumes, we want to make sure that the source is not the same as the destination
+			assert.Assert(base.T, mountPoint.Source != testCase.mountPoint.Destination)
+		} else {
+			assert.Equal(base.T, testCase.mountPoint.Source, mountPoint.Source)
+		}
+
+		if testCase.mountPoint.Name != "" {
+			assert.Equal(base.T, testCase.mountPoint.Name, mountPoint.Name)
+		}
+	}
+}
+
+func TestRunMountAnonymousVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", "TestVolume:C:/mnt", testutil.CommonImage).AssertOK()
+
+	// For docker-campatibility, Unrecognised volume spec: invalid volume specification: 'TestVolume'
+	base.Cmd("run", "--rm", "-v", "TestVolume", testutil.CommonImage).AssertFail()
+
+	// Destination must be an absolute path not named volume
+	base.Cmd("run", "--rm", "-v", "TestVolume2:TestVolumes", testutil.CommonImage).AssertFail()
+}
+
+func TestRunMountRelativePath(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", "./mnt:C:/mnt1", testutil.CommonImage, "cmd").AssertOK()
+
+	// Destination cannot be a relative path
+	base.Cmd("run", "--rm", "-v", "./mnt", testutil.CommonImage).AssertFail()
+	base.Cmd("run", "--rm", "-v", "./mnt:./mnt1", testutil.CommonImage, "cmd").AssertFail()
+}
+
+func TestRunMountNamedPipeVolume(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", `\\.\pipe\containerd-containerd`, testutil.CommonImage).AssertFail()
+}
+
+func TestRunMountVolumeSpec(t *testing.T) {
+	t.Parallel()
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", "-v", `InvalidPathC:\TestVolume:C:\Mount`, testutil.CommonImage).AssertFail()
+	base.Cmd("run", "--rm", "-v", `C:\TestVolume:C:\Mount:ro,rw:boot`, testutil.CommonImage).AssertFail()
+
+	// If -v is an empty string, it will be ignored
+	base.Cmd("run", "--rm", "-v", "", testutil.CommonImage).AssertOK()
+}

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/vishvananda/netns v0.0.4
 	github.com/yuchanns/srslog v1.1.0
+	go.uber.org/mock v0.3.0
 	golang.org/x/crypto v0.17.0
 	golang.org/x/net v0.19.0
 	golang.org/x/sync v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -338,6 +338,8 @@ go.opentelemetry.io/otel/metric v1.19.0/go.mod h1:L5rUsV9kM1IxCj1MmSdS+JQAcVm319
 go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg=
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/mock v0.3.0 h1:3mUxI1No2/60yUYax92Pt8eNOEecx2D3lcXZh2NEZJo=
+go.uber.org/mock v0.3.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -295,7 +295,9 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// perform network setup/teardown in the main nerdctl executable.
 	if containerErr == nil && runtime.GOOS == "windows" {
 		netSetupErr = netManager.SetupNetworking(ctx, id)
-		log.G(ctx).WithError(netSetupErr).Warnf("networking setup error has occurred")
+		if netSetupErr != nil {
+			log.G(ctx).WithError(netSetupErr).Warnf("networking setup error has occurred")
+		}
 	}
 
 	if containerErr != nil || netSetupErr != nil {

--- a/pkg/mountutil/mountutil_freebsd.go
+++ b/pkg/mountutil/mountutil_freebsd.go
@@ -26,13 +26,17 @@ import (
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 )
 
+const (
+	DefaultMountType = "nullfs"
+
+	// FreeBSD doesn't support bind mounts.
+	DefaultPropagationMode = ""
+)
+
 func UnprivilegedMountFlags(path string) ([]string, error) {
 	m := []string{}
 	return m, nil
 }
-
-// FreeBSD doesn't support bind mounts.
-const DefaultPropagationMode = ""
 
 // parseVolumeOptions parses specified optsRaw with using information of
 // the volume type and the src directory when necessary.

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -44,6 +44,15 @@ import (
    NOTICE: https://github.com/moby/moby/blob/v20.10.5/NOTICE
 */
 
+const (
+	DefaultMountType = "none"
+
+	// DefaultPropagationMode is the default propagation of mounts
+	// where user doesn't specify mount propagation explicitly.
+	// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/linux_parser.go#L145
+	DefaultPropagationMode = "rprivate"
+)
+
 // UnprivilegedMountFlags is from https://github.com/moby/moby/blob/v20.10.5/daemon/oci_linux.go#L420-L450
 //
 // Get the set of mount flags that are set on the mount that contains the given
@@ -77,11 +86,6 @@ func UnprivilegedMountFlags(path string) ([]string, error) {
 
 	return flags, nil
 }
-
-// DefaultPropagationMode is the default propagation of mounts
-// where user doesn't specify mount propagation explicitly.
-// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/linux_parser.go#L145
-const DefaultPropagationMode = "rprivate"
 
 // parseVolumeOptions parses specified optsRaw with using information of
 // the volume type and the src directory when necessary.

--- a/pkg/mountutil/mountutil_other.go
+++ b/pkg/mountutil/mountutil_other.go
@@ -1,0 +1,66 @@
+//go:build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mountutil
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
+)
+
+func splitVolumeSpec(s string) ([]string, error) {
+	s = strings.TrimLeft(s, ":")
+	split := strings.Split(s, ":")
+	return split, nil
+}
+
+func handleVolumeToMount(source string, dst string, volStore volumestore.VolumeStore, createDir bool) (volumeSpec, error) {
+	switch {
+	// Handle named volumes
+	case isNamedVolume(source):
+		return handleNamedVolumes(source, volStore)
+
+	// Handle bind volumes (file paths)
+	default:
+		return handleBindMounts(source, createDir)
+	}
+}
+
+func cleanMount(p string) string {
+	return filepath.Clean(p)
+}
+
+func isValidPath(s string) (bool, error) {
+	if filepath.IsAbs(s) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("expected an absolute path, got %q", s)
+}
+
+/*
+For docker compatibility on non-Windows platforms:
+Docker allows anonymous named volumes, relative paths, and absolute paths
+to be mounted into a container.
+*/
+func validateAnonymousVolumeDestination(s string) (bool, error) {
+	return true, nil
+}

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -1,3 +1,5 @@
+//go:build windows
+
 /*
    Copyright The containerd Authors.
 
@@ -14,10 +16,19 @@
    limitations under the License.
 */
 
+/*
+   Portions from https://github.com/moby/moby/blob/f5c7673ff8fcbd359f75fb644b1365ca9d20f176/volume/mounts/windows_parser.go#L26
+   Copyright (C) Docker/Moby authors.
+   Licensed under the Apache License, Version 2.0
+   NOTICE: https://github.com/moby/moby/blob/master/NOTICE
+*/
+
 package mountutil
 
 import (
 	"fmt"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/containerd/containerd/errdefs"
@@ -26,15 +37,21 @@ import (
 	"github.com/containerd/nerdctl/pkg/mountutil/volumestore"
 )
 
+const (
+	// Defaults to an empty string
+	// https://github.com/microsoft/hcsshim/blob/5c75f29c1f5cb4d3498d66228637d07477bcb6a1/internal/hcsoci/resources_wcow.go#L140
+	DefaultMountType = ""
+
+	// DefaultPropagationMode is the default propagation of mounts
+	// where user doesn't specify mount propagation explicitly.
+	// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/windows_parser.go#L440-L442
+	DefaultPropagationMode = ""
+)
+
 func UnprivilegedMountFlags(path string) ([]string, error) {
 	m := []string{}
 	return m, nil
 }
-
-// DefaultPropagationMode is the default propagation of mounts
-// where user doesn't specify mount propagation explicitly.
-// See also: https://github.com/moby/moby/blob/v20.10.7/volume/mounts/windows_parser.go#L440-L442
-const DefaultPropagationMode = ""
 
 // parseVolumeOptions parses specified optsRaw with using information of
 // the volume type and the src directory when necessary.
@@ -67,4 +84,174 @@ func ProcessFlagTmpfs(s string) (*Processed, error) {
 
 func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, error) {
 	return nil, errdefs.ErrNotImplemented
+}
+
+func handleVolumeToMount(source string, dst string, volStore volumestore.VolumeStore, createDir bool) (volumeSpec, error) {
+	// Validate source and destination types
+	if _, err := (validateNamedPipeSpec(source, dst)); err != nil {
+		return volumeSpec{}, err
+	}
+
+	switch {
+	// Handle named volumes
+	case isNamedVolume(source):
+		return handleNamedVolumes(source, volStore)
+
+	// Handle named pipes
+	case isNamedPipe(source):
+		return handleNpipeToMount(source)
+
+	// Handle bind volumes (file paths)
+	default:
+		return handleBindMounts(source, createDir)
+	}
+}
+
+func handleNpipeToMount(source string) (volumeSpec, error) {
+	res := volumeSpec{
+		Type:   Npipe,
+		Source: source,
+	}
+	return res, nil
+}
+
+func splitVolumeSpec(raw string) ([]string, error) {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimLeft(raw, ":")
+	if raw == "" {
+		return nil, fmt.Errorf("invalid empty volume specification")
+	}
+
+	const (
+		// Root drive or relative paths starting with .
+		rxHostDir = `(?:[a-zA-Z]:|\.)[\/\\]`
+
+		// https://learn.microsoft.com/en-us/dotnet/standard/io/file-path-formats
+		// Windows UNC paths and DOS device paths (and namde pipes)
+		rxUNC  = `(?:\\{2}[a-zA-Z0-9_\-\.\?]+\\{1}[^\\*?"|\r\n]+)\\`
+		rxName = `[^\/\\:*?"<>|\r\n]+`
+
+		rxSource      = `((?P<source>((` + rxHostDir + `|` + rxUNC + `)` + `(` + rxName + `[\/\\]?)+` + `|` + rxName + `)):)?`
+		rxDestination = `(?P<destination>(` + rxHostDir + `|` + rxUNC + `)` + `(` + rxName + `[\/\\]?)+` + `|` + rxName + `)`
+		rxMode        = `(?::(?P<mode>(?i)\w+(,\w+)?))`
+
+		rxWindows = `^` + rxSource + rxDestination + `(?:` + rxMode + `)?$`
+	)
+
+	compiledRegex, err := regexp.Compile(rxWindows)
+	if err != nil {
+		return nil, fmt.Errorf("error compiling regex: %s", err)
+	}
+	return splitRawSpec(raw, compiledRegex)
+}
+
+func isNamedPipe(s string) bool {
+	pattern := `^\\{2}.\\pipe\\[^\/\\:*?"<>|\r\n]+$`
+	matches, err := regexp.MatchString(pattern, s)
+	if err != nil {
+		log.L.Errorf("Invalid pattern %s", pattern)
+	}
+
+	return matches
+}
+
+func cleanMount(p string) string {
+	if isNamedPipe(p) {
+		return p
+	}
+	return filepath.Clean(p)
+}
+
+func isValidPath(s string) (bool, error) {
+	if isNamedPipe(s) || filepath.IsAbs(s) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("expected an absolute path or a named pipe, got %q", s)
+}
+
+/*
+For docker compatibility on Windows platforms:
+Docker only allows for absolute paths as anonymous volumes.
+Docker does not allows anonymous named volumes or anonymous named piped
+to be mounted into a container.
+*/
+func validateAnonymousVolumeDestination(s string) (bool, error) {
+	if isNamedPipe(s) || isNamedVolume(s) {
+		return false, fmt.Errorf("invalid volume specification: %q. only directories can be mapped as anonymous volumes", s)
+	}
+
+	if filepath.IsAbs(s) {
+		return true, nil
+	}
+
+	return false, fmt.Errorf("expected an absolute path, got %q", s)
+}
+
+func splitRawSpec(raw string, splitRegexp *regexp.Regexp) ([]string, error) {
+	match := splitRegexp.FindStringSubmatch(raw)
+	if len(match) == 0 {
+		return nil, fmt.Errorf("invalid volume specification: '%s'", raw)
+	}
+
+	var split []string
+	matchgroups := make(map[string]string)
+	// Pull out the sub expressions from the named capture groups
+	for i, name := range splitRegexp.SubexpNames() {
+		matchgroups[name] = match[i]
+	}
+	if source, exists := matchgroups["source"]; exists {
+		if source == "." {
+			return nil, fmt.Errorf("invalid volume specification: %q", raw)
+		}
+
+		if source != "" {
+			split = append(split, source)
+		}
+	}
+
+	mode, modExists := matchgroups["mode"]
+
+	if destination, exists := matchgroups["destination"]; exists {
+		if destination == "." {
+			return nil, fmt.Errorf("invalid volume specification: %q", raw)
+		}
+
+		// If mode exists and destination is empty, set destination to an empty string
+		// source::ro
+		if destination != "" || modExists && mode != "" {
+			split = append(split, destination)
+		}
+	}
+
+	if mode, exists := matchgroups["mode"]; exists {
+		if mode != "" {
+			split = append(split, mode)
+		}
+	}
+	return split, nil
+}
+
+// Function to parse the source type
+func parseSourceType(source string) string {
+	switch {
+	case isNamedVolume(source):
+		return Volume
+	case isNamedPipe(source):
+		return Npipe
+	// Add more cases for different source types as needed
+	default:
+		return Bind
+	}
+}
+
+func validateNamedPipeSpec(source string, dst string) (bool, error) {
+	// Validate source and destination types
+	sourceType := parseSourceType(source)
+	destType := parseSourceType(dst)
+
+	if (destType == Npipe && sourceType != Npipe) || (sourceType == Npipe && destType != Npipe) {
+		return false, fmt.Errorf("invalid volume specification. named pipes can only be mapped to named pipes")
+	}
+	return true, nil
 }

--- a/pkg/mountutil/mountutil_windows_test.go
+++ b/pkg/mountutil/mountutil_windows_test.go
@@ -17,9 +17,14 @@
 package mountutil
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	mocks "github.com/containerd/nerdctl/pkg/mountutil/mountutilmock"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
 )
@@ -75,6 +80,296 @@ func TestParseVolumeOptions(t *testing.T) {
 			}
 			assert.Equal(t, tt.wantFail, false)
 			assert.Check(t, is.DeepEqual(tt.wants, opts))
+		})
+	}
+}
+
+func TestSplitRawSpec(t *testing.T) {
+	tests := []struct {
+		rawSpec string
+		wants   []string
+	}{
+		// Absolute paths
+		{
+			rawSpec: `C:\TestVolume\Path:C:\TestVolume\Path:ro`,
+			wants:   []string{`C:\TestVolume\Path`, `C:\TestVolume\Path`, "ro"},
+		},
+		{
+			rawSpec: `C:\TestVolume\Path:C:\TestVolume\Path:ro,rw`,
+			wants:   []string{`C:\TestVolume\Path`, `C:\TestVolume\Path`, "ro,rw"},
+		},
+		{
+			rawSpec: `C:\TestVolume\Path:C:\TestVolume\Path:ro,undefined`,
+			wants:   []string{`C:\TestVolume\Path`, `C:\TestVolume\Path`, "ro,undefined"},
+		},
+		{
+			rawSpec: `C:\TestVolume\Path:C:\TestVolume\Path`,
+			wants:   []string{`C:\TestVolume\Path`, `C:\TestVolume\Path`},
+		},
+		{
+			rawSpec: `C:\TestVolume\Path`,
+			wants:   []string{`C:\TestVolume\Path`},
+		},
+		{
+			rawSpec: `C:\Test Volume\Path`, // space in path
+			wants:   []string{`C:\Test Volume\Path`},
+		},
+
+		// Relative paths
+		{
+			rawSpec: `.\ContainerVolumes:C:\TestVolumes`,
+			wants:   []string{`.\ContainerVolumes`, `C:\TestVolumes`},
+		},
+		{
+			rawSpec: `.\ContainerVolumes:.\ContainerVolumes`,
+			wants:   []string{`.\ContainerVolumes`, `.\ContainerVolumes`},
+		},
+
+		// Anonymous volumes
+		{
+			rawSpec: `.\ContainerVolumes`,
+			wants:   []string{`.\ContainerVolumes`},
+		},
+		{
+			rawSpec: `TestVolume`,
+			wants:   []string{`TestVolume`},
+		},
+		{
+			rawSpec: `:TestVolume`,
+			wants:   []string{`TestVolume`},
+		},
+
+		// UNC paths
+		{
+			rawSpec: `\\?\UNC\server\share\path:.\ContainerVolumesto`,
+			wants:   []string{`\\?\UNC\server\share\path`, `.\ContainerVolumesto`},
+		},
+		{
+			rawSpec: `\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\Test`,
+			wants:   []string{`\\.\Volume{b75e2c83-0000-0000-0000-602f00000000}\Test`},
+		},
+
+		// Named pipes
+		{
+			rawSpec: `\\.\pipe\containerd-containerd`,
+			wants:   []string{`\\.\pipe\containerd-containerd`},
+		},
+		{
+			rawSpec: `\\.\pipe\containerd-containerd:\\.\pipe\containerd-containerd`,
+			wants:   []string{`\\.\pipe\containerd-containerd`, `\\.\pipe\containerd-containerd`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.rawSpec, func(t *testing.T) {
+			actual, err := splitVolumeSpec(tt.rawSpec)
+			if err != nil {
+				t.Errorf("failed to split raw spec %q: %v", tt.rawSpec, err)
+				return
+
+			}
+			assert.Check(t, is.DeepEqual(tt.wants, actual))
+		})
+	}
+}
+
+func TestSplitRawSpecInvalid(t *testing.T) {
+	tests := []string{
+		"",                                     // Empty string
+		"   ",                                  // Empty string
+		`.`,                                    // Invalid relative path
+		`./`,                                   // Invalid relative path
+		`../`,                                  // Invalid relative path
+		`C:\`,                                  // Cannot mount root directory
+		`~\TestVolume`,                         // Invalid relative path
+		`..\TestVolume`,                        // Invalid relative path
+		`ABC:\ContainerVolumes:C:\TestVolumes`, // Invalid drive letter
+		`UNC\server\share\path`,                // Invalid path
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			_, err := splitVolumeSpec(path)
+			if strings.TrimSpace(path) == "" {
+				assert.Error(t, err, "invalid empty volume specification")
+				return
+			}
+			if path == "." {
+				assert.Error(t, err, "invalid volume specification: \".\"")
+				return
+			}
+			assert.Error(t, err, fmt.Sprintf("invalid volume specification: '%s'", path))
+		})
+	}
+}
+
+func TestProcessFlagV(t *testing.T) {
+	tests := []struct {
+		rawSpec string
+		wants   *Processed
+		err     string
+	}{
+		// Bind volumes: absolute path
+		{
+			rawSpec: "C:/TestVolume/Path:C:/TestVolume/Path:ro",
+			wants: &Processed{
+				Type: "bind",
+				Mount: specs.Mount{
+					Type:        "",
+					Destination: `C:\TestVolume\Path`,
+					Source:      `C:\TestVolume\Path`,
+					Options:     []string{"ro", "rbind"},
+				}},
+		},
+		// Bind volumes: relative path
+		{
+			rawSpec: `.\TestVolume\Path:C:\TestVolume\Path`,
+			wants: &Processed{
+				Type: "bind",
+				Mount: specs.Mount{
+					Type:        "",
+					Source:      "", // will not check source of relative paths
+					Destination: `C:\TestVolume\Path`,
+					Options:     []string{"rbind"},
+				}},
+		},
+		// Named volumes
+		{
+			rawSpec: `TestVolume:C:\TestVolume\Path`,
+			wants: &Processed{
+				Type: "volume",
+				Name: "TestVolume",
+				Mount: specs.Mount{
+					Type:        "",
+					Source:      "", // source of anonymous volume is a generated path, so here will not check it.
+					Destination: `C:\TestVolume\Path`,
+					Options:     []string{"rbind"},
+				}},
+		},
+		// Named pipes
+		{
+			rawSpec: `\\.\pipe\containerd-containerd:\\.\pipe\containerd-containerd`,
+			wants: &Processed{
+				Type: "npipe",
+				Mount: specs.Mount{
+					Type:        "",
+					Source:      `\\.\pipe\containerd-containerd`,
+					Destination: `\\.\pipe\containerd-containerd`,
+					Options:     []string{"rbind"},
+				}},
+		},
+		{
+			rawSpec: `\\.\pipe\containerd-containerd:C:\TestVolume\Path`,
+			err:     "invalid volume specification. named pipes can only be mapped to named pipes",
+		},
+		{
+			rawSpec: `C:\TestVolume\Path:TestVolume`,
+			err:     "expected an absolute path or a named pipe, got \"TestVolume\"",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVolumeStore := mocks.NewMockVolumeStore(ctrl)
+	mockVolumeStore.
+		EXPECT().
+		Get(gomock.Any(), false).
+		Return(&native.Volume{Name: "test_volume", Mountpoint: "C:\\test\\directory", Size: 1024}, nil).
+		AnyTimes()
+	mockVolumeStore.
+		EXPECT().
+		Create(gomock.Any(), nil).
+		Return(&native.Volume{Name: "test_volume", Mountpoint: "C:\\test\\directory"}, nil).AnyTimes()
+
+	mockOs := mocks.NewMockOs(ctrl)
+	mockOs.EXPECT().Stat(gomock.Any()).Return(nil, nil).AnyTimes()
+
+	for _, tt := range tests {
+		t.Run(tt.rawSpec, func(t *testing.T) {
+			processedVolSpec, err := ProcessFlagV(tt.rawSpec, mockVolumeStore, true)
+			if err != nil {
+				assert.Error(t, err, tt.err)
+				return
+			}
+
+			assert.Equal(t, processedVolSpec.Type, tt.wants.Type)
+			assert.Equal(t, processedVolSpec.Mount.Type, tt.wants.Mount.Type)
+			assert.Equal(t, processedVolSpec.Mount.Destination, tt.wants.Mount.Destination)
+			assert.DeepEqual(t, processedVolSpec.Mount.Options, tt.wants.Mount.Options)
+
+			if tt.wants.Name != "" {
+				assert.Equal(t, processedVolSpec.Name, tt.wants.Name)
+			}
+			if tt.wants.Mount.Source != "" {
+				assert.Equal(t, processedVolSpec.Mount.Source, tt.wants.Mount.Source)
+			}
+		})
+	}
+}
+
+func TestProcessFlagVAnonymousVolumes(t *testing.T) {
+	tests := []struct {
+		rawSpec string
+		wants   *Processed
+		err     string
+	}{
+		{
+			rawSpec: `C:\TestVolume\Path`,
+			wants: &Processed{
+				Type: "volume",
+				Mount: specs.Mount{
+					Type:        "",
+					Source:      "", // source of anonymous volume is a generated path, so here will not check it.
+					Destination: `C:\TestVolume\Path`,
+				}},
+		},
+		{
+			rawSpec: `.\TestVolume\Path`,
+			err:     "expected an absolute path",
+		},
+		{
+			rawSpec: `TestVolume`,
+			err:     "only directories can be mapped as anonymous volumes",
+		},
+		{
+			rawSpec: `C:\TestVolume\Path::ro`,
+			err:     "failed to split volume mount specification",
+		},
+		{
+			rawSpec: `\\.\pipe\containerd-containerd`,
+			err:     "only directories can be mapped as anonymous volumes",
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVolumeStore := mocks.NewMockVolumeStore(ctrl)
+	mockVolumeStore.
+		EXPECT().
+		Create(gomock.Any(), []string{}).
+		Return(&native.Volume{Name: "test_volume", Mountpoint: "C:\\test\\directory"}, nil).
+		AnyTimes()
+
+	for _, tt := range tests {
+		t.Run(tt.rawSpec, func(t *testing.T) {
+			processedVolSpec, err := ProcessFlagV(tt.rawSpec, mockVolumeStore, true)
+			if err != nil {
+				assert.ErrorContains(t, err, tt.err)
+				return
+			}
+
+			assert.Equal(t, processedVolSpec.Type, tt.wants.Type)
+			assert.Assert(t, processedVolSpec.AnonymousVolume != "")
+			assert.Equal(t, processedVolSpec.Mount.Type, tt.wants.Mount.Type)
+			assert.Equal(t, processedVolSpec.Mount.Destination, tt.wants.Mount.Destination)
+
+			if tt.wants.Mount.Source != "" {
+				assert.Equal(t, processedVolSpec.Mount.Source, tt.wants.Mount.Source)
+			}
+
+			// for anonymous volumes, we want to make sure that the source is not the same as the destination
+			assert.Assert(t, processedVolSpec.Mount.Source != processedVolSpec.Mount.Destination)
 		})
 	}
 }

--- a/pkg/mountutil/mountutilmock/os.mock.go
+++ b/pkg/mountutil/mountutilmock/os.mock.go
@@ -1,0 +1,56 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mountutilmock
+
+import (
+	"os"
+	"reflect"
+
+	"go.uber.org/mock/gomock"
+)
+
+type MockOs struct {
+	ctrl     *gomock.Controller
+	recorder *MockOsMockRecorder
+}
+
+type MockOsMockRecorder struct {
+	mock *MockOs
+}
+
+func NewMockOs(ctrl *gomock.Controller) *MockOs {
+	mock := &MockOs{ctrl: ctrl}
+	mock.recorder = &MockOsMockRecorder{mock}
+	return mock
+}
+
+func (m *MockOs) EXPECT() *MockOsMockRecorder {
+	return m.recorder
+}
+
+func (m *MockOs) Stat(name string) (os.FileInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stat", name)
+	ret0, _ := ret[0].(os.FileInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (m *MockOsMockRecorder) Stat(name any) *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Stat", reflect.TypeOf((*MockOs)(nil).Stat), name)
+}

--- a/pkg/mountutil/mountutilmock/volumestore.mock.go
+++ b/pkg/mountutil/mountutilmock/volumestore.mock.go
@@ -1,0 +1,121 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package mountutilmock
+
+import (
+	"reflect"
+
+	"github.com/containerd/nerdctl/pkg/inspecttypes/native"
+	"go.uber.org/mock/gomock"
+)
+
+// MockVolumeStore is a mock of VolumeStore interface
+type MockVolumeStore struct {
+	ctrl     *gomock.Controller
+	recorder *MockVolumeStoreMockRecorder
+}
+
+// MockVolumeStoreMockRecorder is the mock recorder for MockVolumeStore
+type MockVolumeStoreMockRecorder struct {
+	mock *MockVolumeStore
+}
+
+// NewMockVolumeStore creates a new mock instance
+func NewMockVolumeStore(ctrl *gomock.Controller) *MockVolumeStore {
+	mock := &MockVolumeStore{ctrl: ctrl}
+	mock.recorder = &MockVolumeStoreMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockVolumeStore) EXPECT() *MockVolumeStoreMockRecorder {
+	return m.recorder
+}
+
+// Create mocks the Create method of VolumeStore
+func (m *MockVolumeStore) Create(name string, labels []string) (*native.Volume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", name, labels)
+	ret0, _ := ret[0].(*native.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create
+func (m *MockVolumeStoreMockRecorder) Create(name any, labels any) *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Create", reflect.TypeOf((*MockVolumeStore)(nil).Create), name, labels)
+}
+
+// Get mocks the Get method of VolumeStore
+func (m *MockVolumeStore) Get(name string, size bool) (*native.Volume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", name, size)
+	ret0, _ := ret[0].(*native.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (m *MockVolumeStoreMockRecorder) Get(name any, size any) *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Get", reflect.TypeOf((*MockVolumeStore)(nil).Get), name, size)
+}
+
+// List mocks the List method of VolumeStore
+func (m *MockVolumeStore) List(size bool) (map[string]native.Volume, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "List", size)
+	ret0, _ := ret[0].(map[string]native.Volume)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// List indicates an expected call of List
+func (m *MockVolumeStoreMockRecorder) List(size any) *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "List", reflect.TypeOf((*MockVolumeStore)(nil).List), size)
+}
+
+// Remove mocks the Remove method of VolumeStore
+func (m *MockVolumeStore) Remove(names []string) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Remove", names)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Remove indicates an expected call of Remove
+func (m *MockVolumeStoreMockRecorder) Remove(names any) *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Remove", reflect.TypeOf((*MockVolumeStore)(nil).Remove), names)
+}
+
+// Dir mocks the Dir method of VolumeStore
+func (m *MockVolumeStore) Dir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Dir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Dir indicates an expected call of Dir
+func (m *MockVolumeStoreMockRecorder) Dir() *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Dir", reflect.TypeOf((*MockVolumeStore)(nil).Dir))
+}


### PR DESCRIPTION
# PR Description

This PR fixes:
- #759 to allow users to mount volumes on Windows
- #2199 to allow users to bind a named pipe on Windows

Also, adds a check in [create.go#L298](https://github.com/containerd/nerdctl/blob/93b90990df9a5871354e7dcfde60ebd528290db6/pkg/cmd/container/create.go#L298) to log a warning only when there is an error