### PR TITLE
Kube on the CI

### DIFF
--- a/.github/workflows/test-kube.yml
+++ b/.github/workflows/test-kube.yml
@@ -1,0 +1,27 @@
+# This pipeline purpose is solely meant to run a subset of our test suites against a kube cluster
+name: kube
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+env:
+  ROOTFUL: true
+
+jobs:
+  linux:
+    runs-on: "ubuntu-24.04"
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          fetch-depth: 1
+      - name: "Run Kube integration tests"
+        run: |
+          ./hack/build-integration-kube.sh
+          sudo ./_output/nerdctl exec nerdctl-test-control-plane bash -c -- 'export TMPDIR="$HOME"/tmp; mkdir -p "$TMPDIR"; cd /nerdctl-source; /usr/local/go/bin/go test ./cmd/nerdctl/ -test.only-kube'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,14 +284,14 @@ jobs:
           timeout_minutes: 30
           max_attempts: 2
           retry_on: error
-          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon
+          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.allow-kill-daemon
       - name: "Ensure that the IPv6 integration test suite is compatible with Docker"
         uses: nick-fields/retry@v3
         with:
           timeout_minutes: 30
           max_attempts: 2
           retry_on: error
-          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.kill-daemon -test.ipv6
+          command: go test -timeout 20m -v -exec sudo ./cmd/nerdctl/... -args -test.target=docker -test.allow-kill-daemon -test.only-ipv6
 
   test-integration-windows:
     runs-on: windows-2022

--- a/Dockerfile
+++ b/Dockerfile
@@ -319,7 +319,7 @@ RUN curl -o nydus-static.tgz -fsSL --proto '=https' --tlsv1.2 "https://github.co
   mv nydus-static/nydus-image nydus-static/nydusd nydus-static/nydusify /usr/bin/ && \
   rm nydus-static.tgz
 CMD ["gotestsum", "--format=testname", "--rerun-fails=2", "--packages=github.com/containerd/nerdctl/v2/cmd/nerdctl/...", \
-  "--", "-timeout=60m", "-args", "-test.kill-daemon"]
+  "--", "-timeout=60m", "-args", "-test.allow-kill-daemon"]
 
 FROM test-integration AS test-integration-rootless
 # Install SSH for creating systemd user session.
@@ -345,7 +345,7 @@ COPY ./Dockerfile.d/test-integration-rootless.sh /
 CMD ["/test-integration-rootless.sh", \
   "gotestsum", "--format=testname", "--rerun-fails=2", "--raw-command", \
   "--", "/usr/local/go/bin/go", "tool", "test2json", "-t", "-p", "github.com/containerd/nerdctl/v2/cmd/nerdctl",  \
-  "/usr/local/bin/nerdctl.test", "-test.v", "-test.timeout=60m", "-test.kill-daemon"]
+  "/usr/local/bin/nerdctl.test", "-test.v", "-test.timeout=60m", "-test.allow-kill-daemon"]
 
 # test for CONTAINERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=slirp4netns
 FROM test-integration-rootless AS test-integration-rootless-port-slirp4netns
@@ -354,6 +354,6 @@ RUN chown -R rootless:rootless /home/rootless/.config
 
 FROM test-integration AS test-integration-ipv6
 CMD ["gotestsum", "--format=testname", "--rerun-fails=2", "--packages=github.com/containerd/nerdctl/v2/cmd/nerdctl/...", \
-  "--", "-timeout=60m", "-args", "-test.kill-daemon", "-test.ipv6"]
+  "--", "-timeout=60m", "-args", "-test.allow-kill-daemon", "-test.only-ipv6"]
 
 FROM base AS demo

