### PR TITLE
CI: use Go 1.22

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v4.1.4
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.21.x
+        go-version: 1.22.x
     - name: "Compile binaries"
       run: make artifacts
     - name: "SHA256SUMS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.21.x
+  GO_VERSION: 1.22.x
 
 jobs:
   project:

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ ARG BYPASS4NETNS_VERSION=v0.4.1
 ARG FUSE_OVERLAYFS_VERSION=v1.13
 ARG CONTAINERD_FUSE_OVERLAYFS_VERSION=v1.0.8
 # Extra deps: IPFS
-# Kubo >= 0.28 needs Go 1.22, but runc is still incompatible with Go 1.22
-# https://github.com/opencontainers/runc/issues/4233
 ARG KUBO_VERSION=v0.27.0
 # Extra deps: Init
 ARG TINI_VERSION=v0.19.0
@@ -46,7 +44,7 @@ ARG TINI_VERSION=v0.19.0
 ARG BUILDG_VERSION=v0.4.1
 
 # Test deps
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.22
 ARG UBUNTU_VERSION=22.04
 ARG CONTAINERIZED_SYSTEMD_VERSION=v0.1.1
 ARG GOTESTSUM_VERSION=v1.11.0
@@ -67,6 +65,18 @@ ARG TARGETARCH
 RUN xx-apt-get update && \
   xx-apt-get install -y binutils gcc libc6-dev libbtrfs-dev libseccomp-dev
 
+# runc still requires Go 1.21
+# https://github.com/opencontainers/runc/issues/4233
+FROM --platform=$BUILDPLATFORM golang:1.21-bullseye AS build-base-debian-go121
+COPY --from=xx / /
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+  apt-get install -y git pkg-config dpkg-dev
+ARG TARGETARCH
+# libseccomp: for runc
+RUN xx-apt-get update && \
+  xx-apt-get install -y binutils gcc libc6-dev libseccomp-dev
+
 FROM build-base-debian AS build-containerd
 ARG TARGETARCH
 ARG CONTAINERD_VERSION
@@ -78,7 +88,9 @@ RUN git checkout ${CONTAINERD_VERSION} && \
 RUN GO=xx-go make STATIC=1 && \
   cp -a bin/containerd bin/containerd-shim-runc-v2 bin/ctr /out/$TARGETARCH
 
-FROM build-base-debian AS build-runc
+# runc still requires Go 1.21
+# https://github.com/opencontainers/runc/issues/4233
+FROM build-base-debian-go121 AS build-runc
 ARG RUNC_VERSION
 ARG TARGETARCH
 RUN git clone https://github.com/opencontainers/runc.git /go/src/github.com/opencontainers/runc


### PR DESCRIPTION
The main branch of containerd now depends on Go 1.22, so we have to upgrade the CI to Go 1.22.

The runc binary is still built with Go 1.21 due to opencontainers/runc#4233.