### PR TITLE
Remove leading slash in Windows path

### DIFF
--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -459,30 +459,6 @@ COPY --from=builder /go/src/logger/logger /
 	assert.Check(t, strings.Contains(log, "bar"))
 }
 
-func TestRunWithTtyAndDetached(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("json-file log driver is not yet implemented on Windows")
-	}
-	base := testutil.NewBase(t)
-	imageName := testutil.CommonImage
-	withoutTtyContainerName := "without-terminal-" + testutil.Identifier(t)
-	withTtyContainerName := "with-terminal-" + testutil.Identifier(t)
-
-	// without -t, fail
-	base.Cmd("run", "-d", "--name", withoutTtyContainerName, imageName, "stty").AssertOK()
-	defer base.Cmd("container", "rm", "-f", withoutTtyContainerName).AssertOK()
-	base.Cmd("logs", withoutTtyContainerName).AssertCombinedOutContains("stty: standard input: Not a tty")
-	withoutTtyContainer := base.InspectContainer(withoutTtyContainerName)
-	assert.Equal(base.T, 1, withoutTtyContainer.State.ExitCode)
-
-	// with -t, success
-	base.Cmd("run", "-d", "-t", "--name", withTtyContainerName, imageName, "stty").AssertOK()
-	defer base.Cmd("container", "rm", "-f", withTtyContainerName).AssertOK()
-	base.Cmd("logs", withTtyContainerName).AssertCombinedOutContains("speed 38400 baud; line = 0;")
-	withTtyContainer := base.InspectContainer(withTtyContainerName)
-	assert.Equal(base.T, 0, withTtyContainer.State.ExitCode)
-}
-
 // history: There was a bug that the --add-host items disappear when the another container created.
 // This case ensures that it's doesn't happen.
 // (https://github.com/containerd/nerdctl/issues/2560)

--- a/cmd/nerdctl/container/container_run_windows_test.go
+++ b/cmd/nerdctl/container/container_run_windows_test.go
@@ -117,3 +117,18 @@ func TestRunProcessContainerWithDevice(t *testing.T) {
 		"cmd", "/S", "/C", "dir C:\\Windows\\System32\\HostDriverStore",
 	).AssertOutContains("FileRepository")
 }
+
+func TestRunWithTtyAndDetached(t *testing.T) {
+	base := testutil.NewBase(t)
+	imageName := testutil.CommonImage
+	withTtyContainerName := "with-terminal-" + testutil.Identifier(t)
+
+	// with -t, success, the container should run with tty support.
+	base.Cmd("run", "-d", "-t", "--name", withTtyContainerName, imageName, "cmd", "/c", "echo", "Hello, World with TTY!").AssertOK()
+	defer base.Cmd("container", "rm", "-f", withTtyContainerName).AssertOK()
+
+	// Check logs for successful command execution (with TTY specific behavior if any)
+	base.Cmd("logs", withTtyContainerName).AssertOutContains("Hello, World with TTY!")
+	withTtyContainer := base.InspectContainer(withTtyContainerName)
+	assert.Equal(base.T, 0, withTtyContainer.State.ExitCode)
+}

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -96,11 +96,15 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 		if len(args) != 2 {
 			return nil, errors.New("parse logging path error")
 		}
-		ioCreator = cio.TerminalBinaryIO(u.Path, map[string]string{
+		parsedPath := u.Path
+		// For Windows, remove the leading slash
+		if (runtime.GOOS == "windows") && (strings.HasPrefix(parsedPath, "/")) {
+			parsedPath = strings.TrimLeft(parsedPath, "/")
+		}
+		ioCreator = cio.TerminalBinaryIO(parsedPath, map[string]string{
 			args[0]: args[1],
 		})
 	} else if flagT && !flagD {
-
 		if con == nil {
 			return nil, errors.New("got nil con with flagT=true")
 		}


### PR DESCRIPTION
## PR Description

This PR resolves #2966

### Background

On Windows, the [LogURIGenerator()](https://github.com/containerd/containerd/blob/a406da962818ba9ca8f38b4ac5215753ceb1846c/pkg/cio/io.go#L295) function in [containerd/containerd](https://github.com/containerd/containerd) fails when it checks if the `logURI` path is absolute. This is due to the leading slash in the parsed logURI, which causes the check to fail and results in an error, ultimately leading to the command's failure.

The logURI parameter is a binary path formatted as a URI, for example:

```
"binary:///C:/Program Files/nerdctl.exe?_NERDCTL_INTERNAL_LOGGING=C%3A%5CProgramData%5Cnerdctl%5C052055e3"
```

When parsed with `url.Parse(logURI)`, the resulting `u.Path` is:

```
"/C:/Program Files/nerdctl.exe"
```

The leading slash is incorrect for Windows paths and causes issues when the path is later checked for being absolute.

### Solution
To resolve this issue, the leading slash must be removed from the `u.Path` before the absolute path check is performed. This ensures the path is correctly recognized as an absolute path on Windows systems.

### Additional tasks

Remove Windows check in [TestRunWithTtyAndDetached](https://github.com/containerd/nerdctl/blob/74f2755c0c3f965e97297b2dd53890724b17467e/cmd/nerdctl/container_run_test.go#L461-L464C3). 'json-file' logging for Windows implemented by PR #1468 .

https://github.com/containerd/nerdctl/blob/74f2755c0c3f965e97297b2dd53890724b17467e/cmd/nerdctl/container_run_test.go#L461-L464
