### PR TITLE
[cherry-picked to v1.7.4] CI: test compilation with Go 1.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
     timeout-minutes: 40
     strategy:
       matrix:
-        go-version: ["1.20.x", "1.21.x"]
+        go-version: ["1.21.x", "1.22.x"]
     steps:
       - uses: actions/checkout@v4.1.1
         with:


### PR DESCRIPTION
The release artifacts are still built with Go 1.21, as Go 1.22 is incompatible with runc (golang/go#65625).