### PR TITLE
Post containerd v2 cleanup

### DIFF
--- a/pkg/bypass4netnsutil/bypass4netnsutil.go
+++ b/pkg/bypass4netnsutil/bypass4netnsutil.go
@@ -23,11 +23,12 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+	b4nnoci "github.com/rootless-containers/bypass4netns/pkg/oci"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
-	"github.com/opencontainers/runtime-spec/specs-go"
-	b4nnoci "github.com/rootless-containers/bypass4netns/pkg/oci"
 )
 
 func generateSecurityOpt(listenerPath string) (oci.SpecOpts, error) {

--- a/pkg/clientutil/client.go
+++ b/pkg/clientutil/client.go
@@ -24,13 +24,14 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/systemutil"
 	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
 )
 
 func NewClient(ctx context.Context, namespace, address string, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
@@ -36,7 +38,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/signutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // New returns a new *composer.Composer.

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -29,6 +29,10 @@ import (
 	"strconv"
 	"strings"
 
+	dockercliopts "github.com/docker/cli/opts"
+	dockeropts "github.com/docker/docker/opts"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -55,9 +59,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	dockercliopts "github.com/docker/cli/opts"
-	dockeropts "github.com/docker/docker/opts"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Create will create a container.

--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/console"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
@@ -33,7 +35,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/taskutil"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // Exec will find the right running container to run a new command.

--- a/pkg/cmd/container/exec_linux.go
+++ b/pkg/cmd/container/exec_linux.go
@@ -17,8 +17,9 @@
 package container
 
 import (
-	"github.com/containerd/containerd/v2/pkg/cap"
 	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/pkg/cap"
 )
 
 func setExecCapabilities(pspec *specs.Process) error {

--- a/pkg/cmd/container/run_cgroup_linux.go
+++ b/pkg/cmd/container/run_cgroup_linux.go
@@ -23,14 +23,15 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/docker/go-units"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/docker/go-units"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type customMemoryOptions struct {

--- a/pkg/cmd/container/run_linux.go
+++ b/pkg/cmd/container/run_linux.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/moby/sys/userns"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -32,8 +35,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/moby/sys/userns"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // WithoutRunMount returns a SpecOpts that unmounts the default tmpfs on "/run"

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -28,6 +28,11 @@ import (
 	"strings"
 	"time"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/moby/sys/userns"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/leases"
@@ -44,10 +49,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/mountutil"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	securejoin "github.com/cyphar/filepath-securejoin"
-	"github.com/moby/sys/userns"
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // copy from https://github.com/containerd/containerd/blob/v1.6.0-rc.1/pkg/cri/opts/spec_linux.go#L129-L151

--- a/pkg/cmd/container/run_runtime.go
+++ b/pkg/cmd/container/run_runtime.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"strings"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	runcoptions "github.com/containerd/containerd/api/types/runc/options"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/containerd/v2/plugins"
 	"github.com/containerd/log"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func generateRuntimeCOpts(cgroupManager, runtimeStr string) ([]containerd.NewContainerOpts, error) {

--- a/pkg/cmd/container/run_ulimit.go
+++ b/pkg/cmd/container/run_ulimit.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"strings"
 
+	"github.com/docker/go-units"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/docker/go-units"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 func generateUlimitsOpts(ulimits []string) ([]oci.SpecOpts, error) {

--- a/pkg/cmd/container/run_windows.go
+++ b/pkg/cmd/container/run_windows.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/go-units"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
-	"github.com/docker/go-units"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -25,6 +25,9 @@ import (
 	"os"
 	"strings"
 
+	"github.com/klauspost/compress/zstd"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	overlaybdconvert "github.com/containerd/accelerated-container-image/pkg/convertor"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
@@ -43,8 +46,6 @@ import (
 	estargzexternaltocconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz/externaltoc"
 	zstdchunkedconvert "github.com/containerd/stargz-snapshotter/nativeconverter/zstdchunked"
 	"github.com/containerd/stargz-snapshotter/recorder"
-	"github.com/klauspost/compress/zstd"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, options types.ImageConvertOptions) error {

--- a/pkg/cmd/image/crypt.go
+++ b/pkg/cmd/image/crypt.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images/converter"
@@ -29,7 +31,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func Crypt(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, encrypt bool, options types.ImageCryptOptions) error {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -29,6 +29,10 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/docker/go-units"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -39,9 +43,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/platforms"
-	"github.com/docker/go-units"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ListCommandHandler `List` and print images matching filters in `options`.

--- a/pkg/cmd/image/prune.go
+++ b/pkg/cmd/image/prune.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/opencontainers/go-digest"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
 )
 
 // Prune will remove all dangling images. If all is specified, will also remove all images not referenced by any container.

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -23,6 +23,10 @@ import (
 	"os"
 	"path/filepath"
 
+	distributionref "github.com/distribution/reference"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -44,9 +48,6 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 	"github.com/containerd/stargz-snapshotter/estargz/zstdchunked"
 	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
-	distributionref "github.com/distribution/reference"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Push pushes an image specified by `rawRef`.

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -27,10 +27,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containerd/errdefs"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types/registry"
-	"github.com/docker/docker/errdefs"
 	"golang.org/x/net/context/ctxhttp"
 	"golang.org/x/term"
 

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -27,7 +27,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/containerd/errdefs"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 	"github.com/docker/docker/api/types/registry"
@@ -36,6 +35,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"

--- a/pkg/containerdutil/content.go
+++ b/pkg/containerdutil/content.go
@@ -23,9 +23,10 @@ package containerdutil
 import (
 	"context"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ContentStore should be called to get a Provider with caching

--- a/pkg/containerdutil/helpers.go
+++ b/pkg/containerdutil/helpers.go
@@ -19,8 +19,9 @@ package containerdutil
 import (
 	"context"
 
-	"github.com/containerd/containerd/v2/core/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/content"
 )
 
 var ReadBlob = readBlobWithCache()

--- a/pkg/containerutil/config.go
+++ b/pkg/containerutil/config.go
@@ -24,12 +24,13 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // ReconfigNetContainer reconfigures the container's network namespace path.

--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -27,6 +27,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
@@ -40,7 +42,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -28,6 +28,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moby/sys/signal"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/console"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
@@ -46,8 +49,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/taskutil"
-	"github.com/moby/sys/signal"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // PrintHostPort writes to `writer` the public (HostIP:HostPort) of a given `containerPort/protocol` in a container.

--- a/pkg/idutil/imagewalker/imagewalker.go
+++ b/pkg/idutil/imagewalker/imagewalker.go
@@ -22,10 +22,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/opencontainers/go-digest"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	"github.com/opencontainers/go-digest"
 )
 
 type Found struct {

--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -27,6 +27,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/identity"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/diff"
@@ -40,10 +45,6 @@ import (
 	imgutil "github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/platforms"
-	"github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/identity"
-	"github.com/opencontainers/image-spec/specs-go"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type Changes struct {

--- a/pkg/imgutil/converter/zstd.go
+++ b/pkg/imgutil/converter/zstd.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/klauspost/compress/zstd"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter"
@@ -28,8 +31,6 @@ import (
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
-	"github.com/klauspost/compress/zstd"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ZstdLayerConvertFunc converts legacy tar.gz layers into zstd layers with

--- a/pkg/imgutil/imgutil.go
+++ b/pkg/imgutil/imgutil.go
@@ -23,6 +23,10 @@ import (
 	"fmt"
 	"reflect"
 
+	distributionref "github.com/distribution/reference"
+	"github.com/opencontainers/image-spec/identity"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -38,9 +42,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
 	"github.com/containerd/platforms"
-	distributionref "github.com/distribution/reference"
-	"github.com/opencontainers/image-spec/identity"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // EnsuredImage contains the image existed in containerd and its metadata.

--- a/pkg/imgutil/imgutil.go
+++ b/pkg/imgutil/imgutil.go
@@ -19,6 +19,7 @@ package imgutil
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
 	"github.com/containerd/log"
@@ -37,7 +39,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
 	"github.com/containerd/platforms"
 	distributionref "github.com/distribution/reference"
-	"github.com/docker/docker/errdefs"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -90,10 +91,10 @@ func GetExistingImage(ctx context.Context, client *containerd.Client, snapshotte
 		return nil, err
 	}
 	if count == 0 {
-		return nil, errdefs.NotFound(fmt.Errorf("got count 0 after walking"))
+		return nil, errors.Join(errdefs.ErrNotFound, errors.New("got count 0 after walking"))
 	}
 	if res == nil {
-		return nil, errdefs.NotFound(fmt.Errorf("got nil res after walking"))
+		return nil, errors.Join(errdefs.ErrNotFound, errors.New("got nil res after walking"))
 	}
 	return res, nil
 }

--- a/pkg/imgutil/jobs/jobs.go
+++ b/pkg/imgutil/jobs/jobs.go
@@ -24,13 +24,14 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/pkg/progress"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // ShowProgress continuously updates the output with job progress

--- a/pkg/imgutil/pull/pull.go
+++ b/pkg/imgutil/pull/pull.go
@@ -21,13 +21,14 @@ import (
 	"context"
 	"io"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/jobs"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // Config for content fetch

--- a/pkg/imgutil/snapshotter_test.go
+++ b/pkg/imgutil/snapshotter_test.go
@@ -21,13 +21,14 @@ import (
 	"reflect"
 	"testing"
 
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gotest.tools/v3/assert"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
-	digest "github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	"gotest.tools/v3/assert"
 )
 
 const (

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -35,6 +35,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/go-connections/nat"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/go-cni"
@@ -43,8 +46,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/ocihook/state"
-	"github.com/docker/go-connections/nat"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // From https://github.com/moby/moby/blob/v26.1.2/api/types/types.go#L34-L140

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -22,12 +22,12 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"gotest.tools/v3/assert"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-
-	"github.com/opencontainers/runtime-spec/specs-go"
-	"gotest.tools/v3/assert"
 )
 
 func TestContainerFromNative(t *testing.T) {

--- a/pkg/inspecttypes/native/image.go
+++ b/pkg/inspecttypes/native/image.go
@@ -17,8 +17,9 @@
 package native
 
 import (
-	"github.com/containerd/containerd/v2/core/images"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"github.com/containerd/containerd/v2/core/images"
 )
 
 // Image corresponds to a containerd-native image object.

--- a/pkg/ipcutil/ipcutil.go
+++ b/pkg/ipcutil/ipcutil.go
@@ -26,13 +26,14 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/docker/go-units"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/docker/go-units"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 type IPCMode string

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -22,6 +22,8 @@ import (
 	"io"
 	"os"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter"
@@ -35,7 +37,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/stargz-snapshotter/ipfs"
 	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const ipfsPathEnv = "IPFS_PATH"

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
@@ -34,7 +35,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/stargz-snapshotter/ipfs"
 	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
-	"github.com/docker/docker/errdefs"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/pkg/ipfs/registry.go
+++ b/pkg/ipfs/registry.go
@@ -29,12 +29,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
 	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
-	"github.com/opencontainers/go-digest"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // RegistryOptions represents options to configure the registry.

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -23,14 +23,15 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/moby/sys/userns"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/moby/sys/userns"
-	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (

--- a/pkg/mountutil/mountutil_linux_test.go
+++ b/pkg/mountutil/mountutil_linux_test.go
@@ -21,14 +21,15 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/containerd/v2/core/mount"
-	"github.com/containerd/containerd/v2/pkg/oci"
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	mocks "github.com/containerd/nerdctl/v2/pkg/mountutil/mountutilmock"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/containerd/containerd/v2/core/mount"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	mocks "github.com/containerd/nerdctl/v2/pkg/mountutil/mountutilmock"
 )
 
 // TestParseVolumeOptions tests volume options are parsed as expected.

--- a/pkg/mountutil/mountutil_windows_test.go
+++ b/pkg/mountutil/mountutil_windows_test.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	mocks "github.com/containerd/nerdctl/v2/pkg/mountutil/mountutilmock"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"go.uber.org/mock/gomock"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	mocks "github.com/containerd/nerdctl/v2/pkg/mountutil/mountutilmock"
 )
 
 func TestParseVolumeOptions(t *testing.T) {

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -28,6 +28,11 @@ import (
 	"strings"
 	"time"
 
+	types100 "github.com/containernetworking/cni/pkg/types/100"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	b4nndclient "github.com/rootless-containers/bypass4netns/pkg/api/daemon/client"
+	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
+
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
 	"github.com/containerd/nerdctl/v2/pkg/bypass4netnsutil"
@@ -38,11 +43,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
 	"github.com/containerd/nerdctl/v2/pkg/ocihook/state"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	types100 "github.com/containernetworking/cni/pkg/types/100"
-	"github.com/opencontainers/runtime-spec/specs-go"
-
-	b4nndclient "github.com/rootless-containers/bypass4netns/pkg/api/daemon/client"
-	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 )
 
 const (

--- a/pkg/platformutil/layers.go
+++ b/pkg/platformutil/layers.go
@@ -19,10 +19,11 @@ package platformutil
 import (
 	"context"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func LayerDescs(ctx context.Context, provider content.Provider, imageTarget ocispec.Descriptor, platform platforms.MatchComparer) ([]ocispec.Descriptor, error) {

--- a/pkg/platformutil/platformutil.go
+++ b/pkg/platformutil/platformutil.go
@@ -19,9 +19,10 @@ package platformutil
 import (
 	"fmt"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/platforms"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewMatchComparerFromOCISpecPlatformSlice returns MatchComparer.

--- a/pkg/snapshotterutil/socisource.go
+++ b/pkg/snapshotterutil/socisource.go
@@ -40,10 +40,11 @@ import (
 	"fmt"
 	"strings"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/pkg/labels"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
-	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 const (

--- a/pkg/sysinfo/doc.go
+++ b/pkg/sysinfo/doc.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// This here is a copy of https://github.com/moby/moby/tree/master/pkg/sysinfo
+// Package sysinfo is a copy of https://github.com/moby/moby/tree/master/pkg/sysinfo
 // as of cff4f20c44a3a7c882ed73934dec6a77246c6323
 // This may be removed (and replaced by a dependency to moby again) once they
 // have migrated to containerd v2.

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -31,6 +31,10 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/opencontainers/go-digest"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
@@ -39,9 +43,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/opencontainers/go-digest"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/icmd"
 )
 
 type Base struct {


### PR DESCRIPTION
This PR is a small follow-up to #3173 and addresses three things:

- docs.go syntax nit (https://github.com/containerd/nerdctl/pull/3173#pullrequestreview-2229399226)
- cleaning / reordering imports for consistency
- getting rid of `docker/errdefs` (used in three locations, two of them being linked, and the third one being just a mistake)