### PR TITLE
doc: should use master tag for binfmt

### DIFF
--- a/docs/multi-platform.md
+++ b/docs/multi-platform.md
@@ -11,7 +11,7 @@ e.g., ARM on Intel, and vice versa.
 ```console
 $ sudo systemctl start containerd
 
-$ sudo nerdctl run --privileged --rm tonistiigi/binfmt --install all
+$ sudo nerdctl run --privileged --rm tonistiigi/binfmt:master --install all
 
 $ ls -1 /proc/sys/fs/binfmt_misc/qemu*
 /proc/sys/fs/binfmt_misc/qemu-aarch64


### PR DESCRIPTION
the latest tag for binfmt was updated 2 years ago, users should use the master tag which is updated regularly.

