### PR TITLE
Support `--ipc=(shareable|container:<container>)` flag

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -351,7 +351,7 @@ Logging flags:
 
 Shared memory flags:
 
-- :whale: `--ipc`: IPC namespace to use
+- :whale: `--ipc=(host|private|shareable|container:<container>)`: IPC namespace to use and mount `/dev/shm`. Default: "private". Only implemented on Linux.
 - :whale: `--shm-size`: Size of `/dev/shm`
 
 GPU flags:

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -44,6 +43,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/logging"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil"
@@ -387,23 +387,6 @@ func generateRootfsOpts(args []string, id string, ensured *imgutil.EnsuredImage,
 	return opts, cOpts, nil
 }
 
-// withBindMountHostIPC replaces /dev/shm and /dev/mqueue  mount with rbind.
-// Required for --ipc=host on rootless.
-func withBindMountHostIPC(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
-	for i, m := range s.Mounts {
-		switch p := path.Clean(m.Destination); p {
-		case "/dev/shm", "/dev/mqueue":
-			s.Mounts[i] = specs.Mount{
-				Destination: p,
-				Type:        "bind",
-				Source:      p,
-				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
-			}
-		}
-	}
-	return nil
-}
-
 // GenerateLogURI generates a log URI for the current container store
 func GenerateLogURI(dataStore string) (*url.URL, error) {
 	selfExe, err := os.Executable()
@@ -516,6 +499,8 @@ type internalLabels struct {
 	anonVolumes []string
 	// pid namespace
 	pidContainer string
+	// ipc namespace & dev/shm
+	ipc string
 	// log
 	logURI string
 }
@@ -589,6 +574,10 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 
 	if internalLabels.pidContainer != "" {
 		m[labels.PIDContainer] = internalLabels.pidContainer
+	}
+
+	if internalLabels.ipc != "" {
+		m[labels.IPC] = internalLabels.ipc
 	}
 
 	return containerd.WithAdditionalContainerLabels(m), nil
@@ -717,6 +706,13 @@ func generateGcFunc(ctx context.Context, container containerd.Container, ns, id,
 			}
 		}
 
+		ipc, ipcErr := ipcutil.DecodeIPCLabel(internalLabels.ipc)
+		if ipcErr != nil {
+			log.G(ctx).WithError(ipcErr).Warnf("failed to decode ipc label for container %q", id)
+		}
+		if ipcErr := ipcutil.CleanUp(ipc); ipcErr != nil {
+			log.G(ctx).WithError(ipcErr).Warnf("failed to clean up ipc for container %q", id)
+		}
 		if rmErr := os.RemoveAll(internalLabels.stateDir); rmErr != nil {
 			log.G(ctx).WithError(rmErr).Warnf("failed to remove container %q state dir %q", id, internalLabels.stateDir)
 		}

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/namestore"
 )
@@ -102,6 +103,14 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 	}
 	id := c.ID()
 	l, err := c.Labels(ctx)
+	if err != nil {
+		return err
+	}
+	ipc, err := ipcutil.DecodeIPCLabel(l[labels.IPC])
+	if err != nil {
+		return err
+	}
+	err = ipcutil.CleanUp(ipc)
 	if err != nil {
 		return err
 	}

