### PR TITLE
feat(compose_up): add --abort-on-container-exit flag

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1383,7 +1383,8 @@ Usage: `nerdctl compose up [OPTIONS] [SERVICE...]`
 
 Flags:
 
-- :whale: `-d, --detach`: Detached mode: Run containers in the background
+- :whale: `--abort-on-container-exit`: Stops all containers if any container was stopped. Incompatible with `-d`.
+- :whale: `-d, --detach`: Detached mode: Run containers in the background. Incompatible with `--abort-on-container-exit`.
 - :whale: `--no-build`: Don't build an image, even if it's missing.
 - :whale: `--no-color`: Produce monochrome output
 - :whale: `--no-log-prefix`: Don't print prefix in logs

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -28,15 +28,16 @@ import (
 )
 
 type UpOptions struct {
-	Detach        bool
-	NoBuild       bool
-	NoColor       bool
-	NoLogPrefix   bool
-	ForceBuild    bool
-	IPFS          bool
-	QuietPull     bool
-	RemoveOrphans bool
-	Scale         map[string]uint64 // map of service name to replicas
+	AbortOnContainerExit bool
+	Detach               bool
+	NoBuild              bool
+	NoColor              bool
+	NoLogPrefix          bool
+	ForceBuild           bool
+	IPFS                 bool
+	QuietPull            bool
+	RemoveOrphans        bool
+	Scale                map[string]uint64 // map of service name to replicas
 }
 
 func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) error {

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -75,11 +75,17 @@ func (c *Composer) upServices(ctx context.Context, parsedServices []*servicepars
 		return nil
 	}
 
+	// this is used to stop containers in case --abort-on-container-exit flag is set.
+	// c.Logs returns an error, so we don't need Ctrl-c to reach the "Stopping containers (forcibly)"
+	if uo.AbortOnContainerExit {
+		defer c.stopContainersFromParsedServices(ctx, containers)
+	}
 	log.G(ctx).Info("Attaching to logs")
 	lo := LogsOptions{
-		Follow:      true,
-		NoColor:     uo.NoColor,
-		NoLogPrefix: uo.NoLogPrefix,
+		AbortOnContainerExit: uo.AbortOnContainerExit,
+		Follow:               true,
+		NoColor:              uo.NoColor,
+		NoLogPrefix:          uo.NoLogPrefix,
 	}
 	if err := c.Logs(ctx, lo, services); err != nil {
 		return err


### PR DESCRIPTION
Fixes #2795 .
This PR adds the flag `--abort-on-container-exit` flag for `nerdctl compose up` command.
As the flag says, using it all containers are being stopped if any container was stopped during the run.