### PR TITLE
CI: use standard GHA runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,9 +283,7 @@ jobs:
 
   test-integration-freebsd:
     name: FreeBSD
-    # "Larger" runner is needed for nested virtualization
-    # https://github.com/organizations/containerd/settings/actions/runners
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
"Larger" runners are no longer required for nested virt with Linux