### PR TITLE
update containerd (1.7.19)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,13 +81,13 @@ jobs:
           - ubuntu: 20.04
             containerd: v1.6.33
           - ubuntu: 20.04
-            containerd: v1.7.18
+            containerd: v1.7.19
           - ubuntu: 22.04
-            containerd: v1.7.18
+            containerd: v1.7.19
           - ubuntu: 22.04
             containerd: main  # v2.0.0-rc.X
           - ubuntu: 24.04
-            containerd: v1.7.18
+            containerd: v1.7.19
           - ubuntu: 24.04
             containerd: main  # v2.0.0-rc.X
     env:
@@ -124,7 +124,7 @@ jobs:
         # ubuntu-20.04: cgroup v1, ubuntu-22.04 and later: cgroup v2
         include:
           - ubuntu: 24.04
-            containerd: v1.7.18
+            containerd: v1.7.19
     env:
       UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
@@ -177,11 +177,11 @@ jobs:
             rootlesskit: v1.1.1
             target: test-integration-rootless
           - ubuntu: 20.04
-            containerd: v1.7.18
+            containerd: v1.7.19
             rootlesskit: v2.1.0
             target: test-integration-rootless
           - ubuntu: 22.04
-            containerd: v1.7.18
+            containerd: v1.7.19
             rootlesskit: v1.1.1
             target: test-integration-rootless
           - ubuntu: 22.04
@@ -189,7 +189,7 @@ jobs:
             rootlesskit: v2.1.0
             target: test-integration-rootless
           - ubuntu: 24.04
-            containerd: v1.7.18
+            containerd: v1.7.19
             rootlesskit: v1.1.1
             target: test-integration-rootless
           - ubuntu: 24.04
@@ -201,11 +201,11 @@ jobs:
             rootlesskit: v1.1.1
             target: test-integration-rootless-port-slirp4netns
           - ubuntu: 20.04
-            containerd: v1.7.18
+            containerd: v1.7.19
             rootlesskit: v2.1.0
             target: test-integration-rootless-port-slirp4netns
           - ubuntu: 24.04
-            containerd: v1.7.18
+            containerd: v1.7.19
             rootlesskit: v1.1.1
             target: test-integration-rootless-port-slirp4netns
           - ubuntu: 24.04
@@ -322,7 +322,7 @@ jobs:
       - uses: actions/checkout@v4.1.7
         with:
           repository: containerd/containerd
-          ref: v1.7.18
+          ref: v1.7.19
           path: containerd
           fetch-depth: 1
       - name: "Set up CNI"
@@ -330,7 +330,7 @@ jobs:
         run: GOPATH=$(go env GOPATH) script/setup/install-cni-windows
       - name: "Set up containerd"
         env:
