### PR TITLE
Volume QA part II: fixes and tests

### DIFF
--- a/cmd/nerdctl/namespace.go
+++ b/cmd/nerdctl/namespace.go
@@ -113,11 +113,11 @@ func namespaceLsAction(cmd *cobra.Command, args []string) error {
 		}
 		numImages = len(images)
 
-		volStore, err := volumestore.Path(dataStore, ns)
+		volStore, err := volumestore.New(dataStore, ns)
 		if err != nil {
 			log.L.Warn(err)
 		} else {
-			volEnts, err := os.ReadDir(volStore)
+			volEnts, err := volStore.List(false)
 			if err != nil {
 				if !os.IsNotExist(err) {
 					log.L.Warn(err)

--- a/cmd/nerdctl/system_prune_linux_test.go
+++ b/cmd/nerdctl/system_prune_linux_test.go
@@ -32,6 +32,10 @@ import (
 
 func TestSystemPrune(t *testing.T) {
 	testutil.RequiresBuild(t)
+	// FIXME: using a dedicated namespace does not work with rootful (because of buildkit running)
+	// t.Parallel()
+	// namespaceID := testutil.Identifier(t)
+	// base := testutil.NewBaseWithNamespace(t, namespaceID)
 	base := testutil.NewBase(t)
 	base.Cmd("container", "prune", "-f").AssertOK()
 	base.Cmd("network", "prune", "-f").AssertOK()

--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -17,6 +17,9 @@
 package main
 
 import (
+	"fmt"
+
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 
@@ -45,6 +48,12 @@ func processVolumeCreateOptions(cmd *cobra.Command) (types.VolumeCreateOptions, 
 	if err != nil {
 		return types.VolumeCreateOptions{}, err
 	}
+	for _, label := range labels {
+		if label == "" {
+			return types.VolumeCreateOptions{}, fmt.Errorf("labels cannot be empty (%w)", errdefs.ErrInvalidArgument)
+		}
+	}
+
 	return types.VolumeCreateOptions{
 		GOptions: globalOptions,
 		Labels:   labels,

--- a/cmd/nerdctl/volume_inspect.go
+++ b/cmd/nerdctl/volume_inspect.go
@@ -66,7 +66,7 @@ func volumeInspectAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	return volume.Inspect(args, options)
+	return volume.Inspect(cmd.Context(), args, options)
 }
 
 func volumeInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/volume_inspect_test.go
+++ b/cmd/nerdctl/volume_inspect_test.go
@@ -18,48 +18,265 @@ package main
 
 import (
 	"crypto/rand"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
 )
 
-func TestVolumeInspectContainsLabels(t *testing.T) {
-	t.Parallel()
-	testVolume := testutil.Identifier(t)
-
-	base := testutil.NewBase(t)
-	base.Cmd("volume", "create", "--label", "tag=testVolume", testVolume).AssertOK()
-	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
-
-	inspect := base.InspectVolume(testVolume)
-	inspectNerdctlLabels := (*inspect.Labels)
-	expected := make(map[string]string, 1)
-	expected["tag"] = "testVolume"
-	assert.DeepEqual(base.T, expected, inspectNerdctlLabels)
+func createFileWithSize(base *testutil.Base, vol string, size int64) {
+	v := base.InspectVolume(vol)
+	token := make([]byte, size)
+	_, _ = rand.Read(token)
+	err := os.WriteFile(filepath.Join(v.Mountpoint, "test-file"), token, 0644)
+	assert.NilError(base.T, err)
 }
 
-func TestVolumeInspectSize(t *testing.T) {
-	testutil.DockerIncompatible(t)
+func TestVolumeInspect(t *testing.T) {
 	t.Parallel()
-	testVolume := testutil.Identifier(t)
+
 	base := testutil.NewBase(t)
-	base.Cmd("volume", "create", testVolume).AssertOK()
-	defer base.Cmd("volume", "rm", "-f", testVolume).Run()
+	tID := testutil.Identifier(t)
 
 	var size int64 = 1028
-	createFileWithSize(t, testVolume, size)
-	volumeWithSize := base.InspectVolume(testVolume, []string{"--size"}...)
-	assert.Equal(t, volumeWithSize.Size, size)
-}
 
-func createFileWithSize(t *testing.T, volume string, bytes int64) {
-	base := testutil.NewBase(t)
-	v := base.InspectVolume(volume)
-	token := make([]byte, bytes)
-	rand.Read(token)
-	err := os.WriteFile(filepath.Join(v.Mountpoint, "test-file"), token, 0644)
-	assert.NilError(t, err)
+	malformed := errdefs.ErrInvalidArgument.Error()
+	notFound := errdefs.ErrNotFound.Error()
+	requireArg := "requires at least 1 arg"
+	if base.Target == testutil.Docker {
+		malformed = "no such volume"
+		notFound = "no such volume"
+	}
+
+	tearUp := func(t *testing.T) {
+		base.Cmd("volume", "create", tID).AssertOK()
+		base.Cmd("volume", "create", "--label", "foo=fooval", "--label", "bar=barval", tID+"-second").AssertOK()
+
+		// Obviously note here that if inspect code gets totally hosed, this entire suite will
+		// probably fail right here on the tearUp instead of actually testing something
+		createFileWithSize(base, tID, size)
+	}
+
+	tearDown := func(t *testing.T) {
+		base.Cmd("volume", "rm", "-f", tID).Run()
+		base.Cmd("volume", "rm", "-f", tID+"-second").Run()
+	}
+
+	tearDown(t)
+	t.Cleanup(func() {
+		tearDown(t)
+	})
+	tearUp(t)
+
+	testCases := []struct {
+		description        string
+		command            func(tID string) *testutil.Cmd
+		tearUp             func(tID string)
+		tearDown           func(tID string)
+		expected           func(tID string) icmd.Expected
+		inspect            func(t *testing.T, stdout string, stderr string)
+		dockerIncompatible bool
+	}{
+		{
+			description: "arg missing should fail",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+					Err:      requireArg,
+				}
+			},
+		},
+		{
+			description: "invalid identifier should fail",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", "∞")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+					Err:      malformed,
+				}
+			},
+		},
+		{
+			description: "non existent volume should fail",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", "doesnotexist")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+					Err:      notFound,
+				}
+			},
+		},
+		{
+			description: "success",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", tID)
+			},
+			tearDown: func(tID string) {
+				base.Cmd("volume", "rm", "-f", tID)
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 0,
+					Out:      tID,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				var dc []native.Volume
+				if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
+					t.Fatal(err)
+				}
+				assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
+				assert.Assert(t, dc[0].Name == tID, fmt.Sprintf("expected name to be %q (was %q)", tID, dc[0].Name))
+				assert.Assert(t, dc[0].Labels == nil, fmt.Sprintf("expected labels to be nil and were %v", dc[0].Labels))
+			},
+		},
+		{
+			description: "inspect labels",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", tID+"-second")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 0,
+					Out:      tID,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				var dc []native.Volume
+				if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
+					t.Fatal(err)
+				}
+
+				labels := *dc[0].Labels
+				assert.Assert(t, len(labels) == 2, fmt.Sprintf("two results, not %d", len(labels)))
+				assert.Assert(t, labels["foo"] == "fooval", fmt.Sprintf("label foo should be fooval, not %s", labels["foo"]))
+				assert.Assert(t, labels["bar"] == "barval", fmt.Sprintf("label bar should be barval, not %s", labels["bar"]))
+			},
+		},
+		{
+			description: "inspect size",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", "--size", tID)
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 0,
+					Out:      tID,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				var dc []native.Volume
+				if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
+					t.Fatal(err)
+				}
+				assert.Assert(t, dc[0].Size == size, fmt.Sprintf("expected size to be %d (was %d)", size, dc[0].Size))
+			},
+			dockerIncompatible: true,
+		},
+		{
+			description: "multi success",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", tID, tID+"-second")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 0,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				var dc []native.Volume
+				if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
+					t.Fatal(err)
+				}
+				assert.Assert(t, len(dc) == 2, fmt.Sprintf("two results, not %d", len(dc)))
+				assert.Assert(t, dc[0].Name == tID, fmt.Sprintf("expected name to be %q (was %q)", tID, dc[0].Name))
+				assert.Assert(t, dc[1].Name == tID+"-second", fmt.Sprintf("expected name to be %q (was %q)", tID+"-second", dc[1].Name))
+			},
+		},
+		{
+			description: "part success multi",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", "invalid∞", "nonexistent", tID)
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+					Out:      tID,
+					Err:      notFound,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				assert.Assert(t, strings.Contains(stderr, notFound))
+				assert.Assert(t, strings.Contains(stderr, malformed))
+
+				var dc []native.Volume
+				if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
+					t.Fatal(err)
+				}
+				assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
+				assert.Assert(t, dc[0].Name == tID, fmt.Sprintf("expected name to be %q (was %q)", tID, dc[0].Name))
+			},
+		},
+		{
+			description: "multi failure",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "inspect", "invalid∞", "nonexistent")
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				assert.Assert(t, strings.Contains(stderr, notFound))
+				assert.Assert(t, strings.Contains(stderr, malformed))
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		currentTest := test
+		t.Run(currentTest.description, func(tt *testing.T) {
+			if currentTest.dockerIncompatible {
+				testutil.DockerIncompatible(tt)
+			}
+
+			tt.Parallel()
+
+			// We use the main test tID here
+			if currentTest.tearDown != nil {
+				currentTest.tearDown(tID)
+				tt.Cleanup(func() {
+					currentTest.tearDown(tID)
+				})
+			}
+			if currentTest.tearUp != nil {
+				currentTest.tearUp(tID)
+			}
+
+			// See https://github.com/containerd/nerdctl/issues/3130
+			// We run first to capture the underlying icmd command and output
+			cmd := currentTest.command(tID)
+			res := cmd.Run()
+			cmd.Assert(currentTest.expected(tID))
+			if currentTest.inspect != nil {
+				currentTest.inspect(tt, res.Stdout(), res.Stderr())
+			}
+		})
+	}
 }

