### PR TITLE
fix missing name container stats

### DIFF
--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -31,10 +31,10 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
+	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/containerd/nerdctl/v2/pkg/labels/k8slabels"
 )
 
 // List prints containers according to `options`.
@@ -138,7 +138,7 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 			ID:        id,
 			Image:     info.Image,
 			Platform:  info.Labels[labels.Platform],
-			Names:     getContainerName(info.Labels),
+			Names:     containerutil.GetContainerName(info.Labels),
 			Ports:     formatter.FormatPorts(info.Labels),
 			Status:    formatter.ContainerStatus(ctx, c),
 			Runtime:   info.Runtime.Name,
@@ -160,24 +160,6 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 		listItems[i] = li
 	}
 	return listItems, nil
-}
-
-func getContainerName(containerLabels map[string]string) string {
-	if name, ok := containerLabels[labels.Name]; ok {
-		return name
-	}
-
-	if ns, ok := containerLabels[k8slabels.PodNamespace]; ok {
-		if podName, ok := containerLabels[k8slabels.PodName]; ok {
-			if containerName, ok := containerLabels[k8slabels.ContainerName]; ok {
-				// Container
-				return fmt.Sprintf("k8s://%s/%s/%s", ns, podName, containerName)
-			}
-			// Pod sandbox
-			return fmt.Sprintf("k8s://%s/%s", ns, podName)
-		}
-	}
-	return ""
 }
 
 func getContainerNetworks(containerLables map[string]string) []string {

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -289,7 +289,7 @@ func (cl *containerFilterContext) matchesNameFilter(info containers.Container) b
 	if len(cl.nameFilterFuncs) == 0 {
 		return true
 	}
-	cName := getContainerName(info.Labels)
+	cName := containerutil.GetContainerName(info.Labels)
 	for _, nameFilterFunc := range cl.nameFilterFuncs {
 		if !nameFilterFunc(cName) {
 			continue
@@ -368,7 +368,7 @@ func idOrNameFilter(ctx context.Context, containers []containerd.Container, valu
 		if err != nil {
 			return nil, err
 		}
-		if strings.HasPrefix(info.ID, value) || strings.Contains(getContainerName(info.Labels), value) {
+		if strings.HasPrefix(info.ID, value) || strings.Contains(containerutil.GetContainerName(info.Labels), value) {
 			return &info, nil
 		}
 	}

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/containerd/nerdctl/v2/pkg/labels/k8slabels"
 	"github.com/containerd/nerdctl/v2/pkg/nsutil"
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -561,4 +562,22 @@ func GetContainerVolumes(containerLabels map[string]string) []*ContainerVolume {
 		vols = append(vols, volumes...)
 	}
 	return vols
+}
+
+func GetContainerName(containerLabels map[string]string) string {
+	if name, ok := containerLabels[labels.Name]; ok {
+		return name
+	}
+
+	if ns, ok := containerLabels[k8slabels.PodNamespace]; ok {
+		if podName, ok := containerLabels[k8slabels.PodName]; ok {
+			if containerName, ok := containerLabels[k8slabels.ContainerName]; ok {
+				// Container
+				return fmt.Sprintf("k8s://%s/%s/%s", ns, podName, containerName)
+			}
+			// Pod sandbox
+			return fmt.Sprintf("k8s://%s/%s", ns, podName)
+		}
+	}
+	return ""
 }

--- a/pkg/statsutil/stats.go
+++ b/pkg/statsutil/stats.go
@@ -19,6 +19,7 @@ package statsutil
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 
 // StatsEntry represents the statistics data collected from a container
 type StatsEntry struct {
-	Container        string
 	Name             string
 	ID               string
 	CPUPercentage    float64
@@ -69,15 +69,14 @@ type ContainerStats struct {
 }
 
 // NewStats is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L113-L116
-func NewStats(container string) *Stats {
-	return &Stats{StatsEntry: StatsEntry{Container: container}}
+func NewStats(containerID string) *Stats {
+	return &Stats{StatsEntry: StatsEntry{ID: containerID}}
 }
 
 // SetStatistics is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L87-L93
 func (cs *Stats) SetStatistics(s StatsEntry) {
 	cs.mutex.Lock()
 	defer cs.mutex.Unlock()
-	s.Container = cs.Container
 	cs.StatsEntry = s
 }
 
@@ -134,7 +133,7 @@ func calculateMemPercent(limit float64, usedNo float64) float64 {
 // Rendering a FormattedStatsEntry from StatsEntry
 func RenderEntry(in *StatsEntry, noTrunc bool) FormattedStatsEntry {
 	return FormattedStatsEntry{
-		Name:     in.EntryName(),
+		Name:     in.EntryName(noTrunc),
 		ID:       in.EntryID(noTrunc),
 		CPUPerc:  in.CPUPerc(),
 		MemUsage: in.MemUsage(),
@@ -148,10 +147,18 @@ func RenderEntry(in *StatsEntry, noTrunc bool) FormattedStatsEntry {
 /*
 a set of functions to format container stats
 */
-func (s *StatsEntry) EntryName() string {
+func (s *StatsEntry) EntryName(noTrunc bool) string {
 	if len(s.Name) > 1 {
-		if len(s.Name) > 12 {
-			return s.Name[:12]
+		if !noTrunc {
+			var truncLen int
+			if strings.HasPrefix(s.Name, "k8s://") {
+				truncLen = 24
+			} else {
+				truncLen = 12
+			}
+			if len(s.Name) > truncLen {
+				return s.Name[:truncLen]
+			}
 		}
 		return s.Name
 	}


### PR DESCRIPTION
fix https://github.com/containerd/nerdctl/issues/3141

> nerdctl --namespace k8s.io stats  --no-stream --no-trunc

```
CONTAINER ID                                                       NAME                                                                                    CPU %     MEM USAGE / LIMIT   MEM %     NET I/O           BLOCK I/O       PIDS
14c31ac2392c4715202d2fd1f1f86d60305b9f123f70b7ef7a926aca7c040676   k8s://kube-system/etcd-kind-control-plane/etcd                                          10.40%    46.13MiB / 16EiB    0.00%     3.04MB / 3.4MB    4.1kB / 412MB   13
3bdbdc1519836c83d902cbac39c97051004fb70a78541172ca21daed64ff012a   k8s://local-path-storage/local-path-provisioner-988d74bc-4whz7                          0.00%     1.043MiB / 16EiB    0.00%     281kB / 130kB     0B / 0B         1
3f37ac1fa40da521a3100da1bc1b627076ae8428829ec7750e8192c6097a034f   k8s://kube-system/kindnet-vkhw4/kindnet-cni                                             0.00%     17.26MiB / 50MiB    34.52%    3.04MB / 3.4MB    0B / 0B         7
424497cb939e92eb2465927459bf74b93b9a1a897a725b6a6e91e675dd50ce3c   k8s://kube-system/kube-controller-manager-kind-control-plane/kube-controller-manager    8.24%     44.04MiB / 16EiB    0.00%     3.04MB / 3.4MB    0B / 0B         8
4a34218ec4c649f08fa1dacc13a38287e2f825da626765931fa1cefe84c266f1   k8s://kube-system/kube-proxy-x9njr                                                      0.00%     1012KiB / 16EiB     0.00%     3.04MB / 3.4MB    0B / 0B         1
6007fdbbc9ad837a1c6f5ae22567d867fc9f4435f7a8d3e791ef081a60d963d1   k8s://kube-system/kube-proxy-x9njr/kube-proxy                                           0.00%     25.12MiB / 16EiB    0.00%     3.04MB / 3.4MB    0B / 0B         8
7073699bbd6566b79eb2d69f40dec3ef1539f1f47256dcce91dd61120a1f76f3   k8s://kube-system/etcd-kind-control-plane                                               0.00%     840KiB / 16EiB      0.00%     3.04MB / 3.4MB    0B / 0B         1
9e06a3d367ed8db2a729f63c6218985adb95482f25eeb12ea3c2711e0a2dbf66   k8s://kube-system/kube-scheduler-kind-control-plane/kube-scheduler                      2.25%     18.5MiB / 16EiB     0.00%     3.04MB / 3.4MB    0B / 0B         11
b003a35472530c4b060890ea10e0ee2f0fa937106333edf3b1fd23a389056da8   k8s://kube-system/kindnet-vkhw4                                                         0.00%     832KiB / 16EiB      0.00%     3.04MB / 3.4MB    0B / 0B         1
b2ffc131002e1f2ed15109c33c363ec918fa6325496856a12c758460f853ec77   k8s://kube-system/coredns-7db6d8ff4d-d58xg                                              0.00%     956KiB / 16EiB      0.00%     1.57MB / 1.46MB   0B / 0B         1
ba99e804828d04fbb8acecddda4a2964d15bfb34502bc1b9dd11639910b258c1   k8s://kube-system/kube-controller-manager-kind-control-plane                            0.00%     972KiB / 16EiB      0.00%     3.04MB / 3.4MB    0B / 0B         1
c1cc6fdb0e705300c1140d7919b690e01d59e50b76835126a78e6b1fdc0121d4   k8s://kube-system/kube-apiserver-kind-control-plane                                     0.00%     948KiB / 16EiB      0.00%     3.04MB / 3.4MB    0B / 0B         1
c342a53394008104cb50c2d9cc863d0102807fd65c293c284b56cb793a48a56b   k8s://kube-system/kube-scheduler-kind-control-plane                                     0.00%     780KiB / 16EiB      0.00%     3.04MB / 3.4MB    0B / 0B         1
c82b9acfe41636ceb60d5510db57d4d40545bf389f080b12b65b1f7c136a5eea   k8s://kube-system/coredns-7db6d8ff4d-r8xzm/coredns                                      2.28%     18.03MiB / 170MiB   10.60%    1.55MB / 1.45MB   0B / 0B         11
d8d0458b38caf7ff30d646b0b7ce8b5de177974969d11a8f6d1edb720262d55f   k8s://kube-system/coredns-7db6d8ff4d-r8xzm                                              0.00%     972KiB / 16EiB      0.00%     1.55MB / 1.45MB   0B / 0B         1
d99eda1d4bb8c6d4418d03fb0fe638d13372f6b61ba65af948e76ec7c5539ca6   k8s://local-path-storage/local-path-provisioner-988d74bc-4whz7/local-path-provisioner   0.19%     10.86MiB / 16EiB    0.00%     281kB / 130kB     0B / 0B         9
e6a6dffc569ad7379eac84bf1d8637239295f1c385ef87d431faab83e8267ba6   k8s://kube-system/coredns-7db6d8ff4d-d58xg/coredns                                      1.59%     17.95MiB / 170MiB   10.56%    1.57MB / 1.46MB   0B / 0B         11
ea38d3ff7fffd82f53f75170c9bd1b8d80368373fd6a7e0a60f74d27acc1c8ad   k8s://kube-system/kube-apiserver-kind-control-plane/kube-apiserver                      26.13%    205.6MiB / 16EiB    0.00%     3.04MB / 3.4MB    0B / 0B         11
```
> nerdctl --namespace k8s.io stats  --no-stream
````
CONTAINER ID   NAME                       CPU %     MEM USAGE / LIMIT   MEM %     NET I/O           BLOCK I/O       PIDS
14c31ac2392c   k8s://kube-system/etcd-k   12.46%    46.05MiB / 16EiB    0.00%     3.03MB / 3.38MB   4.1kB / 409MB   13
3bdbdc151983   k8s://local-path-storage   0.00%     1.043MiB / 16EiB    0.00%     279kB / 130kB     0B / 0B         1
3f37ac1fa40d   k8s://kube-system/kindne   0.00%     17.24MiB / 50MiB    34.48%    3.03MB / 3.38MB   0B / 0B         7
424497cb939e   k8s://kube-system/kube-c   12.69%    44.04MiB / 16EiB    0.00%     3.03MB / 3.38MB   0B / 0B         8
4a34218ec4c6   k8s://kube-system/kube-p   0.00%     1012KiB / 16EiB     0.00%     3.03MB / 3.38MB   0B / 0B         1
6007fdbbc9ad   k8s://kube-system/kube-p   0.00%     25.11MiB / 16EiB    0.00%     3.03MB / 3.38MB   0B / 0B         8
7073699bbd65   k8s://kube-system/etcd-k   0.00%     840KiB / 16EiB      0.00%     3.03MB / 3.38MB   0B / 0B         1
9e06a3d367ed   k8s://kube-system/kube-s   2.08%     18.5MiB / 16EiB     0.00%     3.03MB / 3.38MB   0B / 0B         11
b003a3547253   k8s://kube-system/kindne   0.00%     832KiB / 16EiB      0.00%     3.03MB / 3.38MB   0B / 0B         1
b2ffc131002e   k8s://kube-system/coredn   0.00%     956KiB / 16EiB      0.00%     1.56MB / 1.45MB   0B / 0B         1
ba99e804828d   k8s://kube-system/kube-c   0.00%     972KiB / 16EiB      0.00%     3.03MB / 3.38MB   0B / 0B         1
c1cc6fdb0e70   k8s://kube-system/kube-a   0.00%     948KiB / 16EiB      0.00%     3.03MB / 3.38MB   0B / 0B         1
c342a5339400   k8s://kube-system/kube-s   0.00%     780KiB / 16EiB      0.00%     3.03MB / 3.38MB   0B / 0B         1
c82b9acfe416   k8s://kube-system/coredn   0.00%     18.02MiB / 170MiB   10.60%    1.54MB / 1.45MB   0B / 0B         11
d8d0458b38ca   k8s://kube-system/coredn   0.00%     972KiB / 16EiB      0.00%     1.54MB / 1.45MB   0B / 0B         1
d99eda1d4bb8   k8s://local-path-storage   0.08%     10.86MiB / 16EiB    0.00%     279kB / 130kB     0B / 0B         9
e6a6dffc569a   k8s://kube-system/coredn   0.00%     17.95MiB / 170MiB   10.56%    1.56MB / 1.45MB   0B / 0B         11
ea38d3ff7fff   k8s://kube-system/kube-a   28.39%    205.4MiB / 16EiB    0.00%     3.03MB / 3.38MB   0B / 0B         11
```



