### PR TITLE
Rewrite cp

### DIFF
--- a/cmd/nerdctl/container/container_cp_acid_linux_test.go
+++ b/cmd/nerdctl/container/container_cp_acid_linux_test.go
@@ -1,0 +1,181 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/icmd"
+
+	"github.com/containerd/nerdctl/v2/pkg/containerutil"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+)
+
+// This is a separate set of tests for cp specifically meant to test corner or extreme cases that do not fit in the normal testing rig
+// because of their complexity
+
+func TestCopyAcid(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Travelling along volumes w/o read-only", func(t *testing.T) {
+		t.Parallel()
+		testID := testutil.Identifier(t)
+		tempDir := t.TempDir()
+		base := testutil.NewBase(t)
+		base.Dir = tempDir
+
+		sourceFile := filepath.Join(tempDir, "hostfile")
+		sourceFileContent := []byte(testID)
+
+		roContainer := testID + "-ro"
+		rwContainer := testID + "-rw"
+
+		setup := func() {
+			base.Cmd("volume", "create", testID+"-1-ro").AssertOK()
+			base.Cmd("volume", "create", testID+"-2-rw").AssertOK()
+			base.Cmd("volume", "create", testID+"-3-rw").AssertOK()
+			base.Cmd("run", "-d", "-w", containerCwd, "--name", roContainer, "--read-only",
+				"-v", fmt.Sprintf("%s:%s:ro", testID+"-1-ro", "/vol1/dir1/ro"),
+				"-v", fmt.Sprintf("%s:%s", testID+"-2-rw", "/vol2/dir2/rw"),
+				testutil.CommonImage, "sleep", "Inf",
+			).AssertOK()
+			base.Cmd("run", "-d", "-w", containerCwd, "--name", rwContainer,
+				"-v", fmt.Sprintf("%s:%s:ro", testID+"-1-ro", "/vol1/dir1/ro"),
+				"-v", fmt.Sprintf("%s:%s", testID+"-3-rw", "/vol3/dir3/rw"),
+				testutil.CommonImage, "sleep", "Inf",
+			).AssertOK()
+
+			base.Cmd("exec", rwContainer, "sh", "-euxc", "cd /vol3/dir3/rw; ln -s ../../../ relativelinktoroot").AssertOK()
+			base.Cmd("exec", rwContainer, "sh", "-euxc", "cd /vol3/dir3/rw; ln -s / absolutelinktoroot").AssertOK()
+			base.Cmd("exec", roContainer, "sh", "-euxc", "cd /vol2/dir2/rw; ln -s ../../../ relativelinktoroot").AssertOK()
+			base.Cmd("exec", roContainer, "sh", "-euxc", "cd /vol2/dir2/rw; ln -s / absolutelinktoroot").AssertOK()
+			// Create file on the host
+			err := os.WriteFile(sourceFile, sourceFileContent, filePerm)
+			assert.NilError(t, err)
+		}
+
+		tearDown := func() {
+			base.Cmd("rm", "-f", roContainer).Run()
+			base.Cmd("rm", "-f", rwContainer).Run()
+			base.Cmd("volume", "rm", testID+"-1-ro").Run()
+			base.Cmd("volume", "rm", testID+"-2-rw").Run()
+			base.Cmd("volume", "rm", testID+"-3-rw").Run()
+		}
+
+		t.Cleanup(tearDown)
+		tearDown()
+
+		setup()
+
+		expectedErr := containerutil.ErrTargetIsReadOnly.Error()
+		if testutil.GetTarget() == testutil.Docker {
+			expectedErr = ""
+		}
+
+		t.Run("Cannot copy into a read-only root", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, roContainer+":/").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Cannot copy into a read-only mount, in a rw container", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, rwContainer+":/vol1/dir1/ro").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Can copy into a read-write mount in a read-only container", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, roContainer+":/vol2/dir2/rw").Assert(icmd.Expected{
+				ExitCode: 0,
+			})
+		})
+
+		t.Run("Traverse read-only locations to a read-write location", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, roContainer+":/vol1/dir1/ro/../../../vol2/dir2/rw").Assert(icmd.Expected{
+				ExitCode: 0,
+			})
+		})
+
+		t.Run("Follow an absolute symlink inside a read-write mount to a read-only root", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, roContainer+":/vol2/dir2/rw/absolutelinktoroot").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Follow am absolute symlink inside a read-write mount to a read-only mount", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, rwContainer+":/vol3/dir3/rw/absolutelinktoroot/vol1/dir1/ro").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Follow a relative symlink inside a read-write location to a read-only root", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, roContainer+":/vol2/dir2/rw/relativelinktoroot").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Follow a relative symlink inside a read-write location to a read-only mount", func(t *testing.T) {
+			t.Parallel()
+
+			base.Cmd("cp", sourceFile, rwContainer+":/vol3/dir3/rw/relativelinktoroot/vol1/dir1/ro").Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+		t.Run("Cannot copy into a HOST read-only location", func(t *testing.T) {
+			t.Parallel()
+
+			// Root will just ignore the 000 permission on the host directory.
+			if !rootlessutil.IsRootless() {
+				t.Skip("This test does not work rootful")
+			}
+
+			err := os.MkdirAll(filepath.Join(tempDir, "rotest"), 0o000)
+			assert.NilError(t, err)
+			base.Cmd("cp", roContainer+":/etc/issue", filepath.Join(tempDir, "rotest")).Assert(icmd.Expected{
+				ExitCode: 1,
+				Err:      expectedErr,
+			})
+		})
+
+	})
+}

