### PR TITLE
Remove "soci image rpull" from testing suite

### DIFF
--- a/cmd/nerdctl/container_run_soci_linux_test.go
+++ b/cmd/nerdctl/container_run_soci_linux_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"os"
 	"os/exec"
 	"strings"
 	"testing"
@@ -27,60 +26,51 @@ import (
 
 func TestRunSoci(t *testing.T) {
 	testutil.DockerIncompatible(t)
-	base := testutil.NewBase(t)
-	requiresSoci(base)
-
-	//counting initial snapshot mounts
-	initialMounts, err := exec.Command("mount").Output()
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name                         string
+		image                        string
+		remoteSnapshotsExpectedCount int
+	}{
+		{
+			name:                         "Run with SOCI",
+			image:                        testutil.FfmpegSociImage,
+			remoteSnapshotsExpectedCount: 11,
+		},
 	}
 
-	remoteSnapshotsInitialCount := strings.Count(string(initialMounts), "fuse.rawBridge")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := testutil.NewBase(t)
+			requiresSoci(base)
 
-	if remoteSnapshotsInitialCount != 0 {
-		t.Fatalf("initial mounts count isn't zero")
-	}
+			//counting initial snapshot mounts
+			initialMounts, err := exec.Command("mount").Output()
+			if err != nil {
+				t.Fatal(err)
+			}
 
-	//validating `nerdctl --snapshotter=soci run` and `soci rpull` behave the same using mounts
-	runOutput := base.Cmd("--snapshotter=soci", "run", "--rm", testutil.FfmpegSociImage).Out()
-	base.T.Logf("run output: %s", runOutput)
+			remoteSnapshotsInitialCount := strings.Count(string(initialMounts), "fuse.rawBridge")
 
-	actualMounts, err := exec.Command("mount").Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-	remoteSnapshotsActualCount := strings.Count(string(actualMounts), "fuse.rawBridge")
-	base.T.Logf("number of actual mounts: %v", remoteSnapshotsActualCount)
+			runOutput := base.Cmd("--snapshotter=soci", "run", "--rm", testutil.FfmpegSociImage).Out()
+			base.T.Logf("run output: %s", runOutput)
 
-	rmiOutput := base.Cmd("rmi", testutil.FfmpegSociImage).Out()
-	base.T.Logf("rmi output: %s", rmiOutput)
+			actualMounts, err := exec.Command("mount").Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+			remoteSnapshotsActualCount := strings.Count(string(actualMounts), "fuse.rawBridge")
+			base.T.Logf("number of actual mounts: %v", remoteSnapshotsActualCount)
 
-	sociExecutable, err := exec.LookPath("soci")
-	if err != nil {
-		t.Fatalf("SOCI is not installed.")
-	}
+			rmiOutput := base.Cmd("rmi", testutil.FfmpegSociImage).Out()
+			base.T.Logf("rmi output: %s", rmiOutput)
 
-	rpullCmd := exec.Command(sociExecutable, []string{"image", "rpull", testutil.FfmpegSociImage}...)
+			base.T.Logf("number of expected mounts: %v", tt.remoteSnapshotsExpectedCount)
 
-	rpullCmd.Env = os.Environ()
-
-	err = rpullCmd.Run()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	expectedMounts, err := exec.Command("mount").Output()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	remoteSnapshotsExpectedCount := strings.Count(string(expectedMounts), "fuse.rawBridge")
-	base.T.Logf("number of expected mounts: %v", remoteSnapshotsExpectedCount)
-
-	if remoteSnapshotsExpectedCount != remoteSnapshotsActualCount {
-		t.Fatalf("incorrect number of remote snapshots; expected=%d, actual=%d",
-			remoteSnapshotsExpectedCount, remoteSnapshotsActualCount)
+			if tt.remoteSnapshotsExpectedCount != (remoteSnapshotsActualCount - remoteSnapshotsInitialCount) {
+				t.Fatalf("incorrect number of remote snapshots; expected=%d, actual=%d",
+					tt.remoteSnapshotsExpectedCount, remoteSnapshotsActualCount-remoteSnapshotsInitialCount)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Since SOCI plans on removing this functionality from the CLI, we can preemptively remove our test's dependency on this component of the CLI by hardcoding the expected number of mounts per image. This is fine because the same image with the same SOCI config will always have the same amount of mounts. The only caveat is that one must know how many mounts to expect from a certain image.

Additionally, small refactoring was done to allow for more future test coverage (e.g. testing different images with SOCI), and to allow TestSociRun to be as flexible as TestSociPull. (Though the tests are so similar, I wonder if it may be better to just group the two.)