### PR TITLE
Fix canary test fail in windows by trim the `line` string

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - name: Set GO env
         run: |
+          # Enable extended globbing features to use advanced pattern matching
+          shopt -s extglob
+
           # Get latest containerd
           args=(curl --proto '=https' --tlsv1.2 -fsSL -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
           [ "${GITHUB_TOKEN:-}" == "" ] && {
@@ -59,7 +62,8 @@ jobs:
           # Get latest golang version and split it in components
           norm=()
           while read -r line; do
-            norm+=("$line")
+            line_trimmed="${line//+([[:space:]])/}"
+            norm+=("$line_trimmed")
           done < \
             <(sed -E 's/^go([0-9]+)[.]([0-9]+)([.]([0-9]+))?(([a-z]+)([0-9]+))?/\1.\2\n\4\n\6\n\7/i' \
               <(curl -fsSL "https://go.dev/dl/?mode=json&include=all" | jq -rc .[0].version) \


### PR DESCRIPTION
The test [canary](https://github.com/containerd/nerdctl/actions/workflows/test-canary.yml) test failed because there are `CR` characters in the var norm[3], like https://github.com/containerd/nerdctl/actions/runs/10391374345/job/28774125619#step:2:23 .

The PR is to fix it by trimming the string to remove the invisible characters.

