### PR TITLE
Replace SetEnv invocation by base.Env to unlock parallelization

### DIFF
--- a/cmd/nerdctl/compose_config_test.go
+++ b/cmd/nerdctl/compose_config_test.go
@@ -128,7 +128,7 @@ services:
     image: alpine:3.14
 `)
 
-	base.Env = append(os.Environ(), "COMPOSE_FILE="+comp.YAMLFullPath()+","+filepath.Join(comp.Dir(), "docker-compose.test.yml"), "COMPOSE_PATH_SEPARATOR=,")
+	base.Env = append(base.Env, "COMPOSE_FILE="+comp.YAMLFullPath()+","+filepath.Join(comp.Dir(), "docker-compose.test.yml"), "COMPOSE_PATH_SEPARATOR=,")
 
 	base.ComposeCmd("config").AssertOutContains("alpine:3.14")
 	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutContainsAll("hello1\n", "hello2\n")

--- a/cmd/nerdctl/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose_exec_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -78,7 +77,7 @@ services:
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
 
 	// FYI: https://github.com/containerd/nerdctl/blob/e4b2b6da56555dc29ed66d0fd8e7094ff2bc002d/cmd/nerdctl/run_test.go#L177
-	base.Env = append(os.Environ(), "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
+	base.Env = append(base.Env, "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "exec", "-i=false", "--no-TTY",
 		"--env", "FOO=foo1,foo2",
 		"--env", "BAR=bar1 bar2",

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -269,7 +268,7 @@ services:
 	projectName := comp.ProjectName()
 	t.Logf("projectName=%q", projectName)
 
-	base.Env = append(os.Environ(), "ADDRESS=0.0.0.0")
+	base.Env = append(base.Env, "ADDRESS=0.0.0.0")
 
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()

--- a/cmd/nerdctl/container_exec_test.go
+++ b/cmd/nerdctl/container_exec_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"errors"
-	"os"
 	"runtime"
 	"strings"
 	"testing"
@@ -80,7 +79,7 @@ func TestExecEnv(t *testing.T) {
 	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "1h").AssertOK()
 	base.EnsureContainerStarted(testContainer)
 
-	base.Env = append(os.Environ(), "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
+	base.Env = append(base.Env, "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
 	base.Cmd("exec",
 		"--env", "FOO=foo1,foo2",
 		"--env", "BAR=bar1 bar2",

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -145,7 +145,7 @@ func TestRunCIDFile(t *testing.T) {
 func TestRunEnvFile(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	base.Env = append(os.Environ(), "HOST_ENV=ENV-IN-HOST")
+	base.Env = append(base.Env, "HOST_ENV=ENV-IN-HOST")
 
 	tID := testutil.Identifier(t)
 	file1, err := os.CreateTemp("", tID)
@@ -172,7 +172,7 @@ func TestRunEnvFile(t *testing.T) {
 func TestRunEnv(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	base.Env = append(os.Environ(), "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
+	base.Env = append(base.Env, "CORGE=corge-value-in-host", "GARPLY=garply-value-in-host")
 	base.Cmd("run", "--rm",
 		"--env", "FOO=foo1,foo2",
 		"--env", "BAR=bar1 bar2",

--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -67,7 +66,7 @@ func TestIPFSComposeUp(t *testing.T) {
 			for i, img := range []string{testutil.WordpressImage, testutil.MariaDBImage} {
 				ipfsImgs[i] = pushImageToIPFS(t, base, img, tt.pushOptions...)
 			}
-			base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER="+tt.snapshotter)
+			base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER="+tt.snapshotter)
 			testComposeUp(t, base, fmt.Sprintf(`
 version: '3.1'
 

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
@@ -33,7 +32,7 @@ func TestIPFS(t *testing.T) {
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=overlayfs")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=overlayfs")
 	base.Cmd("pull", ipfsCID).AssertOK()
 	base.Cmd("run", "--rm", ipfsCID, "echo", "hello").AssertOK()
 
@@ -66,7 +65,7 @@ func TestIPFSAddress(t *testing.T) {
 	ipfsaddr, done := runIPFSDaemonContainer(t, base)
 	defer done()
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, fmt.Sprintf("--ipfs-address=%s", ipfsaddr))
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=overlayfs")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=overlayfs")
 	base.Cmd("pull", "--ipfs-address", ipfsaddr, ipfsCID).AssertOK()
 	base.Cmd("run", "--ipfs-address", ipfsaddr, "--rm", ipfsCID, "echo", "hello").AssertOK()
 }
