### PR TITLE
Include init NetworkSettings within inspect response

### DIFF
--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -186,7 +186,7 @@ type ContainerState struct {
 }
 
 type NetworkSettings struct {
-	Ports *nat.PortMap `json:",omitempty"`
+	Ports *nat.PortMap
 	DefaultNetworkSettings
 	Networks map[string]*NetworkEndpointSettings
 }
@@ -398,12 +398,15 @@ func statusFromNative(x containerd.Status, labels map[string]string) string {
 }
 
 func networkSettingsFromNative(n *native.NetNS, sp *specs.Spec) (*NetworkSettings, error) {
-	if n == nil {
-		return nil, nil
-	}
 	res := &NetworkSettings{
 		Networks: make(map[string]*NetworkEndpointSettings),
 	}
+	resPortMap := make(nat.PortMap)
+	res.Ports = &resPortMap
+	if n == nil {
+		return res, nil
+	}
+
 	var primary *NetworkEndpointSettings
 	for _, x := range n.Interfaces {
 		if x.Interface.Flags&net.FlagLoopback != 0 {
@@ -447,8 +450,11 @@ func networkSettingsFromNative(n *native.NetNS, sp *specs.Spec) (*NetworkSetting
 			if err != nil {
 				return nil, err
 			}
-			res.Ports = nports
+			for portLabel, portBindings := range *nports {
+				resPortMap[portLabel] = portBindings
+			}
 		}
+
 		if x.Index == n.PrimaryInterface {
 			primary = nes
 		}

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -17,11 +17,13 @@
 package dockercompat
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/docker/go-connections/nat"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"gotest.tools/v3/assert"
 
@@ -90,6 +92,10 @@ func TestContainerFromNative(t *testing.T) {
 						"nerdctl/hostname":  "host1",
 					},
 					Hostname: "host1",
+				},
+				NetworkSettings: &NetworkSettings{
+					Ports:    &nat.PortMap{},
+					Networks: map[string]*NetworkEndpointSettings{},
 				},
 			},
 		},
@@ -172,6 +178,10 @@ func TestContainerFromNative(t *testing.T) {
 					// ignore sysfs mountpoint
 				},
 				Config: &Config{},
+				NetworkSettings: &NetworkSettings{
+					Ports:    &nat.PortMap{},
+					Networks: map[string]*NetworkEndpointSettings{},
+				},
 			},
 		},
 		// ctr container, mount /mnt/foo:/mnt/foo:rw,rslave; internal sysfs mount; hostname
