### PR TITLE
fix(workflow): remove unknown os/arch build packages

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -65,6 +65,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
+          provenance: false
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
In the currently oci image relase github action page, there is a unknown/unknown manifest which is confused and useless.

According to this PR https://github.com/docker/build-push-action/issues/820, we could remove it.


<img width="732" alt="image" src="https://github.com/user-attachments/assets/d222c78d-e3c4-4e5b-b7e5-8e71af4016a0">
