### PR TITLE
fix: relax identifier limits

### DIFF
--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -21,10 +21,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
-
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/network"
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
@@ -58,8 +57,8 @@ func networkCreateAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	name := args[0]
-	if err := identifiers.Validate(name); err != nil {
-		return fmt.Errorf("malformed name %s: %w", name, err)
+	if err := identifiers.ValidateDockerCompat(name); err != nil {
+		return fmt.Errorf("invalid network name: %w", err)
 	}
 	driver, err := cmd.Flags().GetString("driver")
 	if err != nil {

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -27,10 +27,10 @@ import (
 	compose "github.com/compose-spec/compose-go/v2/types"
 
 	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
 
@@ -63,8 +63,8 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 	}
 
 	if o.Project != "" {
-		if err := identifiers.Validate(o.Project); err != nil {
-			return nil, fmt.Errorf("got invalid project name %q: %w", o.Project, err)
+		if err := identifiers.ValidateDockerCompat(o.Project); err != nil {
+			return nil, fmt.Errorf("invalid project name: %w", err)
 		}
 	}
 

--- a/pkg/composer/serviceparser/build.go
+++ b/pkg/composer/serviceparser/build.go
@@ -25,10 +25,10 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
 
@@ -84,9 +84,11 @@ func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName st
 
 	for _, s := range c.Secrets {
 		fileRef := types.FileReferenceConfig(s)
-		if err := identifiers.Validate(fileRef.Source); err != nil {
-			return nil, fmt.Errorf("secret source %q is invalid: %w", fileRef.Source, err)
+
+		if err := identifiers.ValidateDockerCompat(fileRef.Source); err != nil {
+			return nil, fmt.Errorf("invalid secret source name: %w", err)
 		}
+
 		projectSecret, ok := project.Secrets[fileRef.Source]
 		if !ok {
 			return nil, fmt.Errorf("build: secret %s is undefined", fileRef.Source)

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -31,9 +31,9 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 
 	"github.com/containerd/containerd/v2/contrib/nvidia"
-	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
 
@@ -851,8 +851,8 @@ func fileReferenceConfigToFlagV(c types.FileReferenceConfig, project *types.Proj
 		log.L.Warnf("Ignoring: %s: %+v", objType, unknown)
 	}
 
-	if err := identifiers.Validate(c.Source); err != nil {
-		return "", fmt.Errorf("%s source %q is invalid: %w", objType, c.Source, err)
+	if err := identifiers.ValidateDockerCompat(c.Source); err != nil {
+		return "", fmt.Errorf("invalid source name for %s: %w", objType, err)
 	}
 
 	var obj types.FileObjectConfig

--- a/pkg/identifiers/validate.go
+++ b/pkg/identifiers/validate.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package identifiers implements functions for docker compatible identifier validation.
+package identifiers
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/containerd/errdefs"
+)
+
+const AllowedIdentfierChars = `[a-zA-Z0-9][a-zA-Z0-9_.-]`
+
+var AllowedIdentifierPattern = regexp.MustCompile(`^` + AllowedIdentfierChars + `+$`)
+
+// ValidateDockerCompat implements docker compatible identifier validation.
+// The containerd implementation allows single character identifiers, while the
+// Docker compatible implementation requires at least 2 characters for identifiers.
+// The containerd implementation enforces a maximum length constraint of 76 characters,
+// while the Docker compatible implementation omits the length check entirely.
+func ValidateDockerCompat(s string) error {
+	if len(s) == 0 {
+		return fmt.Errorf("identifier must not be empty %w", errdefs.ErrInvalidArgument)
+	}
+
+	if !AllowedIdentifierPattern.MatchString(s) {
+		return fmt.Errorf("identifier %q must match pattern %q: %w", s, AllowedIdentfierChars, errdefs.ErrInvalidArgument)
+	}
+	return nil
+}

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -26,10 +26,10 @@ import (
 	"github.com/moby/sys/userns"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -260,7 +260,7 @@ func createDirOnHost(src string, createDir bool) error {
 }
 
 func isNamedVolume(s string) bool {
-	err := identifiers.Validate(s)
+	err := identifiers.ValidateDockerCompat(s)
 
 	// If the volume name is invalid, we assume it is a path
 	return err == nil

--- a/pkg/namestore/namestore.go
+++ b/pkg/namestore/namestore.go
@@ -22,8 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/v2/pkg/identifiers"
-
+	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 )
 
@@ -49,8 +48,8 @@ type nameStore struct {
 }
 
 func (x *nameStore) Acquire(name, id string) error {
-	if err := identifiers.Validate(name); err != nil {
-		return fmt.Errorf("invalid name %q: %w", name, err)
+	if err := identifiers.ValidateDockerCompat(name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
 	}
 	if strings.TrimSpace(id) != id {
 		return fmt.Errorf("untrimmed ID %q", id)
@@ -69,8 +68,8 @@ func (x *nameStore) Release(name, id string) error {
 	if name == "" {
 		return nil
 	}
-	if err := identifiers.Validate(name); err != nil {
-		return fmt.Errorf("invalid name %q: %w", name, err)
+	if err := identifiers.ValidateDockerCompat(name); err != nil {
+		return fmt.Errorf("invalid name: %w", err)
 	}
 	if strings.TrimSpace(id) != id {
 		return fmt.Errorf("untrimmed ID %q", id)
@@ -96,8 +95,8 @@ func (x *nameStore) Rename(oldName, id, newName string) error {
 	if oldName == "" || newName == "" {
 		return nil
 	}
-	if err := identifiers.Validate(newName); err != nil {
-		return fmt.Errorf("invalid name %q: %w", oldName, err)
+	if err := identifiers.ValidateDockerCompat(newName); err != nil {
+		return fmt.Errorf("invalid name %q: %w", newName, err)
 	}
 	fn := func() error {
 		oldFileName := filepath.Join(x.dir, oldName)


### PR DESCRIPTION
## Description
Some of users of finch are reporting max length of 76 characters, which seems to stem from this validation
https://github.com/containerd/containerd/blob/92900bf7300b4872db2a43e82128fda9cde08a79/pkg/identifiers/validate.go#L58

Docker skips this validation via containerd library and does its own regex validation

## What changed
This change moves the validation function to nerdctl which would give greater control over it. This change modifies identifier validation for the following:
- volume create
- container create
- network create
- namestore
- composer new project
- buildargs secret

This brings these identifier compatible to docker but doesn't add checks for others. Docker seems to have additional checks, of which not all are required but some might be needed to be ported.

## Test
1. local unit test
