### PR TITLE
Add `shellcheck` lint to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
           version: v1.59.1
           args: --verbose
       - name: yamllint-lint
-        run: yamllint .
+        run: make lint-yaml
       - name: shellcheck
-        run: shellcheck $(find . -name '*.sh')
+        run: make lint-shell
 
   test-unit:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
           args: --verbose
       - name: yamllint-lint
         run: yamllint .
+      - name: shellcheck
+        run: shellcheck $(find . -name '*.sh')
 
   test-unit:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
`find . -name '*.sh` loosk for filenames with .sh extension and passes the list to `shellcheck`.