### PR TITLE
Remove the support for the old CNI isolation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Binaries are available here: <https://github.com/containerd/nerdctl/releases>
 In addition to containerd, the following components should be installed:
 
 - [CNI plugins](https://github.com/containernetworking/plugins): for using `nerdctl run`.
-  - v1.1.0 or later is highly recommended. Older versions require extra [CNI isolation plugin](https://github.com/AkihiroSuda/cni-isolation) for isolating bridge networks (`nerdctl network create`).
+  - v1.1.0 or later is highly recommended.
 - [BuildKit](https://github.com/moby/buildkit) (OPTIONAL): for using `nerdctl build`. BuildKit daemon (`buildkitd`) needs to be running. See also [the document about setting up BuildKit](./docs/build.md).
   - v0.11.0 or later is highly recommended. Some features, such as pruning caches with `nerdctl system prune`, do not work with older versions.
 - [RootlessKit](https://github.com/rootless-containers/rootlesskit) and [slirp4netns](https://github.com/rootless-containers/slirp4netns) (OPTIONAL): for [Rootless mode](./docs/rootless.md)

--- a/docs/cni.md
+++ b/docs/cni.md
@@ -61,10 +61,7 @@ Configuration of the default network `bridge` of Linux:
 nerdctl >= 0.18 sets the `ingressPolicy` to `same-bridge` when `firewall` plugin >= 1.1.0 is installed.
 This `ingressPolicy` replaces the CNI `isolation` plugin used in nerdctl <= 0.17.
 
-When the `isolation` plugin is found, nerdctl uses the `isolation` plugin instead of `ingressPolicy`.
-The `isolation` plugin has been deprecated, and a future version of `nerdctl` will solely support `ingressPolicy`.
-
-When neither of `firewall` plugin >= 1.1.0 or `isolation` plugin is found, nerdctl does not enable the bridge isolation.
+When `firewall` plugin >= 1.1.0 is not found, nerdctl does not enable the bridge isolation.
 This means a container in `--net=foo` can connect to a container in `--net=bar`.
 
 ## macvlan/IPvlan networks

--- a/pkg/netutil/cni_plugin.go
+++ b/pkg/netutil/cni_plugin.go
@@ -33,17 +33,3 @@ type IPAMRoute struct {
 	GW      string `json:"gw,omitempty"`
 	Gateway string `json:"gateway,omitempty"`
 }
-
-type isolationConfig struct {
-	PluginType string `json:"type"`
-}
-
-func newIsolationPlugin() *isolationConfig {
-	return &isolationConfig{
-		PluginType: "isolation",
-	}
-}
-
-func (*isolationConfig) GetPluginType() string {
-	return "isolation"
-}


### PR DESCRIPTION
The old [CNI isolation plugin](https://github.com/AkihiroSuda/cni-isolation) has been deprecated since nerdctl v0.18 (Mar 25, 2022), in favor of the CNI firewall plugin v1.1.