### PR TITLE
Import ordering

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
         run: make lint-yaml
       - name: shellcheck
         run: make lint-shell
+      - name: go imports ordering
+        run: |
+          go install -v github.com/incu6us/goimports-reviser/v3@latest
+          make lint-imports
 
   test-unit:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,13 @@ clean:
 lint: lint-go lint-yaml lint-shell
 
 lint-go:
-	cd $(MAKEFILE_DIR) && golangci-lint run $(VERBOSE_FLAG_LONG)
+	cd $(MAKEFILE_DIR) && golangci-lint run $(VERBOSE_FLAG_LONG) ./...
+
+lint-imports:
+	cd $(MAKEFILE_DIR) && goimports-reviser -list-diff -company-prefixes "github.com/containerd" ./...
+
+lint-fix-imports:
+	cd $(MAKEFILE_DIR) && goimports-reviser -company-prefixes "github.com/containerd" ./...
 
 lint-yaml:
 	cd $(MAKEFILE_DIR) && yamllint .

--- a/cmd/nerdctl/builder.go
+++ b/cmd/nerdctl/builder.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 )
 

--- a/cmd/nerdctl/builder_build_test.go
+++ b/cmd/nerdctl/builder_build_test.go
@@ -23,9 +23,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"github.com/containerd/platforms"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/platforms"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestBuild(t *testing.T) {

