### PR TITLE
Dependabot: add groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,26 @@ updates:
     directory: "/"  # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      golang-x:
+        patterns:
+          - "golang.org/x/*"
+      moby-sys:
+        patterns:
+          - "github.com/moby/sys/*"
+      docker:
+        patterns:
+          - "github.com/docker/docker"
+          - "github.com/docker/cli"
+      containerd:
+        patterns:
+          - "github.com/containerd/containerd"
+          - "github.com/containerd/containerd/api"
+      stargz:
+        patterns:
+          - "github.com/containerd/stargz-snapshotter"
+          - "github.com/containerd/stargz-snapshotter/estargz"
+          - "github.com/containerd/stargz-snapshotter/ipfs"
 
   # Dependencies listed in .github/workflows/*.yml
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Groupify relevant repos to reduce the number of the PRs