### PR TITLE
Fix compose up failed when ipv6 as hostIP

### DIFF
--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -31,20 +31,19 @@ import (
 
 // return respectively ip, hostPort, containerPort
 func splitParts(rawport string) (string, string, string) {
-	parts := strings.Split(rawport, ":")
-	n := len(parts)
-	containerport := parts[n-1]
-
-	switch n {
-	case 1:
-		return "", "", containerport
-	case 2:
-		return "", parts[0], containerport
-	case 3:
-		return parts[0], parts[1], containerport
-	default:
-		return strings.Join(parts[:n-2], ":"), parts[n-2], containerport
+	lastIndex := strings.LastIndex(rawport, ":")
+	containerPort := rawport[lastIndex+1:]
+	if lastIndex == -1 {
+		return "", "", containerPort
 	}
+
+	hostAddrPort := rawport[:lastIndex]
+	addr, port, err := net.SplitHostPort(hostAddrPort)
+	if err != nil {
+		return "", hostAddrPort, containerPort
+	}
+
+	return addr, port, containerPort
 }
 
 // ParseFlagP parse port mapping pair, like "127.0.0.1:3000:8080/tcp",

--- a/pkg/portutil/portutil_test.go
+++ b/pkg/portutil/portutil_test.go
@@ -358,6 +358,21 @@ func TestParseFlagP(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "with ipv6 host ip",
+			args: args{
+				s: "[::0]:8080:80/tcp",
+			},
+			want: []gocni.PortMapping{
+				{
+					HostPort:      8080,
+					ContainerPort: 80,
+					Protocol:      "tcp",
+					HostIP:        "::0",
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "with invalid protocol",
 			args: args{
 				s: "3000:8080/invalid",


### PR DESCRIPTION
when port specify ipv6 host ip:
```yaml
services:
  nginxTest:
    image: nginx
    ports:
      - "::0:8888:80"
    restart: always
    container_name: nginxTest
```
composer will parse ipv6 address with square brackets :
```shell
$ sudo nerdctl compose up -d --debug-full=true
DEBU[0000] printing project JSON                        
DEBU[0000] {
    "name": "dev",
    "networks": {
        "default": {
            "name": "dev_default",
            "ipam": {},
            "external": false
        }
    },
    "services": {
        "nginxTest": {
            "command": null,
            "container_name": "nginxTest",
            "entrypoint": null,
            "image": "nginx",
            "networks": {
                "default": null
            },
            "ports": [
                {
                    "mode": "ingress",
                    "host_ip": "::0",
                    "target": 80,
                    "published": "8888",
                    "protocol": "tcp"
                }
            ],
            "restart": "always"
        }
    }
} 
INFO[0000] Ensuring image nginx                         
DEBU[0000] verifying process skipped                    
DEBU[0000] filters: [labels."com.docker.compose.project"==dev,labels."com.docker.compose.service"==nginxTest] 
INFO[0000] Creating container nginxTest                 
DEBU[0000] Running [/usr/local/bin/nerdctl --debug-full=true run --cidfile=/tmp/compose-3736578835/cid -l=com.docker.compose.project=dev -l=com.docker.compose.service=nginxTest -d --name=nginxTest --pull=never --net=dev_default --hostname=nginxTest -p=[::0]:8888:80/tcp --restart=always nginx]
```
it will cause error:
```shell
FATA[0000] failed to load networking flags: invalid ip address: [::0] 
FATA[0000] error while creating container nginxTest: exit status 1
```
due to net.ParseIP() cannot parse square brackets around the address
https://github.com/containerd/nerdctl/blob/d9d133c1f15ec01407d4758ee7a62acada17b1ef/pkg/portutil/portutil.go#L119 