### PR TITLE
[PRIORITY] Improve tests debugging output

### DIFF
--- a/cmd/nerdctl/container_create_linux_test.go
+++ b/cmd/nerdctl/container_create_linux_test.go
@@ -118,7 +118,7 @@ func TestCreateWithMACAddress(t *testing.T) {
 				"sh", "-c", "--", "ip addr show").Run()
 
 			if !wantErr {
-				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res.Combined())
+				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res)
 				// This is currently blocked by: https://github.com/containerd/nerdctl/pull/3104
 				// res = base.Cmd("start", "-i", containerName).
 				//	CmdOption(testutil.WithStdin(strings.NewReader("ip addr show eth0 | grep ether | awk '{printf $2}'"))).Run()
@@ -131,7 +131,7 @@ func TestCreateWithMACAddress(t *testing.T) {
 					// unlike nerdctl
 					// when using network ipvlan or container in Docker
 					// it delays fail on executing start command
-					assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res.Combined())
+					assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res)
 					res = base.Cmd("start", "-i", "-a", containerName).
 						CmdOption(testutil.WithStdin(strings.NewReader("ip addr show eth0 | grep ether | awk '{printf $2}'"))).Run()
 				}
@@ -146,7 +146,7 @@ func TestCreateWithMACAddress(t *testing.T) {
 				} else {
 					assert.Assert(t, res.Combined() == "", fmt.Sprintf("expected output to be empty: %q", res.Combined()))
 				}
-				assert.Assert(t, res.ExitCode != 0, "Command should have failed", res.Combined())
+				assert.Assert(t, res.ExitCode != 0, "Command should have failed", res)
 			}
 		})
 	}

--- a/cmd/nerdctl/container_run_linux_test.go
+++ b/cmd/nerdctl/container_run_linux_test.go
@@ -321,7 +321,7 @@ func TestRunTTY(t *testing.T) {
 
 	// tests pipe works
 	res := icmd.RunCmd(icmd.Command("unbuffer", "/bin/sh", "-c", fmt.Sprintf("%q run --rm -it %q echo hi | grep hi", base.Binary, testutil.CommonImage)))
-	assert.Equal(t, 0, res.ExitCode, res.Combined())
+	assert.Equal(t, 0, res.ExitCode, res)
 }
 
 func runSigProxy(t *testing.T, args ...string) (string, bool, bool) {

--- a/cmd/nerdctl/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container_run_network_linux_test.go
@@ -512,10 +512,10 @@ func TestRunContainerWithMACAddress(t *testing.T) {
 				CmdOption(testutil.WithStdin(strings.NewReader("ip addr show eth0 | grep ether | awk '{printf $2}'"))).Run()
 
 			if wantErr {
-				assert.Assert(t, res.ExitCode != 0, "Command should have failed", res.Combined())
+				assert.Assert(t, res.ExitCode != 0, "Command should have failed", res)
 				assert.Assert(t, strings.Contains(res.Combined(), expect), fmt.Sprintf("expected output to contain %q: %q", expect, res.Combined()))
 			} else {
-				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res.Combined())
+				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded", res)
 				assert.Assert(t, strings.Contains(res.Stdout(), expect), fmt.Sprintf("expected output to contain %q: %q", expect, res.Stdout()))
 			}
 		})

