### PR TITLE
Support CI on ARM64 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         run: go test -v ./pkg/...
 
   test-integration:
-    runs-on: "ubuntu-${{ matrix.ubuntu }}"
+    runs-on: "${{ matrix.runner }}"
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -64,10 +64,16 @@ jobs:
         include:
           - ubuntu: 20.04
             containerd: v1.6.33
+            runner: "ubuntu-20.04"
           - ubuntu: 22.04
             containerd: v1.7.19
+            runner: "ubuntu-22.04"
           - ubuntu: 24.04
             containerd: v2.0.0-rc.3
+            runner: "ubuntu-24.04"
+          - ubuntu: 24.04
+            containerd: v2.0.0-rc.3
+            runner: github-arm64-2c-8gb
     env:
       UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -40,7 +40,7 @@ var (
 	WordpressIndexHTMLSnippet   = "<title>WordPress &rsaquo; Installation</title>"
 	MariaDBImage                = mirrorOf("mariadb:10.5")
 	DockerAuthImage             = mirrorOf("cesanta/docker_auth:1.7")
-	FluentdImage                = mirrorOf("fluent/fluentd:v1.14-1")
+	FluentdImage                = "fluent/fluentd:v1.17.0-debian-1.0"
 	KuboImage                   = mirrorOf("ipfs/kubo:v0.16.0")
 	SystemdImage                = "ghcr.io/containerd/stargz-snapshotter:0.15.1-kind"
 


### PR DESCRIPTION
To support the ARM64 better, add it to the CI.  And to make the CI pass, there are some changes:

* Because the [fluentd](https://hub.docker.com/r/fluent/fluentd/tags?page=&page_size=&ordering=&name=v1.14) image is not a multi-arch image, so using the arm64 image name
* Because the arm64 system is compatible with armv7, the multi_platform_linux_test.go behavior is different.