### PR TITLE
Makefile fixes and other spring cleanup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     tags:
     - 'v*'
     - 'test-action-release-*'
-env:
-  GO111MODULE: on
 jobs:
   release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: "Prepare integration test environment"
-        run: DOCKER_BUILDKIT=1 docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -114,7 +114,7 @@ jobs:
           echo '{"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
       - name: "Prepare integration test environment"
-        run: DOCKER_BUILDKIT=1 docker build -t test-integration-ipv6 --target test-integration-ipv6 --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: docker build -t test-integration-ipv6 --target test-integration-ipv6 --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -187,7 +187,7 @@ jobs:
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: docker run --privileged --rm tonistiigi/binfmt --install all
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
-        run: DOCKER_BUILDKIT=1 docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
+        run: docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
         run: |
           # https://github.com/containerd/nerdctl/issues/622

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 # Licensed under the Apache License, Version 2.0
 # -----------------------------------------------------------------------------
 
+DOCKER ?= docker
 GO ?= go
 GOOS ?= $(shell $(GO) env GOOS)
 ifeq ($(GOOS),windows)
@@ -32,17 +33,21 @@ BINDIR  ?= $(PREFIX)/bin
 DATADIR ?= $(PREFIX)/share
 DOCDIR  ?= $(DATADIR)/doc
 