--- a/cmd/nerdctl/volume_namespace_test.go
+++ b/cmd/nerdctl/volume_namespace_test.go
@@ -24,18 +24,31 @@ import (
 	"gotest.tools/v3/icmd"
 )
 
-func TestVolumeCreate(t *testing.T) {
+func TestVolumeNamespace(t *testing.T) {
+	testutil.DockerIncompatible(t)
+
 	t.Parallel()
 
 	base := testutil.NewBase(t)
+	tID := testutil.Identifier(t)
+	otherBase := testutil.NewBaseWithNamespace(t, tID+"-1")
+	thirdBase := testutil.NewBaseWithNamespace(t, tID+"-2")
 
-	malformed := errdefs.ErrInvalidArgument.Error()
-	atMost := "at most 1 arg"
-	exitCodeVariant := 1
-	if base.Target == testutil.Docker {
-		malformed = "invalid"
-		exitCodeVariant = 125
+	tearUp := func(t *testing.T) {
+		base.Cmd("volume", "create", tID).AssertOK()
 	}
+
+	tearDown := func(t *testing.T) {
+		base.Cmd("volume", "rm", "-f", tID).Run()
+		otherBase.Cmd("namespace", "rm", "-f", tID+"-1").Run()
+		thirdBase.Cmd("namespace", "rm", "-f", tID+"-2").Run()
+	}
+
+	tearDown(t)
+	t.Cleanup(func() {
+		tearDown(t)
+	})
+	tearUp(t)
 
 	testCases := []struct {
 		description        string
@@ -47,94 +60,52 @@ func TestVolumeCreate(t *testing.T) {
 		dockerIncompatible bool
 	}{
 		{
-			description: "arg missing should create anonymous volume",
+			description: "inspect another namespace volume should fail",
 			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "create")
-			},
-			expected: func(tID string) icmd.Expected {
-				return icmd.Expected{
-					ExitCode: 0,
-				}
-			},
-		},
-		{
-			description: "invalid identifier should fail",
-			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "create", "∞")
+				return otherBase.Cmd("volume", "inspect", tID)
 			},
 			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
 					ExitCode: 1,
-					Err:      malformed,
+					Err:      errdefs.ErrNotFound.Error(),
 				}
 			},
 		},
 		{
-			description: "too many args should fail",
+			description: "remove another namespace volume should fail",
 			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "create", "too", "many")
