### PR TITLE
Support systemd in containers with podman-style `--systemd` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Minor:
 - Better multi-platform support, e.g., `nerdctl pull --all-platforms IMAGE`
 - Applying an (existing) AppArmor profile to rootless containers: `nerdctl run --security-opt apparmor=<PROFILE>`.
   Use `sudo nerdctl apparmor load` to load the `nerdctl-default` profile.
+- Systemd compatibility support: `nerdctl run --systemd=always`
 
 Trivial:
 

--- a/cmd/nerdctl/container_create.go
+++ b/cmd/nerdctl/container_create.go
@@ -255,6 +255,10 @@ func processContainerCreateOptions(cmd *cobra.Command) (opt types.ContainerCreat
 	if err != nil {
 		return
 	}
+	opt.Systemd, err = cmd.Flags().GetString("systemd")
+	if err != nil {
+		return
+	}
 	// #endregion
 
 	// #region for runtime flags

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -184,6 +184,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("cap-drop", []string{}, "Drop Linux capabilities")
 	cmd.RegisterFlagCompletionFunc("cap-drop", capShellComplete)
 	cmd.Flags().Bool("privileged", false, "Give extended privileges to this container")
+	cmd.Flags().String("systemd", "false", "Allow running systemd in this container (default: false)")
 	// #endregion
 
 	// #region runtime flags

--- a/cmd/nerdctl/container_run_systemd_linux_test.go
+++ b/cmd/nerdctl/container_run_systemd_linux_test.go
@@ -1,0 +1,104 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+)
+
+func TestRunWithSystemdAlways(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "--name", containerName, "--systemd=always", "--entrypoint=/bin/bash", testutil.UbuntuImage, "-c", "mount | grep cgroup").AssertOutContains("(rw,")
+
+	base.Cmd("inspect", "--format", "{{json .Config.Labels}}", containerName).AssertOutContains("SIGRTMIN+3")
+
+}
+
+func TestRunWithSystemdTrueEnabled(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "-d", "--name", containerName, "--systemd=true", "--entrypoint=/sbin/init", testutil.SystemdImage).AssertOK()
+
+	base.Cmd("inspect", "--format", "{{json .Config.Labels}}", containerName).AssertOutContains("SIGRTMIN+3")
+
+	base.Cmd("exec", containerName, "systemctl", "list-jobs").AssertOutContains("jobs listed.")
+}
+
+func TestRunWithSystemdTrueDisabled(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "--name", containerName, "--systemd=true", "--entrypoint=/bin/bash", testutil.SystemdImage, "-c", "systemctl list-jobs || true").AssertCombinedOutContains("System has not been booted with systemd as init system")
+}
+
+func TestRunWithSystemdFalse(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "--name", containerName, "--systemd=false", "--entrypoint=/bin/bash", testutil.UbuntuImage, "-c", "mount | grep cgroup").AssertOutContains("(ro,")
+
+	base.Cmd("inspect", "--format", "{{json .Config.Labels}}", containerName).AssertOutContains("SIGTERM")
+}
+
+func TestRunWithNoSystemd(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "--name", containerName, "--entrypoint=/bin/bash", testutil.UbuntuImage, "-c", "mount | grep cgroup").AssertOutContains("(ro,")
+
+	base.Cmd("inspect", "--format", "{{json .Config.Labels}}", containerName).AssertOutContains("SIGTERM")
+}
+
+func TestRunWithSystemdPrivilegedError(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+
+	base.Cmd("run", "--privileged", "--rm", "--systemd=always", "--entrypoint=/sbin/init", testutil.SystemdImage).AssertCombinedOutContains("if --privileged is used with systemd `--security-opt privileged-without-host-devices` must also be used")
+}
+
+func TestRunWithSystemdPrivilegedSuccess(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
+
+	base.Cmd("run", "-d", "--name", containerName, "--privileged", "--security-opt", "privileged-without-host-devices", "--systemd=true", "--entrypoint=/sbin/init", testutil.SystemdImage).AssertOK()
+
+	base.Cmd("inspect", "--format", "{{json .Config.Labels}}", containerName).AssertOutContains("SIGRTMIN+3")
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -232,6 +232,15 @@ Security flags:
 - :whale: `--cap-add=<CAP>`: Add Linux capabilities
 - :whale: `--cap-drop=<CAP>`: Drop Linux capabilities
 - :whale: `--privileged`: Give extended privileges to this container
+- :nerd_face: `--systemd=(true|false|always)`: Enable systemd compatibility (default: false).
+  - Default: "false"
+  - true: Enable systemd compatibility is enabled if the entrypoint executable matches one of the following paths:
+    - `/sbin/init`
+    - `/usr/sbin/init`
+    - `/usr/local/sbin/init`
+  - always: Always enable systemd compatibility
+
+Corresponds to Podman CLI.
 
 Runtime flags:
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -169,6 +169,8 @@ type ContainerCreateOptions struct {
 	CapDrop []string
 	// Privileged gives extended privileges to this container
 	Privileged bool
+	// Systemd
+	Systemd string
 	// #endregion
 
 	// #region for runtime flags

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -41,6 +41,7 @@ var (
 	DockerAuthImage             = mirrorOf("cesanta/docker_auth:1.7")
 	FluentdImage                = mirrorOf("fluent/fluentd:v1.14-1")
 	KuboImage                   = mirrorOf("ipfs/kubo:v0.16.0")
+	SystemdImage                = "ghcr.io/containerd/stargz-snapshotter:0.15.1-kind"
 
 	// Source: https://gist.github.com/cpuguy83/fcf3041e5d8fb1bb5c340915aabeebe0
 	NonDistBlobImage = "ghcr.io/cpuguy83/non-dist-blob:latest"


### PR DESCRIPTION
Adds support for systemd to `nerdctl` with a `--systemd` based on the [flag used in podman](https://docs.podman.io/en/latest/markdown/podman-run.1.html#systemd-true-false-always)

Fixes #2784

Usage:
```
$ sudo nerdctl run --systemd=always --rm -it registry.hub.docker.com/sazzy4o/build
:systemd
systemd v246.15-1.fc33 running in system mode. (+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +ZSTD +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=unified)
Detected virtualization container-other.
Detected architecture x86-64.

Welcome to Fedora 33 (Container Image)!

Set hostname to <9eff88d04af6>.
Queued start job for default target Graphical Interface.
[  OK  ] Created slice Slice /system/getty.
[  OK  ] Created slice Slice /system/modprobe.
[  OK  ] Created slice User and Session Slice.
[  OK  ] Started Dispatch Password Requests to Console Directory Watch.
[  OK  ] Started Forward Password Requests to Wall Directory Watch.
[  OK  ] Reached target Local File Systems.
[  OK  ] Reached target Network is Online.
[  OK  ] Reached target Paths.
[  OK  ] Reached target Remote File Systems.
[  OK  ] Reached target Slices.
[  OK  ] Reached target Swap.
[  OK  ] Listening on Process Core Dump Socket.
[  OK  ] Listening on initctl Compatibility Named Pipe.
[  OK  ] Listening on Journal Socket (/dev/log).
[  OK  ] Listening on Journal Socket.
[  OK  ] Listening on User Database Manager Socket.
         Starting Rebuild Dynamic Linker Cache...
         Starting Journal Service...
         Starting Create System Users...
[  OK  ] Finished Rebuild Dynamic Linker Cache.
[  OK  ] Started Journal Service.
         Starting Flush Journal to Persistent Storage...
[  OK  ] Finished Create System Users.
[  OK  ] Finished Flush Journal to Persistent Storage.
         Starting Create Volatile Files and Directories...
[  OK  ] Finished Create Volatile Files and Directories.
         Starting Rebuild Journal Catalog...
         Starting Network Name Resolution...
         Starting Update UTMP about System Boot/Shutdown...
[  OK  ] Finished Update UTMP about System Boot/Shutdown.
[  OK  ] Finished Rebuild Journal Catalog.
         Starting Update is Completed...
[  OK  ] Finished Update is Completed.
[  OK  ] Reached target System Initialization.
[  OK  ] Started dnf makecache --timer.
[  OK  ] Started Daily rotation of log files.
[  OK  ] Started Daily Cleanup of Temporary Directories.
[  OK  ] Reached target Timers.
[  OK  ] Listening on D-Bus System Message Bus Socket.
[  OK  ] Reached target Sockets.
[  OK  ] Reached target Basic System.
         Starting MariaDB 10.4 database server...
         Starting The PHP FastCGI Process Manager...
         Starting Home Area Manager...
         Starting User Login Management...
         Starting Permit User Sessions...
         Starting D-Bus System Message Bus...
[  OK  ] Started Network Name Resolution.
[  OK  ] Reached target Host and Network Name Lookups.
         Starting The nginx HTTP and reverse proxy server...
[  OK  ] Finished Permit User Sessions.
[  OK  ] Started D-Bus System Message Bus.
[  OK  ] Started Console Getty.
[  OK  ] Reached target Login Prompts.
[  OK  ] Started Home Area Manager.
[  OK  ] Started User Login Management.
[  OK  ] Started The PHP FastCGI Process Manager.
[  OK  ] Started The nginx HTTP and reverse proxy server.
[  OK  ] Started MariaDB 10.4 database server.
[  OK  ] Reached target Multi-User System.
[  OK  ] Reached target Graphical Interface.
         Starting Update UTMP about System Runlevel Changes...
[  OK  ] Finished Update UTMP about System Runlevel Changes.

Fedora 33 (Container Image)
Kernel 6.5.0-14-generic on an x86_64 (console)

9eff88d04af6 login: 
```