### PR TITLE
feat: support for -a and --attach in run

### DIFF
--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/containerd/console"
 	"github.com/containerd/log"
@@ -69,6 +70,7 @@ func newRunCommand() *cobra.Command {
 	setCreateFlags(runCommand)
 
 	runCommand.Flags().BoolP("detach", "d", false, "Run container in background and print container ID")
+	runCommand.Flags().StringSliceP("attach", "a", []string{}, "Attach STDIN, STDOUT, or STDERR")
 
 	return runCommand
 }
@@ -304,6 +306,23 @@ func processCreateCommandFlagsInRun(cmd *cobra.Command) (opt types.ContainerCrea
 	if err != nil {
 		return
 	}
+	opt.Attach, err = cmd.Flags().GetStringSlice("attach")
+	if err != nil {
+		return
+	}
+
+	validAttachFlag := true
+	for i, str := range opt.Attach {
+		opt.Attach[i] = strings.ToUpper(str)
+
+		if opt.Attach[i] != "STDIN" && opt.Attach[i] != "STDOUT" && opt.Attach[i] != "STDERR" {
+			validAttachFlag = false
+		}
+	}
+	if !validAttachFlag {
+		return opt, fmt.Errorf("invalid stream specified with -a flag. Valid streams are STDIN, STDOUT, and STDERR")
+	}
+
 	return opt, nil
 }
 
@@ -323,6 +342,10 @@ func runAction(cmd *cobra.Command, args []string) error {
 
 	if createOpt.Rm && createOpt.Detach {
 		return errors.New("flags -d and --rm cannot be specified together")
+	}
+
+	if len(createOpt.Attach) > 0 && createOpt.Detach {
+		return errors.New("flags -d and -a cannot be specified together")
 	}
 
 	netFlags, err := loadNetworkFlags(cmd)
@@ -381,7 +404,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 	}
 	logURI := lab[labels.LogURI]
 	detachC := make(chan struct{})
-	task, err := taskutil.NewTask(ctx, client, c, false, createOpt.Interactive, createOpt.TTY, createOpt.Detach,
+	task, err := taskutil.NewTask(ctx, client, c, createOpt.Attach, createOpt.Interactive, createOpt.TTY, createOpt.Detach,
 		con, logURI, createOpt.DetachKeys, createOpt.GOptions.Namespace, detachC)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -533,3 +533,123 @@ func TestRunRmTime(t *testing.T) {
 		t.Fatalf("expected to have completed in %v, took %v", deadline, took)
 	}
 }
