### PR TITLE
Fix soci image push with multi-platforms flags

### DIFF
--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -53,12 +53,16 @@ func CreateSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform boo
 	sociCmd.Args = append(sociCmd.Args, "create")
 
 	if allPlatform {
-		sociCmd.Args = append(sociCmd.Args, "--all-platforms", strconv.FormatBool(allPlatform))
+		sociCmd.Args = append(sociCmd.Args, "--all-platforms")
 	}
 	if len(platforms) > 0 {
-		sociCmd.Args = append(sociCmd.Args, "--platform")
-		sociCmd.Args = append(sociCmd.Args, strings.Join(platforms, ","))
+		// multiple values need to be passed as separate, repeating flags in soci as it uses urfave
+		// https://github.com/urfave/cli/blob/main/docs/v2/examples/flags.md#multiple-values-per-single-flag
+		for _, p := range platforms {
+			sociCmd.Args = append(sociCmd.Args, "--platform", p)
+		}
 	}
+
 	if sOpts.SpanSize != -1 {
 		sociCmd.Args = append(sociCmd.Args, "--span-size", strconv.FormatInt(sOpts.SpanSize, 10))
 	}
@@ -107,11 +111,14 @@ func PushSoci(rawRef string, gOpts types.GlobalCommandOptions, allPlatform bool,
 	sociCmd.Args = append(sociCmd.Args, "push")
 
 	if allPlatform {
-		sociCmd.Args = append(sociCmd.Args, "--all-platforms", strconv.FormatBool(allPlatform))
+		sociCmd.Args = append(sociCmd.Args, "--all-platforms")
 	}
 	if len(platforms) > 0 {
-		sociCmd.Args = append(sociCmd.Args, "--platform")
-		sociCmd.Args = append(sociCmd.Args, strings.Join(platforms, ","))
+		// multiple values need to be passed as separate, repeating flags in soci as it uses urfave
+		// https://github.com/urfave/cli/blob/main/docs/v2/examples/flags.md#multiple-values-per-single-flag
+		for _, p := range platforms {
+			sociCmd.Args = append(sociCmd.Args, "--platform", p)
+		}
 	}
 	if gOpts.InsecureRegistry {
 		sociCmd.Args = append(sociCmd.Args, "--skip-verify")


### PR DESCRIPTION
Addresses Issue - https://github.com/containerd/nerdctl/issues/2644

This PR resolves command flag issues encountered with the `nerdctl image push --snapshotter soci` command.

The first issue related to the `--all-platforms` flag. Previously, when set, `nerdctl` would erroneously append a `true` value when invoking the `soci` binary (`--all-platforms true`). This led to an error because `soci` interprets `--all-platforms` as a standalone boolean flag. The fix ensures that the flag is used correctly, as shown below:
`soci create --all-platforms <IMAGE>`

The second issue involved the `--platform` flag. `nerdctl` was combining multiple platform values into a single, comma-separated string, contrary to `soci`'s expectation for separate, repeating flags (as it relies on `github.com/urfave/cli`). The PR corrects this by adjusting the flag usage to match `soci`'s requirements:
`soci create --platform amd64 --platform arm64 <IMAGE>`
