### PR TITLE
enforce authentication realm for dockerhub login

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -67,7 +67,7 @@ func Login(ctx context.Context, options types.LoginCommandOptions, stdout io.Wri
 		authConfig = &registry.AuthConfig{ServerAddress: serverAddress}
 	}
 	if err == nil && authConfig.Username != "" && authConfig.Password != "" {
-		//login With StoreCreds
+		// login With StoreCreds
 		responseIdentityToken, err = loginClientSide(ctx, options.GOptions, *authConfig)
 	}
 
@@ -124,7 +124,7 @@ func GetDefaultAuthConfig(checkCredStore bool, serverAddress string, isDefaultRe
 			return nil, err
 		}
 	}
-	var authconfig = dockercliconfigtypes.AuthConfig{}
+	authconfig := dockercliconfigtypes.AuthConfig{}
 	if checkCredStore {
 		dockerConfigFile, err := dockercliconfig.Load("")
 		if err != nil {

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -53,7 +53,7 @@ type isFileStore interface {
 
 func Login(ctx context.Context, options types.LoginCommandOptions, stdout io.Writer) error {
 	var serverAddress string
-	if options.ServerAddress == "" {
+	if options.ServerAddress == "" || options.ServerAddress == "docker.io" || options.ServerAddress == "index.docker.io" || options.ServerAddress == "registry-1.docker.io" {
 		serverAddress = dockerconfigresolver.IndexServer
 	} else {
 		serverAddress = options.ServerAddress


### PR DESCRIPTION
point dockerhub login addresses to the [authentication legacy default server ](https://github.com/containerd/nerdctl/blob/main/pkg/imgutil/dockerconfigresolver/dockerconfigresolver_util.go#L33)

fixing https://github.com/containerd/nerdctl/issues/3245