### PR TITLE
MAINTAINERS: move Hanchin Hsieh (yuchanns) from a REVIEWER to a EMERITUS

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -1,0 +1,12 @@
+See [`MAINTAINERS`](./MAINTAINERS) for the current active maintainers.
+- - -
+# nerdctl Emeritus Maintainers
+
+## Reviewers
+### Hanchin Hsieh ([@yuchanns](https://github.com/yuchanns))
+Hanchin Hsieh (GitHub ID [@yuchanns](https://github.com/yuchanns)) served as
+a Reviewer of nerdctl from November 2022 to June 2024.
+
+Hanchin has made significant contributions such as the addition of
+[syslog driver](https://github.com/containerd/nerdctl/pull/1377) and
+[IPv6 networking](https://github.com/containerd/nerdctl/pull/1558).

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -20,7 +20,9 @@
 # REVIEWERS
 # GitHub ID, Name, Email address, GPG fingerprint
 "jsturtevant","James Sturtevant","jstur@microsoft.com",""
-"yuchanns", "Hanchin Hsieh", "me@yuchanns.xyz",""
 "manugupt1", "Manu Gupta", "manugupt1@gmail.com","FCA9 504A 4118 EA5C F466 CC30 A5C3 A8F4 E7FE 9E10"
 "djdongjin", "Jin Dong", "djdongjin95@gmail.com",""
 "yankay", "Kay Yan", "kay.yan@daocloud.io", ""
+
+# EMERITUS
+# See EMERITUS.md


### PR DESCRIPTION
Hanchin Hsieh (@yuchanns) served as a Reviewer of nerdctl from November 2022 to June 2024.

Hanchin has made significant contributions such as the addition of syslog driver (#1377) and IPv6 networking (#1558).

We show our huge appreciation to Hanchin.

https://github.com/containerd/nerdctl/issues/3066#issuecomment-2152284905