### PR TITLE
Docker v26 compatibility & test fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,8 +251,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           check-latest: true
-      # Docker >= v25 is still unsupported: https://github.com/containerd/nerdctl/issues/3088
-      - name: "Install Docker v24"
+      - name: "Install Docker v26"
         run: |
           set -eux -o pipefail
           # Uninstall the preinstalled Docker
@@ -264,10 +263,10 @@ jobs:
           cat /etc/docker/daemon.json
           # Download Docker packages
           curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/containerd.io_1.6.33-1_amd64.deb
-          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce_24.0.9-1~ubuntu.22.04~jammy_amd64.deb
-          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce-cli_24.0.9-1~ubuntu.22.04~jammy_amd64.deb
-          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-buildx-plugin_0.13.1-1~ubuntu.22.04~jammy_amd64.deb
-          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-compose-plugin_2.25.0-1~ubuntu.22.04~jammy_amd64.deb
+          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce_26.1.4-1~ubuntu.22.04~jammy_amd64.deb
+          curl -OSl https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-ce-cli_26.1.4-1~ubuntu.22.04~jammy_amd64.deb
+          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-buildx-plugin_0.14.1-1~ubuntu.22.04~jammy_amd64.deb
+          curl -OSL https://download.docker.com/linux/ubuntu/dists/jammy/pool/stable/amd64/docker-compose-plugin_2.27.1-1~ubuntu.22.04~jammy_amd64.deb
           # Install Docker
           sudo apt-get install -y ./*.deb
           rm -f ./*.deb

--- a/cmd/nerdctl/network_inspect_test.go
+++ b/cmd/nerdctl/network_inspect_test.go
@@ -34,7 +34,7 @@ func TestNetworkInspect(t *testing.T) {
 	const (
 		testSubnet  = "10.24.24.0/24"
 		testGateway = "10.24.24.1"
-		testIPRange = "10.24.24.1/25"
+		testIPRange = "10.24.24.0/25"
 	)
 
 	base := testutil.NewBase(t)


### PR DESCRIPTION
This fix #3088 

So far, the issues were:
- [x] docker is now pickier on ip ranges
- [x] WithMacAddress: both host networking and container networking now  apparently allow passing a mac address, though it is a no-op AFAIK - the docker daemon still disallows it - hypothesis is that the new cli just discard the option silently. Anyhow, nerdctl code has been changed to align with that (somewhat abhorrent) behavior and tests have been adjusted
- [x] TestRunContainerWithStaticIP: see #3101  - I am disabling the test for now (which was already broken by the way, since it wasn't testing anything for docker) - we might re-enable pending discussion in the linked ticket
