### PR TITLE
update cosign image to latest release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -288,7 +288,7 @@ WORKDIR /go/src/github.com/containerd/nerdctl
 VOLUME /tmp
 ENV CGO_ENABLED=0
 # copy cosign binary for integration test
-COPY --from=gcr.io/projectsigstore/cosign:v2.0.0@sha256:728944a9542a7235b4358c4ab2bcea855840e9d4b9594febca5c2207f5da7f38 /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v2.2.3@sha256:8fc9cad121611e8479f65f79f2e5bea58949e8a87ffac2a42cb99cf0ff079ba7 /ko-app/cosign /usr/local/bin/cosign
 # installing soci for integration test
 ARG SOCI_SNAPSHOTTER_VERSION
 RUN fname="soci-snapshotter-${SOCI_SNAPSHOTTER_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz" && \


### PR DESCRIPTION
Fix #2895

Update cosign image used by integration test to latest version 2.2.3.

https://console.cloud.google.com/gcr/images/projectsigstore/global/cosign@sha256:8fc9cad121611e8479f65f79f2e5bea58949e8a87ffac2a42cb99cf0ff079ba7/details

Based on https://github.com/containerd/nerdctl/issues/2895#issuecomment-2016843711:

<img width="683" alt="image" src="https://github.com/containerd/nerdctl/assets/28295179/0f29581e-d76c-4975-afba-f303cae53aa5">