-          ctrdVersion: 1.7.18
+          ctrdVersion: 1.7.19
         run: powershell hack/configure-windows-ci.ps1
       # TODO: Run unit tests
       - name: "Run integration tests"

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,8 @@ require (
 	github.com/containerd/accelerated-container-image v1.1.3
 	github.com/containerd/cgroups/v3 v3.0.3
 	github.com/containerd/console v1.0.4
-	github.com/containerd/containerd v1.7.18
+	github.com/containerd/containerd v1.7.19
+	github.com/containerd/containerd/api v1.7.19
 	github.com/containerd/continuity v0.4.3
 	github.com/containerd/fifo v1.1.0
 	github.com/containerd/go-cni v1.1.10
@@ -75,7 +76,7 @@ require (
 	github.com/cilium/ebpf v0.11.0 // indirect
 	github.com/containerd/errdefs v0.1.0 // indirect
 	github.com/containerd/go-runc v1.0.0 // indirect
-	github.com/containerd/ttrpc v1.2.4 // indirect
+	github.com/containerd/ttrpc v1.2.5 // indirect
 	github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67 // indirect
 	github.com/containers/ocicrypt v1.1.10 // indirect
 	github.com/distribution/reference v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,10 @@ github.com/containerd/cgroups/v3 v3.0.3/go.mod h1:8HBe7V3aWGLFPd/k03swSIsGjZhHI2
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
 github.com/containerd/console v1.0.4/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=
-github.com/containerd/containerd v1.7.18 h1:jqjZTQNfXGoEaZdW1WwPU0RqSn1Bm2Ay/KJPUuO8nao=
-github.com/containerd/containerd v1.7.18/go.mod h1:IYEk9/IO6wAPUz2bCMVUbsfXjzw5UNP5fLz4PsUygQ4=
+github.com/containerd/containerd v1.7.19 h1:/xQ4XRJ0tamDkdzrrBAUy/LE5nCcxFKdBm4EcPrSMEE=
+github.com/containerd/containerd v1.7.19/go.mod h1:h4FtNYUUMB4Phr6v+xG89RYKj9XccvbNSCKjdufCrkc=
+github.com/containerd/containerd/api v1.7.19 h1:VWbJL+8Ap4Ju2mx9c9qS1uFSB1OVYr5JJrW2yT5vFoA=
+github.com/containerd/containerd/api v1.7.19/go.mod h1:fwGavl3LNwAV5ilJ0sbrABL44AQxmNjDRcwheXDb6Ig=
 github.com/containerd/continuity v0.4.3 h1:6HVkalIp+2u1ZLH1J/pYX2oBVXlJZvh1X1A7bEZ9Su8=
 github.com/containerd/continuity v0.4.3/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/errdefs v0.1.0 h1:m0wCRBiu1WJT/Fr+iOoQHMQS/eP5myQ8lCv4Dz5ZURM=
@@ -58,8 +60,8 @@ github.com/containerd/stargz-snapshotter/estargz v0.15.1 h1:eXJjw9RbkLFgioVaTG+G
 github.com/containerd/stargz-snapshotter/estargz v0.15.1/go.mod h1:gr2RNwukQ/S9Nv33Lt6UC7xEx58C+LHRdoqbEKjz1Kk=
 github.com/containerd/stargz-snapshotter/ipfs v0.15.1 h1:MMWRYrTu2iVOn9eRJqEer7v0eg34xY2uFZxbrrm2iCY=
 github.com/containerd/stargz-snapshotter/ipfs v0.15.1/go.mod h1:DvrczCWAJnbTOau8txguZXDZdA7r39O3/Aj2olx+Q90=
-github.com/containerd/ttrpc v1.2.4 h1:eQCQK4h9dxDmpOb9QOOMh2NHTfzroH1IkmHiKZi05Oo=
-github.com/containerd/ttrpc v1.2.4/go.mod h1:ojvb8SJBSch0XkqNO0L0YX/5NxR3UnVk2LzFKBK0upc=
+github.com/containerd/ttrpc v1.2.5 h1:IFckT1EFQoFBMG4c3sMdT8EP3/aKfumK1msY+Ze4oLU=
+github.com/containerd/ttrpc v1.2.5/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67 h1:rQvjv7gRi6Ki/NS/U9oLZFhqyk4dh/GH2M3o/4BRkMM=
 github.com/containerd/typeurl v1.0.3-0.20220422153119-7f6e6d160d67/go.mod h1:HDkcKOXRnX6yKnXv3P0QrogFi0DoiauK/LpQi961f0A=
 github.com/containerd/typeurl/v2 v2.1.1 h1:3Q4Pt7i8nYwy2KmQWIw2+1hTvwTE/6w9FqcttATPO/4=

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -32,7 +32,6 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/archive"
-	dockerreference "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
@@ -40,6 +39,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/platforms"
+	distributionref "github.com/distribution/reference"
 )
 
 type PlatformParser interface {
@@ -230,19 +230,19 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 	}
 	if tags = strutil.DedupeStrSlice(options.Tag); len(tags) > 0 {
 		ref := tags[0]
-		named, err := dockerreference.ParseNormalizedNamed(ref)
+		named, err := distributionref.ParseNormalizedNamed(ref)
 		if err != nil {
 			return "", nil, false, "", nil, nil, err
 		}
-		output += ",name=" + dockerreference.TagNameOnly(named).String()
+		output += ",name=" + distributionref.TagNameOnly(named).String()
 
 		// pick the first tag and add it to output
 		for idx, tag := range tags {
-			named, err := dockerreference.ParseNormalizedNamed(tag)
+			named, err := distributionref.ParseNormalizedNamed(tag)
 			if err != nil {
 				return "", nil, false, "", nil, nil, err
 			}
-			tags[idx] = dockerreference.TagNameOnly(named).String()
+			tags[idx] = distributionref.TagNameOnly(named).String()
 		}
 	} else if len(tags) == 0 {
 		output = output + ",dangling-name-prefix=<none>"

--- a/pkg/cmd/builder/build_test.go
+++ b/pkg/cmd/builder/build_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/containerd/containerd/platforms"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 )
@@ -44,10 +44,10 @@ func (m *MockParse) EXPECT() *MockParseRecorder {
 	return m.recorder
 }
 
-func (m *MockParse) Parse(platform string) (platforms.Platform, error) {
+func (m *MockParse) Parse(platform string) (specs.Platform, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Parse")
-	ret0, _ := ret[0].(platforms.Platform)
+	ret0, _ := ret[0].(specs.Platform)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -57,10 +57,10 @@ func (m *MockParseRecorder) Parse(platform string) *gomock.Call {
 	return m.mock.ctrl.RecordCallWithMethodType(m.mock, "Parse", reflect.TypeOf((*MockParse)(nil).Parse))
 }
 
-func (m *MockParse) DefaultSpec() platforms.Platform {
+func (m *MockParse) DefaultSpec() specs.Platform {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DefaultSpec")
-	ret0, _ := ret[0].(platforms.Platform)
+	ret0, _ := ret[0].(specs.Platform)
 	return ret0
 }
 
@@ -80,40 +80,40 @@ func TestIsMatchingRuntimePlatform(t *testing.T) {
 		{
 			name: "Image is shareable when Runtime and build platform match for os, arch and variant",
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: true,
 		},
 		{
 			name: "Image is shareable when Runtime and build platform match for os, arch. Variant is not defined",
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: ""}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: ""}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: true,
 		},
 		{
 			name: "Image is not shareable when Runtime and build platform donot math OS",
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "OS", Architecture: "mockArch", Variant: ""}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "OS", Architecture: "mockArch", Variant: ""}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: false,
 		},
 		{
 			name: "Image is not shareable when Runtime and build platform donot math Arch",
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "mockOS", Architecture: "Arch", Variant: ""}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "mockOS", Architecture: "Arch", Variant: ""}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: false,
 		},
 		{
 			name: "Image is not shareable when Runtime and build platform donot math Variant",
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "Variant"}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "Variant"}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: false,
 		},
