### PR TITLE
Add --pull option to build command

### DIFF
--- a/cmd/nerdctl/builder_build.go
+++ b/cmd/nerdctl/builder_build.go
@@ -51,6 +51,7 @@ If Dockerfile is not present and -f is not specified, it will look for Container
 	buildCommand.Flags().StringP("output", "o", "", "Output destination (format: type=local,dest=path)")
 	buildCommand.Flags().String("progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
 	buildCommand.Flags().String("provenance", "", "Shorthand for \"--attest=type=provenance\"")
+	buildCommand.Flags().Bool("pull", false, "On true, always attempt to pull latest image version from remote. Default uses buildkit's default.")
 	buildCommand.Flags().StringArray("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
 	buildCommand.Flags().StringArray("allow", nil, "Allow extra privileged entitlement, e.g. network.host, security.insecure")
 	buildCommand.RegisterFlagCompletionFunc("allow", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -133,6 +134,14 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 	if err != nil {
 		return types.BuilderBuildOptions{}, err
 	}
+	var pull *bool
+	if cmd.Flags().Changed("pull") {
+		pullFlag, err := cmd.Flags().GetBool("pull")
+		if err != nil {
+			return types.BuilderBuildOptions{}, err
+		}
+		pull = &pullFlag
+	}
 	secret, err := cmd.Flags().GetStringArray("secret")
 	if err != nil {
 		return types.BuilderBuildOptions{}, err
@@ -205,6 +214,7 @@ func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBu
 		BuildArgs:            buildArgs,
 		Label:                label,
 		NoCache:              noCache,
+		Pull:                 pull,
 		Secret:               secret,
 		Allow:                allow,
 		Attest:               attest,

--- a/cmd/nerdctl/builder_linux_test.go
+++ b/cmd/nerdctl/builder_linux_test.go
@@ -19,9 +19,13 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"gotest.tools/v3/assert"
 )
 
 func TestBuilderDebug(t *testing.T) {
@@ -35,4 +39,90 @@ CMD ["echo", "nerdctl-builder-debug-test-string"]
 	buildCtx := createBuildContext(t, dockerfile)
 
 	base.Cmd("builder", "debug", buildCtx).CmdOption(testutil.WithStdin(bytes.NewReader([]byte("c\n")))).AssertOK()
+}
+
+func TestBuildWithPull(t *testing.T) {
+	testutil.DockerIncompatible(t)
+	testutil.RequiresBuild(t)
+
+	oldImage := testutil.BusyboxImage
+	oldImageSha := "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+	newImage := testutil.AlpineImage
+
+	buildkitConfig := fmt.Sprintf(`[worker.oci]
+enabled = false
+
+[worker.containerd]
+enabled = true
+namespace = "%s"`, testutil.Namespace)
+
+	cleanup := useBuildkitConfig(t, buildkitConfig)
+	defer cleanup()
+
+	testCases := []struct {
+		name string
+		pull string
+	}{
+		{
+			name: "build with local image",
+			pull: "false",
+		},
+		{
+			name: "build with newest image",
+			pull: "true",
+		},
+		{
+			name: "build with buildkit default",
+			// buildkit default pulls from remote
+			pull: "default",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			base := testutil.NewBase(t)
+			defer base.Cmd("builder", "prune").AssertOK()
+			base.Cmd("image", "prune", "--force", "--all").AssertOK()
+
+			base.Cmd("pull", oldImage).Run()
+			base.Cmd("tag", oldImage, newImage).Run()
+
+			dockerfile := fmt.Sprintf(`FROM %s`, newImage)
+			tmpDir := t.TempDir()
+			err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644)
+			assert.NilError(t, err)
+
+			buildCtx := createBuildContext(t, dockerfile)
+
+			buildCmd := []string{"build", buildCtx}
+			switch tc.pull {
+			case "false":
+				buildCmd = append(buildCmd, "--pull=false")
+				base.Cmd(buildCmd...).AssertErrContains(oldImageSha)
+			case "true":
+				buildCmd = append(buildCmd, "--pull=true")
+				base.Cmd(buildCmd...).AssertErrNotContains(oldImageSha)
+			case "default":
+				base.Cmd(buildCmd...).AssertErrNotContains(oldImageSha)
+			}
+		})
+	}
+}
+
+func useBuildkitConfig(t *testing.T, config string) (cleanup func()) {
+	buildkitConfigPath := "/etc/buildkit/buildkitd.toml"
+
+	currConfig, err := exec.Command("cat", buildkitConfigPath).Output()
+	assert.NilError(t, err)
+
+	os.WriteFile(buildkitConfigPath, []byte(config), 0644)
+	_, err = exec.Command("systemctl", "restart", "buildkit").Output()
+	assert.NilError(t, err)
+
+	return func() {
+		assert.NilError(t, os.WriteFile(buildkitConfigPath, currConfig, 0644))
+		_, err = exec.Command("systemctl", "restart", "buildkit").Output()
+		assert.NilError(t, err)
+	}
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -692,6 +692,7 @@ Flags:
   - :whale: `type=image,name=example.com/image,push=true`: Push to a registry (see [`buildctl build`](https://github.com/moby/buildkit/tree/v0.9.0#imageregistry) documentation)
 - :whale: `--progress=(auto|plain|tty)`: Set type of progress output (auto, plain, tty). Use plain to show container output
 - :whale: `--provenance`: Shorthand for \"--attest=type=provenance\", see [`buildx_build.md`](https://github.com/docker/buildx/blob/v0.12.1/docs/reference/buildx_build.md#provenance) documentation
+- :whale: `--pull=(true|false)`: On true, always attempt to pull latest image version from remote. Default uses buildkit's default.
 - :whale: `--secret`: Secret file to expose to the build: id=mysecret,src=/local/secret
 - :whale: `--allow`: Allow extra privileged entitlement, e.g. network.host, security.insecure  (It’s required to configure the buildkitd to enable the feature, see [`buildkitd.toml`](https://github.com/moby/buildkit/blob/master/docs/buildkitd.toml.md) documentation)
 - :whale: `--attest`: Attestation parameters (format: "type=sbom,generator=image"), see [`buildx_build.md`](https://github.com/docker/buildx/blob/v0.12.1/docs/reference/buildx_build.md#attest) documentation

--- a/pkg/api/types/builder_types.go
+++ b/pkg/api/types/builder_types.go
@@ -69,6 +69,8 @@ type BuilderBuildOptions struct {
 	ExtendedBuildContext []string
 	// NetworkMode mode for the build context
 	NetworkMode string
+	// Pull determines if we should try to pull latest image from remote. Default is buildkit's default.
+	Pull *bool
 }
 
 // BuilderPruneOptions specifies options for `nerdctl builder prune`.

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -367,6 +367,15 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 		buildctlArgs = append(buildctlArgs, "--no-cache")
 	}
 
+	if options.Pull != nil {
+		switch *options.Pull {
+		case true:
+			buildctlArgs = append(buildctlArgs, "--opt=image-resolve-mode=pull")
+		case false:
+			buildctlArgs = append(buildctlArgs, "--opt=image-resolve-mode=local")
+		}
+	}
+
 	for _, s := range strutil.DedupeStrSlice(options.Secret) {
 		buildctlArgs = append(buildctlArgs, "--secret="+s)
 	}


### PR DESCRIPTION
Fixes #3073 

`docker build` initially had a `--pull` command that forced remote image lookup when building an image. This has been changed when docker switched to buildkit to be default behavior, with an [option](https://github.com/moby/buildkit/blob/efcde2fcfbc4299ad8f07727fd65562409608c88/frontend/dockerui/attr.go#L30) to not check for updates if the image is already cached.

Forcing `nerdctl build` to use local images may be desirable for a few edge cases, so I've implemented a solution via a `--pull` flag in `nerdctl build` that can be set to `false` to enable this behavior, and `true` to always pull from remote. Without it, it will use the buildkit default.

There's a caveat here, which is that buildkit must be set up to use the same namespace as the locally cached image, which the user must set up in their buildkit config file.

Tested in a similar workflow as the integration test:
1. Have a Dockerfile with just `FROM ubuntu:latest`
2. Pull an older image tag (for me, I chose `ubuntu:18.04`) into your buildkit namespace (default should be `buildkit`)
3. Tag it to latest version
4. `nerdctl build --pull false .`
5. Check image sha in output, it should be the same as the one locally cached
6. `nerdctl build --pull true .`
7. Check image sha in output, it should be a different one and should match the same as latest tag.