### PR TITLE
rootless: add `Requires=dbus.socket`

### DIFF
--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -230,6 +230,7 @@ cmd_entrypoint_install() {
 	cat <<-EOT | install_systemd_unit "${SYSTEMD_CONTAINERD_UNIT}"
 		[Unit]
 		Description=containerd (Rootless)
+		Requires=dbus.socket
 
 		[Service]
 		Environment=PATH=$BIN:/sbin:/usr/sbin:$PATH


### PR DESCRIPTION
Equates to
- moby/moby#48134