### PR TITLE
[cherry-picked to v1.7.4] rootless: fix `Not Authorized(uid): org.fedoraproject.FirewallD1.config`

### DIFF
--- a/pkg/netutil/cni_plugin_unix.go
+++ b/pkg/netutil/cni_plugin_unix.go
@@ -18,6 +18,8 @@
 
 package netutil
 
+import "github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+
 // bridgeConfig describes the bridge plugin
 type bridgeConfig struct {
 	PluginType   string                 `json:"type"`
@@ -97,10 +99,15 @@ type firewallConfig struct {
 }
 
 func newFirewallPlugin() *firewallConfig {
-	return &firewallConfig{
+	c := &firewallConfig{
 		PluginType:    "firewall",
 		IngressPolicy: "same-bridge",
 	}
+	if rootlessutil.IsRootless() {
+		// https://github.com/containerd/nerdctl/issues/2818
+		c.Backend = "iptables"
+	}
+	return c
 }
 
 func (*firewallConfig) GetPluginType() string {


### PR DESCRIPTION
Fix #2818
> nerdctl run - failed to add the address
> (`failed to add the address 10.4.0.17/32 to trusted zone: Not Authorized(uid):
> org.fedoraproject.FirewallD1.config`)

To apply this fix on a non-fresh installation, run:
```
nerdctl network rm bridge
nerdctl network create bridge
```