### PR TITLE
fix: add network cleanup for kill and stop cmd

### DIFF
--- a/cmd/nerdctl/container_kill_linux_test.go
+++ b/cmd/nerdctl/container_kill_linux_test.go
@@ -18,79 +18,20 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	iptablesutil "github.com/containerd/nerdctl/v2/pkg/testutil/iptables"
-	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 	"github.com/coreos/go-iptables/iptables"
-
 	"gotest.tools/v3/assert"
 )
 
-func TestStopStart(t *testing.T) {
-	const (
-		hostPort = 8080
-	)
-	testContainerName := testutil.Identifier(t)
-	base := testutil.NewBase(t)
-	defer base.Cmd("rm", "-f", testContainerName).Run()
-
-	base.Cmd("run", "-d",
-		"--restart=no",
-		"--name", testContainerName,
-		"-p", fmt.Sprintf("127.0.0.1:%d:80", hostPort),
-		testutil.NginxAlpineImage).AssertOK()
-
-	check := func(httpGetRetry int) error {
-		resp, err := nettestutil.HTTPGet(fmt.Sprintf("http://127.0.0.1:%d", hostPort), httpGetRetry, false)
-		if err != nil {
-			return err
-		}
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
-		if !strings.Contains(string(respBody), testutil.NginxAlpineIndexHTMLSnippet) {
-			return fmt.Errorf("expected contain %q, got %q",
-				testutil.NginxAlpineIndexHTMLSnippet, string(respBody))
-		}
-		return nil
-	}
-
-	assert.NilError(t, check(30))
-	base.Cmd("stop", testContainerName).AssertOK()
-	base.Cmd("exec", testContainerName, "ps").AssertFail()
-	if check(1) == nil {
-		t.Fatal("expected to get an error")
-	}
-	base.Cmd("start", testContainerName).AssertOK()
-	assert.NilError(t, check(30))
-}
-
-func TestStopWithStopSignal(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	testContainerName := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", testContainerName).Run()
-
-	base.Cmd("run", "-d", "--stop-signal", "SIGQUIT", "--name", testContainerName, testutil.CommonImage, "sh", "-euxc", `#!/bin/sh
-set -eu
-trap 'quit=1' QUIT
-quit=0
-while [ $quit -ne 1 ]; do
-    printf 'wait quit'
-    sleep 1
-done
-echo "signal quit"`).AssertOK()
-	base.Cmd("stop", testContainerName).AssertOK()
-	base.Cmd("logs", "-f", testContainerName).AssertOutContains("signal quit")
-}
-
-func TestStopCleanupForwards(t *testing.T) {
+// TestKillCleanupForwards runs a container that exposes a port and then kill it.
+// The test checks that the kill command effectively clean up
+// the iptables forwards creted from the run.
+func TestKillCleanupForwards(t *testing.T) {
 	const (
 		hostPort          = 9999
 		testContainerName = "ngx"
@@ -132,6 +73,6 @@ func TestStopCleanupForwards(t *testing.T) {
 	}
 	assert.Equal(t, iptablesutil.ForwardExists(t, ipt, chain, containerIP, hostPort), true)
 
-	base.Cmd("stop", testContainerName).AssertOK()
+	base.Cmd("kill", testContainerName).AssertOK()
 	assert.Equal(t, iptablesutil.ForwardExists(t, ipt, chain, containerIP, hostPort), false)
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -484,6 +484,12 @@ func withNerdctlOCIHook(cmd string, args []string) (oci.SpecOpts, error) {
 			Args: crArgs,
 			Env:  os.Environ(),
 		})
+		scArgs := append(args, "startContainer")
+		s.Hooks.CreateRuntime = append(s.Hooks.StartContainer, specs.Hook{
+			Path: cmd,
+			Args: scArgs,
+			Env:  os.Environ(),
+		})
 		argsCopy := append([]string(nil), args...)
 		psArgs := append(argsCopy, "postStop")
 		s.Hooks.Poststop = append(s.Hooks.Poststop, specs.Hook{

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -26,10 +27,16 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/cio"
 	"github.com/containerd/containerd/errdefs"
+	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/containerd/nerdctl/v2/pkg/netutil"
+	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
+	"github.com/containerd/nerdctl/v2/pkg/portutil"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/moby/sys/signal"
 )
 
@@ -49,6 +56,9 @@ func Kill(ctx context.Context, client *containerd.Client, reqs []string, options
 		OnFound: func(ctx context.Context, found containerwalker.Found) error {
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
+			}
+			if err := cleanupNetwork(ctx, found.Container, options.GOptions); err != nil {
+				return fmt.Errorf("unable to cleanup network for container: %s, %q", found.Req, err)
 			}
 			if err := killContainer(ctx, found.Container, parsedSignal); err != nil {
 				if errdefs.IsNotFound(err) {
@@ -105,4 +115,78 @@ func killContainer(ctx context.Context, container containerd.Container, signal s
 		}
 	}
 	return nil
+}
+
+// cleanupNetwork removes cni network setup, specifically the forwards
+func cleanupNetwork(ctx context.Context, container containerd.Container, globalOpts types.GlobalCommandOptions) error {
+	return rootlessutil.WithDetachedNetNSIfAny(func() error {
+		// retrieve info to get current active port mappings
+		info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)
+		if err != nil {
+			return err
+		}
+		ports, portErr := portutil.ParsePortsLabel(info.Labels)
+		if portErr != nil {
+			return fmt.Errorf("no oci spec: %q", portErr)
+		}
+		portMappings := []gocni.NamespaceOpts{
+			gocni.WithCapabilityPortMap(ports),
+		}
+
+		// retrieve info to get cni instance
+		spec, err := container.Spec(ctx)
+		if err != nil {
+			return err
+		}
+		networksJSON := spec.Annotations[labels.Networks]
+		var networks []string
+		if err := json.Unmarshal([]byte(networksJSON), &networks); err != nil {
+			return err
+		}
+		netType, err := nettype.Detect(networks)
+		if err != nil {
+			return err
+		}
+
+		switch netType {
+		case nettype.Host, nettype.None, nettype.Container:
+			// NOP
+		case nettype.CNI:
+			e, err := netutil.NewCNIEnv(globalOpts.CNIPath, globalOpts.CNINetConfPath, netutil.WithDefaultNetwork())
+			if err != nil {
+				return err
+			}
+			cniOpts := []gocni.Opt{
+				gocni.WithPluginDir([]string{globalOpts.CNIPath}),
+			}
+			netMap, err := e.NetworkMap()
+			if err != nil {
+				return err
+			}
+			for _, netstr := range networks {
+				net, ok := netMap[netstr]
+				if !ok {
+					return fmt.Errorf("no such network: %q", netstr)
+				}
+				cniOpts = append(cniOpts, gocni.WithConfListBytes(net.Bytes))
+			}
+			cni, err := gocni.New(cniOpts...)
+			if err != nil {
+				return err
+			}
+
+			var namespaceOpts []gocni.NamespaceOpts
+			namespaceOpts = append(namespaceOpts, portMappings...)
+			namespace := spec.Annotations[labels.Namespace]
+			fullID := namespace + "-" + container.ID()
+			if err := cni.Remove(ctx, fullID, "", namespaceOpts...); err != nil {
+				log.L.WithError(err).Errorf("failed to call cni.Remove")
+				return err
+			}
+			return nil
+		default:
+			return fmt.Errorf("unexpected network type %v", netType)
+		}
+		return nil
+	})
 }

--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -35,6 +35,9 @@ func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt typ
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
+			if err := cleanupNetwork(ctx, found.Container, opt.GOptions); err != nil {
+				return fmt.Errorf("unable to cleanup network for container: %s", found.Req)
+			}
 			if err := containerutil.Stop(ctx, found.Container, opt.Timeout); err != nil {
 				if errdefs.IsNotFound(err) {
 					fmt.Fprintf(opt.Stderr, "No such container: %s\n", found.Req)

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -390,107 +390,94 @@ func getIP6AddressOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 	return nil, nil
 }
 
-func onCreateRuntime(opts *handlerOpts) error {
-	loadAppArmor()
+func applyNetworkSettings(opts *handlerOpts) error {
+	portMapOpts, err := getPortMapOpts(opts)
+	if err != nil {
+		return err
+	}
+	nsPath, err := getNetNSPath(opts.state)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	hs, err := hostsstore.NewStore(opts.dataStore)
+	if err != nil {
+		return err
+	}
+	ipAddressOpts, err := getIPAddressOpts(opts)
+	if err != nil {
+		return err
+	}
+	macAddressOpts, err := getMACAddressOpts(opts)
+	if err != nil {
+		return err
+	}
+	ip6AddressOpts, err := getIP6AddressOpts(opts)
+	if err != nil {
+		return err
+	}
+	var namespaceOpts []gocni.NamespaceOpts
+	namespaceOpts = append(namespaceOpts, portMapOpts...)
+	namespaceOpts = append(namespaceOpts, ipAddressOpts...)
+	namespaceOpts = append(namespaceOpts, macAddressOpts...)
+	namespaceOpts = append(namespaceOpts, ip6AddressOpts...)
+	hsMeta := hostsstore.Meta{
+		Namespace:  opts.state.Annotations[labels.Namespace],
+		ID:         opts.state.ID,
+		Networks:   make(map[string]*types100.Result, len(opts.cniNames)),
+		Hostname:   opts.state.Annotations[labels.Hostname],
+		ExtraHosts: opts.extraHosts,
+		Name:       opts.state.Annotations[labels.Name],
+	}
+	cniRes, err := opts.cni.Setup(ctx, opts.fullID, nsPath, namespaceOpts...)
+	if err != nil {
+		return fmt.Errorf("failed to call cni.Setup: %w", err)
+	}
+	cniResRaw := cniRes.Raw()
+	for i, cniName := range opts.cniNames {
+		hsMeta.Networks[cniName] = cniResRaw[i]
+	}
 
-	if opts.cni != nil {
-		portMapOpts, err := getPortMapOpts(opts)
-		if err != nil {
-			return err
-		}
-		nsPath, err := getNetNSPath(opts.state)
-		if err != nil {
-			return err
-		}
-		ctx := context.Background()
-		hs, err := hostsstore.NewStore(opts.dataStore)
-		if err != nil {
-			return err
-		}
-		ipAddressOpts, err := getIPAddressOpts(opts)
-		if err != nil {
-			return err
-		}
-		macAddressOpts, err := getMACAddressOpts(opts)
-		if err != nil {
-			return err
-		}
-		ip6AddressOpts, err := getIP6AddressOpts(opts)
-		if err != nil {
-			return err
-		}
-		var namespaceOpts []gocni.NamespaceOpts
-		namespaceOpts = append(namespaceOpts, portMapOpts...)
-		namespaceOpts = append(namespaceOpts, ipAddressOpts...)
-		namespaceOpts = append(namespaceOpts, macAddressOpts...)
-		namespaceOpts = append(namespaceOpts, ip6AddressOpts...)
-		hsMeta := hostsstore.Meta{
-			Namespace:  opts.state.Annotations[labels.Namespace],
-			ID:         opts.state.ID,
-			Networks:   make(map[string]*types100.Result, len(opts.cniNames)),
-			Hostname:   opts.state.Annotations[labels.Hostname],
-			ExtraHosts: opts.extraHosts,
-			Name:       opts.state.Annotations[labels.Name],
-		}
-		cniRes, err := opts.cni.Setup(ctx, opts.fullID, nsPath, namespaceOpts...)
-		if err != nil {
-			return fmt.Errorf("failed to call cni.Setup: %w", err)
-		}
-		cniResRaw := cniRes.Raw()
-		for i, cniName := range opts.cniNames {
-			hsMeta.Networks[cniName] = cniResRaw[i]
-		}
+	b4nnEnabled, err := bypass4netnsutil.IsBypass4netnsEnabled(opts.state.Annotations)
+	if err != nil {
+		return err
+	}
 
-		b4nnEnabled, err := bypass4netnsutil.IsBypass4netnsEnabled(opts.state.Annotations)
-		if err != nil {
-			return err
-		}
+	if err := hs.Acquire(hsMeta); err != nil {
+		return err
+	}
 
-		if err := hs.Acquire(hsMeta); err != nil {
-			return err
-		}
-
-		if rootlessutil.IsRootlessChild() {
-			if b4nnEnabled {
-				bm, err := bypass4netnsutil.NewBypass4netnsCNIBypassManager(opts.bypassClient, opts.rootlessKitClient)
-				if err != nil {
-					return err
-				}
-				err = bm.StartBypass(ctx, opts.ports, opts.state.ID, opts.state.Annotations[labels.StateDir])
-				if err != nil {
-					return fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-setuptool.sh install-bypass4netnsd`): %w", err)
-				}
-			} else if len(opts.ports) > 0 {
-				if err := exposePortsRootless(ctx, opts.rootlessKitClient, opts.ports); err != nil {
-					return fmt.Errorf("failed to expose ports in rootless mode: %s", err)
-				}
+	if rootlessutil.IsRootlessChild() {
+		if b4nnEnabled {
+			bm, err := bypass4netnsutil.NewBypass4netnsCNIBypassManager(opts.bypassClient, opts.rootlessKitClient)
+			if err != nil {
+				return err
+			}
+			err = bm.StartBypass(ctx, opts.ports, opts.state.ID, opts.state.Annotations[labels.StateDir])
+			if err != nil {
+				return fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-setuptool.sh install-bypass4netnsd`): %w", err)
+			}
+		} else if len(opts.ports) > 0 {
+			if err := exposePortsRootless(ctx, opts.rootlessKitClient, opts.ports); err != nil {
+				return fmt.Errorf("failed to expose ports in rootless mode: %s", err)
 			}
 		}
 	}
 	return nil
 }
 
-func onStartContainer(opts *handlerOpts) error {
-	// restore portmapping in case it was removed by kill/stop command
-	if opts.cni != nil {
-		portMapOpts, err := getPortMapOpts(opts)
-		if err != nil {
-			return err
-		}
-		nsPath, err := getNetNSPath(opts.state)
-		if err != nil {
-			return err
-		}
-		ctx := context.Background()
-		fmt.Println(portMapOpts)
+func onCreateRuntime(opts *handlerOpts) error {
+	loadAppArmor()
 
-		var namespaceOpts []gocni.NamespaceOpts
-		namespaceOpts = append(namespaceOpts, portMapOpts...)
-		cniRes, err := opts.cni.Setup(ctx, opts.fullID, nsPath, namespaceOpts...)
-		if err != nil {
-			return fmt.Errorf("failed to call cni.Setup: %w", err)
-		}
-		fmt.Println(cniRes)
+	if opts.cni != nil {
+		return applyNetworkSettings(opts)
+	}
+	return nil
+}
+
+func onStartContainer(opts *handlerOpts) error {
+	if opts.cni != nil {
+		return applyNetworkSettings(opts)
 	}
 	return nil
 }

--- a/pkg/testutil/iptables/iptables.go
+++ b/pkg/testutil/iptables/iptables.go
@@ -1,0 +1,99 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package iptables
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/coreos/go-iptables/iptables"
+)
+
+// ForwardExists check that at least 2 rules are present in the CNI-HOSTPORT-DNAT chain
+// and checks for regex matches in the list of rules
+func ForwardExists(t *testing.T, ipt *iptables.IPTables, chain, containerIP string, port int) bool {
+	rules, err := ipt.List("nat", chain)
+	if err != nil {
+		t.Logf("error listing rules in chain: %q\n", err)
+		return false
+	}
+
+	if len(rules) < 1 {
+		t.Logf("not enough rules: %d", len(rules))
+		return false
+	}
+
+	// here we check if at least one of the rules in the chain
+	// matches the required string to identify that the rule was applied
+	found := false
+	matchRule := `--dport ` + fmt.Sprintf("%d", port) + ` .+ --to-destination ` + containerIP
+	for _, rule := range rules {
+		foundInRule, err := regexp.MatchString(matchRule, rule)
+		if err != nil {
+			t.Logf("error in match string: %q\n", err)
+			return false
+		}
+		if foundInRule {
+			found = foundInRule
+		}
+	}
+	return found
+}
+
+// GetRedirectedChain returns the chain where the traffic is being redirected.
+// This is how libcni manage its port maps.
+// Suppose you have the following rule:
+// -A CNI-HOSTPORT-DNAT -p tcp -m comment --comment "dnat name: \"bridge\" id: \"default-YYYYYY\"" -m multiport --dports 9999 -j CNI-DN-XXXXXX
+// So the chain where the traffic is redirected is CNI-DN-XXXXXX
+// Returns an empty string in case nothing was found.
+func GetRedirectedChain(t *testing.T, ipt *iptables.IPTables, chain, namespace, containerID string) string {
+	rules, err := ipt.List("nat", chain)
+	if err != nil {
+		t.Logf("error listing rules in chain: %q\n", err)
+		return ""
+	}
+
+	if len(rules) < 1 {
+		t.Logf("not enough rules: %d", len(rules))
+		return ""
+	}
+
+	var redirectedChain string
+	re := regexp.MustCompile(`-j\s+([^ ]+)`)
+	for _, rule := range rules {
+		// first we verify the comment section is present: "dnat name: \"bridge\" id: \"default-YYYYYY\""
+		matchesContainer, err := regexp.MatchString(namespace+"-"+containerID, rule)
+		if err != nil {
+			t.Logf("error in match string: %q\n", err)
+			return ""
+		}
+		if matchesContainer {
+			// then we find the appropriate chain in the rule
+			matches := re.FindStringSubmatch(rule)
+			fmt.Println(matches)
+			if len(matches) >= 2 {
+				redirectedChain = matches[1]
+			}
+		}
+	}
+	if redirectedChain == "" {
+		t.Logf("no redirectced chain found")
+		return ""
+	}
+	return redirectedChain
+}


### PR DESCRIPTION
Fix #2699

This PR provides code to cleanup CNI network setup when `kill` and `stop` command are typed.
Additionally, the `onStartContainer` hook was added in order to restore the CNI network setup when `start` command is typed (as suggested in the issue by @yankay).

## How to test

In order to test this PR, follow these commands:

```
# compile the binary with the latest changes
make

# create the first container with the built nerdctl version
sudo _output/nerdctl run --name ngx1 -d -p 9999:80 nginx:alpine

# check iptables rules have been setup
sudo iptables-save | grep 9999

# kill the first container previosly created
sudo _output/nerdctl kill ngx1

# (now the iptables rules should disappeared
# create the second container bound on the same port
sudo _output/nerdctl run --name ngx2 -d -p 9999:80 nginx:alpine

# check iptables rules have been setup
sudo iptables-save | grep 9999

# access the second container forward
curl 127.0.0.1:9999
```

## Credits

Thanks to @yankay and @89luca89 for the help