### PR TITLE
MAINTAINERS: move Ye Sijun (junnplus) from a COMMITTER to a EMERITUS

### DIFF
--- a/EMERITUS.md
+++ b/EMERITUS.md
@@ -2,6 +2,15 @@ See [`MAINTAINERS`](./MAINTAINERS) for the current active maintainers.
 - - -
 # nerdctl Emeritus Maintainers
 
+## Committers
+### Ye Sijun ([@junnplus](https://github.com/junnplus))
+Ye Sijun (GitHub ID [@junnplus](https://github.com/junnplus)) served as
+a Committer of nerdctl from November 2022 to June 2024.
+Prior to his role as a Committer, Sijun served as a Reviewer since February 2022.
+
+Sijun has made [significant improvements](https://github.com/containerd/nerdctl/pulls?q=author%3Ajunnplus+)
+especially to `nerdctl compose`, IPAM, and cosign integration.
+
 ## Reviewers
 ### Hanchin Hsieh ([@yuchanns](https://github.com/yuchanns))
 Hanchin Hsieh (GitHub ID [@yuchanns](https://github.com/yuchanns)) served as

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,7 +15,6 @@
 "ktock","Kohei Tokunaga","ktokunaga.mail@gmail.com",""
 "fahedouch","Fahed Dorgaa","fahed.dorgaa@gmail.com","EE7A 5503 CE0D 38AC 5B95  A500 F35F F497 60A8 65FA"
 "Zheaoli", "Zheao Li", "me@manjusaka.me","6E0D D9FA BAD5 AF61 D884 01EE 878F 445D 9C6C E65E"
-"junnplus","Ye Sijun","junnplus@gmail.com",""
 "djdongjin", "Jin Dong", "djdongjin95@gmail.com",""
 "yankay", "Kay Yan", "kay.yan@daocloud.io", ""
 


### PR DESCRIPTION
Ye Sijun (@junnplus) served as a Committer of nerdctl from November 2022 to June 2024.

Sijun has made significant improvements especially to `nerdctl compose`, IPAM, and cosign integration. https://github.com/containerd/nerdctl/pulls?q=author%3Ajunnplus+

We show our huge appreciation to Sijun.