### PR TITLE
Test fixes

### DIFF
--- a/cmd/nerdctl/builder_build_test.go
+++ b/cmd/nerdctl/builder_build_test.go
@@ -152,7 +152,6 @@ CMD ["cat", "/hello2"]
 }
 
 func TestBuildFromStdin(t *testing.T) {
-	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	defer base.Cmd("builder", "prune").Run()
@@ -199,7 +198,6 @@ CMD ["echo", "nerdctl-build-test-dockerfile"]
 }
 
 func TestBuildLocal(t *testing.T) {
-	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	if testutil.GetTarget() == testutil.Docker {
@@ -293,7 +291,6 @@ CMD echo $TEST_STRING
 }
 
 func TestBuildWithIIDFile(t *testing.T) {
-	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	defer base.Cmd("builder", "prune").Run()
@@ -318,7 +315,6 @@ CMD ["echo", "nerdctl-build-test-string"]
 }
 
 func TestBuildWithLabels(t *testing.T) {
-	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	defer base.Cmd("builder", "prune").Run()
@@ -547,7 +543,6 @@ func buildWithNamedBuilder(base *testutil.Base, builderName string, args ...stri
 }
 
 func TestBuildAttestation(t *testing.T) {
-	t.Parallel()
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
 	builderName := testutil.Identifier(t)

--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -209,7 +209,7 @@ func TestLogsWithForegroundContainers(t *testing.T) {
 }
 
 func TestTailFollowRotateLogs(t *testing.T) {
-	// FIXME this is flaky by nature... 5 lines is arbitrary, 2000 ms is arbitrary, and both are some sort of educated
+	// FIXME this is flaky by nature... 2 lines is arbitrary, 10000 ms is arbitrary, and both are some sort of educated
 	// guess that things will mostly always kinda work maybe...
 	// Furthermore, parallelizing will put pressure on the daemon which might be even slower in answering, increasing
 	// the risk of transient failure.
@@ -222,7 +222,7 @@ func TestTailFollowRotateLogs(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	const sampleJSONLog = `{"log":"A\n","stream":"stdout","time":"2024-04-11T12:01:09.800288974Z"}`
-	const linesPerFile = 5
+	const linesPerFile = 2
 
 	defer base.Cmd("rm", "-f", containerName).Run()
 	base.Cmd("run", "-d", "--log-driver", "json-file",
@@ -232,7 +232,7 @@ func TestTailFollowRotateLogs(t *testing.T) {
 		"sh", "-euc", "while true; do echo A; done").AssertOK()
 
 	tailLogCmd := base.Cmd("logs", "-f", containerName)
-	tailLogCmd.Timeout = 2000 * time.Millisecond
+	tailLogCmd.Timeout = 10000 * time.Millisecond
 	tailLogs := strings.Split(strings.TrimSpace(tailLogCmd.Run().Stdout()), "\n")
 	for _, line := range tailLogs {
 		if line != "" {

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -124,7 +124,8 @@ func NewDelayOnceReader(wrapped io.Reader) io.Reader {
 }
 
 func (r *delayOnceReader) Read(p []byte) (int, error) {
-	r.once.Do(func() { time.Sleep(time.Second) })
+	// FIXME: this is obviously not exact science. At 1 second, it will fail regularly on the CI under load.
+	r.once.Do(func() { time.Sleep(2 * time.Second) })
 	n, err := r.wrapped.Read(p)
 	if errors.Is(err, io.EOF) {
 		time.Sleep(time.Second)


### PR DESCRIPTION
Canary build #3189 (without any retry) has ran green for the first time today.

These here are the remaining fixes in the canary branch that have yet to be merged, and that should fix the last flaky tests.

In a shell:
- tests involving `builder prune` are not safe to be parallelized - disabling parallel on them
- increasing delay on `DelayOnceReader` - these things are inherently flaky, but the new extended delay seems to work better
- further increasing timeout for TestTailFollowRotateLogs - this one has been particularly painful - I think we should rewrite this test eventually, but for now, the new timeout seems to help

Once this is merged, I suggest we give it another week of running the Canary PR against main regularly to confirm we are constantly green, then we can consider merging it.