### PR TITLE
Add image prune --filter support

### DIFF
--- a/cmd/nerdctl/image_list_test.go
+++ b/cmd/nerdctl/image_list_test.go
@@ -79,6 +79,7 @@ func TestImages(t *testing.T) {
 
 func TestImagesFilter(t *testing.T) {
 	testutil.RequiresBuild(t)
+	testutil.RegisterBuildCacheCleanup(t)
 	t.Parallel()
 	base := testutil.NewBase(t)
 	tempName := testutil.Identifier(base.T)
@@ -121,6 +122,7 @@ LABEL version=0.1`, testutil.CommonImage)
 
 func TestImagesFilterDangling(t *testing.T) {
 	testutil.RequiresBuild(t)
+	testutil.RegisterBuildCacheCleanup(t)
 	base := testutil.NewBase(t)
 	base.Cmd("images", "prune", "--all").AssertOK()
 

--- a/cmd/nerdctl/image_prune.go
+++ b/cmd/nerdctl/image_prune.go
@@ -38,6 +38,7 @@ func newImagePruneCommand() *cobra.Command {
 	}
 
 	imagePruneCommand.Flags().BoolP("all", "a", false, "Remove all unused images, not just dangling ones")
+	imagePruneCommand.Flags().StringSlice("filter", []string{}, "Filter output based on conditions provided")
 	imagePruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
 	return imagePruneCommand
 }
@@ -52,6 +53,14 @@ func processImagePruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, erro
 		return types.ImagePruneOptions{}, err
 	}
 
+	var filters []string
+	if cmd.Flags().Changed("filter") {
+		filters, err = cmd.Flags().GetStringSlice("filter")
+		if err != nil {
+			return types.ImagePruneOptions{}, err
+		}
+	}
+
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return types.ImagePruneOptions{}, err
@@ -61,6 +70,7 @@ func processImagePruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, erro
 		Stdout:   cmd.OutOrStdout(),
 		GOptions: globalOptions,
 		All:      all,
+		Filters:  filters,
 		Force:    force,
 	}, err
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -746,7 +746,7 @@ Flags:
   - :nerd_face: `--format=wide`: Wide table
   - :nerd_face: `--format=json`: Alias of `--format='{{json .}}'`
 - :whale: `--digests`: Show digests (compatible with Docker, unlike ID)
-- :whale: `-f, --filter`: Filter the images. For now, only 'before=<image:tag>' and 'since=<image:tag>' is supported.
+- :whale: `-f, --filter`: Filter the images.
   - :whale: `--filter=before=<image:tag>`: Images created before given image (exclusive)
   - :whale: `--filter=since=<image:tag>`: Images created after given image (exclusive)
   - :whale: `--filter=label<key>=<value>`: Matches images based on the presence of a label alone or a label and a value

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -886,9 +886,10 @@ Usage: `nerdctl image prune [OPTIONS]`
 Flags:
 
 - :whale: `-a, --all`: Remove all unused images, not just dangling ones
+- :whale: `-f, --filter`: Filter the images.
+  - :whale: `--filter=until=<timestamp>`: Images created before given date formatted timestamps or Go duration strings. Currently does not support Unix timestamps.
+  - :whale: `--filter=label<key>=<value>`: Matches images based on the presence of a label alone or a label and a value
 - :whale: `-f, --force`: Do not prompt for confirmation
-
-Unimplemented `docker image prune` flags: `--filter`
 
 ### :nerd_face: nerdctl image convert
 

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -236,6 +236,8 @@ type ImagePruneOptions struct {
 	GOptions GlobalCommandOptions
 	// All Remove all unused images, not just dangling ones.
 	All bool
+	// Filters output based on conditions provided for the --filter argument
+	Filters []string
 	// Force will not prompt for confirmation.
 	Force bool
 }

--- a/pkg/cmd/image/prune.go
+++ b/pkg/cmd/image/prune.go
@@ -34,45 +34,43 @@ import (
 // Prune will remove all dangling images. If all is specified, will also remove all images not referenced by any container.
 func Prune(ctx context.Context, client *containerd.Client, options types.ImagePruneOptions) error {
 	var (
-		imageStore     = client.ImageService()
-		contentStore   = client.ContentStore()
-		containerStore = client.ContainerService()
+		imageStore   = client.ImageService()
+		contentStore = client.ContentStore()
 	)
 
-	imageList, err := imageStore.List(ctx)
+	var (
+		imagesToBeRemoved []images.Image
+		err               error
+	)
+
+	filters := []imgutil.Filter{}
+	if len(options.Filters) > 0 {
+		parsedFilters, err := imgutil.ParseFilters(options.Filters)
+		if err != nil {
+			return err
+		}
+		if len(parsedFilters.Labels) > 0 {
+			filters = append(filters, imgutil.FilterByLabel(ctx, client, parsedFilters.Labels))
+		}
+		if len(parsedFilters.Until) > 0 {
+			filters = append(filters, imgutil.FilterUntil(parsedFilters.Until))
+		}
+	}
+
+	if options.All {
+		// Remove all unused images; not just dangling ones
+		imagesToBeRemoved, err = imgutil.GetUnusedImages(ctx, client, filters...)
+	} else {
+		// Remove dangling images only
+		imagesToBeRemoved, err = imgutil.GetDanglingImages(ctx, client, filters...)
+	}
 	if err != nil {
 		return err
 	}
 
-	var filteredImages []images.Image
-
-	if options.All {
-		containerList, err := containerStore.List(ctx)
-		if err != nil {
-			return err
-		}
-		usedImages := make(map[string]struct{})
-		for _, container := range containerList {
-			usedImages[container.Image] = struct{}{}
-		}
-
-		for _, image := range imageList {
-			if _, ok := usedImages[image.Name]; ok {
-				continue
-			}
-
-			filteredImages = append(filteredImages, image)
-		}
-	} else {
-		filteredImages, err = imgutil.FilterDanglingImages()(imageList)
-		if err != nil {
-			return err
-		}
-	}
-
 	delOpts := []images.DeleteOpt{images.SynchronousDelete()}
 	removedImages := make(map[string][]digest.Digest)
-	for _, image := range filteredImages {
+	for _, image := range imagesToBeRemoved {
 		digests, err := image.RootFS(ctx, contentStore, platforms.DefaultStrict())
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("failed to enumerate rootfs")

--- a/pkg/cmd/image/prune.go
+++ b/pkg/cmd/image/prune.go
@@ -64,7 +64,10 @@ func Prune(ctx context.Context, client *containerd.Client, options types.ImagePr
 			filteredImages = append(filteredImages, image)
 		}
 	} else {
-		filteredImages = imgutil.FilterDangling(imageList, true)
+		filteredImages, err = imgutil.FilterDanglingImages()(imageList)
+		if err != nil {
+			return err
+		}
 	}
 
 	delOpts := []images.DeleteOpt{images.SynchronousDelete()}

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -27,13 +27,12 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 
 // Filter types supported to filter images.
-var (
+const (
 	FilterBeforeType    = "before"
 	FilterSinceType     = "since"
 	FilterLabelType     = "label"
@@ -49,6 +48,8 @@ type Filters struct {
 	Reference []string
 	Dangling  *bool
 }
+
+type Filter func([]images.Image) ([]images.Image, error)
 
 // ParseFilters parse filter strings.
 func ParseFilters(filters []string) (*Filters, error) {
@@ -105,103 +106,161 @@ func ParseFilters(filters []string) (*Filters, error) {
 	return f, nil
 }
 
-// FilterImages returns images in `labelImages` that are created
-// before MAX(beforeImages.CreatedAt) and after MIN(sinceImages.CreatedAt).
-func FilterImages(labelImages []images.Image, beforeImages []images.Image, sinceImages []images.Image) []images.Image {
-	var filteredImages []images.Image
-	maxTime := time.Now()
-	minTime := time.Date(1970, time.Month(1), 1, 0, 0, 0, 0, time.UTC)
-	if len(beforeImages) > 0 {
-		maxTime = beforeImages[0].CreatedAt
-		for _, value := range beforeImages {
-			if value.CreatedAt.After(maxTime) {
-				maxTime = value.CreatedAt
-			}
+// ApplyFilters applies each filter function in the order provided
+// and returns the resulting filtered image list.
+func ApplyFilters(imageList []images.Image, filters ...Filter) ([]images.Image, error) {
+	var err error
+	for _, filter := range filters {
+		imageList, err = filter(imageList)
+		if err != nil {
+			return []images.Image{}, err
 		}
 	}
-	if len(sinceImages) > 0 {
-		minTime = sinceImages[0].CreatedAt
-		for _, value := range sinceImages {
-			if value.CreatedAt.Before(minTime) {
-				minTime = value.CreatedAt
-			}
-		}
-	}
-	for _, image := range labelImages {
-		if image.CreatedAt.After(minTime) && image.CreatedAt.Before(maxTime) {
-			filteredImages = append(filteredImages, image)
-		}
-	}
-	return filteredImages
+	return imageList, nil
 }
 
-// FilterByReference filters images using references given in `filters`.
-func FilterByReference(imageList []images.Image, filters []string) ([]images.Image, error) {
-	var filteredImageList []images.Image
-	log.L.Debug(filters)
-	for _, image := range imageList {
-		log.L.Debug(image.Name)
-		var matches int
-		for _, f := range filters {
-			var ref distributionref.Reference
-			var err error
-			ref, err = distributionref.ParseAnyReference(image.Name)
-			if err != nil {
-				return nil, fmt.Errorf("unable to parse image name: %s while filtering by reference because of %s", image.Name, err.Error())
-			}
+// FilterByCreatedAt filters an image list to images created before MAX(before.<Image>.CreatedAt)
+// and after MIN(since.<Image>.CreatedAt).
+func FilterByCreatedAt(ctx context.Context, client *containerd.Client, before []string, since []string) Filter {
+	return func(imageList []images.Image) ([]images.Image, error) {
+		var (
+			minTime = time.Date(1970, time.Month(1), 1, 0, 0, 0, 0, time.UTC)
+			maxTime = time.Now()
+		)
 
-			familiarMatch, err := distributionref.FamiliarMatch(f, ref)
+		imageStore := client.ImageService()
+		if len(before) > 0 {
+			beforeImages, err := imageStore.List(ctx, before...)
 			if err != nil {
-				return nil, err
+				return []images.Image{}, err
 			}
-			regexpMatch, err := regexp.MatchString(f, image.Name)
-			if err != nil {
-				return nil, err
-			}
-			if familiarMatch || regexpMatch {
-				matches++
-			}
-		}
-		if matches == len(filters) {
-			filteredImageList = append(filteredImageList, image)
-		}
-	}
-	return filteredImageList, nil
-}
-
-// FilterDangling filters dangling images (or keeps if `dangling` == false).
-func FilterDangling(imageList []images.Image, dangling bool) []images.Image {
-	var filtered []images.Image
-	for _, image := range imageList {
-		_, tag := ParseRepoTag(image.Name)
-
-		if dangling && tag == "" {
-			filtered = append(filtered, image)
-		}
-		if !dangling && tag != "" {
-			filtered = append(filtered, image)
-		}
-	}
-	return filtered
-}
-
-// FilterByLabel filters images based on labels given in `filters`.
-func FilterByLabel(ctx context.Context, client *containerd.Client, imageList []images.Image, filters map[string]string) ([]images.Image, error) {
-	for lk, lv := range filters {
-		var imageLabels []images.Image
-		for _, img := range imageList {
-			ci := containerd.NewImage(client, img)
-			cfg, _, err := ReadImageConfig(ctx, ci)
-			if err != nil {
-				return nil, err
-			}
-			if val, ok := cfg.Config.Labels[lk]; ok {
-				if val == lv || lv == "" {
-					imageLabels = append(imageLabels, img)
+			maxTime = beforeImages[0].CreatedAt
+			for _, image := range beforeImages {
+				if image.CreatedAt.After(maxTime) {
+					maxTime = image.CreatedAt
 				}
 			}
 		}
-		imageList = imageLabels
+
+		if len(since) > 0 {
+			sinceImages, err := imageStore.List(ctx, since...)
+			if err != nil {
+				return []images.Image{}, err
+			}
+			minTime = sinceImages[0].CreatedAt
+			for _, image := range sinceImages {
+				if image.CreatedAt.Before(minTime) {
+					minTime = image.CreatedAt
+				}
+			}
+		}
+
+		return filter(imageList, func(i images.Image) (bool, error) {
+			return imageCreatedBetween(i, minTime, maxTime), nil
+		})
 	}
-	return imageList, nil
+}
+
+// FilterByLabel filters an image list based on labels applied to the image's config specification for the platform.
+// Any matching label will include the image in the list.
+func FilterByLabel(ctx context.Context, client *containerd.Client, labels map[string]string) Filter {
+	return func(imageList []images.Image) ([]images.Image, error) {
+		return filter(imageList, func(i images.Image) (bool, error) {
+			clientImage := containerd.NewImage(client, i)
+			imageCfg, _, err := ReadImageConfig(ctx, clientImage)
+			if err != nil {
+				return false, err
+			}
+			return matchesAllLabels(imageCfg.Config.Labels, labels), nil
+		})
+	}
+}
+
+// FilterByReference filters an image list based on <image:tag>
+// matching the provided reference patterns
+func FilterByReference(referencePatterns []string) Filter {
+	return func(imageList []images.Image) ([]images.Image, error) {
+		return filter(imageList, func(i images.Image) (bool, error) {
+			return matchesReferences(i, referencePatterns)
+		})
+	}
+}
+
+// FilterDanglingImages filters an image list for dangling (untagged) images.
+func FilterDanglingImages() Filter {
+	return func(imageList []images.Image) ([]images.Image, error) {
+		return filter(imageList, func(i images.Image) (bool, error) {
+			return isDangling(i), nil
+		})
+	}
+}
+
+// FilterTaggedImages filters an image list for tagged images.
+func FilterTaggedImages() Filter {
+	return func(imageList []images.Image) ([]images.Image, error) {
+		return filter(imageList, func(i images.Image) (bool, error) {
+			return !isDangling(i), nil
+		})
+	}
+}
+
+func filter[T any](items []T, f func(item T) (bool, error)) ([]T, error) {
+	filteredItems := make([]T, 0, len(items))
+	for _, item := range items {
+		ok, err := f(item)
+		if err != nil {
+			return []T{}, err
+		} else if ok {
+			filteredItems = append(filteredItems, item)
+		}
+	}
+	return filteredItems, nil
+}
+
+func imageCreatedBetween(image images.Image, min time.Time, max time.Time) bool {
+	return image.CreatedAt.After(min) && image.CreatedAt.Before(max)
+}
+
+func matchesAllLabels(imageCfgLabels map[string]string, filterLabels map[string]string) bool {
+	var matches int
+	for lk, lv := range filterLabels {
+		if val, ok := imageCfgLabels[lk]; ok {
+			if val == lv || lv == "" {
+				matches++
+			}
+		}
+	}
+	return matches == len(filterLabels)
+}
+
+func matchesReferences(image images.Image, referencePatterns []string) (bool, error) {
+	var matches int
+
+	reference, err := distributionref.ParseAnyReference(image.Name)
+	if err != nil {
+		return false, err
+	}
+
+	for _, pattern := range referencePatterns {
+		familiarMatch, err := distributionref.FamiliarMatch(pattern, reference)
+		if err != nil {
+			return false, err
+		}
+
+		regexpMatch, err := regexp.MatchString(pattern, image.Name)
+		if err != nil {
+			return false, err
+		}
+
+		if familiarMatch || regexpMatch {
+			matches++
+		}
+	}
+
+	return matches == len(referencePatterns), nil
+}
+
+func isDangling(image images.Image) bool {
+	_, tag := ParseRepoTag(image.Name)
+	return tag == ""
 }

--- a/pkg/imgutil/filtering_test.go
+++ b/pkg/imgutil/filtering_test.go
@@ -1,0 +1,382 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package imgutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"gotest.tools/v3/assert"
+)
+
+func TestApplyFilters(t *testing.T) {
+	tests := []struct {
+		name           string
+		images         []images.Image
+		filters        []Filter
+		expectedImages []images.Image
+		expectedErr    error
+	}{
+		{
+			name:   "EmptyList",
+			images: []images.Image{},
+			filters: []Filter{
+				FilterDanglingImages(),
+			},
+			expectedImages: []images.Image{},
+		},
+		{
+			name: "ApplyNoFilters",
+			images: []images.Image{
+				{
+					Name: "<none>",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+			},
+			filters: []Filter{},
+			expectedImages: []images.Image{
+				{
+					Name: "<none>",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+			},
+		},
+		{
+			name: "ApplySingleFilter",
+			images: []images.Image{
+				{
+					Name: "<none>",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+			},
+			filters: []Filter{
+				FilterDanglingImages(),
+			},
+			expectedImages: []images.Image{
+				{
+					Name: "<none>",
+				},
+			},
+		},
+		{
+			name: "ApplyMultipleFilters",
+			images: []images.Image{
+				{
+					Name: "<none>",
+				},
+				{
+					Name: "alpine:3.19",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name: "public.ecr.aws/docker/library/hello-world:latest",
+				},
+			},
+			filters: []Filter{
+				FilterTaggedImages(),
+				FilterByReference([]string{"hello-world"}),
+			},
+			expectedImages: []images.Image{
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name: "public.ecr.aws/docker/library/hello-world:latest",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualImages, err := ApplyFilters(test.images, test.filters...)
+			if test.expectedErr == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorIs(t, err, test.expectedErr)
+			}
+			assert.Equal(t, len(actualImages), len(test.expectedImages))
+			assert.DeepEqual(t, actualImages, test.expectedImages)
+		})
+	}
+}
+
+func TestFilterByReference(t *testing.T) {
+	tests := []struct {
+		name              string
+		referencePatterns []string
+		images            []images.Image
+		expectedImages    []images.Image
+		expectedErr       error
+	}{
+		{
+			name:           "EmptyList",
+			images:         []images.Image{},
+			expectedImages: []images.Image{},
+		},
+		{
+			name: "MatchByReference",
+			images: []images.Image{
+				{
+					Name: "foo:latest",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name: "public.ecr.aws/docker/library/hello-world:latest",
+				},
+			},
+			referencePatterns: []string{"hello-world"},
+			expectedImages: []images.Image{
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name: "public.ecr.aws/docker/library/hello-world:latest",
+				},
+			},
+		},
+		{
+			name: "NoMatchExists",
+			images: []images.Image{
+				{
+					Name: "foo:latest",
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name: "public.ecr.aws/docker/library/hello-world:latest",
+				},
+			},
+			referencePatterns: []string{"foobar"},
+			expectedImages:    []images.Image{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualImages, err := FilterByReference(test.referencePatterns)(test.images)
+			if test.expectedErr == nil {
+				assert.NilError(t, err)
+			} else {
+				assert.ErrorIs(t, err, test.expectedErr)
+			}
+			assert.Equal(t, len(actualImages), len(test.expectedImages))
+			assert.DeepEqual(t, actualImages, test.expectedImages)
+		})
+	}
+}
+
+func TestFilterDanglingImages(t *testing.T) {
+	tests := []struct {
+		name           string
+		dangling       bool
+		images         []images.Image
+		expectedImages []images.Image
+	}{
+		{
+			name:           "EmptyList",
+			dangling:       true,
+			images:         []images.Image{},
+			expectedImages: []images.Image{},
+		},
+		{
+			name:     "IsDangling",
+			dangling: true,
+			images: []images.Image{
+				{
+					Name:   "",
+					Labels: map[string]string{"ref": "dangling1"},
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name:   "<none>",
+					Labels: map[string]string{"ref": "dangling2"},
+				},
+			},
+			expectedImages: []images.Image{
+				{
+					Name:   "",
+					Labels: map[string]string{"ref": "dangling1"},
+				},
+				{
+					Name:   "<none>",
+					Labels: map[string]string{"ref": "dangling2"},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualImages, err := FilterDanglingImages()(test.images)
+			assert.NilError(t, err)
+			assert.Equal(t, len(actualImages), len(test.expectedImages))
+			assert.DeepEqual(t, actualImages, test.expectedImages)
+		})
+	}
+}
+
+func TestFilterTaggedImages(t *testing.T) {
+	tests := []struct {
+		name           string
+		dangling       bool
+		images         []images.Image
+		expectedImages []images.Image
+	}{
+		{
+			name:           "EmptyList",
+			dangling:       true,
+			images:         []images.Image{},
+			expectedImages: []images.Image{},
+		},
+		{
+			name:     "IsTagged",
+			dangling: true,
+			images: []images.Image{
+				{
+					Name:   "",
+					Labels: map[string]string{"ref": "dangling1"},
+				},
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+				{
+					Name:   "<none>",
+					Labels: map[string]string{"ref": "dangling2"},
+				},
+			},
+			expectedImages: []images.Image{
+				{
+					Name: "docker.io/library/hello-world:latest",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualImages, err := FilterTaggedImages()(test.images)
+			assert.NilError(t, err)
+			assert.Equal(t, len(actualImages), len(test.expectedImages))
+			assert.DeepEqual(t, actualImages, test.expectedImages)
+		})
+	}
+}
+
+func TestImageCreatedBetween(t *testing.T) {
+	tests := []struct {
+		name         string
+		image        images.Image
+		lhs          time.Time
+		rhs          time.Time
+		fallsBetween bool
+	}{
+		{
+			name: "BetweenImage",
+			image: images.Image{
+				CreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			lhs:          time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			rhs:          time.Now(),
+			fallsBetween: true,
+		},
+		{
+			name: "ExclusiveLeft",
+			image: images.Image{
+				CreatedAt: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			lhs:          time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			rhs:          time.Now(),
+			fallsBetween: false,
+		},
+		{
+			name: "ExclusiveRight",
+			image: images.Image{
+				CreatedAt: time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+			lhs:          time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+			rhs:          time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC),
+			fallsBetween: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, imageCreatedBetween(test.image, test.lhs, test.rhs), test.fallsBetween)
+		})
+	}
+}
+
+func TestMatchesAnyLabel(t *testing.T) {
+	tests := []struct {
+		name          string
+		imageLabels   map[string]string
+		labelsToMatch map[string]string
+		matches       bool
+	}{
+		{
+			name:          "ImageHasNoLabels",
+			imageLabels:   map[string]string{},
+			labelsToMatch: map[string]string{"foo": "bar"},
+			matches:       false,
+		},
+		{
+			name:          "SingleMatchingLabel",
+			imageLabels:   map[string]string{"org": "com.containerd.nerdctl"},
+			labelsToMatch: map[string]string{"org": "com.containerd.nerdctl"},
+			matches:       true,
+		},
+		{
+			name:          "KeyOnlyMatchingLabel",
+			imageLabels:   map[string]string{"org": "com.containerd.nerdctl"},
+			labelsToMatch: map[string]string{"org": ""},
+			matches:       true,
+		},
+		{
+			name:          "KeyValueDoesNotMatch",
+			imageLabels:   map[string]string{"org": "com.containerd.nerdctl"},
+			labelsToMatch: map[string]string{"org": "com.containerd.containerd"},
+			matches:       false,
+		},
+		{
+			name:          "AllMatchingLabel",
+			imageLabels:   map[string]string{"org": "com.containerd.nerdctl", "foo": "bar"},
+			labelsToMatch: map[string]string{"org": "com.containerd.containerd", "foo": "bar"},
+			matches:       false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, matchesAllLabels(test.imageLabels, test.labelsToMatch), test.matches)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This change adds nerdctl image prune `--filter` support including:

- `image prune --filter label=<key>=<value>`
- `image prune --filter until=<timestamp>`

### Testing

- Added unit tests for `pkg/imgutil` code
- Added integration tests for `cmd/nerdctl/image_prune` code
  - `TestImagePruneFilterUntil` does not currently work on Docker. Docker image's created timestamp is aligning with the timestamp of the base image. Docker supports the `until` filter; just didn't have any ideas for deterministically testing both behaviors.

### References

- https://docs.docker.com/reference/cli/docker/image/prune/#filter