### PR TITLE
platform: support loongarch64

### DIFF
--- a/pkg/platformutil/binfmt.go
+++ b/pkg/platformutil/binfmt.go
@@ -36,6 +36,8 @@ func qemuArchFromOCIArch(ociArch string) (string, error) {
 		return ociArch, nil
 	case "mips64le":
 		return "mips64el", nil // NOT typo
+	case "loong64":
+		return "loongarch64", nil // NOT typo
 	}
 	return "", fmt.Errorf("unknown OCI architecture string: %q", ociArch)
 }


### PR DESCRIPTION
binfmt has the loongarch64 support now: https://github.com/tonistiigi/binfmt/blob/51a64e64ef8e523f7ab4d5bbbd376d0ff76fcd3c/cmd/binfmt/config.go#L68