### PR TITLE
[Proposal] Implement namespacing for networks

### DIFF
--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -109,7 +109,7 @@ func shellCompleteNetworkNames(cmd *cobra.Command, exclude []string) ([]string, 
 		excludeMap[ex] = struct{}{}
 	}
 
-	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath, netutil.WithNamespace(globalOptions.Namespace))
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/nerdctl/network_remove_linux_test.go
+++ b/cmd/nerdctl/network_remove_linux_test.go
@@ -25,30 +25,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestNetworkRemoveInOtherNamespace(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for remove rootless network")
-	}
-	if testutil.GetTarget() == testutil.Docker {
-		t.Skip("test skipped for docker")
-	}
-	// --namespace=nerdctl-test
-	base := testutil.NewBase(t)
-	// --namespace=nerdctl-other
-	baseOther := testutil.NewBaseWithNamespace(t, "nerdctl-other")
-	networkName := testutil.Identifier(t)
-
-	base.Cmd("network", "create", networkName).AssertOK()
-	defer base.Cmd("network", "rm", networkName).AssertOK()
-
-	tID := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--net", networkName, "--name", tID, testutil.AlpineImage, "sleep", "infinity").AssertOK()
-	defer base.Cmd("rm", "-f", tID).Run()
-
-	// delete network in namespace nerdctl-other
-	baseOther.Cmd("network", "rm", networkName).AssertFail()
-}
-
 func TestNetworkRemove(t *testing.T) {
 	if rootlessutil.IsRootless() {
 		t.Skip("test skipped for remove rootless network")

--- a/docs/cni.md
+++ b/docs/cni.md
@@ -116,7 +116,16 @@ For example:
 ## Custom networks
 
 You can also customize your CNI network by providing configuration files.
-For example you have one configuration file(`/etc/cni/net.d/10-mynet.conf`)
+
+When rootful, the expected root location is `/etc/cni/net.d`.
+For rootless, the expected root location is `~/.config/cni/net.d/`
+
+Configuration files (like `10-mynet.conf`) can be placed either in the root location,
+or under a subfolder.
+If in the root location, this network will be available to all nerdctl namespaces.
+If placed in a subfolder, it will be available only to the identically named namespace.
+
+For example, you have one configuration file(`/etc/cni/net.d/10-mynet.conf`)
 for `bridge` network:
 
 ```json
@@ -138,7 +147,7 @@ for `bridge` network:
 ```
 
 This will configure a new CNI network with the name `mynet`, and you can use
-this network to create a container:
+this network to create a container in any namespace:
 
 ```console
 # nerdctl run -it --net mynet --rm alpine ip addr show

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -65,5 +65,9 @@ Data volume
 
 Can be overridden with `nerdctl --cni-netconfpath=<NETCONFPATH>` flag and environment variable `$NETCONFPATH`.
 
+At the top-level of <NETCONFPATH>, network (files) are shared accross all namespaces.
+Sub-folders inside <NETCONFPATH> are only available to the namespace bearing the same name,
+and its networks definitions are private.
+
 Files:
 - `nerdctl-<NWNAME>.conflist`: CNI conf list created by nerdctl

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -41,7 +41,7 @@ import (
 
 // New returns a new *composer.Composer.
 func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, options composer.Options, stdout, stderr io.Writer) (*composer.Composer, error) {
-	cniEnv, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath, netutil.WithDefaultNetwork())
+	cniEnv, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath, netutil.WithNamespace(globalOptions.Namespace), netutil.WithDefaultNetwork())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -152,7 +152,7 @@ func cleanupNetwork(ctx context.Context, container containerd.Container, globalO
 		case nettype.Host, nettype.None, nettype.Container:
 			// NOP
 		case nettype.CNI:
-			e, err := netutil.NewCNIEnv(globalOpts.CNIPath, globalOpts.CNINetConfPath, netutil.WithDefaultNetwork())
+			e, err := netutil.NewCNIEnv(globalOpts.CNIPath, globalOpts.CNINetConfPath, netutil.WithNamespace(globalOpts.Namespace), netutil.WithDefaultNetwork())
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/network/create.go
+++ b/pkg/cmd/network/create.go
@@ -33,7 +33,7 @@ func Create(options types.NetworkCreateOptions, stdout io.Writer) error {
 		options.Subnets = []string{""}
 	}
 
-	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath, netutil.WithNamespace(options.GOptions.Namespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -32,7 +32,7 @@ import (
 
 func Inspect(ctx context.Context, options types.NetworkInspectOptions) error {
 	globalOptions := options.GOptions
-	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath, netutil.WithNamespace(options.GOptions.Namespace))
 
 	if err != nil {
 		return err

--- a/pkg/cmd/network/list.go
+++ b/pkg/cmd/network/list.go
@@ -65,7 +65,7 @@ func List(ctx context.Context, options types.NetworkListOptions) error {
 		}
 	}
 
-	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(globalOptions.CNIPath, globalOptions.CNINetConfPath, netutil.WithNamespace(options.GOptions.Namespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/network/prune.go
+++ b/pkg/cmd/network/prune.go
@@ -28,7 +28,7 @@ import (
 )
 
 func Prune(ctx context.Context, client *containerd.Client, options types.NetworkPruneOptions) error {
-	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath, netutil.WithNamespace(options.GOptions.Namespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/network/remove.go
+++ b/pkg/cmd/network/remove.go
@@ -27,7 +27,7 @@ import (
 )
 
 func Remove(ctx context.Context, client *containerd.Client, options types.NetworkRemoveOptions) error {
-	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath)
+	e, err := netutil.NewCNIEnv(options.GOptions.CNIPath, options.GOptions.CNINetConfPath, netutil.WithNamespace(options.GOptions.Namespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/containerutil/container_network_manager_linux.go
+++ b/pkg/containerutil/container_network_manager_linux.go
@@ -39,7 +39,7 @@ type cniNetworkManagerPlatform struct {
 
 // Verifies that the internal network settings are correct.
 func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
-	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithDefaultNetwork())
+	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithNamespace(m.globalOptions.Namespace), netutil.WithDefaultNetwork())
 	if err != nil {
 		return err
 	}

--- a/pkg/containerutil/container_network_manager_windows.go
+++ b/pkg/containerutil/container_network_manager_windows.go
@@ -36,7 +36,7 @@ type cniNetworkManagerPlatform struct {
 
 // Verifies that the internal network settings are correct.
 func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
-	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithDefaultNetwork())
+	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithNamespace(m.globalOptions.Namespace), netutil.WithDefaultNetwork())
 	if err != nil {
 		return err
 	}
@@ -67,7 +67,7 @@ func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
 }
 
 func (m *cniNetworkManager) getCNI() (gocni.CNI, error) {
-	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithDefaultNetwork())
+	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithNamespace(m.globalOptions.Namespace), netutil.WithDefaultNetwork())
 	if err != nil {
 		return nil, fmt.Errorf("failed to instantiate CNI env: %s", err)
 	}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -152,7 +152,7 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 	case nettype.Host, nettype.None, nettype.Container:
 		// NOP
 	case nettype.CNI:
-		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath, netutil.WithDefaultNetwork())
+		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath, netutil.WithNamespace(namespace), netutil.WithDefaultNetwork())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Hey folks.

From the conversation at #3095 I appreciate that plugins networks cannot be fully "isolated" from one another, and as such that there is no concept of namespacing in the spec.

Nevertheless, not having namespace for networks commands is very surprising for the user - especially since we do not complain at all about the use of the global `--namespace` flag alongside the `network` command. Furthermore, I certainly see use cases where it would make a lot of sense as a feature.

This (relatively simple) proof of concept does implement "namespace-ing", effectively preventing one namespace from listing or manipulating directly networks of another.

Let me know what you are thinking about this - and if this would be a welcome feature or not.