### PR TITLE
Snapshotter with caching

### DIFF
--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/v2/pkg/imageinspector"
+	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 )
 
@@ -35,13 +36,14 @@ func Inspect(ctx context.Context, client *containerd.Client, images []string, op
 	f := &imageInspector{
 		mode: options.Mode,
 	}
+	snapshotter := imgutil.SnapshotServiceWithCache(client.SnapshotService(options.GOptions.Snapshotter))
 	walker := &imagewalker.ImageWalker{
 		Client: client,
 		OnFound: func(ctx context.Context, found imagewalker.Found) error {
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			n, err := imageinspector.Inspect(ctx, client, found.Image, options.GOptions.Snapshotter)
+			n, err := imageinspector.Inspect(ctx, client, found.Image, snapshotter)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -169,7 +169,7 @@ func printImages(ctx context.Context, client *containerd.Client, imageList []ima
 		tmpl:         tmpl,
 		client:       client,
 		contentStore: client.ContentStore(),
-		snapshotter:  client.SnapshotService(options.GOptions.Snapshotter),
+		snapshotter:  imgutil.SnapshotServiceWithCache(client.SnapshotService(options.GOptions.Snapshotter)),
 	}
 
 	for _, img := range imageList {

--- a/pkg/imageinspector/imageinspector.go
+++ b/pkg/imageinspector/imageinspector.go
@@ -21,13 +21,14 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/log"
-	imgutil "github.com/containerd/nerdctl/v2/pkg/imgutil"
+	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )
 
 // Inspect inspects the image, for the platform specified in image.platform.
-func Inspect(ctx context.Context, client *containerd.Client, image images.Image, snapshotter string) (*native.Image, error) {
+func Inspect(ctx context.Context, client *containerd.Client, image images.Image, snapshotter snapshots.Snapshotter) (*native.Image, error) {
 
 	n := &native.Image{}
 
@@ -55,8 +56,7 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 		n.ImageConfigDesc = imageConfigDesc
 		n.ImageConfig = imageConfig
 	}
-	snapSvc := client.SnapshotService(snapshotter)
-	n.Size, err = imgutil.UnpackedImageSize(ctx, snapSvc, img)
+	n.Size, err = imgutil.UnpackedImageSize(ctx, snapshotter, img)
 	if err != nil {
 		log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to inspect calculate size")
 	}


### PR DESCRIPTION
This is a proof of concept / draft for #3027

Average, very un-scientific measurements for`nerdctl images`:

On 500 identical images at 270MB:
- without cache: 5.2 seconds
- with cache: 3.3 seconds

On 500 identical images (buysbox, one layer, 4.174MB):
- without cache: 5.0 seconds
- with cache: 4.8 seconds

For about 250 containers (`nerdctl ps -as`) started from the same image (the big one above), results are in the same ballpark: about 50% gain with cache.

This PR also consolidates code and reduce duplication I did introduce... 

Let me know if this is something we should consider.

If yes, we can iterate on design / code location and possibly simplify the signature of `imgutil.SnapshotServiceWithCache` for eg.