### PR TITLE
[Design Review] StartedAt for containers

### DIFF
--- a/docs/dir.md
+++ b/docs/dir.md
@@ -34,6 +34,7 @@ Files:
 - `log-config.json`: used for storing the `--log-opts` map of `nerdctl run`
 - `<CID>-json.log`: used by `nerdctl logs`
 - `oci-hook.*.log`: logs of the OCI hook
+- `lifecycle.json`: used to store stateful information about the container that can only be retrieved through OCI hooks
 
 ### `<DATAROOT>/<ADDRHASH>/names/<NAMESPACE>`
 e.g. `/var/lib/nerdctl/1935db59/names/default`

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -70,7 +70,7 @@ func TestContainerFromNative(t *testing.T) {
 					Status:     "running",
 					Running:    true,
 					Pid:        10000,
-					FinishedAt: "0001-01-01T00:00:00Z",
+					FinishedAt: "",
 				},
 				Mounts: []MountPoint{
 					{
@@ -141,7 +141,7 @@ func TestContainerFromNative(t *testing.T) {
 					Status:     "running",
 					Running:    true,
 					Pid:        10000,
-					FinishedAt: "0001-01-01T00:00:00Z",
+					FinishedAt: "",
 				},
 				Mounts: []MountPoint{
 					{
@@ -209,7 +209,7 @@ func TestContainerFromNative(t *testing.T) {
 					Status:     "running",
 					Running:    true,
 					Pid:        10000,
-					FinishedAt: "0001-01-01T00:00:00Z",
+					FinishedAt: "",
 				},
 				Mounts: []MountPoint{
 					{

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
@@ -35,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/namestore"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
+	"github.com/containerd/nerdctl/v2/pkg/ocihook/state"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	types100 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -284,7 +286,7 @@ func getNetNSPath(state *specs.State) (string, error) {
 		return netNsPath, nil
 	}
 
-	if state.Pid == 0 && !netNsFound {
+	if state.Pid == 0 {
 		return "", errors.New("both state.Pid and the netNs annotation are unset")
 	}
 
@@ -487,9 +489,21 @@ func onStartContainer(opts *handlerOpts) error {
 	}
 
 	if opts.cni != nil {
-		return applyNetworkSettings(opts)
+		if err = applyNetworkSettings(opts); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	// Set StartedAt
+	lf := state.NewLifecycleState(opts.state.Annotations[labels.StateDir])
+	return lf.WithLock(func() error {
+		err := lf.Load()
+		if err != nil {
+			return err
+		}
+		lf.StartedAt = time.Now()
+		return lf.Save()
+	})
 }
 
 func onPostStop(opts *handlerOpts) error {

--- a/pkg/ocihook/state/state.go
+++ b/pkg/ocihook/state/state.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package state
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+)
+
+// This is meant to store stateful informations about containers that we receive from ocihooks
+// We are storing them inside the container statedir
+// Note that you MUST use WithLock to perform any operation (like Read or Write).
+// Typically:
+// lf.WithLock(func ()error {
+//   lf.Load()
+//   // Modify something on the object
+//   lf.StartedAt = ...
+//   lf.Save()
+// })
+
+const (
+	lifecycleFile = "lifecycle.json"
+)
+
+func NewLifecycleState(stateDir string) *LifecycleState {
+	return &LifecycleState{
+		stateDir: stateDir,
+	}
+}
+
+type LifecycleState struct {
+	stateDir  string
+	StartedAt time.Time `json:"started_at"`
+}
+
+func (lf *LifecycleState) WithLock(fun func() error) error {
+	err := lockutil.WithDirLock(lf.stateDir, fun)
+	if err != nil {
+		return fmt.Errorf("failed to lock state dir: %w", err)
+	}
+
+	return nil
+}
+
+func (lf *LifecycleState) Load() error {
+	data, err := os.ReadFile(filepath.Join(lf.stateDir, lifecycleFile))
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("unable to read lifecycle file: %w", err)
+		}
+	} else {
+		err = json.Unmarshal(data, lf)
+		if err != nil {
+			return fmt.Errorf("unable to unmarshall lifecycle data: %w", err)
+		}
+	}
+	return nil
+}
+
+func (lf *LifecycleState) Save() error {
+	data, err := json.Marshal(lf)
+	if err != nil {
+		return fmt.Errorf("unable to marshall lifecycle data: %w", err)
+	}
+	err = os.WriteFile(filepath.Join(lf.stateDir, lifecycleFile), data, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to write lifecycle file: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This is a proposal to implement StartedAt (see #2335).

Short of containerd exposing this, the right place to implement is likely inside `ocihook.onStart` (to account for containers with a restart policy).

I do not know how or if it is possible to modify annotations from inside ocihooks. If it is, that would be a better solution and would love to see an example of how to do that.

So, instead, I am maintaining a new state file inside the stateDir.
For that, there is a `LifecycleState` struct that we can leverage in the future to store more information that has to be updated inside ocihooks.

This PR also contains a two lines minor change to fix #3002.

Let me know what you folks think.
As usual, happy to adapt to feedback on the right way to do this. 