### PR TITLE
update golangci-lint (1.55.2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.7.0
         with:
-          version: v1.54.2
+          version: v1.55.2
           args: --verbose
       - name: yamllint-lint
         run: yamllint .

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -76,13 +76,13 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 		return nil, err
 	}
 	options.VolumeExists = func(volName string) (bool, error) {
-		if _, volGetErr := volStore.Get(volName, false); volGetErr == nil {
+		_, volGetErr := volStore.Get(volName, false)
+		if volGetErr == nil {
 			return true, nil
 		} else if errors.Is(volGetErr, errdefs.ErrNotFound) {
 			return false, nil
-		} else {
-			return false, volGetErr
 		}
+		return false, volGetErr
 	}
 
 	options.ImageExists = func(ctx context.Context, rawRef string) (bool, error) {

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -642,7 +642,8 @@ func propagateContainerdLabelsToOCIAnnotations() oci.SpecOpts {
 }
 
 func writeCIDFile(path, id string) error {
-	if _, err := os.Stat(path); err == nil {
+	_, err := os.Stat(path)
+	if err == nil {
 		return fmt.Errorf("container ID file found, make sure the other container isn't running or delete %s", path)
 	} else if errors.Is(err, os.ErrNotExist) {
 		f, err := os.Create(path)
@@ -655,9 +656,8 @@ func writeCIDFile(path, id string) error {
 			return err
 		}
 		return nil
-	} else {
-		return err
 	}
+	return err
 }
 
 // generateLogConfig creates a LogConfig for the current container store


### PR DESCRIPTION
Fix:
```
pkg/cmd/compose/compose.go:83:10: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
                } else {
                        return false, volGetErr
                }
pkg/cmd/container/create.go:658:9: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
        } else {
                return err
        }
```