### PR TITLE
fix: filter container state without option "-a"

### DIFF
--- a/cmd/nerdctl/container_list.go
+++ b/cmd/nerdctl/container_list.go
@@ -53,7 +53,7 @@ func newPsCommand() *cobra.Command {
 	psCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "table", "wide"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	psCommand.Flags().StringSliceP("filter", "f", nil, "Filter matches containers based on given conditions")
+	psCommand.Flags().StringSliceP("filter", "f", nil, "Filter matches containers based on given conditions. When specifying the condition 'status', it filters all containers")
 	return psCommand
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -460,7 +460,7 @@ Flags:
   - :nerd_face: `--format=json`: Alias of `--format='{{json .}}'`
 - :whale: `-n, --last`: Show n last created containers (includes all states)
 - :whale: `-l, --latest`: Show the latest created container (includes all states)
-- :whale: `-f, --filter`: Filter containers based on given conditions
+- :whale: `-f, --filter`: Filter containers based on given conditions. When specifying the condition 'status', it filters all containers
   - :whale: `--filter id=<value>`: Container's ID. Both full ID and
     truncated ID are supported
   - :whale: `--filter name=<value>`: Container's name
@@ -470,7 +470,7 @@ Flags:
     `--all`
   - :whale: `--filter status=<value>`: One of `created, running, paused,
     stopped, exited, pausing, unknown`. Note that `restarting, removing, dead` are
-    not supported and will be ignored
+    not supported and will be ignored. When specifying this condition, it filters all containers.
   - :whale: `--filter before/since=<ID/name>`: Filter containers created before
     or after a given ID or name
   - :whale: `--filter volume=<value>`: Filter by a given mounted volume or bind

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -77,9 +77,10 @@ func filterContainers(ctx context.Context, client *containerd.Client, filters []
 		}
 	}
 
-	if all {
+	if all || filterCtx.all {
 		return containers, nil
 	}
+
 	var upContainers []containerd.Container
 	for _, c := range containers {
 		cStatus := formatter.ContainerStatus(ctx, c)

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -48,6 +48,8 @@ type containerFilterContext struct {
 	labelFilterFuncs   []func(map[string]string) bool
 	volumeFilterFuncs  []func([]*containerutil.ContainerVolume) bool
 	networkFilterFuncs []func([]string) bool
+
+	all bool
 }
 
 func (cl *containerFilterContext) MatchesFilters(ctx context.Context) []containerd.Container {
@@ -264,6 +266,7 @@ func (cl *containerFilterContext) matchesStatusFilter(status containerd.Status) 
 	if len(cl.statusFilterFuncs) == 0 {
 		return true
 	}
+	cl.all = true
 	for _, statusFilterFunc := range cl.statusFilterFuncs {
 		if !statusFilterFunc(status.Status) {
 			continue


### PR DESCRIPTION
`docker ps -f status=exited` will filter and output exited containers.