### PR TITLE
refactor: replace os.MkdirTemp with t.TempDir with cleanup

### DIFF
--- a/cmd/nerdctl/builder_linux_test.go
+++ b/cmd/nerdctl/builder_linux_test.go
@@ -19,11 +19,9 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestBuilderDebug(t *testing.T) {
@@ -34,9 +32,7 @@ func TestBuilderDebug(t *testing.T) {
 CMD ["echo", "nerdctl-builder-debug-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("builder", "debug", buildCtx).CmdOption(testutil.WithStdin(bytes.NewReader([]byte("c\n")))).AssertOK()
 }

--- a/cmd/nerdctl/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container_run_mount_linux_test.go
@@ -122,9 +122,7 @@ func TestRunAnonymousVolumeWithBuild(t *testing.T) {
 VOLUME /foo
         `, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 	base.Cmd("run", "--rm", "-v", "/foo", testutil.AlpineImage,
@@ -146,9 +144,7 @@ RUN mkdir -p /mnt && echo hi > /mnt/initial_file
 CMD ["cat", "/mnt/initial_file"]
         `, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 
@@ -176,9 +172,7 @@ VOLUME /mnt
 CMD ["cat", "/mnt/initial_file"]
         `, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 	//AnonymousVolume
@@ -211,9 +205,7 @@ CMD ["readlink", "/mnt/passwd"]
         `, testutil.AlpineImage)
 	const expected = "../../../../../../../../../../../../../../../../../../etc/passwd\n"
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 
@@ -240,9 +232,7 @@ func TestRunCopyingUpInitialContentsShouldNotResetTheCopiedContents(t *testing.T
 RUN echo -n "rev0" > /mnt/file
 `, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -49,9 +49,7 @@ ENTRYPOINT ["echo", "foo"]
 CMD ["echo", "bar"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 	base.Cmd("run", "--rm", imageName).AssertOutExactly("foo echo bar\n")
@@ -428,9 +426,7 @@ FROM scratch
 COPY --from=builder /go/src/logger/logger /
 	`
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 	tmpDir := t.TempDir()
 	base.Cmd("build", buildCtx, "--output", fmt.Sprintf("type=local,src=/go/src/logger/logger,dest=%s", tmpDir)).AssertOK()
 	defer base.Cmd("image", "rm", "-f", imageName).AssertOK()

--- a/cmd/nerdctl/container_run_verify_linux_test.go
+++ b/cmd/nerdctl/container_run_verify_linux_test.go
@@ -18,12 +18,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 func TestRunVerifyCosign(t *testing.T) {
@@ -48,9 +46,7 @@ func TestRunVerifyCosign(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
 	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.privateKey).AssertOK()

--- a/cmd/nerdctl/image_list_test.go
+++ b/cmd/nerdctl/image_list_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -88,9 +87,7 @@ CMD ["echo", "nerdctl-build-test-string"] \n
 LABEL foo=bar
 LABEL version=0.1`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 	base.Cmd("build", "-t", tempName, "-f", buildCtx+"/Dockerfile", buildCtx).AssertOK()
 	defer base.Cmd("rmi", tempName).AssertOK()
 
@@ -128,10 +125,8 @@ func TestImagesFilterDangling(t *testing.T) {
 	dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-notag-string"]
 	`, testutil.CommonImage)
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
+	buildCtx := createBuildContext(t, dockerfile)
 
-	defer os.RemoveAll(buildCtx)
 	base.Cmd("build", "-f", buildCtx+"/Dockerfile", buildCtx).AssertOK()
 
 	// dangling image test

--- a/cmd/nerdctl/image_prune_test.go
+++ b/cmd/nerdctl/image_prune_test.go
@@ -18,11 +18,9 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestImagePrune(t *testing.T) {
@@ -36,9 +34,7 @@ func TestImagePrune(t *testing.T) {
 	dockerfile := fmt.Sprintf(`FROM %s
 	CMD ["echo", "nerdctl-test-image-prune"]`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", buildCtx).AssertOK()
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
@@ -59,9 +55,7 @@ func TestImagePruneAll(t *testing.T) {
 	dockerfile := fmt.Sprintf(`FROM %s
 	CMD ["echo", "nerdctl-test-image-prune"]`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, buildCtx).AssertOK()
 	// The following commands will clean up all images, so it should fail at this point.

--- a/cmd/nerdctl/image_pull_linux_test.go
+++ b/cmd/nerdctl/image_pull_linux_test.go
@@ -79,9 +79,7 @@ func TestImageVerifyWithCosign(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
 	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.privateKey).AssertOK()
@@ -103,9 +101,7 @@ func TestImagePullPlainHttpWithDefaultPort(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
 	base.Cmd("--insecure-registry", "push", testImageRef).AssertOK()
 	base.Cmd("--insecure-registry", "pull", testImageRef).AssertOK()
@@ -133,9 +129,7 @@ func TestImageVerifyWithCosignShouldFailWhenKeyIsNotCorrect(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
 	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.privateKey).AssertOK()
@@ -202,5 +196,4 @@ func TestPullSoci(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/cmd/nerdctl/ipfs_build_linux_test.go
+++ b/cmd/nerdctl/ipfs_build_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -44,9 +43,7 @@ func TestIPFSBuild(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, ipfsCIDBase)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	done := ipfsRegistryUp(t, base)
 	defer done()

--- a/cmd/nerdctl/multi_platform_linux_test.go
+++ b/cmd/nerdctl/multi_platform_linux_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -68,9 +67,7 @@ func TestMultiPlatformBuildPush(t *testing.T) {
 RUN echo dummy
 	`, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, "--platform=amd64,arm64,linux/arm/v7", buildCtx).AssertOK()
 	testMultiPlatformRun(base, imageName)
@@ -97,9 +94,7 @@ func TestMultiPlatformBuildPushNoRun(t *testing.T) {
 CMD echo dummy
 	`, testutil.AlpineImage)
 
-	buildCtx, err := createBuildContext(dockerfile)
-	assert.NilError(t, err)
-	defer os.RemoveAll(buildCtx)
+	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("build", "-t", imageName, "--platform=amd64,arm64,linux/arm/v7", buildCtx).AssertOK()
 	testMultiPlatformRun(base, imageName)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR comes as suggested by @AkihiroSuda on [this discussion](https://github.com/containerd/nerdctl/pull/2861#discussion_r1519566913).
It's a simple refactor to use `t.TempDir` instead of `os.MkdirTemp` in test files to leverage `testing` package's automatically cleanup. 