-VERSION ?= $(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+MAKEFILE_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+VERSION ?= $(shell git -C $(MAKEFILE_DIR) describe --match 'v[0-9]*' --dirty='.m' --always --tags)
 VERSION_TRIMMED := $(VERSION:v%=%)
-REVISION ?= $(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
-
-GO_BUILD_LDFLAGS ?= -s -w
-GO_BUILD_FLAGS ?=
-export GO_BUILD=GO111MODULE=on CGO_ENABLED=0 GOOS=$(GOOS) $(GO) build -ldflags "$(GO_BUILD_LDFLAGS) -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.Revision=$(REVISION)"
+REVISION ?= $(shell git -C $(MAKEFILE_DIR) rev-parse HEAD)$(shell if ! git -C $(MAKEFILE_DIR) diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
 
 ifdef VERBOSE
 	VERBOSE_FLAG := -v
+	VERBOSE_FLAG_LONG := --verbose
 endif
+
+GO_BUILD_LDFLAGS ?= -s -w
+GO_BUILD_FLAGS ?=
+export GO_BUILD=CGO_ENABLED=0 GOOS=$(GOOS) $(GO) -C $(MAKEFILE_DIR) build -ldflags "$(GO_BUILD_LDFLAGS) $(VERBOSE_FLAG) -X $(PACKAGE)/pkg/version.Version=$(VERSION) -X $(PACKAGE)/pkg/version.Revision=$(REVISION)"
+
+recursive_wildcard=$(wildcard $1$2) $(foreach e,$(wildcard $1*),$(call recursive_wildcard,$e/,$2))
 
 all: binaries
 
@@ -52,63 +57,76 @@ help:
 	@echo " * 'install' - Install binaries to system locations."
 	@echo " * 'binaries' - Build nerdctl."
 	@echo " * 'clean' - Clean artifacts."
+	@echo " * 'lint' - Run various linters."
 
 nerdctl:
-	$(GO_BUILD) $(GO_BUILD_FLAGS) $(VERBOSE_FLAG) -o $(CURDIR)/_output/nerdctl$(BIN_EXT) $(PACKAGE)/cmd/nerdctl
+	$(GO_BUILD) $(GO_BUILD_FLAGS) $(VERBOSE_FLAG) -o $(CURDIR)/_output/nerdctl$(BIN_EXT) ./cmd/nerdctl
 
 clean:
 	find . -name \*~ -delete
 	find . -name \#\* -delete
-	rm -rf _output/* vendor
+	rm -rf $(CURDIR)/_output/* $(MAKEFILE_DIR)/vendor
+
+lint: lint-go lint-yaml lint-shell
+
+lint-go:
+	cd $(MAKEFILE_DIR) && golangci-lint run $(VERBOSE_FLAG_LONG)
+
+lint-yaml:
+	cd $(MAKEFILE_DIR) && yamllint .
+
+lint-shell: $(call recursive_wildcard,$(MAKEFILE_DIR)/,*.sh)
+	shellcheck -a -x $^
 
 binaries: nerdctl
 
 install:
 	install -D -m 755 $(CURDIR)/_output/nerdctl $(DESTDIR)$(BINDIR)/nerdctl
-	install -D -m 755 $(CURDIR)/extras/rootless/containerd-rootless.sh $(DESTDIR)$(BINDIR)/containerd-rootless.sh
-	install -D -m 755 $(CURDIR)/extras/rootless/containerd-rootless-setuptool.sh $(DESTDIR)$(BINDIR)/containerd-rootless-setuptool.sh
-	install -D -m 644 -t $(DESTDIR)$(DOCDIR)/nerdctl docs/*.md
+	install -D -m 755 $(MAKEFILE_DIR)/extras/rootless/containerd-rootless.sh $(DESTDIR)$(BINDIR)/containerd-rootless.sh
+	install -D -m 755 $(MAKEFILE_DIR)/extras/rootless/containerd-rootless-setuptool.sh $(DESTDIR)$(BINDIR)/containerd-rootless-setuptool.sh
+	install -D -m 644 -t $(DESTDIR)$(DOCDIR)/nerdctl $(MAKEFILE_DIR)/docs/*.md
 
-define make_artifact_full_linux
-	DOCKER_BUILDKIT=1 docker build --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) --build-arg GO_VERSION $(CURDIR)
-	gzip -9 $(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar
-endef
-
+# Note that these options will not work on macOS - unless you use gnu-tar instead of tar
 TAR_OWNER0_FLAGS=--owner=0 --group=0
 TAR_FLATTEN_FLAGS=--transform 's/.*\///g'
 
+define make_artifact_full_linux
+	$(DOCKER) build --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) --build-arg GO_VERSION -f $(MAKEFILE_DIR)/Dockerfile $(MAKEFILE_DIR)
+	gzip -9 $(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar
+endef
+
 artifacts: clean
-	GOOS=linux GOARCH=amd64       make -C $(CURDIR)  binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-amd64.tar.gz   _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=amd64       make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-amd64.tar.gz   $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=linux GOARCH=arm64       make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-arm64.tar.gz   _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=arm64       make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-arm64.tar.gz   $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=linux GOARCH=arm GOARM=7 make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-arm-v7.tar.gz  _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=arm GOARM=7 make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-arm-v7.tar.gz  $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=linux GOARCH=ppc64le     make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-ppc64le.tar.gz _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=ppc64le     make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-ppc64le.tar.gz $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=linux GOARCH=riscv64     make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-riscv64.tar.gz   _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=riscv64     make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-riscv64.tar.gz $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=linux GOARCH=s390x       make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-s390x.tar.gz   _output/nerdctl extras/rootless/*
+	GOOS=linux GOARCH=s390x       make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-linux-s390x.tar.gz   $(CURDIR)/_output/nerdctl $(MAKEFILE_DIR)/extras/rootless/*
 
-	GOOS=windows GOARCH=amd64     make -C $(CURDIR) binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-windows-amd64.tar.gz _output/nerdctl.exe
+	GOOS=windows GOARCH=amd64     make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-windows-amd64.tar.gz $(CURDIR)/_output/nerdctl.exe
 
-	GOOS=freebsd GOARCH=amd64     make -C $(CURDIR)  binaries
-	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-freebsd-amd64.tar.gz _output/nerdctl
+	GOOS=freebsd GOARCH=amd64     make -C $(CURDIR) -f $(MAKEFILE_DIR)/Makefile binaries
+	tar $(TAR_OWNER0_FLAGS) $(TAR_FLATTEN_FLAGS) -czvf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-freebsd-amd64.tar.gz $(CURDIR)/_output/nerdctl
 
 	rm -f $(CURDIR)/_output/nerdctl $(CURDIR)/_output/nerdctl.exe
 
 	$(call make_artifact_full_linux,amd64)
 	$(call make_artifact_full_linux,arm64)
 
-	go mod vendor
-	tar $(TAR_OWNER0_FLAGS) -czf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-go-mod-vendor.tar.gz go.mod go.sum vendor
+	$(GO) -C $(MAKEFILE_DIR) mod vendor
+	tar $(TAR_OWNER0_FLAGS) -czf $(CURDIR)/_output/nerdctl-$(VERSION_TRIMMED)-go-mod-vendor.tar.gz $(MAKEFILE_DIR)/go.mod $(MAKEFILE_DIR)/go.sum $(MAKEFILE_DIR)/vendor
 
 .PHONY: \
 	help \
@@ -117,3 +135,7 @@ artifacts: clean
 	binaries \
 	install \
 	artifacts
+	lint \
+	lint-yaml \
+	lint-go \
+	lint-shell

--- a/cmd/nerdctl/builder_build_test.go
+++ b/cmd/nerdctl/builder_build_test.go
@@ -45,15 +45,12 @@ CMD ["echo", "nerdctl-build-test-string"]
 	base.Cmd("build", buildCtx, "-t", imageName).AssertOK()
 	base.Cmd("run", "--rm", imageName).AssertOutExactly("nerdctl-build-test-string\n")
 
-	// DOCKER_BUILDKIT (v20.10): `Error response from daemon: exporter "docker" could not be found`
-	if base.Target == testutil.Nerdctl {
-		ignoredImageNamed := imageName + "-" + "ignored"
-		outputOpt := fmt.Sprintf("--output=type=docker,name=%s", ignoredImageNamed)
-		base.Cmd("build", buildCtx, "-t", imageName, outputOpt).AssertOK()
+	ignoredImageNamed := imageName + "-" + "ignored"
+	outputOpt := fmt.Sprintf("--output=type=docker,name=%s", ignoredImageNamed)
+	base.Cmd("build", buildCtx, "-t", imageName, outputOpt).AssertOK()
 
-		base.Cmd("run", "--rm", imageName).AssertOutExactly("nerdctl-build-test-string\n")
-		base.Cmd("run", "--rm", ignoredImageNamed).AssertFail()
-	}
+	base.Cmd("run", "--rm", imageName).AssertOutExactly("nerdctl-build-test-string\n")
+	base.Cmd("run", "--rm", ignoredImageNamed).AssertFail()
 }
 
 func TestBuildIsShareableForCompatiblePlatform(t *testing.T) {
@@ -200,9 +197,6 @@ CMD ["echo", "nerdctl-build-test-dockerfile"]
 func TestBuildLocal(t *testing.T) {
 	testutil.RequiresBuild(t)
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Docker {
-		base.Env = append(base.Env, "DOCKER_BUILDKIT=1")
-	}
 	defer base.Cmd("builder", "prune").Run()
 	const testFileName = "nerdctl-build-test"
 	const testContent = "nerdctl"


### PR DESCRIPTION
First commit removes DOCKER_BUILDKIT references, which have been the default for a while now.

Second commit focuses on the Makefile:
- most importantly, make it possible to run make targets outside of source tree - clarifying and fixing use of CURDIR vs. newly introduced MAKEFILE_DIR
- introducing `lint` tasks (golint & yamllint) - and also introducing the use of shellcheck
- remove references to GO111MODULE which are no longer useful in 2024
- some minor maintenance (variable-ize calls to `docker`, etc)

