### PR TITLE
Support `nerdctl build` args: `--attest`,` --sbom`,`--provenance`

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -680,10 +680,13 @@ Flags:
   - :whale: `type=tar[,dest=path/to/output.tar]`: Raw tar ball
   - :whale: `type=image,name=example.com/image,push=true`: Push to a registry (see [`buildctl build`](https://github.com/moby/buildkit/tree/v0.9.0#imageregistry) documentation)
 - :whale: `--progress=(auto|plain|tty)`: Set type of progress output (auto, plain, tty). Use plain to show container output
+- :whale: `--provenance`: Shorthand for \"--attest=type=provenance\", see [`buildx_build.md`](https://github.com/docker/buildx/blob/v0.12.1/docs/reference/buildx_build.md#provenance) documentation
 - :whale: `--secret`: Secret file to expose to the build: id=mysecret,src=/local/secret
 - :whale: `--allow`: Allow extra privileged entitlement, e.g. network.host, security.insecure  (It’s required to configure the buildkitd to enable the feature, see [`buildkitd.toml`](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md) documentation)
+- :whale: `--attest`: Attestation parameters (format: "type=sbom,generator=image"), see [`buildx_build.md`](https://github.com/docker/buildx/blob/v0.12.1/docs/reference/buildx_build.md#attest) documentation
 - :whale: `--ssh`: SSH agent socket or keys to expose to the build (format: `default|<id>[=<socket>|<key>[,<key>]]`)
 - :whale: `-q, --quiet`: Suppress the build output and print image ID on success
+- :whale: `--sbom`: Shorthand for \"--attest=type=sbom\", see [`buildx_build.md`](https://github.com/docker/buildx/blob/v0.12.1/docs/reference/buildx_build.md#sbom) documentation
 - :whale: `--cache-from=CACHE`: External cache sources (eg. user/app:cache, type=local,src=path/to/dir) (compatible with `docker buildx build`)
 - :whale: `--cache-to=CACHE`: Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir) (compatible with `docker buildx build`)
 - :whale: `--platform=(amd64|arm64|...)`: Set target platform for build (compatible with `docker buildx build`)

--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -45,6 +45,8 @@ type BuilderBuildOptions struct {
 	Secret []string
 	// Allow extra privileged entitlement, e.g. network.host, security.insecure
 	Allow []string
+	// Attestation parameters (format: "type=sbom,generator=image")"
+	Attest []string
 	// SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])
 	SSH []string
 	// Quiet suppress the build output and print image ID on success

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -338,6 +338,16 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 		buildctlArgs = append(buildctlArgs, "--allow="+s)
 	}
 
+	for _, s := range strutil.DedupeStrSlice(options.Attest) {
+		optAttestType, optAttestAttrs, _ := strings.Cut(s, ",")
+		if strings.HasPrefix(optAttestType, "type=") {
+			optAttestType := strings.TrimPrefix(optAttestType, "type=")
+			buildctlArgs = append(buildctlArgs, fmt.Sprintf("--opt=attest:%s=%s", optAttestType, optAttestAttrs))
+		} else {
+			return "", nil, false, "", nil, nil, fmt.Errorf("attestation type not specified")
+		}
+	}
+
 	for _, s := range strutil.DedupeStrSlice(options.SSH) {
 		buildctlArgs = append(buildctlArgs, "--ssh="+s)
 	}


### PR DESCRIPTION
Build attestations describe how an image was built, and what it contains.
Support `nerdctl build` args: `--attest`,` --sbom`,`--provenance` .

fix: https://github.com/containerd/nerdctl/issues/2745