--- a/cmd/nerdctl/container_run_security_linux_test.go
+++ b/cmd/nerdctl/container_run_security_linux_test.go
@@ -224,7 +224,7 @@ func TestRunPrivileged(t *testing.T) {
 	res := base.Cmd("run", "--rm", "--privileged", "--security-opt", "privileged-without-host-devices", testutil.AlpineImage, "ls", devPath).Run()
 
 	// normally for not a exists file, the `ls` will return `1``.
-	assert.Check(t, res.ExitCode != 0, res.Combined())
+	assert.Check(t, res.ExitCode != 0, res)
 
 	// something like `ls: /dev/dummy-zero: No such file or directory`
 	assert.Check(t, strings.Contains(res.Combined(), "No such file or directory"))

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -330,7 +330,7 @@ func TestRunWithJournaldLogDriver(t *testing.T) {
 	found := 0
 	check := func(log poll.LogT) poll.Result {
 		res := icmd.RunCmd(icmd.Command(journalctl, "--no-pager", "--since", "2 minutes ago", fmt.Sprintf("SYSLOG_IDENTIFIER=%s", inspectedContainer.ID[:12])))
-		assert.Equal(t, 0, res.ExitCode, res.Combined())
+		assert.Equal(t, 0, res.ExitCode, res)
 		if strings.Contains(res.Stdout(), "bar") && strings.Contains(res.Stdout(), "foo") {
 			found = 1
 			return poll.Success()
@@ -359,7 +359,7 @@ func TestRunWithJournaldLogDriverAndLogOpt(t *testing.T) {
 	found := 0
 	check := func(log poll.LogT) poll.Result {
 		res := icmd.RunCmd(icmd.Command(journalctl, "--no-pager", "--since", "2 minutes ago", fmt.Sprintf("SYSLOG_IDENTIFIER=%s", inspectedContainer.ID)))
-		assert.Equal(t, 0, res.ExitCode, res.Combined())
+		assert.Equal(t, 0, res.ExitCode, res)
 		if strings.Contains(res.Stdout(), "bar") && strings.Contains(res.Stdout(), "foo") {
 			found = 1
 			return poll.Success()

--- a/cmd/nerdctl/image_push_linux_test.go
+++ b/cmd/nerdctl/image_push_linux_test.go
@@ -41,7 +41,7 @@ func TestPushPlainHTTPFails(t *testing.T) {
 
 	res := base.Cmd("push", testImageRef).Run()
 	resCombined := res.Combined()
-	t.Logf("result: exitCode=%d, out=%q", res.ExitCode, res.Combined())
+	t.Logf("result: exitCode=%d, out=%q", res.ExitCode, res)
 	assert.Assert(t, res.ExitCode != 0)
 	assert.Assert(t, strings.Contains(resCombined, "server gave HTTP response to HTTPS client"))
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -397,7 +397,7 @@ func (c *Cmd) AssertFail() {
 func (c *Cmd) AssertExitCode(exitCode int) {
 	c.Base.T.Helper()
 	res := c.runIfNecessary()
-	assert.Assert(c.Base.T, res.ExitCode == exitCode, res.Combined())
+	assert.Assert(c.Base.T, res.ExitCode == exitCode, res)
 }
 
 func (c *Cmd) AssertOutContains(s string) {
@@ -502,21 +502,21 @@ func (c *Cmd) AssertOutStreamsExactly(stdout, stderr string) {
 func (c *Cmd) AssertOutWithFunc(fn func(stdout string) error) {
 	c.Base.T.Helper()
 	res := c.runIfNecessary()
-	assert.Equal(c.Base.T, 0, res.ExitCode, res.Combined())
+	assert.Equal(c.Base.T, 0, res.ExitCode, res)
 	assert.NilError(c.Base.T, fn(res.Stdout()), res.Combined())
 }
 
 func (c *Cmd) AssertOutStreamsWithFunc(fn func(stdout, stderr string) error) {
 	c.Base.T.Helper()
 	res := c.runIfNecessary()
-	assert.Equal(c.Base.T, 0, res.ExitCode, res.Combined())
+	assert.Equal(c.Base.T, 0, res.ExitCode, res)
 	assert.NilError(c.Base.T, fn(res.Stdout(), res.Stderr()), res.Combined())
 }
 
 func (c *Cmd) Out() string {
 	c.Base.T.Helper()
 	res := c.runIfNecessary()
-	assert.Equal(c.Base.T, 0, res.ExitCode, res.Combined())
+	assert.Equal(c.Base.T, 0, res.ExitCode, res)
 	return res.Stdout()
 }
 


### PR DESCRIPTION
This is a small quality of life improvement to ease debugging of tests.

When commands are unexpectedly failing, output `.String()` which includes the actual command and the exit code instead of `.Combined()` which only shows stdout+stderr.