### PR TITLE
fix: restart lark loguri cause start failed

### DIFF
--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -117,6 +117,8 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			return nil, err
 		}
 		ioCreator = cio.LogURI(u)
+	} else if flagD && logURI == "" {
+		ioCreator = cio.NullIO
 	} else {
 		var in io.Reader
 		if flagI {


### PR DESCRIPTION
if the container was not created by nerdctl, by default logURI args is empty.
https://github.com/containerd/nerdctl/blob/d273fd202abdf8153cc7d8739fc1a2eda1a9efc1/pkg/cmd/container/create.go#L178
when exec nerdctl restart, it will use logURI start log path, then will cause
`FATA[0000] 1 errors:
failed to start binary process with cmdArgs []: exec: no command`

https://github.com/containerd/nerdctl/blob/d273fd202abdf8153cc7d8739fc1a2eda1a9efc1/pkg/cioutil/container_io.go#L179