### PR TITLE
Adding tests for Dedup mounts for /etc/hosts /etc/resolv.conf 

### DIFF
--- a/cmd/nerdctl/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container_run_network_linux_test.go
@@ -493,6 +493,21 @@ func TestRunContainerWithMACAddress(t *testing.T) {
 	}
 }
 
+func TestHostsFilePermissions(t *testing.T) {
+	base := testutil.NewBase(t)
+	base.Cmd("run", "--rm", testutil.CommonImage,
+		"sh", "-c", "echo > /etc/hosts").AssertOK()
+	base.Cmd("run", "--rm", "-v", "/etc/hosts:/etc/hosts", "--network", "host", testutil.CommonImage,
+		"sh", "-c", "echo > /etc/hosts").AssertOK()
+	base.Cmd("run", "--rm", "-v", "/etc/hosts:/etc/hosts:ro", "--network", "host", testutil.CommonImage,
+		"sh", "-c", "echo > /etc/hosts").AssertFail()
+
+	// The mount of /etc/hosts is incompatible with docker
+	testutil.DockerIncompatible(t)
+	base.Cmd("run", "--rm", "--network", "host", testutil.CommonImage,
+		"sh", "-c", "echo > /etc/hosts").AssertFail()
+}
+
 func TestRunContainerWithStaticIP6(t *testing.T) {
 	if rootlessutil.IsRootless() {
 		t.Skip("Static IP6 assignment is not supported rootless mode yet.")


### PR DESCRIPTION
Adding tests for [Dedup mounts for /etc/hosts /etc/resolv.conf](https://github.com/containerd/nerdctl/pull/2686), ref to https://github.com/containerd/nerdctl/pull/2686#pullrequestreview-1773710428