--- a/cmd/nerdctl/container/container_cp_linux.go
+++ b/cmd/nerdctl/container/container_cp_linux.go
@@ -115,16 +115,16 @@ func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptio
 	}
 
 	container2host := srcSpec.Container != nil
-	var container string
+	var containerReq string
 	if container2host {
-		container = *srcSpec.Container
+		containerReq = *srcSpec.Container
 	} else {
-		container = *destSpec.Container
+		containerReq = *destSpec.Container
 	}
 	return types.ContainerCpOptions{
 		GOptions:       globalOptions,
 		Container2Host: container2host,
-		ContainerReq:   container,
+		ContainerReq:   containerReq,
 		DestPath:       destSpec.Path,
 		SrcPath:        srcSpec.Path,
 		FollowSymLink:  flagL,

--- a/pkg/cmd/container/cp_linux.go
+++ b/pkg/cmd/container/cp_linux.go
@@ -39,17 +39,22 @@ func Cp(ctx context.Context, client *containerd.Client, options types.ContainerC
 				ctx,
 				client,
 				found.Container,
-				options.Container2Host,
-				options.DestPath,
-				options.SrcPath,
-				options.GOptions.Snapshotter,
-				options.FollowSymLink)
+				options)
 		},
 	}
 	count, err := walker.Walk(ctx, options.ContainerReq)
 