+
+func runAttachStdin(t *testing.T, testStr string, args []string) string {
+	if runtime.GOOS == "windows" {
+		t.Skip("run attach test is not yet implemented on Windows")
+	}
+
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	opts := []func(*testutil.Cmd){
+		testutil.WithStdin(strings.NewReader("echo " + testStr + "\nexit\n")),
+	}
+
+	fullArgs := []string{"run", "--rm", "-i"}
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs,
+		"--name",
+		containerName,
+		testutil.CommonImage,
+	)
+
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+	result := base.Cmd(fullArgs...).CmdOption(opts...).Run()
+
+	return result.Combined()
+}
+
+func runAttach(t *testing.T, testStr string, args []string) string {
+	if runtime.GOOS == "windows" {
+		t.Skip("run attach test is not yet implemented on Windows")
+	}
+
+	t.Parallel()
+	base := testutil.NewBase(t)
+	containerName := testutil.Identifier(t)
+
+	fullArgs := []string{"run"}
+	fullArgs = append(fullArgs, args...)
+	fullArgs = append(fullArgs,
+		"--name",
+		containerName,
+		testutil.CommonImage,
+		"sh",
+		"-euxc",
+		"echo "+testStr,
+	)
+
+	defer base.Cmd("rm", "-f", containerName).AssertOK()
+	result := base.Cmd(fullArgs...).Run()
+
+	return result.Combined()
+}
+
+func TestRunAttachFlag(t *testing.T) {
+
+	type testCase struct {
+		name        string
+		args        []string
+		testFunc    func(t *testing.T, testStr string, args []string) string
+		testStr     string
+		expectedOut string
+		dockerOut   string
+	}
+	testCases := []testCase{
+		{
+			name:        "AttachFlagStdin",
+			args:        []string{"-a", "STDIN", "-a", "STDOUT"},
+			testFunc:    runAttachStdin,
+			testStr:     "test-run-stdio",
+			expectedOut: "test-run-stdio",
+			dockerOut:   "test-run-stdio",
+		},
+		{
+			name:        "AttachFlagStdOut",
+			args:        []string{"-a", "STDOUT"},
+			testFunc:    runAttach,
+			testStr:     "foo",
+			expectedOut: "foo",
+			dockerOut:   "foo",
+		},
+		{
+			name:        "AttachFlagMixedValue",
+			args:        []string{"-a", "STDIN", "-a", "invalid-value"},
+			testFunc:    runAttach,
+			testStr:     "foo",
+			expectedOut: "invalid stream specified with -a flag. Valid streams are STDIN, STDOUT, and STDERR",
+			dockerOut:   "valid streams are STDIN, STDOUT and STDERR",
+		},
+		{
+			name:        "AttachFlagInvalidValue",
+			args:        []string{"-a", "invalid-stream"},
+			testFunc:    runAttach,
+			testStr:     "foo",
+			expectedOut: "invalid stream specified with -a flag. Valid streams are STDIN, STDOUT, and STDERR",
+			dockerOut:   "valid streams are STDIN, STDOUT and STDERR",
+		},
+		{
+			name:        "AttachFlagCaseInsensitive",
+			args:        []string{"-a", "stdin", "-a", "stdout"},
+			testFunc:    runAttachStdin,
+			testStr:     "test-run-stdio",
+			expectedOut: "test-run-stdio",
+			dockerOut:   "test-run-stdio",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actualOut := tc.testFunc(t, tc.testStr, tc.args)
+			errorMsg := fmt.Sprintf("%s failed;\nExpected: '%s'\nActual: '%s'", tc.name, tc.expectedOut, actualOut)
+			if testutil.GetTarget() == testutil.Docker {
+				assert.Equal(t, true, strings.Contains(actualOut, tc.dockerOut), errorMsg)
+			} else {
+				assert.Equal(t, true, strings.Contains(actualOut, tc.expectedOut), errorMsg)
+			}
+		})
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -137,6 +137,7 @@ Usage: `nerdctl run [OPTIONS] IMAGE [COMMAND] [ARG...]`
 
 Basic flags:
 
+- :whale: `-a, --attach`: Attach STDIN, STDOUT, or STDERR
 - :whale: :blue_square: `-i, --interactive`: Keep STDIN open even if not attached"
 - :whale: :blue_square: `-t, --tty`: Allocate a pseudo-TTY
   - :warning: WIP: currently `-t` conflicts with `-d`
@@ -387,7 +388,7 @@ IPFS flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker run` flags:
-    `--attach`, `--blkio-weight-device`, `--cpu-rt-*`, `--device-*`,
+    `--blkio-weight-device`, `--cpu-rt-*`, `--device-*`,
     `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
     `--link*`, `--publish-all`, `--storage-opt`,
     `--userns`, `--volume-driver`

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -68,6 +68,8 @@ type ContainerCreateOptions struct {
 	Detach bool
 	// The key sequence for detaching a container.
 	DetachKeys string
+	// Attach STDIN, STDOUT, or STDERR
+	Attach []string
 	// Restart specifies the policy to apply when a container exits
 	Restart string
 	// Rm specifies whether to remove the container automatically when it exits

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -272,7 +272,13 @@ func Start(ctx context.Context, container containerd.Container, flagA bool, clie
 		}
 	}
 	detachC := make(chan struct{})
-	task, err := taskutil.NewTask(ctx, client, container, flagA, false, flagT, true, con, logURI, detachKeys, namespace, detachC)
+	attachStreamOpt := []string{}
+	if flagA {
+		// In start, flagA attaches only STDOUT/STDERR
+		// source: https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-nerdctl-start
+		attachStreamOpt = []string{"STDOUT", "STDERR"}
+	}
+	task, err := taskutil.NewTask(ctx, client, container, attachStreamOpt, false, flagT, true, con, logURI, detachKeys, namespace, detachC)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds support for the ```-a, --attach``` in ```nerdctl run```

Address #3113 

**Context:** 

- ```--attach``` is listed as unimplemented under [```nerdctl run```](https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-blue_square-nerdctl-run) 
- [Docker run --attach docs](https://docs.docker.com/reference/cli/docker/container/run/#attach)