### PR TITLE
Re-acquire name in onStartContainer (see #2992)

### DIFF
--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -477,6 +477,15 @@ func onCreateRuntime(opts *handlerOpts) error {
 }
 
 func onStartContainer(opts *handlerOpts) error {
+	name := opts.state.Annotations[labels.Name]
+	ns := opts.state.Annotations[labels.Namespace]
+	namst, err := namestore.New(opts.dataStore, ns)
+	if err != nil {
+		log.L.WithError(err).Error("failed opening the namestore in onStartContainer")
+	} else if err := namst.Acquire(name, opts.state.ID); err != nil {
+		log.L.WithError(err).Error("failed re-acquiring name - see https://github.com/containerd/nerdctl/issues/2992")
+	}
+
 	if opts.cni != nil {
 		return applyNetworkSettings(opts)
 	}


### PR DESCRIPTION
@AkihiroSuda 

This is solution A (fix #2992 ).

It does make things much better of course, but yes, it is still racy.

With `while true; do sudo ./nerdctl-patch run -d --restart always --name whatevername debian bash; done` it will race out the container restart about 1 time out of 30 (on an old rpi).

IMHO, we should go ahead and merge this anyway - because it is drastically improving the situation.