### PR TITLE
Fix panic when stdout is not a tty

### DIFF
--- a/cmd/nerdctl/compose_exec.go
+++ b/cmd/nerdctl/compose_exec.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"errors"
+	"os"
 
+	"github.com/moby/term"
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -37,7 +39,8 @@ func newComposeExecCommand() *cobra.Command {
 	}
 	composeExecCommand.Flags().SetInterspersed(false)
 
-	composeExecCommand.Flags().BoolP("no-TTY", "T", false, "Disable pseudo-TTY allocation. By default nerdctl compose exec allocates a TTY.")
+	_, isTerminal := term.GetFdInfo(os.Stdout)
+	composeExecCommand.Flags().BoolP("no-TTY", "T", !isTerminal, "Disable pseudo-TTY allocation. By default nerdctl compose exec allocates a TTY.")
 	composeExecCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
 	composeExecCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
 	// env needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}

--- a/cmd/nerdctl/container_exec.go
+++ b/cmd/nerdctl/container_exec.go
@@ -18,7 +18,9 @@ package main
 
 import (
 	"errors"
+	"os"
 
+	"github.com/moby/term"
 	"github.com/spf13/cobra"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -81,6 +83,13 @@ func processExecCommandOptions(cmd *cobra.Command) (types.ContainerExecOptions, 
 	if flagT {
 		if flagD {
 			return types.ContainerExecOptions{}, errors.New("currently flag -t and -d cannot be specified together (FIXME)")
+		}
+	}
+
+	_, isTerminal := term.GetFdInfo(os.Stdin)
+	if !flagD {
+		if flagT && flagI && !isTerminal {
+			return types.ContainerExecOptions{}, errors.New("the input device is not a TTY")
 		}
 	}
 


### PR DESCRIPTION
Tentatively fix https://github.com/rootless-containers/usernetes/pull/327 - if that PR unblocks it, my job is done here :).

And some of #3297 is likely fixed as well.

Now, I am pretty sure there are other conditions where we still panic.
I would rather leave this to someone who is more knowledgeable on these areas though (including writing exhaustive tests).