+				return otherBase.Cmd("volume", "remove", tID)
 			},
 			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
 					ExitCode: 1,
-					Err:      atMost,
+					Err:      errdefs.ErrNotFound.Error(),
 				}
 			},
 		},
 		{
-			description: "success",
+			description: "prune should leave other namespace untouched",
 			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "create", tID)
+				return otherBase.Cmd("volume", "prune", "-a", "-f")
 			},
 			tearDown: func(tID string) {
-				base.Cmd("volume", "rm", "-f", tID).Run()
+				// Assert that the volume is here in the base namespace
+				// both before and after the prune command
+				base.Cmd("volume", "inspect", tID).AssertOK()
 			},
 			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
 					ExitCode: 0,
-					Out:      tID,
 				}
 			},
 		},
 		{
-			description: "success with labels",
+			description: "create with namespace should work",
 			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "create", "--label", "foo1=baz1", "--label", "foo2=baz2", tID)
+				return thirdBase.Cmd("volume", "create", tID)
 			},
 			tearDown: func(tID string) {
-				base.Cmd("volume", "rm", "-f", tID).Run()
-			},
-			expected: func(tID string) icmd.Expected {
-				return icmd.Expected{
-					ExitCode: 0,
-					Out:      tID,
-				}
-			},
-		},
-		{
-			description: "invalid labels",
-			command: func(tID string) *testutil.Cmd {
-				// See https://github.com/containerd/nerdctl/issues/3126
-				return base.Cmd("volume", "create", "--label", "a", "--label", "", tID)
-			},
-			tearDown: func(tID string) {
-				base.Cmd("volume", "rm", "-f", tID).Run()
-			},
-			expected: func(tID string) icmd.Expected {
-				return icmd.Expected{
-					ExitCode: exitCodeVariant,
-					Err:      malformed,
-				}
-			},
-		},
-		{
-			description: "creating already existing volume should succeed",
-			command: func(tID string) *testutil.Cmd {
-				base.Cmd("volume", "create", tID).AssertOK()
-				return base.Cmd("volume", "create", tID)
-			},
-			tearDown: func(tID string) {
-				base.Cmd("volume", "rm", "-f", tID).Run()
+				thirdBase.Cmd("volume", "remove", "-f", tID).Run()
 			},
 			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
@@ -148,10 +119,14 @@ func TestVolumeCreate(t *testing.T) {
 	for _, test := range testCases {
 		currentTest := test
 		t.Run(currentTest.description, func(tt *testing.T) {
+			if currentTest.dockerIncompatible {
+				testutil.DockerIncompatible(tt)
+			}
+
 			tt.Parallel()
 
-			tID := testutil.Identifier(tt)
-
+			// Note that here we are using the main test tID
+			// since we are testing against the volume created in it
 			if currentTest.tearDown != nil {
 				currentTest.tearDown(tID)
 				tt.Cleanup(func() {
@@ -162,8 +137,14 @@ func TestVolumeCreate(t *testing.T) {
 				currentTest.tearUp(tID)
 			}
 
+			// See https://github.com/containerd/nerdctl/issues/3130
+			// We run first to capture the underlying icmd command and output
 			cmd := currentTest.command(tID)
+			res := cmd.Run()
 			cmd.Assert(currentTest.expected(tID))
+			if currentTest.inspect != nil {
+				currentTest.inspect(tt, res.Stdout(), res.Stderr())
+			}
 		})
 	}
 }

--- a/cmd/nerdctl/volume_remove_linux_test.go
+++ b/cmd/nerdctl/volume_remove_linux_test.go
@@ -18,34 +18,45 @@ package main
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 )
 
+// TestVolumeRemove does test a large variety of volume remove situations, albeit none of them being
+// hard filesystem errors.
+// Behavior in such cases is largely unspecified, as there is no easy way to compare with Docker.
+// Anyhow, borked filesystem conditions is not something we should be expected to deal with in a smart way.
 func TestVolumeRemove(t *testing.T) {
 	t.Parallel()
 
 	base := testutil.NewBase(t)
 
-	malformed := "malformed volume name"
-	notFound := "no such volume"
+	inUse := errdefs.ErrFailedPrecondition.Error()
+	malformed := errdefs.ErrInvalidArgument.Error()
+	notFound := errdefs.ErrNotFound.Error()
 	requireArg := "requires at least 1 arg"
-	inUse := "is in use"
 	if base.Target == testutil.Docker {
 		malformed = "no such volume"
+		notFound = "no such volume"
+		inUse = "volume is in use"
 	}
 
 	testCases := []struct {
-		description string
-		command     func(tID string) *testutil.Cmd
-		tearUp      func(tID string)
-		tearDown    func(tID string)
-		expected    func(tID string) icmd.Expected
+		description        string
+		command            func(tID string) *testutil.Cmd
+		tearUp             func(tID string)
+		tearDown           func(tID string)
+		expected           func(tID string) icmd.Expected
+		inspect            func(t *testing.T, stdout string, stderr string)
+		dockerIncompatible bool
 	}{
 		{
-			description: "arg missing",
+			description: "arg missing should fail",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm")
 			},
@@ -57,7 +68,7 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			description: "invalid identifier",
+			description: "invalid identifier should fail",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm", "∞")
 			},
@@ -69,7 +80,7 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			description: "non existent volume",
+			description: "non existent volume should fail",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm", "doesnotexist")
 			},
@@ -81,7 +92,7 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			description: "busy volume",
+			description: "busy volume should fail",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm", tID)
 			},
@@ -102,7 +113,39 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			description: "freed volume",
+			description: "busy anonymous volume should fail",
+			command: func(tID string) *testutil.Cmd {
+				// Inspect the container and find the anonymous volume id
+				inspect := base.InspectContainer(tID)
+				var anonName string
+				for _, v := range inspect.Mounts {
+					if v.Destination == "/volume" {
+						anonName = v.Name
+						break
+					}
+				}
+				assert.Assert(t, anonName != "", "Failed to find anonymous volume id")
+
+				// Try to remove that anon volume
+				return base.Cmd("volume", "rm", anonName)
+			},
+			tearUp: func(tID string) {
+				// base.Cmd("volume", "create", tID).AssertOK()
+				base.Cmd("run", "-v", fmt.Sprintf("%s:/volume", tID), "--name", tID, testutil.CommonImage).AssertOK()
+			},
+			tearDown: func(tID string) {
+				base.Cmd("rm", "-f", tID).Run()
+			},
+			expected: func(tID string) icmd.Expected {
+				return icmd.Expected{
+					ExitCode: 1,
+					Err:      inUse,
+				}
+
+			},
+		},
+		{
+			description: "freed volume should succeed",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm", tID)
 			},
@@ -122,7 +165,7 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			description: "dangling volume",
+			description: "dangling volume should succeed",
 			command: func(tID string) *testutil.Cmd {
 				return base.Cmd("volume", "rm", tID)
 			},
@@ -139,22 +182,30 @@ func TestVolumeRemove(t *testing.T) {
 			},
 		},
 		{
-			"part success multi remove",
-			func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "rm", "invalid∞", "nonexistent", tID)
+			description: "part success multi-remove",
+			command: func(tID string) *testutil.Cmd {
+				return base.Cmd("volume", "rm", "invalid∞", "nonexistent", tID+"-busy", tID)
 			},