--- a/pkg/ipcutil/ipcutil.go
+++ b/pkg/ipcutil/ipcutil.go
@@ -1,0 +1,250 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ipcutil
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/docker/go-units"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type IPCMode string
+
+type IPC struct {
+	Mode IPCMode `json:"mode,omitempty"`
+	// VictimContainer is only used when mode is container
+	VictimContainerID *string `json:"victimContainerId,omitempty"`
+
+	// HostShmPath is only used when mode is shareable
+	HostShmPath *string `json:"hostShmPath,omitempty"`
+
+	// ShmSize is only used when mode is private or shareable
+	// Devshm size in bytes
+	ShmSize string `json:"shmSize,omitempty"`
+}
+
+const (
+	Private   IPCMode = "private"
+	Host      IPCMode = "host"
+	Shareable IPCMode = "shareable"
+	Container IPCMode = "container"
+)
+
+// DetectFlags detects IPC mode from the given ipc string and shmSize string.
+// If ipc is empty, it returns IPC{Mode: Private}.
+func DetectFlags(ctx context.Context, client *containerd.Client, stateDir string, ipc string, shmSize string) (IPC, error) {
+	var res IPC
+	res.ShmSize = shmSize
+	switch ipc {
+	case "", "private":
+		res.Mode = Private
+	case "host":
+		res.Mode = Host
+	case "shareable":
+		res.Mode = Shareable
+		shmPath := filepath.Join(stateDir, "shm")
+		res.HostShmPath = &shmPath
+	default: // container:<id|name>
+		res.Mode = Container
+		parsed := strings.Split(ipc, ":")
+		if len(parsed) < 2 || parsed[0] != "container" {
+			return res, fmt.Errorf("invalid ipc namespace. Set --ipc=[host|container:<name|id>")
+		}
+
+		containerName := parsed[1]
+		walker := &containerwalker.ContainerWalker{
+			Client: client,
+			OnFound: func(ctx context.Context, found containerwalker.Found) error {
+				if found.MatchCount > 1 {
+					return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+				}
+				victimContainerID := found.Container.ID()
+				res.VictimContainerID = &victimContainerID
+
+				return nil
+			},
+		}
+		matchedCount, err := walker.Walk(ctx, containerName)
+		if err != nil {
+			return res, err
+		}
+		if matchedCount < 1 {
+			return res, fmt.Errorf("no such container: %s", containerName)
+		}
+	}
+
+	return res, nil
+}
+
+// EncodeIPCLabel encodes IPC spec into a label.
+func EncodeIPCLabel(ipc IPC) (string, error) {
+	if ipc.Mode == "" {
+		return "", nil
+	}
+	b, err := json.Marshal(ipc)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// DecodeIPCLabel decodes IPC spec from a label.
+// For backward compatibility, if ipcLabel is empty, it returns IPC{Mode: Private}.
+func DecodeIPCLabel(ipcLabel string) (IPC, error) {
+	if ipcLabel == "" {
+		return IPC{
+			Mode: Private,
+		}, nil
+	}
+
+	var ipc IPC
+	if err := json.Unmarshal([]byte(ipcLabel), &ipc); err != nil {
+		return IPC{}, err
+	}
+	return ipc, nil
+}
+
+// GenerateIPCOpts generates IPC spec opts from the given IPC.
+func GenerateIPCOpts(ctx context.Context, ipc IPC, client *containerd.Client) ([]oci.SpecOpts, error) {
+	opts := make([]oci.SpecOpts, 0)
+
+	switch ipc.Mode {
+	case Private:
+		// If nothing is specified, or if private, default to normal behavior
+		if len(ipc.ShmSize) > 0 {
+			shmBytes, err := units.RAMInBytes(ipc.ShmSize)
+			if err != nil {
+				return nil, err
+			}
+			opts = append(opts, oci.WithDevShmSize(shmBytes/1024))
+		}
+	case Host:
+		opts = append(opts, withBindMountHostIPC)
+		if runtime.GOOS != "windows" {
+			opts = append(opts, oci.WithHostNamespace(specs.IPCNamespace))
+		}
+	case Shareable:
+		if ipc.HostShmPath == nil {
+			return nil, errors.New("ipc mode is shareable, but host shm path is nil")
+		}
+		err := makeShareableDevshm(*ipc.HostShmPath, ipc.ShmSize)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, withBindMountHostOtherSourceIPC(*ipc.HostShmPath))
+	case Container:
+		if ipc.VictimContainerID == nil {
+			return nil, errors.New("ipc mode is container, but victim container id is nil")
+		}
+		targetCon, err := client.LoadContainer(ctx, *ipc.VictimContainerID)
+		if err != nil {
+			return nil, err
+		}
+
+		task, err := targetCon.Task(ctx, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		status, err := task.Status(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if status.Status != containerd.Running {
+			return nil, fmt.Errorf("shared container is not running")
+		}
+
+		targetConLabels, err := targetCon.Labels(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		targetConIPC, err := DecodeIPCLabel(targetConLabels[labels.IPC])
+		if err != nil {
+			return nil, err
+		}
+
+		if targetConIPC.Mode == Host {
+			opts = append(opts, oci.WithHostNamespace(specs.IPCNamespace))
+			opts = append(opts, withBindMountHostIPC)
+			return opts, nil
+		} else if targetConIPC.Mode != Shareable {
+			return nil, errors.New("victim container's ipc mode is not shareable")
+		}
+
+		if targetConIPC.HostShmPath == nil {
+			return nil, errors.New("victim container's host shm path is nil")
+		}
+
+		opts = append(opts, withBindMountHostOtherSourceIPC(*targetConIPC.HostShmPath))
+	}
+
+	return opts, nil
+}
+
+// WithBindMountHostOtherSourceIPC replaces /dev/shm mount with rbind by the given path on host
+func withBindMountHostOtherSourceIPC(source string) oci.SpecOpts {
+	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+		for i, m := range s.Mounts {
+			p := path.Clean(m.Destination)
+			if p == "/dev/shm" {
+				s.Mounts[i] = specs.Mount{
+					Type:        "bind",
+					Destination: p,
+					Source:      source,
+					Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
+				}
+			}
+		}
+		return nil
+	}
+}
+
+// WithBindMountHostIPC replaces /dev/shm and /dev/mqueue mount with rbind.
+// Required for --ipc=host on rootless.
+func withBindMountHostIPC(_ context.Context, _ oci.Client, _ *containers.Container, s *oci.Spec) error {
+	for i, m := range s.Mounts {
+		switch p := path.Clean(m.Destination); p {
+		case "/dev/shm", "/dev/mqueue":
+			s.Mounts[i] = specs.Mount{
+				Destination: p,
+				Type:        "bind",
+				Source:      p,
+				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
+			}
+		}
+	}
+	return nil
+}
+
+func CleanUp(ipc IPC) error {
+	return cleanUpPlatformSpecificIPC(ipc)
+}

--- a/pkg/ipcutil/ipcutil_linux.go
+++ b/pkg/ipcutil/ipcutil_linux.go
@@ -1,0 +1,64 @@
+//go:build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ipcutil
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/docker/go-units"
+	"golang.org/x/sys/unix"
+)
+
+// makeShareableDevshm returns devshm directory path on host when there is no error.
+func makeShareableDevshm(shmPath, shmSize string) error {
+	shmproperty := "mode=1777"
+	if len(shmSize) > 0 {
+		shmBytes, err := units.RAMInBytes(shmSize)
+		if err != nil {
+			return err
+		}
+		shmproperty = fmt.Sprintf("%s,size=%d", shmproperty, shmBytes)
+	}
+	err := os.MkdirAll(shmPath, 0700)
+	if err != nil {
+		return err
+	}
+	err = unix.Mount("/dev/shm", shmPath, "tmpfs", uintptr(unix.MS_NOEXEC|unix.MS_NOSUID|unix.MS_NODEV), shmproperty)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// cleanUpPlatformSpecificIPC cleans up platform specific IPC.
+func cleanUpPlatformSpecificIPC(ipc IPC) error {
+	if ipc.Mode == Shareable && ipc.HostShmPath != nil {
+		err := unix.Unmount(*ipc.HostShmPath, 0)
+		if err != nil {
+			return err
+		}
+		err = os.RemoveAll(*ipc.HostShmPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/ipcutil/ipcutil_unix.go
+++ b/pkg/ipcutil/ipcutil_unix.go
@@ -1,0 +1,34 @@
+//go:build freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ipcutil
+
+import "fmt"
+
+// makeShareableDevshm returns devshm directory path on host when there is no error.
+func makeShareableDevshm(shmPath, shmSize string) error {
+	return fmt.Errorf("unix does not support shareable devshm")
+}
+
+// cleanUpPlatformSpecificIPC cleans up platform specific IPC.
+func cleanUpPlatformSpecificIPC(ipc IPC) error {
+	if ipc.Mode == Shareable {
+		return fmt.Errorf("unix does not support shareable devshm")
+	}
+	return nil
+}

--- a/pkg/ipcutil/ipcutil_windows.go
+++ b/pkg/ipcutil/ipcutil_windows.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package ipcutil
+
+import "fmt"
+
+// makeShareableDevshm returns devshm directory path on host when there is no error.
+func makeShareableDevshm(shmPath, shmSize string) error {
+	return fmt.Errorf("windows does not support shareable devshm")
+}
+
+// cleanUpPlatformSpecificIPC cleans up platform specific IPC.
+func cleanUpPlatformSpecificIPC(ipc IPC) error {
+	if ipc.Mode == Shareable {
+		return fmt.Errorf("windows does not support shareable devshm")
+	}
+	return nil
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -92,6 +92,10 @@ const (
 	// PIDContainer is the `nerdctl run --pid` for restarting
 	PIDContainer = Prefix + "pid-container"
 
+	// IPC is the `nerectl run --ipc` for restrating
+	// IPC indicates ipc victim container.
+	IPC = Prefix + "ipc"
+
 	// Error encapsulates a container human-readable string
 	// that describes container error.
 	Error = Prefix + "error"


### PR DESCRIPTION
#1293 

(Late reviews are also okay. Please review carefully.)

- Add `ipcutil`:
  - To support `--ipc=shareable`, a container mounts a path on host as an intermediary for `/dev/shm`.
  - For its persistency, the ipc info is saved in the containers label.
  - For backward compatibility, if ipcLabel is empty, ipc mode will be private.
- When to remove container and stoping container, call `ipcutil.CleanUp()` to clean mounted `/dev/shm`.