### PR TITLE
test-integration-rootless: enable BuildKit for RootlessKit v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,13 +218,21 @@ jobs:
         run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
         run: DOCKER_BUILDKIT=1 docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
+      - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
+        run: |
+          # https://github.com/containerd/nerdctl/issues/622
+          WORKAROUND_ISSUE_622=
+          if echo "${ROOTLESSKIT_VERSION}" | grep -q v1; then
+            WORKAROUND_ISSUE_622=1
+          fi
+          echo "WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622}" >>$GITHUB_ENV
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           max_attempts: 2
           retry_on: error
-          command: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=1 ${TEST_TARGET}
+          command: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET}
 
   cross:
     runs-on: ubuntu-24.04

--- a/cmd/nerdctl/builder_linux_test.go
+++ b/cmd/nerdctl/builder_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
 )
@@ -43,6 +44,9 @@ CMD ["echo", "nerdctl-builder-debug-test-string"]
 
 func TestBuildWithPull(t *testing.T) {
 	testutil.DockerIncompatible(t)
+	if rootlessutil.IsRootless() {
+		t.Skipf("skipped because the test needs a custom buildkitd config")
+	}
 	testutil.RequiresBuild(t)
 
 	oldImage := testutil.BusyboxImage


### PR DESCRIPTION
BuildKit has been disabled in test-integration-rootless due to the issue #622, but this should not happen with RootlessKit v2 (detach-netns mode).