-	if count < 1 {
-		err = fmt.Errorf("could not find container: %s, with error: %w", options.ContainerReq, err)
+	if count == -1 {
+		if err == nil {
+			panic("nil error and count == -1 from ContainerWalker.Walk should never happen")
+		}
+		err = fmt.Errorf("unable to copy: %w", err)
+	} else if count == 0 {
+		if err != nil {
+			err = fmt.Errorf("unable to retrieve containers with error: %w", err)
+		} else {
+			err = fmt.Errorf("no container found for: %s", options.ContainerReq)
+		}
 	}
 
 	return err

--- a/pkg/containerutil/cp_resolve_linux.go
+++ b/pkg/containerutil/cp_resolve_linux.go
@@ -1,0 +1,444 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package containerutil
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"syscall"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/containerd/containerd/v2/pkg/oci"
+)
+
+// volumeNameLen returns length of the leading volume name on Windows.
+// It returns 0 elsewhere.
+// FIXME: whenever we will want to port cp to windows, we will need the windows implementation of volumeNameLen
+func volumeNameLen(_ string) int {
+	return 0
+}
+
+var (
+	errDoesNotExist           = errors.New("resource does not exist")                                            // when a path parent dir does not exist
+	errIsNotADir              = errors.New("is not a dir")                                                       // when a path is a file, ending with path separator
+	errCannotResolvePathNoCwd = errors.New("unable to resolve path against undefined current working directory") // relative host path, no cwd
+)
+
+// pathSpecifier represents a path to be used by cp
+// besides exposing relevant properties (endsWithSeparator, etc), it also provides a fully resolved *host* path to
+// access the resource
+type pathSpecifier struct {
+	originalPath         string
+	endsWithSeparator    bool
+	endsWithSeparatorDot bool
+	exists               bool
+	isADir               bool
+	readOnly             bool
+	resolvedPath         string
+}
+
+// getPathSpecFromHost builds a pathSpecifier from a host location
+// errors with errDoesNotExist, errIsNotADir, "EvalSymlinks: too many links", or other hard filesystem errors from lstat/stat
+func getPathSpecFromHost(originalPath string) (*pathSpecifier, error) {
+	pathSpec := &pathSpecifier{
+		originalPath:         originalPath,
+		endsWithSeparator:    strings.HasSuffix(originalPath, string(os.PathSeparator)),
+		endsWithSeparatorDot: filepath.Base(originalPath) == ".",
+	}
+
+	path := originalPath
+
+	// Path may still be relative at this point. If it is, figure out getwd.
+	if !filepath.IsAbs(path) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, errors.Join(errCannotResolvePathNoCwd, err)
+		}
+		path = cwd + string(os.PathSeparator) + path
+	}
+
+	// Try to fully resolve the path
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, syscall.ENOTDIR) {
+			return nil, errors.Join(errIsNotADir, err)
+		}
+
+		// Other errors:
+		// - "EvalSymlinks: too many links"
+		// - any other error coming from lstat
+		return nil, err
+	}
+
+	pathSpec.exists = err == nil
+
+	// Ensure the parent exists if the path itself does not
+	if !pathSpec.exists {
+		// Try the parent - obtain it by removing any trailing / or /., then the base
+		cleaned := strings.TrimRight(strings.TrimSuffix(path, string(os.PathSeparator)+"."), string(os.PathSeparator))
+		for len(cleaned) < len(path) {
+			path = cleaned
+			cleaned = strings.TrimRight(strings.TrimSuffix(path, string(os.PathSeparator)+"."), string(os.PathSeparator))
+		}
+
+		base := filepath.Base(path)
+		path = strings.TrimSuffix(path, string(os.PathSeparator)+base)
+
+		// Resolve it
+		resolvedPath, err = filepath.EvalSymlinks(path)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, errors.Join(errDoesNotExist, err)
+			} else if errors.Is(err, syscall.ENOTDIR) {
+				return nil, errors.Join(errIsNotADir, err)
+			}
+
+			return nil, err
+		}
+
+		resolvedPath = filepath.Join(resolvedPath, base)
+	} else {
+		// If it exists, we can check if it is a dir
+		var st os.FileInfo
+		st, err = os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		pathSpec.isADir = st.IsDir()
+	}
+
+	pathSpec.resolvedPath = resolvedPath
+
+	return pathSpec, nil
+}
+
+// getPathSpecFromHost builds a pathSpecifier from a container location
+func getPathSpecFromContainer(originalPath string, conSpec *oci.Spec, containerHostRoot string) (*pathSpecifier, error) {
+	pathSpec := &pathSpecifier{
+		originalPath:         originalPath,
+		endsWithSeparator:    strings.HasSuffix(originalPath, string(os.PathSeparator)),
+		endsWithSeparatorDot: filepath.Base(originalPath) == ".",
+	}
+
+	path := originalPath
+
+	// Path may still be relative at this point. If it is, join it to the root
+	// NOTE: this is specifically called out in the docker reference. Paths in the container are assumed
+	// relative to the root, and not to the current (container) working directory.
+	// Though this seems like a questionable decision, it is set.
+	if !filepath.IsAbs(path) {
+		path = string(os.PathSeparator) + path
+	}
+
+	// Now, fully resolve the path - resolving all symlinks and cleaning-up the end result, following across mounts
+	pathResolver := newResolver(conSpec, containerHostRoot)
+	resolvedContainerPath, err := pathResolver.resolvePath(path)
+
+	// Errors we get from that are from Lstat or Readlink
+	// Either the object does not exist, or we have a dangling symlink, or otherwise hosed filesystem entries
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, syscall.ENOTDIR) {
+			return nil, errors.Join(errIsNotADir, err)
+		}
+
+		// errors.New("EvalSymlinks: too many links")
+		// other errors would come from lstat
+		return nil, err
+	}
+
+	pathSpec.exists = err == nil
+
+	// If the resource does not exist
+	if !pathSpec.exists {
+		// Try the parent
+		cleaned := strings.TrimRight(strings.TrimSuffix(path, string(os.PathSeparator)+"."), string(os.PathSeparator))
+		for len(cleaned) < len(path) {
+			path = cleaned
+			cleaned = strings.TrimRight(strings.TrimSuffix(path, string(os.PathSeparator)+"."), string(os.PathSeparator))
+		}
+
+		base := filepath.Base(path)
+		path = strings.TrimSuffix(path, string(os.PathSeparator)+base)
+
+		resolvedContainerPath, err = pathResolver.resolvePath(path)
+
+		// Error? That is the end
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil, errors.Join(errDoesNotExist, err)
+			} else if errors.Is(err, syscall.ENOTDIR) {
+				return nil, errors.Join(errIsNotADir, err)
+			}
+
+			return nil, err
+		}
+
+		resolvedContainerPath = filepath.Join(resolvedContainerPath, base)
+	}
+
+	// Now, finally get the location of the fully resolved containerPath (in the root? in a volume?)
+	containerMount, relativePath := pathResolver.getMount(resolvedContainerPath)
+	pathSpec.resolvedPath = filepath.Join(containerMount.hostPath, relativePath)
+	// If the endpoint is readonly, flag it as such
+	if containerMount.readonly {
+		pathSpec.readOnly = true
+	}
+
+	// If it exists, we can check if it is a dir
+	if pathSpec.exists {
+		var st os.FileInfo
+		st, err = os.Stat(pathSpec.resolvedPath)
+		if err != nil {
+			return nil, err
+		}
+
+		pathSpec.isADir = st.IsDir()
+	}
+
+	return pathSpec, nil
+}
+
+// resolver provides methods to fully resolve any given container given path to a host location
+// accounting for rootfs and mounts location
+type resolver struct {
+	root     *specs.Root
+	mounts   []specs.Mount
+	hostRoot string
+}
+
+// locator represents a container mount
+type locator struct {
+	containerPath string
+	hostPath      string
+	readonly      bool
+}
+
+func isParent(child []string, candidate []string) (bool, []string) {
+	if len(child) < len(candidate) {
+		return false, child
+	}
+	return slices.Equal(child[0:len(candidate)], candidate), child[len(candidate):]
+}
+
+// newResolver returns a resolver struct
+func newResolver(conSpec *oci.Spec, hostRoot string) *resolver {
+	return &resolver{
+		root:     conSpec.Root,
+		mounts:   conSpec.Mounts,
+		hostRoot: hostRoot,
+	}
+}
+
+// pathOnHost will return the *host* location of a container path, accounting for volumes.
+// The provided path must be fully resolved, as returned by `resolvePath`.
+func (res *resolver) pathOnHost(path string) string {
+	hostRoot := res.hostRoot
+	path = filepath.Clean(path)
+	itemized := strings.Split(path, string(os.PathSeparator))
+
+	containerRoot := "/"
+	sub := itemized
+
+	for _, mnt := range res.mounts {
+		if candidateIsParent, subPath := isParent(itemized, strings.Split(mnt.Destination, string(os.PathSeparator))); candidateIsParent {
+			if len(mnt.Destination) > len(containerRoot) {
+				containerRoot = mnt.Destination
+				hostRoot = mnt.Source
+				sub = subPath
+			}
+		}
+	}
+
+	return filepath.Join(append([]string{hostRoot}, sub...)...)
+}
+
+// getMount returns the mount locator for a given fully-resolved path, along with the corresponding subpath of the path
+// relative to the locator
+func (res *resolver) getMount(path string) (*locator, string) {
+	itemized := strings.Split(path, string(os.PathSeparator))
+
+	loc := &locator{
+		containerPath: "/",
+		hostPath:      res.hostRoot,
+		readonly:      res.root.Readonly,
+	}
+
+	sub := itemized
+
+	for _, mnt := range res.mounts {
+		if candidateIsParent, subPath := isParent(itemized, strings.Split(mnt.Destination, string(os.PathSeparator))); candidateIsParent {
+			if len(mnt.Destination) > len(loc.containerPath) {
+				loc.readonly = false
+				for _, option := range mnt.Options {
+					if option == "ro" {
+						loc.readonly = true
+					}
+				}
+				loc.containerPath = mnt.Destination
+				loc.hostPath = mnt.Source
+				sub = subPath
+			}
+		}
+	}
+
+	return loc, filepath.Join(sub...)
+}
+
+// resolvePath is adapted from https://cs.opensource.google/go/go/+/go1.23.0:src/path/filepath/path.go;l=147
+// The (only) changes are on Lstat and ReadLink, which are fed the actual host path, that is computed by `res.pathOnHost`
+func (res *resolver) resolvePath(path string) (string, error) {
+	volLen := volumeNameLen(path)
+	pathSeparator := string(os.PathSeparator)
+
+	if volLen < len(path) && os.IsPathSeparator(path[volLen]) {
+		volLen++
+	}
+	vol := path[:volLen]
+	dest := vol
+	linksWalked := 0
+	//nolint:ineffassign
+	for start, end := volLen, volLen; start < len(path); start = end {
+		for start < len(path) && os.IsPathSeparator(path[start]) {
+			start++
+		}
+		end = start
+		for end < len(path) && !os.IsPathSeparator(path[end]) {
+			end++
+		}
+
+		// On Windows, "." can be a symlink.
+		// We look it up, and use the value if it is absolute.
+		// If not, we just return ".".
+		//nolint:staticcheck
+		isWindowsDot := runtime.GOOS == "windows" && path[volumeNameLen(path):] == "."
+
+		// The next path component is in path[start:end].
+		if end == start {
+			// No more path components.
+			break
+		} else if path[start:end] == "." && !isWindowsDot {
+			// Ignore path component ".".
+			continue
+		} else if path[start:end] == ".." {
+			// Back up to previous component if possible.
+			// Note that volLen includes any leading slash.
+
+			// Set r to the index of the last slash in dest,
+			// after the volume.
+			var r int
+			for r = len(dest) - 1; r >= volLen; r-- {
+				if os.IsPathSeparator(dest[r]) {
+					break
+				}
+			}
+			if r < volLen || dest[r+1:] == ".." {
+				// Either path has no slashes
+				// (it's empty or just "C:")
+				// or it ends in a ".." we had to keep.
+				// Either way, keep this "..".
+				if len(dest) > volLen {
+					dest += pathSeparator
+				}
+				dest += ".."
+			} else {
+				// Discard everything since the last slash.
+				dest = dest[:r]
+			}
+			continue
+		}
+
+		// Ordinary path component. Add it to result.
+
+		if len(dest) > volumeNameLen(dest) && !os.IsPathSeparator(dest[len(dest)-1]) {
+			dest += pathSeparator
+		}
+
+		dest += path[start:end]
+
+		// Resolve symlink.
+		hostPath := res.pathOnHost(dest)
+		fi, err := os.Lstat(hostPath)
+		if err != nil {
+			return "", err
+		}
+
+		if fi.Mode()&fs.ModeSymlink == 0 {
+			if !fi.Mode().IsDir() && end < len(path) {
+				return "", syscall.ENOTDIR
+			}
+			continue
+		}
+
+		// Found symlink.
+		linksWalked++
+		if linksWalked > 255 {
+			return "", errors.New("EvalSymlinks: too many links")
+		}
+
+		link, err := os.Readlink(hostPath)
+		if err != nil {
+			return "", err
+		}
+
+		if isWindowsDot && !filepath.IsAbs(link) {
+			// On Windows, if "." is a relative symlink,
+			// just return ".".
+			break
+		}
+
+		path = link + path[end:]
+
+		v := volumeNameLen(link)
+		if v > 0 {
+			// Symlink to drive name is an absolute path.
+			if v < len(link) && os.IsPathSeparator(link[v]) {
+				v++
+			}
+			vol = link[:v]
+			dest = vol
+			end = len(vol)
+		} else if len(link) > 0 && os.IsPathSeparator(link[0]) {
+			// Symlink to absolute path.
+			dest = link[:1]
+			end = 1
+			vol = link[:1]
+			volLen = 1
+		} else {
+			// Symlink to relative path; replace last
+			// path component in dest.
+			var r int
+			for r = len(dest) - 1; r >= volLen; r-- {
+				if os.IsPathSeparator(dest[r]) {
+					break
+				}
+			}
+			if r < volLen {
+				dest = vol
+			} else {
+				dest = dest[:r]
+			}
+			end = 0
+		}
+	}
+	return filepath.Clean(dest), nil
+}