@@ -103,7 +102,7 @@ func TestIPFSCommit(t *testing.T) {
 	base := testutil.NewBase(t)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
 
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=overlayfs")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=overlayfs")
 	base.Cmd("pull", ipfsCID).AssertOK()
 	base.Cmd("run", "--rm", ipfsCID, "echo", "hello").AssertOK()
 	tID := testutil.Identifier(t)
@@ -124,7 +123,7 @@ func TestIPFSWithLazyPulling(t *testing.T) {
 	requiresStargz(base)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
 
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=stargz")
 	base.Cmd("pull", ipfsCID).AssertOK()
 	base.Cmd("run", "--rm", ipfsCID, "ls", "/.stargz-snapshotter").AssertOK()
 }
@@ -139,7 +138,7 @@ func TestIPFSWithLazyPullingCommit(t *testing.T) {
 	requiresStargz(base)
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
 
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=stargz")
 	base.Cmd("pull", ipfsCID).AssertOK()
 	base.Cmd("run", "--rm", ipfsCID, "ls", "/.stargz-snapshotter").AssertOK()
 	tID := testutil.Identifier(t)

--- a/cmd/nerdctl/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs_registry_linux_test.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestIPFSRegistry(t *testing.T) {
 	testutil.DockerIncompatible(t)
 
 	base := testutil.NewBase(t)
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=overlayfs")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=overlayfs")
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage)
 	ipfsRegistryAddr := "localhost:5555"
 	ipfsRegistryRef := ipfsRegistryReference(ipfsRegistryAddr, ipfsCID)
@@ -44,7 +43,7 @@ func TestIPFSRegistryWithLazyPulling(t *testing.T) {
 
 	base := testutil.NewBase(t)
 	requiresStargz(base)
-	base.Env = append(os.Environ(), "CONTAINERD_SNAPSHOTTER=stargz")
+	base.Env = append(base.Env, "CONTAINERD_SNAPSHOTTER=stargz")
 	ipfsCID := pushImageToIPFS(t, base, testutil.AlpineImage, "--estargz")
 	ipfsRegistryAddr := "localhost:5555"
 	ipfsRegistryRef := ipfsRegistryReference(ipfsRegistryAddr, ipfsCID)

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -58,9 +58,6 @@ snapshotter = "dummy-snapshotter-via-toml"
 	base.Cmd("info", "-f", "{{.Driver}}").AssertOutExactly(containerd.DefaultSnapshotter + "\n")
 
 	// [TOML, Default]
-	if len(base.Env) == 0 {
-		base.Env = os.Environ()
-	}
 	base.Env = append(base.Env, "NERDCTL_TOML="+tomlPath)
 	base.Cmd("info", "-f", "{{.Driver}}").AssertOutExactly("dummy-snapshotter-via-toml\n")
 

--- a/cmd/nerdctl/system_info_test.go
+++ b/cmd/nerdctl/system_info_test.go
@@ -19,7 +19,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
@@ -57,6 +56,6 @@ func TestInfoWithNamespace(t *testing.T) {
 
 	base.Cmd("info").AssertOutContains("Namespace:	default")
 
-	base.Env = append(os.Environ(), "CONTAINERD_NAMESPACE=test")
+	base.Env = append(base.Env, "CONTAINERD_NAMESPACE=test")
 	base.Cmd("info").AssertOutContains("Namespace:	test")
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -685,6 +685,7 @@ func newBase(t *testing.T, ns string, ipv6Compatible bool) *Base {
 		DaemonIsKillable: GetDaemonIsKillable(),
 		EnableIPv6:       GetEnableIPv6(),
 		IPv6Compatible:   ipv6Compatible,
+		Env:              os.Environ(),
 	}
 	if base.EnableIPv6 && !base.IPv6Compatible {
 		t.Skip("runner skips non-IPv6 compatible tests in the IPv6 environment")


### PR DESCRIPTION
This is to fix #3081 

cosign related code (which required signature change) and related tests have been cleaned-up slightly on top of that and parallelized. 