### PR TITLE
Network prune should not fail if containers vanish

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -88,12 +88,17 @@ func namespaceUsedNetworks(ctx context.Context, containers []containerd.Containe
 		task, err := c.Task(ctx, nil)
 		if err != nil {
 			if errdefs.IsNotFound(err) {
+				log.G(ctx).Debugf("task not found - likely container %q was removed", c.ID())
 				continue
 			}
 			return nil, err
 		}
 		status, err := task.Status(ctx)
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				log.G(ctx).Debugf("task not found - likely container %q was removed", c.ID())
+				continue
+			}
 			return nil, err
 		}
 		switch status.Status {
@@ -103,6 +108,10 @@ func namespaceUsedNetworks(ctx context.Context, containers []containerd.Containe
 		}
 		l, err := c.Labels(ctx)
 		if err != nil {
+			if errdefs.IsNotFound(err) {
+				log.G(ctx).Debugf("container %q is gone", c.ID())
+				continue
+			}
 			return nil, err
 		}
 		networkJSON, ok := l[labels.Networks]


### PR DESCRIPTION
This is yet another instance of #3167

This here is less urgent than #3192 as it only affects `network prune`.

Issue was seen 3 times on this specific canary build: https://github.com/containerd/nerdctl/actions/runs/9815148442?pr=3189

Note that this is on top of #3192 - I will rebase on main as soon as it gets merged.