--- a/cmd/nerdctl/builder_linux_test.go
+++ b/cmd/nerdctl/builder_linux_test.go
@@ -24,9 +24,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestBuilderDebug(t *testing.T) {

--- a/cmd/nerdctl/completion.go
+++ b/cmd/nerdctl/completion.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"

--- a/cmd/nerdctl/compose_config_test.go
+++ b/cmd/nerdctl/compose_config_test.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestComposeConfig(t *testing.T) {

--- a/cmd/nerdctl/compose_cp.go
+++ b/cmd/nerdctl/compose_cp.go
@@ -19,11 +19,12 @@ package main
 import (
 	"errors"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/spf13/cobra"
 )
 
 func newComposeCopyCommand() *cobra.Command {

--- a/cmd/nerdctl/compose_cp_linux_test.go
+++ b/cmd/nerdctl/compose_cp_linux_test.go
@@ -22,8 +22,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestComposeCopy(t *testing.T) {

--- a/cmd/nerdctl/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose_exec_linux_test.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestComposeExec(t *testing.T) {

--- a/cmd/nerdctl/compose_images.go
+++ b/cmd/nerdctl/compose_images.go
@@ -28,6 +28,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/containerd/v2/pkg/progress"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"

--- a/cmd/nerdctl/compose_ps.go
+++ b/cmd/nerdctl/compose_ps.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/errdefs"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"

--- a/cmd/nerdctl/compose_ps_linux_test.go
+++ b/cmd/nerdctl/compose_ps_linux_test.go
@@ -23,9 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestComposePs(t *testing.T) {

--- a/cmd/nerdctl/compose_push.go
+++ b/cmd/nerdctl/compose_push.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
-	"github.com/spf13/cobra"
 )
 
 func newComposePushCommand() *cobra.Command {

--- a/cmd/nerdctl/compose_rm.go
+++ b/cmd/nerdctl/compose_rm.go
@@ -20,10 +20,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
-	"github.com/spf13/cobra"
 )
 
 func newComposeRemoveCommand() *cobra.Command {

--- a/cmd/nerdctl/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose_run_linux_test.go
@@ -23,11 +23,13 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 func TestComposeRun(t *testing.T) {

--- a/cmd/nerdctl/compose_start.go
+++ b/cmd/nerdctl/compose_start.go
@@ -26,6 +26,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"

--- a/cmd/nerdctl/compose_top.go
+++ b/cmd/nerdctl/compose_top.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"

--- a/cmd/nerdctl/compose_up.go
+++ b/cmd/nerdctl/compose_up.go
@@ -22,10 +22,11 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
-	"github.com/spf13/cobra"
 )
 
 func newComposeUpCommand() *cobra.Command {

--- a/cmd/nerdctl/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose_up_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"gotest.tools/v3/icmd"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"

--- a/cmd/nerdctl/compose_up_test.go
+++ b/cmd/nerdctl/compose_up_test.go
@@ -23,9 +23,10 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 // https://github.com/containerd/nerdctl/issues/1942

--- a/cmd/nerdctl/compose_version.go
+++ b/cmd/nerdctl/compose_version.go
@@ -20,8 +20,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/containerd/nerdctl/v2/pkg/version"
 	"github.com/spf13/cobra"
+
+	"github.com/containerd/nerdctl/v2/pkg/version"
 )
 
 func newComposeVersionCommand() *cobra.Command {

--- a/cmd/nerdctl/container_attach.go
+++ b/cmd/nerdctl/container_attach.go
@@ -17,12 +17,14 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
-	"github.com/spf13/cobra"
 )
 
 func newAttachCommand() *cobra.Command {

--- a/cmd/nerdctl/container_attach_linux_test.go
+++ b/cmd/nerdctl/container_attach_linux_test.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 // skipAttachForDocker should be called by attach-related tests that assert 'read detach keys' in stdout.

--- a/cmd/nerdctl/container_cp_linux_test.go
+++ b/cmd/nerdctl/container_cp_linux_test.go
@@ -24,9 +24,10 @@ import (
 	"syscall"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestCopyToContainer(t *testing.T) {

--- a/cmd/nerdctl/container_create.go
+++ b/cmd/nerdctl/container_create.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
-	"github.com/spf13/cobra"
 )
 
 func newCreateCommand() *cobra.Command {

--- a/cmd/nerdctl/container_create_linux_test.go
+++ b/cmd/nerdctl/container_create_linux_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestCreate(t *testing.T) {

--- a/cmd/nerdctl/container_diff.go
+++ b/cmd/nerdctl/container_diff.go
@@ -31,13 +31,14 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/containerd/platforms"
 )
 
 func newDiffCommand() *cobra.Command {

--- a/cmd/nerdctl/container_exec.go
+++ b/cmd/nerdctl/container_exec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_inspect_windows_test.go
+++ b/cmd/nerdctl/container_inspect_windows_test.go
@@ -19,8 +19,9 @@ package main
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestInspectProcessContainerContainsLabel(t *testing.T) {

--- a/cmd/nerdctl/container_kill.go
+++ b/cmd/nerdctl/container_kill.go
@@ -17,11 +17,13 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
-	"github.com/spf13/cobra"
 )
 
 func newKillCommand() *cobra.Command {

--- a/cmd/nerdctl/container_kill_linux_test.go
+++ b/cmd/nerdctl/container_kill_linux_test.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-iptables/iptables"
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	iptablesutil "github.com/containerd/nerdctl/v2/pkg/testutil/iptables"
-	"github.com/coreos/go-iptables/iptables"
-	"gotest.tools/v3/assert"
 )
 
 // TestKillCleanupForwards runs a container that exposes a port and then kill it.

--- a/cmd/nerdctl/container_list_linux_test.go
+++ b/cmd/nerdctl/container_list_linux_test.go
@@ -24,11 +24,12 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 type psTestContainer struct {

--- a/cmd/nerdctl/container_list_windows_test.go
+++ b/cmd/nerdctl/container_list_windows_test.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 type psTestContainer struct {

--- a/cmd/nerdctl/container_logs_test.go
+++ b/cmd/nerdctl/container_logs_test.go
@@ -23,8 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestLogs(t *testing.T) {

--- a/cmd/nerdctl/container_pause.go
+++ b/cmd/nerdctl/container_pause.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_remove_windows_test.go
+++ b/cmd/nerdctl/container_remove_windows_test.go
@@ -19,8 +19,9 @@ package main
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestRemoveProcessContainer(t *testing.T) {

--- a/cmd/nerdctl/container_rename.go
+++ b/cmd/nerdctl/container_rename.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
-	"github.com/spf13/cobra"
 )
 
 func newRenameCommand() *cobra.Command {

--- a/cmd/nerdctl/container_restart_linux_test.go
+++ b/cmd/nerdctl/container_restart_linux_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestRestart(t *testing.T) {

--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -22,8 +22,11 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/console"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -37,7 +40,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/taskutil"
-	"github.com/spf13/cobra"
 )
 
 const (

--- a/cmd/nerdctl/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container_run_cgroup_linux_test.go
@@ -23,12 +23,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/cgroups/v3"
-	"github.com/containerd/continuity/testutil/loopback"
-	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/moby/sys/userns"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/continuity/testutil/loopback"
+
+	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestRunCgroupV2(t *testing.T) {

--- a/cmd/nerdctl/container_run_gpus_test.go
+++ b/cmd/nerdctl/container_run_gpus_test.go
@@ -19,9 +19,10 @@ package main
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"gotest.tools/v3/assert"
 	is "gotest.tools/v3/assert/cmp"
+
+	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
 func TestParseGpusOptAll(t *testing.T) {

--- a/cmd/nerdctl/container_run_linux.go
+++ b/cmd/nerdctl/container_run_linux.go
@@ -19,8 +19,9 @@ package main
 import (
 	"strings"
 
-	"github.com/containerd/containerd/v2/pkg/cap"
 	"github.com/spf13/cobra"
+
+	"github.com/containerd/containerd/v2/pkg/cap"
 )
 
 func capShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/container_run_linux_test.go
+++ b/cmd/nerdctl/container_run_linux_test.go
@@ -33,11 +33,12 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/icmd"
 )
 
 func TestRunCustomRootfs(t *testing.T) {

--- a/cmd/nerdctl/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container_run_mount_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/containerd/v2/core/mount"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )

--- a/cmd/nerdctl/container_run_mount_windows_test.go
+++ b/cmd/nerdctl/container_run_mount_windows_test.go
@@ -21,9 +21,10 @@ import (
 	"os"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestRunMountVolume(t *testing.T) {

--- a/cmd/nerdctl/container_run_network.go
+++ b/cmd/nerdctl/container_run_network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	gocni "github.com/containerd/go-cni"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/cmd/nerdctl/container_run_network_base_test.go
+++ b/cmd/nerdctl/container_run_network_base_test.go
@@ -26,9 +26,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
-	"gotest.tools/v3/assert"
 )
 
 // Tests various port mapping argument combinations by starting an nginx container and

--- a/cmd/nerdctl/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container_run_network_linux_test.go
@@ -25,12 +25,14 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
-	"gotest.tools/v3/assert"
-	"gotest.tools/v3/icmd"
 )
 
 // TestRunInternetConnectivity tests Internet connectivity with `apk update`

--- a/cmd/nerdctl/container_run_network_windows_test.go
+++ b/cmd/nerdctl/container_run_network_windows_test.go
@@ -23,10 +23,11 @@ import (
 	"testing"
 
 	"github.com/Microsoft/hcsshim"
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 // TestRunInternetConnectivity tests Internet connectivity by pinging github.com.

--- a/cmd/nerdctl/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container_run_restart_linux_test.go
@@ -24,11 +24,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
-
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 )
 
 func TestRunRestart(t *testing.T) {

--- a/cmd/nerdctl/container_run_security_linux_test.go
+++ b/cmd/nerdctl/container_run_security_linux_test.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-
-	"gotest.tools/v3/assert"
 )
 
 func getCapEff(base *testutil.Base, args ...string) uint64 {

--- a/cmd/nerdctl/container_run_test.go
+++ b/cmd/nerdctl/container_run_test.go
@@ -30,10 +30,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 	"gotest.tools/v3/poll"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestRunEntrypointWithBuild(t *testing.T) {

--- a/cmd/nerdctl/container_run_windows_test.go
+++ b/cmd/nerdctl/container_run_windows_test.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestRunHostProcessContainer(t *testing.T) {

--- a/cmd/nerdctl/container_start.go
+++ b/cmd/nerdctl/container_start.go
@@ -17,12 +17,14 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
-	"github.com/spf13/cobra"
 )
 
 func newStartCommand() *cobra.Command {

--- a/cmd/nerdctl/container_start_linux_test.go
+++ b/cmd/nerdctl/container_start_linux_test.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestStartDetachKeys(t *testing.T) {

--- a/cmd/nerdctl/container_stats.go
+++ b/cmd/nerdctl/container_stats.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_stop.go
+++ b/cmd/nerdctl/container_stop.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_stop_linux_test.go
+++ b/cmd/nerdctl/container_stop_linux_test.go
@@ -22,13 +22,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/coreos/go-iptables/iptables"
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	iptablesutil "github.com/containerd/nerdctl/v2/pkg/testutil/iptables"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
-	"github.com/coreos/go-iptables/iptables"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestStopStart(t *testing.T) {

--- a/cmd/nerdctl/container_top.go
+++ b/cmd/nerdctl/container_top.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_unpause.go
+++ b/cmd/nerdctl/container_unpause.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/container_update.go
+++ b/cmd/nerdctl/container_update.go
@@ -31,13 +31,14 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	nerdctlContainer "github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
-	"github.com/containerd/typeurl/v2"
 )
 
 type updateResourceOptions struct {

--- a/cmd/nerdctl/container_wait.go
+++ b/cmd/nerdctl/container_wait.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/cmd/nerdctl/flagutil.go
+++ b/cmd/nerdctl/flagutil.go
@@ -17,8 +17,9 @@
 package main
 
 import (
-	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/spf13/cobra"
+
+	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 
 func processImageSignOptions(cmd *cobra.Command) (opt types.ImageSignOptions, err error) {

--- a/cmd/nerdctl/image_convert_linux_test.go
+++ b/cmd/nerdctl/image_convert_linux_test.go
@@ -21,10 +21,11 @@ import (
 	"runtime"
 	"testing"
 
+	"gotest.tools/v3/icmd"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/icmd"
 )
 
 func TestImageConvertNydus(t *testing.T) {

--- a/cmd/nerdctl/image_cryptutil.go
+++ b/cmd/nerdctl/image_cryptutil.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
-	"github.com/spf13/cobra"
 )
 
 // registerImgcryptFlags register flags that correspond to parseImgcryptFlags().

--- a/cmd/nerdctl/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image_encrypt_linux_test.go
@@ -24,12 +24,14 @@ import (
 	"path/filepath"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
+
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 type jweKeyPair struct {

--- a/cmd/nerdctl/image_history.go
+++ b/cmd/nerdctl/image_history.go
@@ -34,6 +34,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"

--- a/cmd/nerdctl/image_history_test.go
+++ b/cmd/nerdctl/image_history_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 type historyObj struct {

--- a/cmd/nerdctl/image_list.go
+++ b/cmd/nerdctl/image_list.go
@@ -19,11 +19,12 @@ package main
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	"github.com/spf13/cobra"
 )
 
 func newImagesCommand() *cobra.Command {

--- a/cmd/nerdctl/image_list_test.go
+++ b/cmd/nerdctl/image_list_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestImagesWithNames(t *testing.T) {

--- a/cmd/nerdctl/image_load_linux_test.go
+++ b/cmd/nerdctl/image_load_linux_test.go
@@ -24,8 +24,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestLoadStdinFromPipe(t *testing.T) {

--- a/cmd/nerdctl/image_pull_linux_test.go
+++ b/cmd/nerdctl/image_pull_linux_test.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 type cosignKeyPair struct {

--- a/cmd/nerdctl/image_push_linux_test.go
+++ b/cmd/nerdctl/image_push_linux_test.go
@@ -22,9 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 func TestPushPlainHTTPFails(t *testing.T) {

--- a/cmd/nerdctl/image_save.go
+++ b/cmd/nerdctl/image_save.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
-	"github.com/mattn/go-isatty"
-	"github.com/spf13/cobra"
 )
 
 func newSaveCommand() *cobra.Command {

--- a/cmd/nerdctl/image_save_linux_test.go
+++ b/cmd/nerdctl/image_save_linux_test.go
@@ -26,9 +26,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
-
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestSave(t *testing.T) {

--- a/cmd/nerdctl/ipfs_build_linux_test.go
+++ b/cmd/nerdctl/ipfs_build_linux_test.go
@@ -22,10 +22,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
-
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestIPFSBuild(t *testing.T) {

--- a/cmd/nerdctl/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs_compose_linux_test.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 func TestIPFSComposeUp(t *testing.T) {

--- a/cmd/nerdctl/ipfs_linux_test.go
+++ b/cmd/nerdctl/ipfs_linux_test.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-
-	"gotest.tools/v3/assert"
 )
 
 func TestIPFS(t *testing.T) {

--- a/cmd/nerdctl/login.go
+++ b/cmd/nerdctl/login.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/login"
 )

--- a/cmd/nerdctl/login_linux_test.go
+++ b/cmd/nerdctl/login_linux_test.go
@@ -25,10 +25,11 @@ import (
 	"strconv"
 	"testing"
 
+	"gotest.tools/v3/icmd"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testca"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/icmd"
 )
 
 func safeRandomString(n int) string {

--- a/cmd/nerdctl/logout.go
+++ b/cmd/nerdctl/logout.go
@@ -19,9 +19,10 @@ package main
 import (
 	"fmt"
 
-	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	dockercliconfig "github.com/docker/cli/cli/config"
 	"github.com/spf13/cobra"
+
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 )
 
 func newLogoutCommand() *cobra.Command {

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/config"
 	ncdefaults "github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -21,9 +21,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containerd/containerd/v2/defaults"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/containerd/v2/defaults"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestMain(m *testing.M) {

--- a/cmd/nerdctl/main_unix.go
+++ b/cmd/nerdctl/main_unix.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"

--- a/cmd/nerdctl/multi_platform_linux_test.go
+++ b/cmd/nerdctl/multi_platform_linux_test.go
@@ -22,10 +22,11 @@ import (
 	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
-	"gotest.tools/v3/assert"
 )
 
 func testMultiPlatformRun(base *testutil.Base, alpineImage string) {

--- a/cmd/nerdctl/namespace.go
+++ b/cmd/nerdctl/namespace.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 )

--- a/cmd/nerdctl/namespace_remove.go
+++ b/cmd/nerdctl/namespace_remove.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/namespace"
-	"github.com/spf13/cobra"
 )
 
 func newNamespaceRmCommand() *cobra.Command {

--- a/cmd/nerdctl/network_create.go
+++ b/cmd/nerdctl/network_create.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/containerd/v2/pkg/identifiers"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/network"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/cmd/nerdctl/network_create_linux_test.go
+++ b/cmd/nerdctl/network_create_linux_test.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestNetworkCreateWithMTU(t *testing.T) {

--- a/cmd/nerdctl/network_inspect_test.go
+++ b/cmd/nerdctl/network_inspect_test.go
@@ -20,9 +20,10 @@ import (
 	"runtime"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestNetworkInspect(t *testing.T) {

--- a/cmd/nerdctl/network_remove.go
+++ b/cmd/nerdctl/network_remove.go
@@ -17,12 +17,12 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/network"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
-
-	"github.com/spf13/cobra"
 )
 
 func newNetworkRmCommand() *cobra.Command {

--- a/cmd/nerdctl/system_events_linux_test.go
+++ b/cmd/nerdctl/system_events_linux_test.go
@@ -22,8 +22,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func testEventFilter(t *testing.T, args ...string) string {

--- a/cmd/nerdctl/system_info.go
+++ b/cmd/nerdctl/system_info.go
@@ -17,10 +17,11 @@
 package main
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/system"
-	"github.com/spf13/cobra"
 )
 
 func newInfoCommand() *cobra.Command {

--- a/cmd/nerdctl/system_prune.go
+++ b/cmd/nerdctl/system_prune.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/system"

--- a/cmd/nerdctl/system_prune_linux_test.go
+++ b/cmd/nerdctl/system_prune_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )

--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -23,13 +23,15 @@ import (
 	"os"
 	"text/template"
 
+	"github.com/spf13/cobra"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/spf13/cobra"
 )
 
 func newVersionCommand() *cobra.Command {

--- a/cmd/nerdctl/volume_create.go
+++ b/cmd/nerdctl/volume_create.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )

--- a/cmd/nerdctl/volume_create_test.go
+++ b/cmd/nerdctl/volume_create_test.go
@@ -19,9 +19,11 @@ package main
 import (
 	"testing"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestVolumeCreate(t *testing.T) {

--- a/cmd/nerdctl/volume_inspect_test.go
+++ b/cmd/nerdctl/volume_inspect_test.go
@@ -25,11 +25,13 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func createFileWithSize(base *testutil.Base, vol string, size int64) {

--- a/cmd/nerdctl/volume_namespace_test.go
+++ b/cmd/nerdctl/volume_namespace_test.go
@@ -19,9 +19,11 @@ package main
 import (
 	"testing"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func TestVolumeNamespace(t *testing.T) {

--- a/cmd/nerdctl/volume_remove_linux_test.go
+++ b/cmd/nerdctl/volume_remove_linux_test.go
@@ -21,10 +21,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 // TestVolumeRemove does test a large variety of volume remove situations, albeit none of them being

--- a/pkg/apparmorutil/apparmorutil_linux.go
+++ b/pkg/apparmorutil/apparmorutil_linux.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/moby/sys/userns"
+
 	"github.com/containerd/containerd/v2/pkg/apparmor"
 	"github.com/containerd/log"
-	"github.com/moby/sys/userns"
 )
 
 // CanLoadNewProfile returns whether the current process can load a new AppArmor profile.

--- a/pkg/buildkitutil/buildkitutil.go
+++ b/pkg/buildkitutil/buildkitutil.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 

--- a/pkg/buildkitutil/buildkitutil_linux.go
+++ b/pkg/buildkitutil/buildkitutil_linux.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 

--- a/pkg/bypass4netnsutil/bypass.go
+++ b/pkg/bypass4netnsutil/bypass.go
@@ -23,12 +23,14 @@ import (
 	"net"
 	"path/filepath"
 
-	"github.com/containerd/errdefs"
-	gocni "github.com/containerd/go-cni"
-	"github.com/containerd/nerdctl/v2/pkg/annotations"
 	b4nnapi "github.com/rootless-containers/bypass4netns/pkg/api"
 	"github.com/rootless-containers/bypass4netns/pkg/api/daemon/client"
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
+
+	"github.com/containerd/errdefs"
+	gocni "github.com/containerd/go-cni"
+
+	"github.com/containerd/nerdctl/v2/pkg/annotations"
 )
 
 func NewBypass4netnsCNIBypassManager(client client.Client, rlkClient rlkclient.Client, annotationsMap map[string]string) (*Bypass4netnsCNIBypassManager, error) {

--- a/pkg/bypass4netnsutil/bypass4netnsutil.go
+++ b/pkg/bypass4netnsutil/bypass4netnsutil.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 )
 

--- a/pkg/cioutil/container_io_windows.go
+++ b/pkg/cioutil/container_io_windows.go
@@ -22,6 +22,7 @@ import (
 	"os/exec"
 
 	"github.com/Microsoft/go-winio"
+
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
 )

--- a/pkg/clientutil/client.go
+++ b/pkg/clientutil/client.go
@@ -29,9 +29,10 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/systemutil"
-	"github.com/containerd/platforms"
 )
 
 func NewClient(ctx context.Context, namespace, address string, opts ...containerd.Opt) (*containerd.Client, context.Context, context.CancelFunc, error) {

--- a/pkg/cmd/apparmor/inspect_linux.go
+++ b/pkg/cmd/apparmor/inspect_linux.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/v2/contrib/apparmor"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )

--- a/pkg/cmd/apparmor/load_linux.go
+++ b/pkg/cmd/apparmor/load_linux.go
@@ -19,6 +19,7 @@ package apparmor
 import (
 	"github.com/containerd/containerd/v2/contrib/apparmor"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )
 

--- a/pkg/cmd/apparmor/unload_linux.go
+++ b/pkg/cmd/apparmor/unload_linux.go
@@ -18,6 +18,7 @@ package apparmor
 
 import (
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/apparmorutil"
 )
 

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -28,18 +28,20 @@ import (
 	"strconv"
 	"strings"
 
+	distributionref "github.com/distribution/reference"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/containerd/platforms"
-	distributionref "github.com/distribution/reference"
 )
 
 type PlatformParser interface {

--- a/pkg/cmd/builder/prune.go
+++ b/pkg/cmd/builder/prune.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 )

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -27,6 +27,8 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
@@ -37,7 +39,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/signutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/containerd/platforms"
 )
 
 // New returns a new *composer.Composer.

--- a/pkg/cmd/container/attach.go
+++ b/pkg/cmd/container/attach.go
@@ -25,6 +25,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -24,6 +24,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/commit"

--- a/pkg/cmd/container/cp_linux.go
+++ b/pkg/cmd/container/cp_linux.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"

--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -28,6 +28,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/flagutil"

--- a/pkg/cmd/container/inspect.go
+++ b/pkg/cmd/container/inspect.go
@@ -24,6 +24,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerinspector"

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -24,11 +24,14 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/moby/sys/signal"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/errdefs"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
@@ -37,7 +40,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/moby/sys/signal"
 )
 
 // Kill kills a list of containers

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/progress"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -26,6 +26,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 )
 

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -26,6 +26,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/api/types/cri"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"

--- a/pkg/cmd/container/pause.go
+++ b/pkg/cmd/container/pause.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/prune.go
+++ b/pkg/cmd/container/prune.go
@@ -24,6 +24,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"

--- a/pkg/cmd/container/rename.go
+++ b/pkg/cmd/container/rename.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"

--- a/pkg/cmd/container/restart.go
+++ b/pkg/cmd/container/restart.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/run_cgroup_freebsd.go
+++ b/pkg/cmd/container/run_cgroup_freebsd.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/container/run_cgroup_linux.go
+++ b/pkg/cmd/container/run_cgroup_linux.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"

--- a/pkg/cmd/container/run_cgroup_windows.go
+++ b/pkg/cmd/container/run_cgroup_windows.go
@@ -18,6 +18,7 @@ package container
 
 import (
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/container/run_freebsd.go
+++ b/pkg/cmd/container/run_freebsd.go
@@ -22,6 +22,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/container/run_gpus.go
+++ b/pkg/cmd/container/run_gpus.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/containerd/v2/contrib/nvidia"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 

--- a/pkg/cmd/container/run_linux.go
+++ b/pkg/cmd/container/run_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/bypass4netnsutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -41,6 +41,7 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"

--- a/pkg/cmd/container/run_restart.go
+++ b/pkg/cmd/container/run_restart.go
@@ -23,6 +23,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/restart"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 

--- a/pkg/cmd/container/run_security_linux.go
+++ b/pkg/cmd/container/run_security_linux.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cap"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/maputil"

--- a/pkg/cmd/container/run_ulimit.go
+++ b/pkg/cmd/container/run_ulimit.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 

--- a/pkg/cmd/container/run_windows.go
+++ b/pkg/cmd/container/run_windows.go
@@ -28,6 +28,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/container/start.go
+++ b/pkg/cmd/container/start.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/stats.go
+++ b/pkg/cmd/container/stats.go
@@ -32,6 +32,8 @@ import (
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerinspector"
@@ -42,7 +44,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/statsutil"
-	"github.com/containerd/typeurl/v2"
 )
 
 type stats struct {

--- a/pkg/cmd/container/stats_linux.go
+++ b/pkg/cmd/container/stats_linux.go
@@ -23,12 +23,14 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
-	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	"github.com/containerd/nerdctl/v2/pkg/statsutil"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
+	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/statsutil"
 )
 
 //nolint:nakedret

--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/top.go
+++ b/pkg/cmd/container/top.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )

--- a/pkg/cmd/container/top_windows.go
+++ b/pkg/cmd/container/top_windows.go
@@ -26,9 +26,10 @@ import (
 	"time"
 
 	"github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/options"
+	"github.com/docker/go-units"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/typeurl/v2"
-	"github.com/docker/go-units"
 )
 
 // containerTop was inspired from https://github.com/moby/moby/blob/master/daemon/top_windows.go

--- a/pkg/cmd/container/unpause.go
+++ b/pkg/cmd/container/unpause.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"

--- a/pkg/cmd/container/wait.go
+++ b/pkg/cmd/container/wait.go
@@ -23,6 +23,7 @@ import (
 	"io"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -35,17 +35,18 @@ import (
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/containerd/v2/core/images/converter/uncompress"
 	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/api/types"
-	"github.com/containerd/nerdctl/v2/pkg/clientutil"
-	converterutil "github.com/containerd/nerdctl/v2/pkg/imgutil/converter"
-	"github.com/containerd/nerdctl/v2/pkg/platformutil"
-	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	nydusconvert "github.com/containerd/nydus-snapshotter/pkg/converter"
 	"github.com/containerd/stargz-snapshotter/estargz"
 	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
 	estargzexternaltocconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz/externaltoc"
 	zstdchunkedconvert "github.com/containerd/stargz-snapshotter/nativeconverter/zstdchunked"
 	"github.com/containerd/stargz-snapshotter/recorder"
+
+	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/clientutil"
+	converterutil "github.com/containerd/nerdctl/v2/pkg/imgutil/converter"
+	"github.com/containerd/nerdctl/v2/pkg/platformutil"
+	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 
 func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRawRef string, options types.ImageConvertOptions) error {

--- a/pkg/cmd/image/crypt.go
+++ b/pkg/cmd/image/crypt.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images/converter"
 	"github.com/containerd/imgcrypt/images/encryption"
 	"github.com/containerd/imgcrypt/images/encryption/parsehelpers"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -23,16 +23,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/distribution/reference"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imageinspector"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	"github.com/distribution/reference"
 )
 
 func inspectIdentifier(ctx context.Context, client *containerd.Client, identifier string) ([]images.Image, string, string, error) {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -38,11 +38,12 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
-	"github.com/containerd/platforms"
 )
 
 // ListCommandHandler `List` and print images matching filters in `options`.

--- a/pkg/cmd/image/load.go
+++ b/pkg/cmd/image/load.go
@@ -27,10 +27,11 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/images/archive"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
-	"github.com/containerd/platforms"
 )
 
 type readCounter struct {

--- a/pkg/cmd/image/prune.go
+++ b/pkg/cmd/image/prune.go
@@ -25,9 +25,10 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
-	"github.com/containerd/platforms"
 )
 
 // Prune will remove all dangling images. If all is specified, will also remove all images not referenced by any container.

--- a/pkg/cmd/image/pull.go
+++ b/pkg/cmd/image/pull.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -38,6 +38,10 @@ import (
 	dockerconfig "github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/containerd/v2/pkg/reference"
 	"github.com/containerd/log"
+	"github.com/containerd/stargz-snapshotter/estargz"
+	"github.com/containerd/stargz-snapshotter/estargz/zstdchunked"
+	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
@@ -47,9 +51,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/signutil"
 	"github.com/containerd/nerdctl/v2/pkg/snapshotterutil"
-	"github.com/containerd/stargz-snapshotter/estargz"
-	"github.com/containerd/stargz-snapshotter/estargz/zstdchunked"
-	estargzconvert "github.com/containerd/stargz-snapshotter/nativeconverter/estargz"
 )
 
 // Push pushes an image specified by `rawRef`.

--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -25,10 +25,11 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
-	"github.com/containerd/platforms"
 )
 
 // Remove removes a list of `images`.

--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images/archive"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"

--- a/pkg/cmd/image/tag.go
+++ b/pkg/cmd/image/tag.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"

--- a/pkg/cmd/ipfs/registry_serve.go
+++ b/pkg/cmd/ipfs/registry_serve.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
 )

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"

--- a/pkg/cmd/namespace/create.go
+++ b/pkg/cmd/namespace/create.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/namespace/inspect.go
+++ b/pkg/cmd/namespace/inspect.go
@@ -21,6 +21,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"

--- a/pkg/cmd/namespace/remove.go
+++ b/pkg/cmd/namespace/remove.go
@@ -23,6 +23,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/namespace/update.go
+++ b/pkg/cmd/namespace/update.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/cmd/network/create.go
+++ b/pkg/cmd/network/create.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 )

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/netwalker"

--- a/pkg/cmd/network/prune.go
+++ b/pkg/cmd/network/prune.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/pkg/cmd/network/remove.go
+++ b/pkg/cmd/network/remove.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/netwalker"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"

--- a/pkg/cmd/system/events.go
+++ b/pkg/cmd/system/events.go
@@ -30,9 +30,10 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/log"
+	"github.com/containerd/typeurl/v2"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
-	"github.com/containerd/typeurl/v2"
 )
 
 // EventOut contains information about an event.

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/api/services/introspection/v1"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"

--- a/pkg/cmd/system/prune.go
+++ b/pkg/cmd/system/prune.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/builder"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"

--- a/pkg/cmd/volume/create.go
+++ b/pkg/cmd/volume/create.go
@@ -19,11 +19,12 @@ package volume
 import (
 	"fmt"
 
+	"github.com/docker/docker/pkg/stringid"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/docker/docker/pkg/stringid"
 )
 
 func Create(name string, options types.VolumeCreateOptions) (*native.Volume, error) {

--- a/pkg/cmd/volume/inspect.go
+++ b/pkg/cmd/volume/inspect.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 )

--- a/pkg/cmd/volume/list.go
+++ b/pkg/cmd/volume/list.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/containerd/v2/pkg/progress"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"

--- a/pkg/cmd/volume/prune.go
+++ b/pkg/cmd/volume/prune.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/cmd/volume/rm.go
+++ b/pkg/cmd/volume/rm.go
@@ -25,6 +25,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/composer/build.go
+++ b/pkg/composer/build.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 )
 

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -25,9 +25,11 @@ import (
 
 	composecli "github.com/compose-spec/compose-go/v2/cli"
 	compose "github.com/compose-spec/compose-go/v2/types"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )

--- a/pkg/composer/container.go
+++ b/pkg/composer/container.go
@@ -22,6 +22,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 

--- a/pkg/composer/copy.go
+++ b/pkg/composer/copy.go
@@ -22,10 +22,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker/pkg/system"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/docker/docker/pkg/system"
 )
 
 type CopyOptions struct {

--- a/pkg/composer/create.go
+++ b/pkg/composer/create.go
@@ -23,10 +23,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/compose-spec/compose-go/v2/types"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/compose-spec/compose-go/v2/types"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -26,6 +26,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/composer/logs.go
+++ b/pkg/composer/logs.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/pipetagger"
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/composer/orphans.go
+++ b/pkg/composer/orphans.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/composer/pause.go
+++ b/pkg/composer/pause.go
@@ -25,6 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/composer/pull.go
+++ b/pkg/composer/pull.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 )
 

--- a/pkg/composer/push.go
+++ b/pkg/composer/push.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 )
 

--- a/pkg/composer/restart.go
+++ b/pkg/composer/restart.go
@@ -22,8 +22,10 @@ import (
 	"sync"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 

--- a/pkg/composer/rm.go
+++ b/pkg/composer/rm.go
@@ -23,6 +23,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -22,11 +22,12 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/sync/errgroup"
-
 	"github.com/compose-spec/compose-go/v2/format"
 	"github.com/compose-spec/compose-go/v2/types"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 )

--- a/pkg/composer/serviceparser/build.go
+++ b/pkg/composer/serviceparser/build.go
@@ -23,12 +23,13 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	securejoin "github.com/cyphar/filepath-securejoin"
+
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 
-	securejoin "github.com/cyphar/filepath-securejoin"
+	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
 
 func parseBuildConfig(c *types.BuildConfig, project *types.Project, imageName string) (*Build, error) {

--- a/pkg/composer/serviceparser/build_test.go
+++ b/pkg/composer/serviceparser/build_test.go
@@ -19,8 +19,9 @@ package serviceparser
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func lastOf(ss []string) string {

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -29,9 +29,11 @@ import (
 	"time"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/containerd/containerd/v2/contrib/nvidia"
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
 

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 
 	"github.com/compose-spec/compose-go/v2/types"
+	"gotest.tools/v3/assert"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"gotest.tools/v3/assert"
 )
 
 func TestServicePortConfigToFlagP(t *testing.T) {

--- a/pkg/composer/stop.go
+++ b/pkg/composer/stop.go
@@ -23,6 +23,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -22,7 +22,9 @@ import (
 	"os"
 
 	"github.com/compose-spec/compose-go/v2/types"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )

--- a/pkg/composer/up_network.go
+++ b/pkg/composer/up_network.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/composer/up_volume.go
+++ b/pkg/composer/up_volume.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+
 	ncdefaults "github.com/containerd/nerdctl/v2/pkg/defaults"
 )
 

--- a/pkg/consoleutil/detach.go
+++ b/pkg/consoleutil/detach.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/containerd/log"
 	"github.com/moby/term"
+
+	"github.com/containerd/log"
 )
 
 const DefaultDetachKeys = "ctrl-p,ctrl-q"

--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -22,8 +22,9 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/typeurl/v2"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )
 
 func Inspect(ctx context.Context, container containerd.Container) (*native.Container, error) {

--- a/pkg/containerinspector/containerinspector_linux.go
+++ b/pkg/containerinspector/containerinspector_linux.go
@@ -22,9 +22,9 @@ import (
 	"net"
 	"strings"
 
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-
 	"github.com/containernetworking/plugins/pkg/ns"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )
 
 func InspectNetNS(ctx context.Context, pid int) (*native.NetNS, error) {

--- a/pkg/containerutil/config.go
+++ b/pkg/containerutil/config.go
@@ -28,6 +28,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"

--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -32,6 +32,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"

--- a/pkg/containerutil/container_network_manager_linux.go
+++ b/pkg/containerutil/container_network_manager_linux.go
@@ -25,6 +25,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil"

--- a/pkg/containerutil/container_network_manager_other.go
+++ b/pkg/containerutil/container_network_manager_other.go
@@ -25,6 +25,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"

--- a/pkg/containerutil/cp_linux.go
+++ b/pkg/containerutil/cp_linux.go
@@ -28,13 +28,15 @@ import (
 	"strconv"
 	"strings"
 
+	securejoin "github.com/cyphar/filepath-securejoin"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/tarutil"
-	securejoin "github.com/cyphar/filepath-securejoin"
 )
 
 // CopyFiles implements `nerdctl cp`.

--- a/pkg/defaults/cgroup_linux.go
+++ b/pkg/defaults/cgroup_linux.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/containerd/cgroups/v3"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containerd/containerd/v2/plugins"
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 

--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -24,9 +24,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/errdefs"
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 	types100 "github.com/containernetworking/cni/pkg/types/100"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 )
 
 const (

--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 )
 

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
 )
 

--- a/pkg/idutil/containerwalker/containerwalker.go
+++ b/pkg/idutil/containerwalker/containerwalker.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 

--- a/pkg/idutil/imagewalker/imagewalker.go
+++ b/pkg/idutil/imagewalker/imagewalker.go
@@ -26,6 +26,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
+
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 

--- a/pkg/imageinspector/imageinspector.go
+++ b/pkg/imageinspector/imageinspector.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )

--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -42,9 +42,10 @@ import (
 	"github.com/containerd/containerd/v2/pkg/rootfs"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	imgutil "github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/containerd/platforms"
 )
 
 type Changes struct {

--- a/pkg/imgutil/converter/zstd.go
+++ b/pkg/imgutil/converter/zstd.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images/converter/uncompress"
 	"github.com/containerd/containerd/v2/pkg/archive/compression"
 	"github.com/containerd/errdefs"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
+++ b/pkg/imgutil/dockerconfigresolver/dockerconfigresolver.go
@@ -23,14 +23,15 @@ import (
 	"fmt"
 	"os"
 
+	dockercliconfig "github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/credentials"
+	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
+
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	dockerconfig "github.com/containerd/containerd/v2/core/remotes/docker/config"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	dockercliconfig "github.com/docker/cli/cli/config"
-	"github.com/docker/cli/cli/config/credentials"
-	dockercliconfigtypes "github.com/docker/cli/cli/config/types"
 )
 
 var PushTracker = docker.NewInMemoryTracker()

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -23,11 +23,13 @@ import (
 	"strings"
 	"time"
 
+	distributionref "github.com/distribution/reference"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	distributionref "github.com/distribution/reference"
 )
 
 // Filter types supported to filter images.

--- a/pkg/imgutil/imgutil.go
+++ b/pkg/imgutil/imgutil.go
@@ -37,12 +37,13 @@ import (
 	"github.com/containerd/imgcrypt"
 	"github.com/containerd/imgcrypt/images/encryption"
 	"github.com/containerd/log"
+	"github.com/containerd/platforms"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
-	"github.com/containerd/platforms"
 )
 
 // EnsuredImage contains the image existed in containerd and its metadata.

--- a/pkg/imgutil/pull/pull.go
+++ b/pkg/imgutil/pull/pull.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/jobs"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 )

--- a/pkg/imgutil/push/push.go
+++ b/pkg/imgutil/push/push.go
@@ -34,8 +34,9 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes/docker"
 	"github.com/containerd/containerd/v2/pkg/progress"
 	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/imgutil/jobs"
 	"github.com/containerd/platforms"
+
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/jobs"
 )
 
 // Push pushes an image to a remote registry.

--- a/pkg/imgutil/snapshotter.go
+++ b/pkg/imgutil/snapshotter.go
@@ -23,10 +23,11 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
 	"github.com/containerd/log"
+	"github.com/containerd/stargz-snapshotter/fs/source"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
 	"github.com/containerd/nerdctl/v2/pkg/snapshotterutil"
-	"github.com/containerd/stargz-snapshotter/fs/source"
 )
 
 const (

--- a/pkg/imgutil/snapshotter_test.go
+++ b/pkg/imgutil/snapshotter_test.go
@@ -27,6 +27,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	ctdsnapshotters "github.com/containerd/containerd/v2/pkg/snapshotters"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/pull"
 )

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -26,10 +26,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/introspection"
 	ptypes "github.com/containerd/containerd/v2/pkg/protobuf/types"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"

--- a/pkg/infoutil/infoutil_linux.go
+++ b/pkg/infoutil/infoutil_linux.go
@@ -20,13 +20,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/docker/docker/pkg/meminfo"
+
 	"github.com/containerd/cgroups/v3"
+
 	"github.com/containerd/nerdctl/v2/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/sysinfo"
-	"github.com/docker/docker/pkg/meminfo"
 )
 
 const UnameO = "GNU/Linux"

--- a/pkg/infoutil/infoutil_test.go
+++ b/pkg/infoutil/infoutil_test.go
@@ -19,8 +19,9 @@ package infoutil
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 )
 
 func TestParseBuildctlVersion(t *testing.T) {

--- a/pkg/infoutil/infoutil_windows.go
+++ b/pkg/infoutil/infoutil_windows.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/sys/windows/registry"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/sysinfo"
 )

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -27,6 +27,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )
 

--- a/pkg/ipcutil/ipcutil.go
+++ b/pkg/ipcutil/ipcutil.go
@@ -32,6 +32,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )

--- a/pkg/ipfs/image.go
+++ b/pkg/ipfs/image.go
@@ -30,13 +30,14 @@ import (
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/containerd/stargz-snapshotter/ipfs"
+	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
-	"github.com/containerd/stargz-snapshotter/ipfs"
-	ipfsclient "github.com/containerd/stargz-snapshotter/ipfs/client"
 )
 
 const ipfsPathEnv = "IPFS_PATH"

--- a/pkg/logging/cri_logger.go
+++ b/pkg/logging/cri_logger.go
@@ -34,9 +34,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
 )
 
 // LogStreamType is the type of the stream in CRI container log.

--- a/pkg/logging/fluentd_logger.go
+++ b/pkg/logging/fluentd_logger.go
@@ -26,10 +26,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fluent/fluent-logger-golang/fluent"
+
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/fluent/fluent-logger-golang/fluent"
 )
 
 type FluentdLogger struct {

--- a/pkg/logging/journald_logger.go
+++ b/pkg/logging/journald_logger.go
@@ -28,12 +28,14 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
-	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/coreos/go-systemd/v22/journal"
 	"github.com/docker/cli/templates"
 	timetypes "github.com/docker/docker/api/types/time"
+
+	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
 var JournalDriverLogOpts = []string{

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -26,15 +26,17 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
-	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-	"github.com/containerd/nerdctl/v2/pkg/logging/jsonfile"
-	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
-	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/docker/go-units"
 	"github.com/fahedouch/go-logrotate"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/logging/jsonfile"
+	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
+	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
 var JSONDriverLogOpts = []string{

--- a/pkg/logging/jsonfile/jsonfile.go
+++ b/pkg/logging/jsonfile/jsonfile.go
@@ -26,8 +26,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/log"
 	timetypes "github.com/docker/docker/api/types/time"
+
+	"github.com/containerd/log"
 )
 
 // Entry is compatible with Docker "json-file" logs

--- a/pkg/logging/log_viewer.go
+++ b/pkg/logging/log_viewer.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels/k8slabels"
 )
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -29,11 +29,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
+	"github.com/muesli/cancelreader"
+
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
-	"github.com/fsnotify/fsnotify"
-	"github.com/muesli/cancelreader"
 )
 
 const (

--- a/pkg/logging/syslog_logger.go
+++ b/pkg/logging/syslog_logger.go
@@ -27,11 +27,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/containerd/log"
 	"github.com/docker/go-connections/tlsconfig"
 	syslog "github.com/yuchanns/srslog"
 
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
+	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/idgen"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/pkg/mountutil/mountutil_freebsd.go
+++ b/pkg/mountutil/mountutil_freebsd.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 )
 

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 )
 

--- a/pkg/mountutil/mountutil_linux_test.go
+++ b/pkg/mountutil/mountutil_linux_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/oci"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	mocks "github.com/containerd/nerdctl/v2/pkg/mountutil/mountutilmock"
 )

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 )
 

--- a/pkg/mountutil/mountutilmock/volumestore.mock.go
+++ b/pkg/mountutil/mountutilmock/volumestore.mock.go
@@ -19,8 +19,9 @@ package mountutilmock
 import (
 	"reflect"
 
-	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"go.uber.org/mock/gomock"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 )
 
 // MockVolumeStore is a mock of VolumeStore interface

--- a/pkg/mountutil/volumestore/volumestore.go
+++ b/pkg/mountutil/volumestore/volumestore.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/identifiers"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"

--- a/pkg/namestore/namestore.go
+++ b/pkg/namestore/namestore.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/v2/pkg/identifiers"
+
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 )
 

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -30,17 +30,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containernetworking/cni/libcni"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
 	subnetutil "github.com/containerd/nerdctl/v2/pkg/netutil/subnet"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
-	"github.com/containernetworking/cni/libcni"
 )
 
 type CNIEnv struct {

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -26,11 +26,11 @@ import (
 	"testing"
 	"text/template"
 
+	"gotest.tools/v3/assert"
+
 	ncdefaults "github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-
-	"gotest.tools/v3/assert"
 )
 
 const preExistingNetworkConfigTemplate = `

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -29,13 +29,15 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/vishvananda/netlink"
+
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/systemutil"
-	"github.com/go-viper/mapstructure/v2"
-	"github.com/vishvananda/netlink"
 )
 
 const (

--- a/pkg/nsutil/nsutil_test.go
+++ b/pkg/nsutil/nsutil_test.go
@@ -19,8 +19,9 @@ package nsutil_test
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/nsutil"
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/nsutil"
 )
 
 func TestValidateNamespaceName(t *testing.T) {

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -35,6 +35,7 @@ import (
 
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/bypass4netnsutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/ocihook/ocihook_linux.go
+++ b/pkg/ocihook/ocihook_linux.go
@@ -19,6 +19,7 @@ package ocihook
 import (
 	"github.com/containerd/containerd/v2/contrib/apparmor"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/apparmorutil"
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )

--- a/pkg/ocihook/rootless_linux.go
+++ b/pkg/ocihook/rootless_linux.go
@@ -19,9 +19,11 @@ package ocihook
 import (
 	"context"
 
-	gocni "github.com/containerd/go-cni"
-	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
+
+	gocni "github.com/containerd/go-cni"
+
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
 func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {

--- a/pkg/ocihook/rootless_other.go
+++ b/pkg/ocihook/rootless_other.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"fmt"
 
-	gocni "github.com/containerd/go-cni"
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
+
+	gocni "github.com/containerd/go-cni"
 )
 
 func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {

--- a/pkg/platformutil/platformutil.go
+++ b/pkg/platformutil/platformutil.go
@@ -21,8 +21,9 @@ import (
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/platforms"
+
+	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
 // NewMatchComparerFromOCISpecPlatformSlice returns MatchComparer.

--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -22,11 +22,13 @@ import (
 	"net"
 	"strings"
 
+	"github.com/docker/go-connections/nat"
+
 	gocni "github.com/containerd/go-cni"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
-	"github.com/docker/go-connections/nat"
 )
 
 // return respectively ip, hostPort, containerPort

--- a/pkg/portutil/portutil_test.go
+++ b/pkg/portutil/portutil_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	gocni "github.com/containerd/go-cni"
+
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )

--- a/pkg/rootlessutil/port_linux.go
+++ b/pkg/rootlessutil/port_linux.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"net"
 
-	"github.com/containerd/errdefs"
-	gocni "github.com/containerd/go-cni"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 	"github.com/rootless-containers/rootlesskit/v2/pkg/port"
+
+	"github.com/containerd/errdefs"
+	gocni "github.com/containerd/go-cni"
 )
 
 func NewRootlessCNIPortManager(client client.Client) (*RootlessCNIPortManager, error) {

--- a/pkg/signutil/cosignutil.go
+++ b/pkg/signutil/cosignutil.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 )
 

--- a/pkg/signutil/notationutil.go
+++ b/pkg/signutil/notationutil.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 )
 

--- a/pkg/signutil/signutil.go
+++ b/pkg/signutil/signutil.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 

--- a/pkg/statsutil/stats_linux.go
+++ b/pkg/statsutil/stats_linux.go
@@ -19,9 +19,10 @@ package statsutil
 import (
 	"time"
 
+	"github.com/vishvananda/netlink"
+
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	v2 "github.com/containerd/cgroups/v3/cgroup2/stats"
-	"github.com/vishvananda/netlink"
 )
 
 func SetCgroupStatsFields(previousStats *ContainerStats, data *v1.Metrics, links []netlink.Link) (StatsEntry, error) {

--- a/pkg/sysinfo/cgroup2_linux.go
+++ b/pkg/sysinfo/cgroup2_linux.go
@@ -29,10 +29,11 @@ import (
 	"path"
 	"strings"
 
+	"github.com/moby/sys/userns"
+
 	"github.com/containerd/cgroups/v3"
 	cgroupsV2 "github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/containerd/log"
-	"github.com/moby/sys/userns"
 )
 
 func newV2(options ...Opt) *SysInfo {

--- a/pkg/sysinfo/sysinfo_linux.go
+++ b/pkg/sysinfo/sysinfo_linux.go
@@ -31,11 +31,12 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/moby/sys/mountinfo"
+
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
 	"github.com/containerd/containerd/v2/pkg/seccomp"
 	"github.com/containerd/log"
-	"github.com/moby/sys/mountinfo"
 )
 
 var (

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -35,6 +35,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -36,6 +36,7 @@ import (
 	"gotest.tools/v3/icmd"
 
 	"github.com/containerd/containerd/v2/defaults"
+
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"


### PR DESCRIPTION
This here expands on re-ordering imports for increased code legibility and import assessment, and provides tooling to help developers, and enforce ordering on the CI.

Commit number 1 is just the actual reordering.

Commit number 2 has the tooling and documentation.

In a shell:
- `make lint-imports` will yell at you if ordering is not right
- `make lint-fix-imports` will fix the ordering for you

The current ordering will be:

```
import (
   "gopackages"
   "gopackages"

   "non_containerd_packages"
   "non_containerd_packages"

   "containerd_packages"
   "containerd_packages"

   "nerdctl_packages"
   "nerdctl_packages"
)
```

This order here is configurable, and if we would prefer another way to order imports, I believe we can just do that.

The tool being used is https://github.com/incu6us/goimports-reviser


cc @fahedouch thanks for pointing out ^
