### PR TITLE
bypass4netns: allow disabling bind

### DIFF
--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -29,10 +29,16 @@ const (
 	// Bypass4netnsIgnoreSubnets is a JSON of []string that is appended to
 	// the `bypass4netns --ignore` list.
 	Bypass4netnsIgnoreSubnets = Bypass4netns + "-ignore-subnets"
+
+	// Bypass4netnsIgnoreBind disables acceleration for bind.
+	// Boolean value which can be parsed with strconv.ParseBool() is required.
+	Bypass4netnsIgnoreBind = Bypass4netns + "-ignore-bind"
 )
 
 var ShellCompletions = []string{
 	Bypass4netns + "=true",
 	Bypass4netns + "=false",
 	Bypass4netnsIgnoreSubnets + "=",
+	Bypass4netnsIgnoreBind + "=true",
+	Bypass4netnsIgnoreBind + "=false",
 }

--- a/pkg/bypass4netnsutil/bypass4netnsutil.go
+++ b/pkg/bypass4netnsutil/bypass4netnsutil.go
@@ -133,15 +133,21 @@ func GetPidFilePathByID(id string) (string, error) {
 	return socketPath, nil
 }
 
-func IsBypass4netnsEnabled(annotationsMap map[string]string) (bool, error) {
+func IsBypass4netnsEnabled(annotationsMap map[string]string) (enabled, bindEnabled bool, err error) {
 	if b4nn, ok := annotationsMap[annotations.Bypass4netns]; ok {
-		b4nnEnable, err := strconv.ParseBool(b4nn)
+		enabled, err = strconv.ParseBool(b4nn)
 		if err != nil {
-			return false, err
+			return
 		}
-
-		return b4nnEnable, nil
+		bindEnabled = enabled
+		if s, ok := annotationsMap[annotations.Bypass4netnsIgnoreBind]; ok {
+			var bindDisabled bool
+			bindDisabled, err = strconv.ParseBool(s)
+			if err != nil {
+				return
+			}
+			bindEnabled = !bindDisabled
+		}
 	}
-
-	return false, nil
+	return
 }


### PR DESCRIPTION
The bypass for bind can be disabled with the new annotation `nerdctl/bypass4netns-ignore--bind=true`.

Depends on:
- rootless-containers/bypass4netns#68