### PR TITLE
gracefully terminate containers on nerdctl compose down

### DIFF
--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -40,6 +40,10 @@ func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
 		if err != nil {
 			return err
 		}
+		// use default Options to stop service containers.
+		if err := c.stopContainers(ctx, containers, StopOptions{}); err != nil {
+			return err
+		}
 		if err := c.removeContainers(ctx, containers, RemoveOptions{Stop: true, Volumes: downOptions.RemoveVolumes}); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fix for https://github.com/containerd/nerdctl/issues/3262

I am just an amateur copying code from:
https://github.com/containerd/nerdctl/blob/b030e1dc7d95d2147e5dd653de18afb57d67ab5f/pkg/composer/rm.go#L53-L56

I don't actually write any code. I wonder if this is enough.