### PR TITLE
MAINTAINERS: promote Jin Dong (djdongjin) from a REVIEWER to a COMMITTER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -16,11 +16,11 @@
 "fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com","EE7A 5503 CE0D 38AC 5B95  A500 F35F F497 60A8 65FA"
 "Zheaoli", "Zheao Li", "me@manjusaka.me","6E0D D9FA BAD5 AF61 D884 01EE 878F 445D 9C6C E65E"
 "junnplus","Ye Sijun","junnplus@gmail.com",""
+"djdongjin", "Jin Dong", "djdongjin95@gmail.com",""
 
 # REVIEWERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "jsturtevant","James Sturtevant","jstur@microsoft.com",""
 "yuchanns", "Hanchin Hsieh", "me@yuchanns.xyz",""
 "manugupt1", "Manu Gupta", "manugupt1@gmail.com","FCA9 504A 4118 EA5C F466 CC30 A5C3 A8F4 E7FE 9E10"
-"djdongjin", "Jin Dong", "djdongjin95@gmail.com",""
 "yankay", "Kay Yan", "kay.yan@daocloud.io", ""


### PR DESCRIPTION
@djdongjin has been a reviewer since Dec 2022 (https://github.com/containerd/nerdctl/pull/1649), and he has been very actively contributing to the project:
https://github.com/containerd/nerdctl/pulls?q=author%3Adjdongjin+

So I'd like to promote @djdongjin to a committer.

Needs explicit LGTM from @djdongjin and 2/3 of the nerdctl Committers ( $ceil \left( 4 \times \frac{2}{3} \right) = 3$ ), according to https://github.com/containerd/project/blob/main/GOVERNANCE.md :


> After a candidate has been informally proposed in the maintainers forum, the
> existing maintainers are given seven days to discuss the candidate, raise
> objections and show their support. Formal voting takes place on a pull request
> that adds the contributor to the MAINTAINERS file. Candidates must be approved
> by 2/3 of the current committers by adding their approval or LGTM to the pull
> request. The reviewer role has the same process but only requires 1/3 of current
> committers.
> 
> If a candidate is approved, they will be invited to add their own LGTM or
> approval to the pull request to acknowledge their agreement. A committer will
> verify the numbers of votes that have been received and the allotted seven days
> have passed, then merge the pull request and invite the contributor to the
> organization.
> 
> For non-core sub-projects, only committers of the repository that the candidate
> is proposed for are given votes.


- [x] @djdongjin
- [x] @ktock (nerdctl Committer)
- [x] @fahedouch (nerdctl Committer)
- [x] @Zheaoli (nerdctl Committer)
- [ ] @junnplus (nerdctl Committer)


I'd also like to get a few LGTMs from the Core Committers too. (not necessary)

This PR will remain open for 7 days.