### PR TITLE
ci: Add retry on github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,12 @@ jobs:
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Run integration tests"
-        run: docker run -t --rm --privileged test-integration
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: docker run -t --rm --privileged test-integration
 
   test-integration-ipv6:
     runs-on: "ubuntu-${{ matrix.ubuntu }}"
@@ -146,7 +151,12 @@ jobs:
         # On the other side, using the host network is easier at configuration.
         # Besides, each job is running on a different instance, which means using host network here
         # is safe and has no side effects on others.
-        run: docker run --network host -t --rm --privileged test-integration-ipv6
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: docker run --network host -t --rm --privileged test-integration-ipv6
 
   test-integration-rootless:
     runs-on: "ubuntu-${{ matrix.ubuntu }}"
@@ -202,7 +212,12 @@ jobs:
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
         run: DOCKER_BUILDKIT=1 docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=1 ${TEST_TARGET}
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=1 ${TEST_TARGET}
 
   cross:
     runs-on: ubuntu-22.04
@@ -224,7 +239,7 @@ jobs:
 
   test-integration-docker-compatibility:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4.1.6
         with:
@@ -252,9 +267,19 @@ jobs:
         run: |
           sudo apt-get install -y expect
       - name: "Ensure that the integration test suite is compatible with Docker"
-        run: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon
       - name: "Ensure that the IPv6 integration test suite is compatible with Docker"
-        run: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon -test.ipv6
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_on: error
+          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon -test.ipv6
 
   test-integration-windows:
     runs-on: windows-2022


### PR DESCRIPTION
Some flaky tests make the GitHub action fail pretty often.

- https://github.com/containerd/nerdctl/issues/2690
- https://github.com/containerd/nerdctl/issues/2327

The developer needs to retry the test several times to make it successful.

So, add a retry on GitHub action to make the development work more effectively.