--- a/cmd/nerdctl/container_commit_linux_test.go
+++ b/cmd/nerdctl/container_commit_linux_test.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+)
+
+func TestKubeCommitPush(t *testing.T) {
+	t.Parallel()
+
+	base := testutil.NewBaseForKube(t)
+	tID := testutil.Identifier(t)
+
+	var containerID string
+
+	setup := func() {
+		testutil.KubectlHelper(base, "run", "--image", testutil.CommonImage, tID, "--", "sleep", "Inf").
+			AssertOK()
+
+		testutil.KubectlHelper(base, "wait", "pod", tID, "--for=condition=ready", "--timeout=1m").
+			AssertOK()
+
+		testutil.KubectlHelper(base, "exec", tID, "--", "mkdir", "-p", "/tmp/whatever").
+			AssertOK()
+
+		cmd := testutil.KubectlHelper(base, "get", "pods", tID, "-o", "jsonpath={ .status.containerStatuses[0].containerID }")
+		cmd.Run()
+		containerID = strings.TrimPrefix(cmd.Out(), "containerd://")
+	}
+
+	tearDown := func() {
+		testutil.KubectlHelper(base, "delete", "pod", tID).Run()
+	}
+
+	tearDown()
+	t.Cleanup(tearDown)
+	setup()
+
+	t.Run("test commit / push on Kube (https://github.com/containerd/nerdctl/issues/827)", func(t *testing.T) {
+		t.Log("This test is meant to verify that we can commit / push an image from a pod." +
+			"Currently, this is broken, hence the test assumes it will fail. Once the problem is fixed, we should just" +
+			"change the expectation to 'success'.")
+
+		base.Cmd("commit", containerID, "registry.example.com/my-app:v1").AssertOK()
+		base.Cmd("push", "registry.example.com/my-app:v1").Assert(icmd.Expected{
+			ExitCode: 1,
+			Err:      "failed to create a tmp single-platform image",
+		})
+	})
+}

--- a/cmd/nerdctl/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container_run_restart_linux_test.go
@@ -41,7 +41,7 @@ func TestRunRestart(t *testing.T) {
 	}
 	base := testutil.NewBase(t)
 	if !base.DaemonIsKillable {
-		t.Skip("daemon is not killable (hint: set \"-test.kill-daemon\")")
+		t.Skip("daemon is not killable (hint: set \"-test.allow-kill-daemon\")")
 	}
 	t.Log("NOTE: this test may take a while")
 

--- a/hack/build-integration-kube.sh
+++ b/hack/build-integration-kube.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# shellcheck disable=SC2034,SC2015
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]:-$PWD}")" 2>/dev/null 1>&2 && pwd)"
+readonly root
+# shellcheck source=/dev/null
+. "$root/scripts/lib.sh"
+
+GO_VERSION=1.22
+KIND_VERSION=v0.23.0
+
+[ "$(uname -m)" == "aarch64" ] && GOARCH=arm64 || GOARCH=amd64
+
+_rootful=
+
+configure::rootful(){
+  log::debug "Configuring rootful to: ${1:+true}"
+  _rootful="${1:+true}"
+}
+
+install::kind(){
+  local version="$1"
+  local temp
+  temp="$(fs::mktemp "install")"
+
+  http::get "$temp"/kind "https://kind.sigs.k8s.io/dl/$version/kind-linux-${GOARCH:-amd64}"
+  host::install "$temp"/kind
+}
+
+# shellcheck disable=SC2120
+install::kubectl(){
+  local version="${1:-}"
+  [ "$version" ] || version="$(http::get /dev/stdout https://dl.k8s.io/release/stable.txt)"
+  local temp
+  temp="$(fs::mktemp "install")"
+
+  http::get "$temp"/kubectl "https://storage.googleapis.com/kubernetes-release/release/$version/bin/linux/${GOARCH:-amd64}/kubectl"
+  host::install "$temp"/kubectl
+}
+
+exec::kind(){
+  local args=()
+  [ ! "$_rootful" ] || args=(sudo env PATH="$PATH" KIND_EXPERIMENTAL_PROVIDER="$KIND_EXPERIMENTAL_PROVIDER")
+  args+=(kind)
+
+  log::debug "${args[*]} $*"
+  "${args[@]}" "$@"
+}
+
+exec::nerdctl(){
+  local args=()
+  [ ! "$_rootful" ] || args=(sudo env PATH="$PATH")
+  args+=("$(pwd)"/_output/nerdctl)
+
+  log::debug "${args[*]} $*"
+  "${args[@]}" "$@"
+}
+
+# Install dependencies
+main(){
+  log::info "Configuring rootful"
+  configure::rootful "${ROOTFUL:-}"
+
+  log::info "Installing host dependencies if necessary"
+  host::require kind 2>/dev/null || install::kind "$KIND_VERSION"
+  host::require kubectl 2>/dev/null || install::kubectl
+
+  # Build nerdctl to use for kind
+  make binaries
+  PATH=$(pwd)/_output:"$PATH"
+  export PATH
+
+  # Hack to get go into kind control plane
+  exec::nerdctl rm -f go-kind 2>/dev/null || true
+  exec::nerdctl run -d --name go-kind golang:"$GO_VERSION" sleep Inf
+  exec::nerdctl cp go-kind:/usr/local/go /tmp/go
+
+  # Create fresh cluster
+  log::info "Creating new cluster"
+  export KIND_EXPERIMENTAL_PROVIDER=nerdctl
+  exec::kind delete cluster --name nerdctl-test 2>/dev/null || true
+  exec::kind create cluster --name nerdctl-test --config=./hack/kind.yaml
+}
+
+main "$@"

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -1,0 +1,12 @@
+# https://pkg.go.dev/sigs.k8s.io/kind/pkg/apis/config/v1alpha4#Cluster
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: _output/nerdctl
+        containerPath: /usr/local/bin/nerdctl
+      - hostPath: /tmp/go
+        containerPath: /usr/local/go
+      - hostPath: .
+        containerPath: /nerdctl-source

