### PR TITLE
fix the created tasks cannot be deleted

### DIFF
--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -274,8 +274,17 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		if err == nil {
 			<-es
 		}
-	case containerd.Created, containerd.Stopped:
-		// Created and stopped containers always get removed
+	case containerd.Created:
+		// TODO(Iceber): Since `containerd.WithProcessKill` blocks the killing of tasks with PID 0,
+		// remove the judgment and break when it is compatible with the tasks.
+		if task.Pid() == 0 {
+			// Created tasks with PID 0 always get removed
+			// Delete the task, without forcing kill
+			_, err = task.Delete(ctx)
+			return err
+		}
+	case containerd.Stopped:
+		// Stopped containers always get removed
 		// Delete the task, without forcing kill
 		_, err = task.Delete(ctx)
 		return err


### PR DESCRIPTION
[task.Delete](https://github.com/containerd/containerd/blob/6e67345ab7ed68d08155dcd39353344b9a098a49/task.go#L314) only allows direct deletion of tasks with PID 0.

fix: https://github.com/containerd/containerd/issues/10438


Related pr: https://github.com/containerd/containerd/pull/10442