### PR DESCRIPTION
The motivation for this is to address all issues (and variants not listed as individual tickets) in:
- fix #3315
- fix #3313 
- (hopefully) fix #1257
- fix #3197

The fundamental problem with our current implementation of cp is that the logic to figure out if a destination is read-only is incomplete.
One of the key reason for it is that we do not follow symlinks, or relative paths, inside a container destination. For example, if we are copying to a path located into a readonly volume, we stop there, while the path may very well resolve to a completely different volume (or the rootfs).
Furthermore, there are other logic issues involving readonly rootfs, leading to situations where we DO copy while we should not, and conversely, where we do NOT copy while we should.

There is a also a fair amount of duplication, and finally, test isolation was problematic.

For this PR, the highlights are, for the testing part:
- tests rewritten from scratch to cleanly separate test cases and test rig (should make adding more tests cases easier)
- expanded test-suite to add more cases
- better isolation
- beside the "regular" expanded tests, added a "TestAcidCopy" test meant to reproduce corner/complicated cases and other "special" conditions that do not fit in the normal test rig

For the code part:
- provide a mechanism to fully resolve a *container* path while on the host when all we have is the mounted root snapshot
- provide a range of more expressive and informative errors for the user to diagnose issues
- should address all link resolution, relative paths and read-only concerns

Also note this is superseding #3275

I appreciate this is a somewhat sizable PR (although a very large part of it (about 1500 lines) are just for tests).

If there is a different (simpler) approach to this problem - that would pass the test-suite - I am happy to re-evaluate of course.