### PR TITLE
Fix cni plugins sha after spurious 1.4.1 re-release

### DIFF
--- a/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.4.1
+++ b/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.4.1
@@ -1,2 +1,2 @@
-1511f6c003ace805eafeb1132727791326283cff88a923d76329e1892bba7a10  cni-plugins-linux-amd64-v1.4.1.tgz
-72644e13557cda8a5b39baf97fc5e93d23fdf7baba7700000e7e9efd8bdf9234  cni-plugins-linux-arm64-v1.4.1.tgz
+2a0ea7072d1806b8526489bcd3b4847a06ab010ee32ba3c3d4e5a3235d3eb138  cni-plugins-linux-amd64-v1.4.1.tgz
+56fe62d73942cffd8f119d2b8ecb6a062e85f529a3dbfc7aa5cd83c2c01929a7  cni-plugins-linux-arm64-v1.4.1.tgz


### PR DESCRIPTION
cni apparently re-released 1.4.1 (see https://github.com/containernetworking/plugins/issues/1038).

Updating the sha to match the currently uploaded archive.

Pending CI to run successfully, we should merge this to unblock other PRs.

cc @AkihiroSuda 