### PR TITLE
Shellscript sanity / cleanup PR

### DIFF
--- a/examples/nerdctl-ipfs-registry-kubernetes/ipfs-cluster/bootstrap.yaml.sh
+++ b/examples/nerdctl-ipfs-registry-kubernetes/ipfs-cluster/bootstrap.yaml.sh
@@ -28,7 +28,7 @@ done
 
 TMPIDFILE=$(mktemp)
 BOOTSTRAP_KEY=$(ipfs-key 2>"${TMPIDFILE}" | base64 -w 0)
-ID=$(cat "${TMPIDFILE}" | grep "ID " | sed -E 's/[^:]*: (.*)/\1/')
+ID=$(grep "ID " "${TMPIDFILE}" | sed -E 's/[^:]*: (.*)/\1/')
 rm "${TMPIDFILE}"
 
 BOOTSTRAP_PEER_PRIV_KEY=$(echo "${BOOTSTRAP_KEY}" | base64 -w 0)

--- a/examples/nerdctl-ipfs-registry-kubernetes/ipfs-stargz-snapshotter/bootstrap.yaml.sh
+++ b/examples/nerdctl-ipfs-registry-kubernetes/ipfs-stargz-snapshotter/bootstrap.yaml.sh
@@ -19,12 +19,10 @@
 
 set -eu -o pipefail
 
-for d in ipfs-swarm-key-gen ; do
-    if ! command -v $d >/dev/null 2>&1 ; then
-        echo "$d not found"
-        exit 1
-    fi
-done
+if ! command -v ipfs-swarm-key-gen >/dev/null 2>&1 ; then
+    echo "ipfs-swarm-key-gen not found"
+    exit 1
+fi
 
 SWARM_KEY=$(ipfs-swarm-key-gen | base64 | tr -d '\n')
 

--- a/examples/nerdctl-ipfs-registry-kubernetes/ipfs/bootstrap.yaml.sh
+++ b/examples/nerdctl-ipfs-registry-kubernetes/ipfs/bootstrap.yaml.sh
@@ -19,12 +19,10 @@
 
 set -eu -o pipefail
 
-for d in ipfs-swarm-key-gen ; do
-    if ! command -v $d >/dev/null 2>&1 ; then
-        echo "$d not found"
-        exit 1
-    fi
-done
+if ! command -v ipfs-swarm-key-gen >/dev/null 2>&1 ; then
+    echo "ipfs-swarm-key-gen not found"
+    exit 1
+fi
 
 SWARM_KEY=$(ipfs-swarm-key-gen | base64 | tr -d '\n')
 

--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -29,19 +29,15 @@ set -eu
 
 # utility functions
 INFO() {
-	# https://github.com/koalaman/shellcheck/issues/1593
-	# shellcheck disable=SC2039
-	/bin/echo -e "\e[104m\e[97m[INFO]\e[49m\e[39m ${*}"
+	printf "\e[104m\e[97m[INFO]\e[49m\e[39m %s\n" "$*"
 }
 
 WARNING() {
-	# shellcheck disable=SC2039
-	/bin/echo >&2 -e "\e[101m\e[97m[WARNING]\e[49m\e[39m ${*}"
+	>&2 printf "\e[101m\e[97m[WARNING]\e[49m\e[39m %s\n" "$*"
 }
 
 ERROR() {
-	# shellcheck disable=SC2039
-	/bin/echo >&2 -e "\e[101m\e[97m[ERROR]\e[49m\e[39m ${*}"
+	>&2 printf "\e[101m\e[97m[ERROR]\e[49m\e[39m %s\n" "$*"
 }
 
 # constants
@@ -143,8 +139,8 @@ propagate_env_from() {
 	pid="$1"
 	env="$(sed -e "s/\x0/'\n/g" <"/proc/${pid}/environ" | sed -Ee "s/^[^=]*=/export \0'/g")"
 	shift
-	for key in $@; do
-		eval $(echo "$env" | grep "^export ${key=}")
+	for key in "$@"; do
+		eval "$(echo "$env" | grep "^export ${key=}")"
 	done
 }
 

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -17,8 +17,8 @@
 minimal_amd64tgz="$(find _output -name '*linux-amd64.tar.gz*' -and ! -name '*full*')"
 full_amd64tgz="$(find _output -name '*linux-amd64.tar.gz*' -and -name '*full*')"
 
-minimal_amd64tgz_basename="$(basename ${minimal_amd64tgz})"
-full_amd64tgz_basename="$(basename ${full_amd64tgz})"
+minimal_amd64tgz_basename="$(basename "${minimal_amd64tgz}")"
+full_amd64tgz_basename="$(basename "${full_amd64tgz}")"
 
 cat <<-EOX
 ## Changes
@@ -37,7 +37,7 @@ Extract the archive to a path like \`/usr/local/bin\` or \`~/bin\` .
 <p>
 
 \`\`\`
-$(tar tzvf ${minimal_amd64tgz})
+$(tar tzvf "${minimal_amd64tgz}")
 \`\`\`
 </p>
 </details>
@@ -49,7 +49,7 @@ Extract the archive to a path like \`/usr/local\` or \`~/.local\` .
 <p>
 
 \`\`\`
-$(tar tzvf ${full_amd64tgz})
+$(tar tzvf "${full_amd64tgz}")
 \`\`\`
 </p>
 </details>
@@ -59,7 +59,7 @@ $(tar tzvf ${full_amd64tgz})
 
 See \`share/doc/nerdctl-full/README.md\`:
 \`\`\`markdown
-$(tar xOzf ${full_amd64tgz} share/doc/nerdctl-full/README.md)
+$(tar xOzf "${full_amd64tgz}" share/doc/nerdctl-full/README.md)
 \`\`\`
 </p>
 </details>


### PR DESCRIPTION
This focuses on our shell scripts.

Fixes one major issue:
- `--detach-ns` is not set in some cases when it should, because of mis-assignment of `CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS`

And a bunch of more minor ones (mainly quoting variables to prevent expansion).

Some simplification (removing useless loop, useless pipe / cat).

And some sanity - remove `echo -e` and replace with `printf`.

It is likely that none of the minor stuff would change behavior "in normal circumstances" (although it could definitely help with issues from unexpected values), but the `--detach-ns` will likely have an impact and we should double check what's going on with this (I am not super familiar with that part of the codebase yet).

Thanks.