### PR TITLE
nerdctl run: reset the default value of limits.

### DIFF
--- a/pkg/cmd/container/run_linux.go
+++ b/pkg/cmd/container/run_linux.go
@@ -95,6 +95,13 @@ func setPlatformOptions(ctx context.Context, client *containerd.Client, id, uts 
 	if err != nil {
 		return nil, err
 	}
+
+	// If without any ulimitOpts, we need to reset the default value from spec
+	// which has 1024 as file limit. Make this behavior same as containerd/cri.
+	if len(ulimitOpts) == 0 {
+		ulimitOpts = append(ulimitOpts, withRlimits(nil))
+	}
+
 	opts = append(opts, ulimitOpts...)
 	if options.Sysctl != nil {
 		opts = append(opts, WithSysctls(strutil.ConvertKVStringsToMap(options.Sysctl)))


### PR DESCRIPTION
With the oci spec, we have the default rlimits RLIMIT_NOFILE=1024:1024, If we start a pod in kubelet, this value we be reset to nil by cri. We use the nerdctl to start containers in production, this difference will cause user confused.

When run a container if don't get any ulimit opts, reset the rlimits to nil. This will remove the default 1024 file limit.
```go
if len(ulimitOpts) == 0 {
	ulimitOpts = append(ulimitOpts, withRlimits(nil))
}
```

Warning: this PR will make `nerdctl run` behave differently than before.