@@ -151,8 +151,8 @@ func TestIsBuildPlatformDefault(t *testing.T) {
 			name:     "Image is shareable when Runtime and build platform match for os, arch and variant",
 			platform: []string{"test"},
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: true,
 		},
@@ -160,8 +160,8 @@ func TestIsBuildPlatformDefault(t *testing.T) {
 			name:     "Image is not shareable when Runtime build platform dont match",
 			platform: []string{"test"},
 			mock: func(mockParser *MockParse) {
-				mockParser.EXPECT().Parse("test").Return(platforms.Platform{OS: "OS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
-				mockParser.EXPECT().DefaultSpec().Return(platforms.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
+				mockParser.EXPECT().Parse("test").Return(specs.Platform{OS: "OS", Architecture: "mockArch", Variant: "mockVariant"}, nil)
+				mockParser.EXPECT().DefaultSpec().Return(specs.Platform{OS: "mockOS", Architecture: "mockArch", Variant: "mockVariant"})
 			},
 			want: false,
 		},

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -28,7 +28,6 @@ import (
 	"github.com/containerd/containerd/images"
 	"github.com/containerd/containerd/images/converter"
 	"github.com/containerd/containerd/reference"
-	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	dockerconfig "github.com/containerd/containerd/remotes/docker/config"
@@ -45,6 +44,7 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/estargz/zstdchunked"
 	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
+	distributionref "github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -83,12 +83,12 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		return nil
 	}
 
-	named, err := refdocker.ParseDockerRef(rawRef)
+	named, err := distributionref.ParseDockerRef(rawRef)
 	if err != nil {
 		return err
 	}
 	ref := named.String()
-	refDomain := refdocker.Domain(named)
+	refDomain := distributionref.Domain(named)
 
 	platMC, err := platformutil.NewMatchComparer(options.AllPlatforms, options.Platforms)
 	if err != nil {

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -25,9 +25,9 @@ import (
 
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/images"
-	dockerreference "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
+	distributionref "github.com/distribution/reference"
 )
 
 // Filter types supported to filter images.
@@ -141,14 +141,14 @@ func FilterByReference(imageList []images.Image, filters []string) ([]images.Ima
 		log.L.Debug(image.Name)
 		var matches int
 		for _, f := range filters {
-			var ref dockerreference.Reference
+			var ref distributionref.Reference
 			var err error
-			ref, err = dockerreference.ParseAnyReference(image.Name)
+			ref, err = distributionref.ParseAnyReference(image.Name)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse image name: %s while filtering by reference because of %s", image.Name, err.Error())
 			}
 
-			familiarMatch, err := dockerreference.FamiliarMatch(f, ref)
+			familiarMatch, err := distributionref.FamiliarMatch(f, ref)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/imgutil/imgutil.go
+++ b/pkg/imgutil/imgutil.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/images"
-	refdocker "github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/snapshots"
 	"github.com/containerd/imgcrypt"
@@ -38,6 +37,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
 	"github.com/containerd/platforms"
+	distributionref "github.com/distribution/reference"
 	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -125,12 +125,12 @@ func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr 
 		return nil, fmt.Errorf("image not available: %q", rawRef)
 	}
 
-	named, err := refdocker.ParseDockerRef(rawRef)
+	named, err := distributionref.ParseDockerRef(rawRef)
 	if err != nil {
 		return nil, err
 	}
 	ref := named.String()
-	refDomain := refdocker.Domain(named)
+	refDomain := distributionref.Domain(named)
 
 	var dOpts []dockerconfigresolver.Opt
 	if insecure {
@@ -168,12 +168,12 @@ func EnsureImage(ctx context.Context, client *containerd.Client, stdout, stderr 
 
 // ResolveDigest resolves `rawRef` and returns its descriptor digest.
 func ResolveDigest(ctx context.Context, rawRef string, insecure bool, hostsDirs []string) (string, error) {
-	named, err := refdocker.ParseDockerRef(rawRef)
+	named, err := distributionref.ParseDockerRef(rawRef)
 	if err != nil {
 		return "", err
 	}
 	ref := named.String()
-	refDomain := refdocker.Domain(named)
+	refDomain := distributionref.Domain(named)
 
 	var dOpts []dockerconfigresolver.Opt
 	if insecure {
@@ -361,7 +361,7 @@ func ReadImageConfig(ctx context.Context, img containerd.Image) (ocispec.Image, 
 func ParseRepoTag(imgName string) (string, string) {
 	log.L.Debugf("raw image name=%q", imgName)
 
-	ref, err := refdocker.ParseDockerRef(imgName)
+	ref, err := distributionref.ParseDockerRef(imgName)
 	if err != nil {
 		log.L.WithError(err).Debugf("unparsable image name %q", imgName)
 		return "", ""
@@ -369,10 +369,10 @@ func ParseRepoTag(imgName string) (string, string) {
 
 	var tag string
 
-	if tagged, ok := ref.(refdocker.Tagged); ok {
+	if tagged, ok := ref.(distributionref.Tagged); ok {
 		tag = tagged.Tag()
 	}
-	repository := refdocker.FamiliarName(ref)
+	repository := distributionref.FamiliarName(ref)
 
 	return repository, tag
 }

--- a/pkg/referenceutil/referenceutil.go
+++ b/pkg/referenceutil/referenceutil.go
@@ -21,7 +21,7 @@ import (
 	"path"
 	"strings"
 
-	refdocker "github.com/containerd/containerd/reference/docker"
+	distributionref "github.com/distribution/reference"
 	"github.com/ipfs/go-cid"
 )
 
@@ -42,7 +42,7 @@ func ParseAnyReference(rawRef string) (Reference, error) {
 	if c, err := cid.Decode(rawRef); err == nil {
 		return c, nil
 	}
-	return refdocker.ParseAnyReference(rawRef)
+	return distributionref.ParseAnyReference(rawRef)
 }
 
 // ParseAny parses the passed reference with allowing it to be non-docker reference.
@@ -59,8 +59,8 @@ func ParseAny(rawRef string) (Reference, error) {
 }
 
 // ParseDockerRef parses the passed reference with assuming it's a docker reference.
-func ParseDockerRef(rawRef string) (refdocker.Named, error) {
-	return refdocker.ParseDockerRef(rawRef)
+func ParseDockerRef(rawRef string) (distributionref.Named, error) {
+	return distributionref.ParseDockerRef(rawRef)
 }
 
 // ParseIPFSRefWithScheme parses the passed reference with assuming it's an IPFS reference with scheme prefix.
@@ -92,7 +92,7 @@ func SuggestContainerName(rawRef, containerID string) string {
 		r, err := ParseAny(rawRef)
 		if err == nil {
 			switch rr := r.(type) {
-			case refdocker.Named:
+			case distributionref.Named:
 				if rrName := rr.Name(); rrName != "" {
 					imageNameBased := path.Base(rrName)
 					if imageNameBased != "" {


### PR DESCRIPTION
needs bump containerd from 1.7.18 to 1.7.19: https://github.com/containerd/containerd/releases/tag/v1.7.19
And update the deprecated package reported by golangci-lint
