### PR TITLE
Fix check for empty $HOME and $XDG_RUNTIME_DIR

### DIFF
--- a/extras/rootless/containerd-rootless.sh
+++ b/extras/rootless/containerd-rootless.sh
@@ -49,11 +49,11 @@
 # See also: https://github.com/containerd/nerdctl/blob/main/docs/rootless.md#configuring-rootlesskit
 
 set -e
-if ! [ -w $XDG_RUNTIME_DIR ]; then
+if ! [ -w "$XDG_RUNTIME_DIR" ]; then
 	echo "XDG_RUNTIME_DIR needs to be set and writable"
 	exit 1
 fi
-if ! [ -w $HOME ]; then
+if ! [ -w "$HOME" ]; then
 	echo "HOME needs to be set and writable"
 	exit 1
 fi


### PR DESCRIPTION
If $XDG_RUNTIME_DIR is not set, then [ -w $XDG_RUNTIME_DIR ] passes.

Quotes fix the issue.

`shellcheck` was able to detect this, but fails to explain what happens (https://github.com/koalaman/shellcheck/issues/3006).