### PR TITLE
Disable build and publish on PR for purely md changes

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -12,6 +12,8 @@ on:
     tags: ['v*.*.*']
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
Just realized with #3106 that we are still building some stuff with purely .md file changes.
This PR just disables that behavior to speed-up doc changes CI and reviews.

cc @AkihiroSuda PTAL at your convenience.