@@ -226,12 +236,128 @@ func TestContainerFromNative(t *testing.T) {
 				Config: &Config{
 					Hostname: "host1",
 				},
+				NetworkSettings: &NetworkSettings{
+					Ports:    &nat.PortMap{},
+					Networks: map[string]*NetworkEndpointSettings{},
+				},
 			},
 		},
 	}
 
 	for _, tc := range testcase {
-		d, _ := ContainerFromNative(tc.n)
-		assert.DeepEqual(t, d, tc.expected)
+		t.Run(tc.name, func(tt *testing.T) {
+			d, _ := ContainerFromNative(tc.n)
+			assert.DeepEqual(tt, d, tc.expected)
+		})
+	}
+}
+
+func TestNetworkSettingsFromNative(t *testing.T) {
+	tempStateDir, err := os.MkdirTemp(t.TempDir(), "rw")
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
+	defer os.RemoveAll(tempStateDir)
+
+	testcase := []struct {
+		name     string
+		n        *native.NetNS
+		s        *specs.Spec
+		expected *NetworkSettings
+	}{
+		// Given null native.NetNS, Return initialized NetworkSettings
+		//    UseCase: Inspect a Stopped Container
+		{
+			name: "Given Null NetNS, Return initialized NetworkSettings",
+			n:    nil,
+			s:    &specs.Spec{},
+			expected: &NetworkSettings{
+				Ports:    &nat.PortMap{},
+				Networks: map[string]*NetworkEndpointSettings{},
+			},
+		},
+		// Given native.NetNS with single Interface with Port Annotations, Return populated NetworkSettings
+		//   UseCase: Inspect a Running Container with published ports
+		{
+			name: "Given NetNS with single Interface with Port Annotation, Return populated NetworkSettings",
+			n: &native.NetNS{
+				Interfaces: []native.NetInterface{
+					{
+						Interface: net.Interface{
+							Index: 1,
+							MTU:   1500,
+							Name:  "eth0.100",
+							Flags: net.FlagUp,
+						},
+						HardwareAddr: "xx:xx:xx:xx:xx:xx",
+						Flags:        []string{},
+						Addrs:        []string{"10.0.4.30/24"},
+					},
+				},
+			},
+			s: &specs.Spec{
+				Annotations: map[string]string{
+					"nerdctl/ports": "[{\"HostPort\":8075,\"ContainerPort\":77,\"Protocol\":\"tcp\",\"HostIP\":\"127.0.0.1\"}]",
+				},
+			},
+			expected: &NetworkSettings{
+				Ports: &nat.PortMap{
+					nat.Port("77/tcp"): []nat.PortBinding{
+						{
+							HostIP:   "127.0.0.1",
+							HostPort: "8075",
+						},
+					},
+				},
+				Networks: map[string]*NetworkEndpointSettings{
+					"unknown-eth0.100": {
+						IPAddress:   "10.0.4.30",
+						IPPrefixLen: 24,
+						MacAddress:  "xx:xx:xx:xx:xx:xx",
+					},
+				},
+			},
+		},
+		// Given native.NetNS with single Interface without Port Annotations, Return valid NetworkSettings w/ empty Ports
+		//   UseCase: Inspect a Running Container without published ports
+		{
+			name: "Given NetNS with single Interface without Port Annotations, Return valid NetworkSettings w/ empty Ports",
+			n: &native.NetNS{
+				Interfaces: []native.NetInterface{
+					{
+						Interface: net.Interface{
+							Index: 1,
+							MTU:   1500,
+							Name:  "eth0.100",
+							Flags: net.FlagUp,
+						},
+						HardwareAddr: "xx:xx:xx:xx:xx:xx",
+						Flags:        []string{},
+						Addrs:        []string{"10.0.4.30/24"},
+					},
+				},
+			},
+			s: &specs.Spec{
+				Annotations: map[string]string{},
+			},
+			expected: &NetworkSettings{
+				Ports: &nat.PortMap{},
+				Networks: map[string]*NetworkEndpointSettings{
+					"unknown-eth0.100": {
+						IPAddress:   "10.0.4.30",
+						IPPrefixLen: 24,
+						MacAddress:  "xx:xx:xx:xx:xx:xx",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcase {
+		t.Run(tc.name, func(tt *testing.T) {
+			d, _ := networkSettingsFromNative(tc.n, tc.s)
+			assert.DeepEqual(tt, d, tc.expected)
+		})
 	}
 }


### PR DESCRIPTION
Related to [containerd#3310](https://github.com/containerd/nerdctl/issues/3310)

Replacing [Previous Pull Request 3311](https://github.com/containerd/nerdctl/pull/3311)

New behavior will always initialize a NetworkSettings entity for the inspect response, including Ports child member.

If inspecting a running container with published ports, then all information will be correctly returned.
If inspecting a running container without published ports, then NetworkSettings will include an initialized Ports member. If inspecting a stopped/exited container,
then an entirely initialized, "empty-value" NetworkSettings is returned.



### Background

Research related to Scenario 1:
According to [dockercompat line189](https://github.com/containerd/nerdctl/blob/74f2755c0c3f965e97297b2dd53890724b17467e/pkg/inspecttypes/dockercompat/dockercompat.go#L189) and the [logical evaluation of Port Annotations](https://github.com/containerd/nerdctl/blob/74f2755c0c3f965e97297b2dd53890724b17467e/pkg/inspecttypes/dockercompat/dockercompat.go#L440), the `Ports` are not assigned within the response when values are present within the Annotations.
Therefore, containers without published ports yield an `NetworkSettings` structure without a `Ports` key-value pair.

Research related to Scenario 2:
According to [dockercompat line401](https://github.com/containerd/nerdctl/blob/74f2755c0c3f965e97297b2dd53890724b17467e/pkg/inspecttypes/dockercompat/dockercompat.go#L401), the `native.NetNS` of a stopped/exited container is a null pointer, which would return `nil`.

### Solution

To resolve this issue, the `NetworkSettings` and `PortMap` are initialized at the beginning of the method to ensure that at least "Empty-value" structs are always included within the `inspect` response.
When "Port Annotations" are available, the new logic will add the key-value pairs into the initialized `PortMap` of the response.

Since `Ports` should not be omitted, this change also removes the `json:",omitempty"` decorator for the `NetworkSettings` struct.

### Additional Tasks

This bug is also present within `v1.7.6` and the change can be easily reconciled with the released version.

- [ ] **Please consider this PR for Back Porting into `Release/1.7` branch.**