-			func(tID string) {
+			tearUp: func(tID string) {
 				base.Cmd("volume", "create", tID).AssertOK()
+				base.Cmd("volume", "create", tID+"-busy").AssertOK()
+				base.Cmd("run", "-v", fmt.Sprintf("%s:/volume", tID+"-busy"), "--name", tID, testutil.CommonImage).AssertOK()
 			},
-			func(tID string) {
+			tearDown: func(tID string) {
+				base.Cmd("rm", "-f", tID).Run()
 				base.Cmd("volume", "rm", "-f", tID).Run()
+				base.Cmd("volume", "rm", "-f", tID+"-busy").Run()
 			},
-			func(tID string) icmd.Expected {
+			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
 					ExitCode: 1,
 					Out:      tID,
-					Err:      notFound,
 				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				assert.Assert(t, strings.Contains(stderr, notFound))
+				assert.Assert(t, strings.Contains(stderr, inUse))
+				assert.Assert(t, strings.Contains(stderr, malformed))
 			},
 		},
 		{
@@ -177,14 +228,26 @@ func TestVolumeRemove(t *testing.T) {
 		},
 		{
 			description: "failing multi-remove",
+			tearUp: func(tID string) {
+				base.Cmd("volume", "create", tID+"-busy").AssertOK()
+				base.Cmd("run", "-v", fmt.Sprintf("%s:/volume", tID+"-busy"), "--name", tID, testutil.CommonImage).AssertOK()
+			},
+			tearDown: func(tID string) {
+				base.Cmd("rm", "-f", tID).Run()
+				base.Cmd("volume", "rm", "-f", tID+"-busy").Run()
+			},
 			command: func(tID string) *testutil.Cmd {
-				return base.Cmd("volume", "rm", "nonexist1", "nonexist2")
+				return base.Cmd("volume", "rm", "invalid∞", "nonexistent", tID+"-busy")
 			},
 			expected: func(tID string) icmd.Expected {
 				return icmd.Expected{
 					ExitCode: 1,
-					Err:      notFound,
 				}
+			},
+			inspect: func(t *testing.T, stdout string, stderr string) {
+				assert.Assert(t, strings.Contains(stderr, notFound))
+				assert.Assert(t, strings.Contains(stderr, inUse))
+				assert.Assert(t, strings.Contains(stderr, malformed))
 			},
 		},
 	}
@@ -192,6 +255,10 @@ func TestVolumeRemove(t *testing.T) {
 	for _, test := range testCases {
 		currentTest := test
 		t.Run(currentTest.description, func(tt *testing.T) {
+			if currentTest.dockerIncompatible {
+				testutil.DockerIncompatible(tt)
+			}
+
 			tt.Parallel()
 
 			tID := testutil.Identifier(tt)
@@ -206,8 +273,14 @@ func TestVolumeRemove(t *testing.T) {
 				currentTest.tearUp(tID)
 			}
 
+			// See https://github.com/containerd/nerdctl/issues/3130
+			// We run first to capture the underlying icmd command and output
 			cmd := currentTest.command(tID)
+			res := cmd.Run()
 			cmd.Assert(currentTest.expected(tID))
+			if currentTest.inspect != nil {
+				currentTest.inspect(tt, res.Stdout(), res.Stderr())
+			}
 		})
 	}
 }

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -37,7 +37,6 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
-	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
@@ -122,13 +121,8 @@ func parseMountFlags(volStore volumestore.VolumeStore, options types.ContainerCr
 
 // generateMountOpts generates volume-related mount opts.
 // Other mounts such as procfs mount are not handled here.
-func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredImage *imgutil.EnsuredImage, options types.ContainerCreateOptions) ([]oci.SpecOpts, []string, []*mountutil.Processed, error) {
-	// volume store is corresponds to a directory like `/var/lib/nerdctl/1935db59/volumes/default`
-	volStore, err := volume.Store(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
+func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredImage *imgutil.EnsuredImage,
+	volStore volumestore.VolumeStore, options types.ContainerCreateOptions) ([]oci.SpecOpts, []string, []*mountutil.Processed, error) {
 	//nolint:golint,prealloc
 	var (
 		opts        []oci.SpecOpts

--- a/pkg/cmd/volume/create.go
+++ b/pkg/cmd/volume/create.go
@@ -19,7 +19,6 @@ package volume
 import (
 	"fmt"
 
-	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
@@ -31,9 +30,6 @@ func Create(name string, options types.VolumeCreateOptions) (*native.Volume, err
 	if name == "" {
 		name = stringid.GenerateRandomID()
 		options.Labels = append(options.Labels, labels.AnonymousVolumes+"=")
-	}
-	if err := identifiers.Validate(name); err != nil {
-		return nil, fmt.Errorf("malformed name %s: %w", name, err)
 	}
 	volStore, err := Store(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address)
 	if err != nil {

--- a/pkg/cmd/volume/rm.go
+++ b/pkg/cmd/volume/rm.go
@@ -32,47 +32,61 @@ import (
 )
 
 func Remove(ctx context.Context, client *containerd.Client, volumes []string, options types.VolumeRemoveOptions) error {
-	containers, err := client.Containers(ctx)
-	if err != nil {
-		return err
-	}
+	// Get the volume store and lock it until we are done.
+	// This will prevent racing new containers from being created or removed until we are done with the cleanup of volumes
 	volStore, err := Store(options.GOptions.Namespace, options.GOptions.DataRoot, options.GOptions.Address)
 	if err != nil {
 		return err
 	}
-	usedVolumes, err := usedVolumes(ctx, containers)
+	err = volStore.Lock()
+	if err != nil {
+		return err
+	}
+	defer volStore.Unlock()
+
+	// Get containers and see which volumes are used
+	containers, err := client.Containers(ctx)
 	if err != nil {
 		return err
 	}
 
-	var volumenames []string // nolint: prealloc
-	for _, name := range volumes {
-		if _, ok := usedVolumes[name]; ok {
-			return fmt.Errorf("volume %q is in use", name)
-		}
-		volumenames = append(volumenames, name)
-	}
-	// if err is set, this is a hard filesystem error
-	removedNames, warns, err := volStore.Remove(volumenames)
+	usedVolumesList, err := usedVolumes(ctx, containers)
 	if err != nil {
 		return err
 	}
+
+	volumeNames := []string{}
+	cannotRemove := []error{}
+
+	for _, name := range volumes {
+		if _, ok := usedVolumesList[name]; ok {
+			cannotRemove = append(cannotRemove, fmt.Errorf("volume %q is in use (%w)", name, errdefs.ErrFailedPrecondition))
+			continue
+		}
+		volumeNames = append(volumeNames, name)
+	}
+	// if err is set, this is a hard filesystem error
+	removedNames, warns, err := volStore.Remove(volumeNames)
+	if err != nil {
+		return err
+	}
+	cannotRemove = append(cannotRemove, warns...)
 	// Otherwise, output on stdout whatever was successful
 	for _, name := range removedNames {
 		fmt.Fprintln(options.Stdout, name)
 	}
 	// Log the rest
-	for _, volErr := range warns {
+	for _, volErr := range cannotRemove {
 		log.G(ctx).Warn(volErr)
 	}
-	if len(warns) > 0 {
+	if len(cannotRemove) > 0 {
 		return errors.New("some volumes could not be removed")
 	}
 	return nil
 }
 
 func usedVolumes(ctx context.Context, containers []containerd.Container) (map[string]struct{}, error) {
-	usedVolumes := make(map[string]struct{})
+	usedVolumesList := make(map[string]struct{})
 	for _, c := range containers {
 		l, err := c.Labels(ctx)
 		if err != nil {
@@ -95,9 +109,9 @@ func usedVolumes(ctx context.Context, containers []containerd.Container) (map[st
 		}
 		for _, m := range mounts {
 			if m.Type == mountutil.Volume {
-				usedVolumes[m.Name] = struct{}{}
+				usedVolumesList[m.Name] = struct{}{}
 			}
 		}
 	}
-	return usedVolumes, nil
+	return usedVolumesList, nil
 }

--- a/pkg/composer/up_volume.go
+++ b/pkg/composer/up_volume.go
@@ -41,6 +41,9 @@ func (c *Composer) upVolume(ctx context.Context, shortName string) error {
 
 	// shortName is like "db_data", fullName is like "compose-wordpress_db_data"
 	fullName := vol.Name
+	// FIXME: this is racy. By the time we get below to creating the volume, there is no guarantee that things are still fine
+	// Furthermore, volStore.Get no longer errors if the volume already exists (docker behavior), so, the purpose of this
+	// call needs to be assessed (it might still error if the name is malformed, or if there is a filesystem error)
 	volExists, err := c.VolumeExists(fullName)
 	if err != nil {
 		return err

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -17,14 +17,12 @@
 package mountutil
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 
-	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/identifiers"
 	"github.com/containerd/containerd/oci"
 	"github.com/containerd/containerd/pkg/userns"
@@ -203,16 +201,11 @@ func handleAnonymousVolumes(s string, volStore volumestore.VolumeStore) (volumeS
 func handleNamedVolumes(source string, volStore volumestore.VolumeStore) (volumeSpec, error) {
 	var res volumeSpec
 	res.Name = source
-	vol, err := volStore.Get(res.Name, false)
+
+	// Create returns an existing volume or creates a new one if necessary.
+	vol, err := volStore.Create(res.Name, nil)
 	if err != nil {
-		if errors.Is(err, errdefs.ErrNotFound) {
-			vol, err = volStore.Create(res.Name, nil)
-			if err != nil {
-				return res, fmt.Errorf("failed to create volume %q: %w", res.Name, err)
-			}
-		} else {
-			return res, fmt.Errorf("failed to get volume %q: %w", res.Name, err)
-		}
+		return res, fmt.Errorf("failed to get volume %q: %w", res.Name, err)
 	}
 	// src is now an absolute path
 	res.Type = Volume

--- a/pkg/mountutil/mountutilmock/volumestore.mock.go
+++ b/pkg/mountutil/mountutilmock/volumestore.mock.go
@@ -106,16 +106,26 @@ func (m *MockVolumeStoreMockRecorder) Remove(names any) *gomock.Call {
 	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Remove", reflect.TypeOf((*MockVolumeStore)(nil).Remove), names)
 }
 
-// Dir mocks the Dir method of VolumeStore
-func (m *MockVolumeStore) Dir() string {
+// Lock mocks the Lock method of VolumeStore
+func (m *MockVolumeStore) Lock() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Dir")
-	ret0, _ := ret[0].(string)
-	return ret0
+	return nil
 }
 
-// Dir indicates an expected call of Dir
-func (m *MockVolumeStoreMockRecorder) Dir() *gomock.Call {
+// Lock indicates an expected call of Lock
+func (m *MockVolumeStoreMockRecorder) Lock() *gomock.Call {
 	m.mock.ctrl.T.Helper()
-	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Dir", reflect.TypeOf((*MockVolumeStore)(nil).Dir))
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Lock", reflect.TypeOf((*MockVolumeStore)(nil).Lock))
+}
+
+// Unlock mocks the Unlock method of VolumeStore
+func (m *MockVolumeStore) Unlock() error {
+	m.ctrl.T.Helper()
+	return nil
+}
+
+// Unlock indicates an expected call of Unlock
+func (m *MockVolumeStoreMockRecorder) Unlock() *gomock.Call {
+	m.mock.ctrl.T.Helper()
+	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Unlock", reflect.TypeOf((*MockVolumeStore)(nil).Unlock))
 }


### PR DESCRIPTION
This is part 2 of #3125 - same idea.

The original motivation was to significantly increase testing coverage & quality, convergence with docker behavior, and stability wrt concurrency for anything related to volume lifecycle.

In the process of doing so, several issues cropped-up, that this PR also fix.

Tests:
- parallelized (which does also serve as a very good way to uncover raciness)
- expanded
- cleaned-up / normalized
- added namespace testing
- test more thoroughly, both in terms of cases and validating content of stdout / stderr
- ~~move tests from _linux to all platforms (not sure why it was linux only in the first place)~~ - wish I had a windows env to test

Code changes:
- docker align: "no labels" should be `nil`, not `[]string{}`
- docker align: `--label ""` should error
- docker align: multi-inspect that is partly failing, and other partly failing conditions
- remove useless / duplicated code (specifically around validation of identifiers that was performed multiple times)
- make sure all methods of the volume store are locking (to avoid racy behavior)
- replace broken/racy logic "`get` then `create`" by just `create` (since behavior has been recently changed and now always returns success)
- make the underlying filesystem implementation private (eg: no longer expose `Path`) to prevent leaking implementation to the consumer (see for example `cmd/nerdctl/namespace.go b/cmd/nerdctl/namespace.go` that was reading the filesystem directly instead of calling `List`)
- added a "persistent" `Lock` and `Unlock` methods on the store, for operations that need to call multiple methods successively or need guarantees that volumes cannot be modified at all until they are done
- cleaned-up and expanded `lockutil`, so that we don't expose anymore `Flock` (unimplemented for non Unix), and instead expose new lock/unlock methods
- reviewed all the codebase for any cases where that global lock call is necessary and added them
- reviewed codebase to fix #3132 (and fix #3123 hopefully)

While this is a significant PR in term of apparent code change size, the added testing should give us a good confidence boost on what's happening wrt volumes.
