### PR TITLE
feat: add extra local contexts to buildctl call

### DIFF
--- a/cmd/nerdctl/builder_build.go
+++ b/cmd/nerdctl/builder_build.go
@@ -72,6 +72,7 @@ If Dockerfile is not present and -f is not specified, it will look for Container
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
 	buildCommand.Flags().StringSlice("platform", []string{}, "Set target platform for build (e.g., \"amd64\", \"arm64\")")
 	buildCommand.RegisterFlagCompletionFunc("platform", shellCompletePlatforms)
+	buildCommand.Flags().StringArray("build-context", []string{}, "Additional build contexts (e.g., name=path)")
 	// #endregion
 
 	buildCommand.Flags().String("iidfile", "", "Write the image ID to the file")
@@ -188,33 +189,38 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 	if provenance != "" {
 		attest = append(attest, canonicalizeAttest("provenance", provenance))
 	}
+	extendedBuildCtx, err := cmd.Flags().GetStringArray("build-context")
+	if err != nil {
+		return types.BuilderBuildOptions{}, err
+	}
 
 	return types.BuilderBuildOptions{
-		GOptions:     globalOptions,
-		BuildKitHost: buildKitHost,
-		BuildContext: buildContext,
-		Output:       output,
-		Tag:          tagValue,
-		Progress:     progress,
-		File:         filename,
-		Target:       target,
-		BuildArgs:    buildArgs,
-		Label:        label,
-		NoCache:      noCache,
-		Secret:       secret,
-		Allow:        allow,
-		Attest:       attest,
-		SSH:          ssh,
-		CacheFrom:    cacheFrom,
-		CacheTo:      cacheTo,
-		Rm:           rm,
-		IidFile:      iidfile,
-		Quiet:        quiet,
-		Platform:     platform,
-		Stdout:       cmd.OutOrStdout(),
-		Stderr:       cmd.OutOrStderr(),
-		Stdin:        cmd.InOrStdin(),
-		NetworkMode:  network,
+		GOptions:             globalOptions,
+		BuildKitHost:         buildKitHost,
+		BuildContext:         buildContext,
+		Output:               output,
+		Tag:                  tagValue,
+		Progress:             progress,
+		File:                 filename,
+		Target:               target,
+		BuildArgs:            buildArgs,
+		Label:                label,
+		NoCache:              noCache,
+		Secret:               secret,
+		Allow:                allow,
+		Attest:               attest,
+		SSH:                  ssh,
+		CacheFrom:            cacheFrom,
+		CacheTo:              cacheTo,
+		Rm:                   rm,
+		IidFile:              iidfile,
+		Quiet:                quiet,
+		Platform:             platform,
+		Stdout:               cmd.OutOrStdout(),
+		Stderr:               cmd.OutOrStderr(),
+		Stdin:                cmd.InOrStdin(),
+		NetworkMode:          network,
+		ExtendedBuildContext: extendedBuildCtx,
 	}, nil
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -703,6 +703,7 @@ Flags:
 - :nerd_face: `--ipfs`: Build image with pulling base images from IPFS. See [`ipfs.md`](./ipfs.md) for details.
 - :whale: `--label`: Set metadata for an image
 - :whale: `--network=(default|host|none)`: Set the networking mode for the RUN instructions during build.(compatible with `buildctl build`)
+- :whale: --build-context: Set additional contexts for build (e.g. dir2=/path/to/dir2, myorg/myapp=docker-image://path/to/myorg/myapp)
 
 Unimplemented `docker build` flags: `--add-host`, `--squash`
 

--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -65,6 +65,8 @@ type BuilderBuildOptions struct {
 	Label []string
 	// BuildContext is the build context
 	BuildContext string
+	// ExtendedBuildContext is a pair of key=value (e.g. myorg/myapp=docker-image://path/to/image, dir2=/path/to/dir2)
+	ExtendedBuildContext []string
 	// NetworkMode mode for the build context
 	NetworkMode string
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR adds the `--build-context` flag, as explain in the issue #2835 and linked [blog post](https://www.docker.com/blog/dockerfiles-now-support-multiple-build-contexts/). The code is inspired by buildx's implementation [here](https://github.com/docker/buildx/blob/master/build/build.go#L1222-L1299) by same author of the blog post.

It adds support to:
- context from a separate local directory: e.g. `--build-context dir2=/path/to/dir2` if available as `COPY --from=dir2` in `Dockerfile`
- alias to docker images: e.g. `--build-context myorg/myapp=docker-image://path/to/dockerimage:tag` if available as `FROM myorg/myapp`. This also works by providing specific hash: `docker buildx build --build-context myorg/myapp=docker-image://alpine:3.15@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300 .`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#2835 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
See https://github.com/containerd/nerdctl/blob/fd30597d15b7183965281307236f39c70d4b8055/examples/nerdctl-build-context/README.md for some examples
