### PR TITLE
Fix IPFS container start routine

### DIFF
--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -24,14 +24,20 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
 	"gotest.tools/v3/assert"
 )
 
 func TestIPFSComposeUp(t *testing.T) {
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
-	ipfsaddr, done := runIPFSDaemonContainer(t, base)
-	defer done()
+
+	iReg := testregistry.NewIPFSRegistry(base, nil, 0, nil, nil)
+	t.Cleanup(func() {
+		iReg.Cleanup(nil)
+	})
+	ipfsaddr := fmt.Sprintf("/ip4/%s/tcp/%d", iReg.IP, iReg.Port)
+
 	tests := []struct {
 		name           string
 		snapshotter    string


### PR DESCRIPTION
TestIPFSAddress and TestIPFSComposeUp have been failing regularly on the CI (with a rather long timeout).

Furthermore, the initialization code was using static ports and container name, making it impossible to parallelize.

This PR rewrites the initialization code of the IPFS registry container after the regular registry container start method - giving guarantees that there is no port or name collision, a sensible timeout in case of failure, an actual test to verify the registry is up and running.
It also removes the unnecessary testing of `detached-ns` (apparently triggering failures with rootlesskit 1).

CI is green on push (except for 1 unrelated failure involving systemctl that we have seen somewhere else).

Along with the other changes from today, this PR should increase CI reliability quite a bit.

PTAL at your convenience @AkihiroSuda @ktock .

Of course would love to see this in ASAP as failing CI has been a massive PITA, but lmk evidently if there is anything you would like tweaked.

Cheers.