--- a/hack/scripts/lib.sh
+++ b/hack/scripts/lib.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# shellcheck disable=SC2034,SC2015
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+
+## This is a library of generic helpers that can be used across different projects
+
+# Simple logger
+readonly LOG_LEVEL_DEBUG=0
+readonly LOG_LEVEL_INFO=1
+readonly LOG_LEVEL_WARNING=2
+readonly LOG_LEVEL_ERROR=3
+
+readonly LOG_COLOR_BLACK=0
+readonly LOG_COLOR_RED=1
+readonly LOG_COLOR_GREEN=2
+readonly LOG_COLOR_YELLOW=3
+readonly LOG_COLOR_BLUE=4
+readonly LOG_COLOR_MAGENTA=5
+readonly LOG_COLOR_CYAN=6
+readonly LOG_COLOR_WHITE=7
+readonly LOG_COLOR_DEFAULT=9
+
+readonly LOG_STYLE_DEBUG=( setaf "$LOG_COLOR_WHITE" )
+readonly LOG_STYLE_INFO=( setaf "$LOG_COLOR_GREEN" )
+readonly LOG_STYLE_WARNING=( setaf "$LOG_COLOR_YELLOW" )
+readonly LOG_STYLE_ERROR=( setaf "$LOG_COLOR_RED" )
+
+_log::log(){
+  local level
+  local style
+  local numeric_level
+  local message="$2"
+
+  level="$(printf "%s" "$1" | tr '[:lower:]' '[:upper:]')"
+  numeric_level="$(printf "LOG_LEVEL_%s" "$level")"
+  style="LOG_STYLE_${level}[@]"
+
+  [ "${!numeric_level}" -ge "$LOG_LEVEL" ] || return 0
+
+  [ ! "$TERM" ] || [ ! -t 2 ] || >&2 tput "${!style}" 2>/dev/null || true
+  >&2 printf "[%s] %s: %s\n" "$(date 2>/dev/null || true)" "$(printf "%s" "$level" | tr '[:lower:]' '[:upper:]')" "$message"
+  [ ! "$TERM" ] || [ ! -t 2 ] || >&2 tput op 2>/dev/null || true
+}
+
+log::init(){
+  local _ll
+  # Default log to warning if unspecified
+  _ll="$(printf "LOG_LEVEL_%s" "${LOG_LEVEL:-warning}" | tr '[:lower:]' '[:upper:]')"
+  # Default to 3 (warning) if unrecognized
+  LOG_LEVEL="${!_ll:-3}"
+}
+
+log::debug(){
+  _log::log debug "$@"
+}
+
+log::info(){
+  _log::log info "$@"
+}
+
+log::warning(){
+  _log::log warning "$@"
+}
+
+log::error(){
+  _log::log error "$@"
+}
+
+# Helpers
+host::require(){
+  local binary="$1"
+
+  log::debug "Checking presence of $binary"
+  command -v "$binary" >/dev/null || {
+    log::error "You need $binary for this script to work, and it cannot be found in your path"
+    return 1
+  }
+}
+
+host::install(){
+  local binary
+
+  for binary in "$@"; do
+    log::debug "sudo install -D -m 755 $binary /usr/local/bin/$(basename "$binary")"
+    sudo install -D -m 755 "$binary" /usr/local/bin/"$(basename "$binary")"
+  done
+}
+
+fs::mktemp(){
+  local prefix="${1:-temporary}"
+
+  mktemp -dq "${TMPDIR:-/tmp}/$prefix.XXXXXX" 2>/dev/null || mktemp -dq || {
+    log::error "Failed to create temporary directory"
+    return 1
+  }
+}
+
+tar::expand(){
+  local dir="$1"
+  local arc="$2"
+
+  log::debug "tar -C $dir -xzf $arc"
+  tar -C "$dir" -xzf "$arc"
+}
+
+_http::get(){
+  local url="$1"
+  local output="$2"
+  local retry="$3"
+  local delay="$4"
+  local user="${5:-}"
+  local password="${6:-}"
+  shift
+  shift
+  shift
+  shift
+  shift
+  shift
+
+  local header
+  local command=(curl -fsSL --retry "$retry" --retry-delay "$delay" -o "$output")
+  # Add a basic auth user if necessary
+  [ "$user" == "" ] || command+=(--user "$user:$password")
+  # Force tls v1.2 and no redirect to http if url scheme is https
+  [ "${url:0:5}" != "https" ] || command+=(--proto '=https' --tlsv1.2)
+  # Stuff in any additional arguments as headers
+  for header in "$@"; do
+    command+=(-H "$header")
+  done
+  # Debug
+  log::debug "${command[*]} $url"
+  # Exec
+  "${command[@]}" "$url" || {
+    log::error "Failed to connect to $url with $retry retries every $delay seconds"
+    return 1
+  }
+}
+
+http::get(){
+  local output="$1"
+  local url="$2"
+  shift
+  shift
+
+  _http::get "$url" "$output" "2" "1" "" "" "$@"
+}
+
+http::healthcheck(){
+  local url="$1"
+  local retry="${2:-5}"
+  local delay="${3:-1}"
+  local user="${4:-}"
+  local password="${5:-}"
+  shift
+  shift
+  shift
+  shift
+  shift
+
+  _http::get "$url" /dev/null "$retry" "$delay" "$user" "$password" "$@"
+}
+
+http::checksum(){
+  local urls=("$@")
+  local url
+
+  local temp
+  temp="$(fs::mktemp "http-checksum")"
+
+  for url in "${urls[@]}"; do
+    http::get "$temp/${url##*/}" "$url"
+  done
+
+  cd "$temp"
+  shasum -a 256 ./*
+  cd - >/dev/null || true
+}
+
+# Github API helpers
+# Set GITHUB_TOKEN to use authenticated requests to workaround limitations
+
+github::settoken(){
+  local token="$1"
+  # If passed token is a github action pattern replace, and we are NOT on github, ignore it
+  # shellcheck disable=SC2016
+  [ "${token:0:3}" == '${{' ] || GITHUB_TOKEN="$token"
+}
+
+github::request(){
+  local endpoint="$1"
+  local args=(
+    "Accept: application/vnd.github+json"
+    "X-GitHub-Api-Version: 2022-11-28"
+  )
+
+  [ "${GITHUB_TOKEN:-}" == "" ] || args+=("Authorization: Bearer $GITHUB_TOKEN")
+
+  http::get /dev/stdout https://api.github.com/"$endpoint" "${args[@]}"
+}
+
+github::tags::latest(){
+  local repo="$1"
+  github::request "repos/$repo/tags" | jq -rc .[0].name
+}
+
+github::releases(){
+  local repo="$1"
+  github::request "repos/$repo/releases" |
+    jq -rc .[]
+}
+
+github::releases::latest(){
+  local repo="$1"
+  github::request "repos/$repo/releases/latest" | jq -rc .
+}
+
+log::init
+host::require jq
+host::require tar
+host::require curl
+host::require shasum


### PR DESCRIPTION
This is meant to bring in kube testing (fix #3282):
- using `kind` to spin-up `kube`
   - script usable locally or on the CI indifferently
   - most of it comes from what I committed recently to nydus
- mimic the ipv6 mechanism: `-test.kube` will run only "kube-compatible" tests - see testutils
- example / placeholder test inside container_commit_test, since this is where we will need the first one

Tagging @lingdie because of recent work on kube issues with #827 and #3268 and facing that question of how to test on kube in here.

@fahedouch @AkihiroSuda and other folks - thoughts/feeback?
