### PR TITLE
Move image pull args into struct

### DIFF
--- a/cmd/nerdctl/image_pull.go
+++ b/cmd/nerdctl/image_pull.go
@@ -20,6 +20,8 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
+	"github.com/containerd/nerdctl/v2/pkg/platformutil"
+	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/spf13/cobra"
 )
 
@@ -81,7 +83,16 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 		return types.ImagePullOptions{}, err
 	}
 
+	ociSpecPlatform, err := platformutil.NewOCISpecPlatformSlice(allPlatforms, platform)
+	if err != nil {
+		return types.ImagePullOptions{}, err
+	}
+
 	unpackStr, err := cmd.Flags().GetString("unpack")
+	if err != nil {
+		return types.ImagePullOptions{}, err
+	}
+	unpack, err := strutil.ParseBoolOrAuto(unpackStr)
 	if err != nil {
 		return types.ImagePullOptions{}, err
 	}
@@ -105,13 +116,13 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 		return types.ImagePullOptions{}, err
 	}
 	return types.ImagePullOptions{
-		GOptions:      globalOptions,
-		VerifyOptions: verifyOptions,
-		AllPlatforms:  allPlatforms,
-		Platform:      platform,
-		Unpack:        unpackStr,
-		Quiet:         quiet,
-		IPFSAddress:   ipfsAddressStr,
+		GOptions:        globalOptions,
+		VerifyOptions:   verifyOptions,
+		OCISpecPlatform: ociSpecPlatform,
+		Unpack:          unpack,
+		Mode:            "always",
+		Quiet:           quiet,
+		IPFSAddress:     ipfsAddressStr,
 		RFlags: types.RemoteSnapshotterFlags{
 			SociIndexDigest: sociIndexDigest,
 		},

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -18,6 +18,8 @@ package types
 
 import (
 	"io"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ImageListOptions specifies options for `nerdctl image list`.
@@ -191,12 +193,13 @@ type ImagePullOptions struct {
 	Stderr        io.Writer
 	GOptions      GlobalCommandOptions
 	VerifyOptions ImageVerifyOptions
-	// Unpack the image for the current single platform (auto/true/false)
-	Unpack string
-	// Pull content for a specific platform
-	Platform []string
-	// Pull content for all platforms
-	AllPlatforms bool
+	// Unpack the image for the current single platform.
+	// If nil, it will unpack automatically if only 1 platform is specified.
+	Unpack *bool
+	// Content for specific platforms. Empty if `--all-platforms` is true
+	OCISpecPlatform []v1.Platform
+	// Pull mode
+	Mode string
 	// Suppress verbose output
 	Quiet bool
 	// multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -110,6 +110,17 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 			ocispecPlatforms = []ocispec.Platform{parsed} // no append
 		}
 
+		imgPullOpts := types.ImagePullOptions{
+			GOptions:        globalOptions,
+			OCISpecPlatform: ocispecPlatforms,
+			Unpack:          nil,
+			Mode:            pullMode,
+			Quiet:           quiet,
+			RFlags:          types.RemoteSnapshotterFlags{},
+			Stdout:          stdout,
+			Stderr:          stderr,
+		}
+
 		// IPFS reference
 		if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(imageName); err == nil {
 			var ipfsPath string
@@ -124,8 +135,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 				}
 				ipfsPath = dir
 			}
-			_, err = ipfs.EnsureImage(ctx, client, stdout, stderr, globalOptions.Snapshotter, scheme, ref,
-				pullMode, ocispecPlatforms, nil, quiet, ipfsPath, types.RemoteSnapshotterFlags{})
+			_, err = ipfs.EnsureImage(ctx, client, scheme, ref, ipfsPath, imgPullOpts)
 			return err
 		}
 
@@ -135,8 +145,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 			return err
 		}
 
-		_, err = imgutil.EnsureImage(ctx, client, stdout, stderr, globalOptions.Snapshotter, ref,
-			pullMode, globalOptions.InsecureRegistry, globalOptions.HostsDir, ocispecPlatforms, nil, quiet, types.RemoteSnapshotterFlags{})
+		_, err = imgutil.EnsureImage(ctx, client, ref, imgPullOpts)
 		return err
 	}
 

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -130,7 +130,12 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		}
 		rawRef := args[0]
 
-		ensuredImage, err = image.EnsureImage(ctx, client, rawRef, ocispecPlatforms, options.Pull, nil, false, options.ImagePullOpt)
+		options.ImagePullOpt.Mode = options.Pull
+		options.ImagePullOpt.OCISpecPlatform = ocispecPlatforms
+		options.ImagePullOpt.Unpack = nil
+		options.ImagePullOpt.Quiet = false
+
+		ensuredImage, err = image.EnsureImage(ctx, client, rawRef, options.ImagePullOpt)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
In the image pull workflow, the function headers are getting far too large. (imgutil.EnsureImage had 13 required arguments as of the time of this PR.) This change consolidates many of the arguments in `imgutil.PullImage` into `types.ImagePullTypes`, and the necessary refactors that come with this change.

I did as much pre-processing in `processPullCommandFlags` as possible. So, anything that cannot be declared from the function flags did not fall in the options.

Did some basic testing with `make` and running some basic image commands to do a sanity check that functionality remained intact.

Very open to suggestions on how to structure this a bit more logically. I made a best effort but a fresh pair of eyes always helps 😅