### PR TITLE
docs: Fix typo in command-reference.md

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1170,7 +1170,7 @@ Flags:
 
 ### :nerd_face: :blue_square: nerdctl namespace update
 
-Udapte labels for a namespace.
+Update labels for a namespace.
 
 Usage: `nerdctl namespace update NAMESPACE`
 


### PR DESCRIPTION
There is a simple but ugly typo in a manual.