### PR TITLE
[PRIORITY] Do not hard error if containers are gone

### DIFF
--- a/pkg/cmd/volume/rm.go
+++ b/pkg/cmd/volume/rm.go
@@ -79,6 +79,7 @@ func usedVolumes(ctx context.Context, containers []containerd.Container) (map[st
 			// Containerd note: there is no guarantee that the containers we got from the list still exist at this point
 			// If that is the case, just ignore and move on
 			if errors.Is(err, errdefs.ErrNotFound) {
+				log.G(ctx).Debugf("container %q is gone - ignoring", c.ID())
 				continue
 			}
 			return nil, err


### PR DESCRIPTION
This is another instance of #3167 (see ticket for rationale - in a shell: do not assume containers are still there after a call to client.Containers...)

In that specific case, it will make `create` fail if another unrelated container got removed in a racy way.

It is very likely responsible for a large number of failures on the CI, and definitely strikes more with parallelization.

This very likely will address #3092, #3186, and possibly a number of others.


@AkihiroSuda @fahedouch if you are around - would appreciate a quick merge on this, preferably before other QA/CI PRs so that I can rebase and see what problems are left (specifically for the IPFS  one).

Of course, I will rebase #3189 as well ASAP which should give us a good hint.

Finally, if this is as bad as I think it is, merging this should give us a good speed boost on the CI (as a lot of "retries" will no longer be necessary).

Thanks a lot! 