### PR TITLE
docs: update gpu cuda image to 12.3.1-base-ubuntu20.04

### DIFF
--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -20,7 +20,7 @@ You can specify number of GPUs to use via `--gpus` option.
 The following example exposes all available GPUs.
 
 ```
-nerdctl run -it --rm --gpus all nvidia/cuda:9.0-base nvidia-smi
+nerdctl run -it --rm --gpus all nvidia/cuda:12.3.1-base-ubuntu20.04 nvidia-smi
 ```
 
 You can also pass detailed configuration to `--gpus` option as a list of key-value pairs. The following options are provided.
@@ -32,7 +32,7 @@ You can also pass detailed configuration to `--gpus` option as a list of key-val
 The following example exposes a specific GPU to the container.
 
 ```
-nerdctl run -it --rm --gpus '"capabilities=utility,compute",device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a' nvidia/cuda:9.0-base nvidia-smi
+nerdctl run -it --rm --gpus '"capabilities=utility,compute",device=GPU-3a23c669-1f69-c64e-cf85-44e9b07e7a2a' nvidia/cuda:12.3.1-base-ubuntu20.04 nvidia-smi
 ```
 
 ## Fields for `nerdctl compose`
@@ -53,7 +53,7 @@ The following exposes all available GPUs to the container.
 version: "3.8"
 services:
   demo:
-    image: nvidia/cuda:9.0-base
+    image: nvidia/cuda:12.3.1-base-ubuntu20.04
     command: nvidia-smi
     deploy:
       resources:


### PR DESCRIPTION
The `nvidia/cuda:9.0-base` image has been deleted. And The Nvidia CUDA image has been updated at https://catalog.ngc.nvidia.com/orgs/nvidia/containers/cuda/tags.
So update it to `12.3.1-base-ubuntu20.0` like https://docs.docker.com/compose/gpu-support/#example-of-a-compose-file-for-running-a-service-with-access-to-1-gpu-device.


fixes: https://github.com/containerd/nerdctl/issues/2755