### PR TITLE
Deflake IPFS and EStargz tests

### DIFF
--- a/cmd/nerdctl/image_convert_test.go
+++ b/cmd/nerdctl/image_convert_test.go
@@ -28,7 +28,6 @@ func TestImageConvertEStargz(t *testing.T) {
 		t.Skip("no windows support yet")
 	}
 	testutil.DockerIncompatible(t)
-	t.Parallel()
 	base := testutil.NewBase(t)
 	convertedImage := testutil.Identifier(t) + ":esgz"
 	base.Cmd("rmi", convertedImage).Run()

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -159,7 +159,7 @@ func TestIPFSWithLazyPullingCommit(t *testing.T) {
 func pushImageToIPFS(t *testing.T, base *testutil.Base, name string, opts ...string) string {
 	base.Cmd("pull", name).AssertOK()
 	ipfsCID := cidOf(t, base.Cmd(append([]string{"push"}, append(opts, "ipfs://"+name)...)...).OutLines())
-	base.Cmd("rmi", name).AssertOK()
+	base.Cmd("rmi", name).Run()
 	return ipfsCID
 }
 


### PR DESCRIPTION
IPFS related flaky tests have the following error, e.g. in https://github.com/containerd/nerdctl/actions/runs/8412061811/job/23032444940 (error attached below)

I think the change can mitigate this flaky tests to some extends.

Also the other estargz test shouldn't be executed in parallel since it pulls and `rmi`s a common image. (I also saw flaky related to that)

```
=== RUN   TestIPFS
    ipfs_linux_test.go:162: assertion failed: res.ExitCode is not exitCode: time="2024-03-24T21:11:22Z" level=fatal msg="1 errors:\nconflict: unable to delete ghcr.io/stargz-containers/alpine:3.13-org (must be forced) - image is being used by stopped container e5d04bd64e173db20d5585cd4a6376e8efa6bf6708df0d0b1859bd798c88acbf"
        
--- FAIL: TestIPFS (0.34s)
FAIL cmd/nerdctl.TestIPFS (0.34s)
=== RUN   TestIPFSAddress
    ipfs_linux_test.go:84: IPAddress=['"10.4.0.61"' ]
    ipfs_linux_test.go:87: ip address matches=["10.4.0.61" 10.4.0.61]
    ipfs_linux_test.go:162: assertion failed: res.ExitCode is not exitCode: time="2024-03-24T21:11:23Z" level=fatal msg="1 errors:\nconflict: unable to delete ghcr.io/stargz-containers/alpine:3.13-org (must be forced) - image is being used by stopped container e5d04bd64e173db20d5585cd4a6376e8efa6bf6708df0d0b1859bd798c88acbf"
        
--- FAIL: TestIPFSAddress (0.80s)
FAIL cmd/nerdctl.TestIPFSAddress (0.80s)
=== RUN   TestIPFSCommit
    ipfs_linux_test.go:162: assertion failed: res.ExitCode is not exitCode: time="2024-03-24T21:11:23Z" level=fatal msg="1 errors:\nconflict: unable to delete ghcr.io/stargz-containers/alpine:3.13-org (must be forced) - image is being used by stopped container e5d04bd64e173db20d5585cd4a6376e8efa6bf6708df0d0b1859bd798c88acbf"
        
--- FAIL: TestIPFSCommit (0.24s)
FAIL cmd/nerdctl.TestIPFSCommit (0.24s)
=== RUN   TestIPFSWithLazyPulling
    ipfs_linux_test.go:162: assertion failed: res.ExitCode is not exitCode: time="2024-03-24T21:11:24Z" level=fatal msg="1 errors:\nconflict: unable to delete ghcr.io/stargz-containers/alpine:3.13-org (must be forced) - image is being used by stopped container e5d04bd64e173db20d5585cd4a6376e8efa6bf6708df0d0b1859bd798c88acbf"
```



