### PR TITLE
Ensure binfmt does install emulation for arm7 on the CI

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -32,7 +32,14 @@ jobs:
           sudo losetup -Dv
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: |
+          # `--install all` will only install emulation for architectures that cannot be natively executed
+          # Since some arm64 platforms do provide native fallback execution for 32 bits,
+          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
+          # To avoid that, we explicitly list the architectures we do want emulation for.
+          docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run unit tests"
         run: go test -v ./pkg/...
       - name: "Run integration tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,14 @@ jobs:
           sudo losetup -Dv
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: |
+          # `--install all` will only install emulation for architectures that cannot be natively executed
+          # Since some arm64 platforms do provide native fallback execution for 32 bits,
+          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
+          # To avoid that, we explicitly list the architectures we do want emulation for.
+          docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run integration tests"
         uses: nick-fields/retry@v3
         with:
@@ -128,7 +135,14 @@ jobs:
           sudo losetup -Dv
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: |
+          # `--install all` will only install emulation for architectures that cannot be natively executed
+          # Since some arm64 platforms do provide native fallback execution for 32 bits,
+          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
+          # To avoid that, we explicitly list the architectures we do want emulation for.
+          docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run integration tests"
         # The nested IPv6 network inside docker and qemu is complex and needs a bunch of sysctl config.
         # Therefore it's hard to debug why the IPv6 tests fail in such an isolation layer.
@@ -191,7 +205,14 @@ jobs:
         with:
           fetch-depth: 1
       - name: "Register QEMU (tonistiigi/binfmt)"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: |
+          # `--install all` will only install emulation for architectures that cannot be natively executed
+          # Since some arm64 platforms do provide native fallback execution for 32 bits,
+          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
+          # To avoid that, we explicitly list the architectures we do want emulation for.
+          docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
         run: docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
@@ -246,7 +267,14 @@ jobs:
           docker info
           docker version
       - name: "Register QEMU (tonistiigi/binfmt)"
-        run: docker run --privileged --rm tonistiigi/binfmt --install all
+        run: |
+          # `--install all` will only install emulation for architectures that cannot be natively executed
+          # Since some arm64 platforms do provide native fallback execution for 32 bits,
+          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
+          # To avoid that, we explicitly list the architectures we do want emulation for.
+          docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
+          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Prepare integration test environment"
         run: |
           sudo apt-get install -y expect


### PR DESCRIPTION
Tonis binfmt `--install all` does NOT install all - but only the stuff that it thinks should be installed.

On most arm64 rigs, it will NOT install emulation for armv7l. On an M1 though, it WILL.

This leads to inconsistent behaviors that break our tests: https://github.com/containerd/nerdctl/pull/3045#pullrequestreview-2220234696

Replacing `--install all` on the CI by explicitly installing the architectures we need.