### PR TITLE
feat: add Status and ID as event attributes

### DIFF
--- a/pkg/cmd/system/events.go
+++ b/pkg/cmd/system/events.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"text/template"
 	"time"
 
@@ -37,9 +38,26 @@ import (
 // EventOut contains information about an event.
 type EventOut struct {
 	Timestamp time.Time
+	ID        string
 	Namespace string
 	Topic     string
+	Status    Status
 	Event     string
+}
+
+type Status string
+
+const (
+	START   Status = "START"
+	UNKNOWN Status = "UNKNOWN"
+)
+
+func TopicToStatus(topic string) Status {
+	if strings.Contains(strings.ToUpper(topic), string(START)) {
+		return START
+	}
+
+	return UNKNOWN
 }
 
 // Events is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/events/events.go
@@ -68,6 +86,7 @@ func Events(ctx context.Context, client *containerd.Client, options types.System
 		}
 		if e != nil {
 			var out []byte
+			var id string
 			if e.Event != nil {
 				v, err := typeurl.UnmarshalAny(e.Event)
 				if err != nil {
@@ -81,7 +100,18 @@ func Events(ctx context.Context, client *containerd.Client, options types.System
 				}
 			}
 			if tmpl != nil {
-				out := EventOut{e.Timestamp, e.Namespace, e.Topic, string(out)}
+				var data map[string]interface{}
+				err := json.Unmarshal(out, &data)
+				if err != nil {
+					log.G(ctx).WithError(err).Warn("cannot marshal Any into JSON")
+				} else {
+					_, ok := data["container_id"]
+					if ok {
+						id = data["container_id"].(string)
+					}
+				}
+
+				out := EventOut{e.Timestamp, id, e.Namespace, e.Topic, TopicToStatus(e.Topic), string(out)}
 				var b bytes.Buffer
 				if err := tmpl.Execute(&b, out); err != nil {
 					return err


### PR DESCRIPTION
Adding Status and ID as attributes

Makes `nerdctl events --format=json` output more docker compatible by adding some missing attributes in nerdctl

**Example `docker events --format json` output:**

```
{"status":"start","id":"196016a57679bf42424484918746a9474cd905dd993c4d0f42..
```

[(src: docker events doc)](https://docs.docker.com/reference/cli/docker/system/events/#format-as-json)

**Example `nerdctl events --format json` output after change:**

```
{"Timestamp":"2024-07-18T19:10:40.489404968Z","ID":"ea3b75d7c5cf7e81b13f151dc7b4875e13c4f19776ca4c74f213866f0b016971","Namespace":"finch","Topic":"/tasks/start","Status":"START","Event":"{\"container_id\":\"ea3b75d7c5cf7e81b13f151dc7b4875e13c4f19776ca4c74f213866f0b016971\",\"pid\":39443}"}
```
(includes both status and id in output)