### PR TITLE
Add builder OCI layout build context

### DIFF
--- a/cmd/nerdctl/builder_build_linux_test.go
+++ b/cmd/nerdctl/builder_build_linux_test.go
@@ -1,0 +1,84 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+)
+
+func TestBuildContextWithOCILayout(t *testing.T) {
+	testutil.RequiresBuild(t)
+	testutil.RegisterBuildCacheCleanup(t)
+
+	var dockerBuilderArgs []string
+	if testutil.IsDocker() {
+		// Default docker driver does not support OCI exporter.
+		// Reference: https://docs.docker.com/build/exporters/oci-docker/
+		builderName := testutil.SetupDockerContainerBuilder(t)
+		dockerBuilderArgs = []string{"buildx", "--builder", builderName}
+	}
+
+	base := testutil.NewBase(t)
+	imageName := testutil.Identifier(t)
+	ociLayout := "parent"
+	parentImageName := fmt.Sprintf("%s-%s", imageName, ociLayout)
+
+	teardown := func() {
+		base.Cmd("rmi", parentImageName, imageName).Run()
+	}
+	t.Cleanup(teardown)
+	teardown()
+
+	dockerfile := fmt.Sprintf(`FROM %s
+LABEL layer=oci-layout-parent
+CMD ["echo", "test-nerdctl-build-context-oci-layout-parent"]`, testutil.CommonImage)
+	buildCtx := createBuildContext(t, dockerfile)
+
+	tarPath := fmt.Sprintf("%s/%s.tar", buildCtx, ociLayout)
+
+	// Create OCI archive from parent image.
+	base.Cmd("build", buildCtx, "--tag", parentImageName).AssertOK()
+	base.Cmd("image", "save", "--output", tarPath, parentImageName).AssertOK()
+
+	// Unpack OCI archive into OCI layout directory.
+	ociLayoutDir := t.TempDir()
+	err := extractTarFile(ociLayoutDir, tarPath)
+	assert.NilError(t, err)
+
+	dockerfile = fmt.Sprintf(`FROM %s
+CMD ["echo", "test-nerdctl-build-context-oci-layout"]`, ociLayout)
+	buildCtx = createBuildContext(t, dockerfile)
+
+	var buildArgs = []string{}
+	if testutil.IsDocker() {
+		buildArgs = dockerBuilderArgs
+	}
+
+	buildArgs = append(buildArgs, "build", buildCtx, fmt.Sprintf("--build-context=%s=oci-layout://%s", ociLayout, ociLayoutDir), "--tag", imageName)
+	if testutil.IsDocker() {
+		// Need to load the container image from the builder to be able to run it.
+		buildArgs = append(buildArgs, "--load")
+	}
+
+	base.Cmd(buildArgs...).AssertOK()
+	base.Cmd("run", "--rm", imageName).AssertOutContains("test-nerdctl-build-context-oci-layout")
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -708,7 +708,7 @@ Flags:
 - :nerd_face: `--ipfs`: Build image with pulling base images from IPFS. See [`ipfs.md`](./ipfs.md) for details.
 - :whale: `--label`: Set metadata for an image
 - :whale: `--network=(default|host|none)`: Set the networking mode for the RUN instructions during build.(compatible with `buildctl build`)
-- :whale: --build-context: Set additional contexts for build (e.g. dir2=/path/to/dir2, myorg/myapp=docker-image://path/to/myorg/myapp)
+- :whale: `--build-context`: Set additional contexts for build (e.g. dir2=/path/to/dir2, myorg/myapp=docker-image://path/to/myorg/myapp)
 
 Unimplemented `docker build` flags: `--add-host`, `--squash`
 

--- a/pkg/cmd/builder/build_test.go
+++ b/pkg/cmd/builder/build_test.go
@@ -187,3 +187,42 @@ func TestIsBuildPlatformDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestParseBuildctlArgsForOCILayout(t *testing.T) {
+	tests := []struct {
+		name          string
+		ociLayoutName string
+		ociLayoutPath string
+		expectedArgs  []string
+		errorIsNil    bool
+		expectedErr   string
+	}{
+		{
+			name:          "PrefixNotFoundError",
+			ociLayoutName: "unit-test",
+			ociLayoutPath: "/tmp/oci-layout/",
+			expectedArgs:  []string{},
+			expectedErr:   ErrOCILayoutPrefixNotFound.Error(),
+		},
+		{
+			name:          "DirectoryNotFoundError",
+			ociLayoutName: "unit-test",
+			ociLayoutPath: "oci-layout:///tmp/oci-layout",
+			expectedArgs:  []string{},
+			expectedErr:   "open /tmp/oci-layout/index.json: no such file or directory",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			args, err := parseBuildContextFromOCILayout(test.ociLayoutName, test.ociLayoutPath)
+			if test.errorIsNil {
+				assert.NilError(t, err)
+			} else {
+				assert.Error(t, err, test.expectedErr)
+			}
+			assert.Equal(t, len(args), len(test.expectedArgs))
+			assert.DeepEqual(t, args, test.expectedArgs)
+		})
+	}
+}


### PR DESCRIPTION
### Description
This change adds building images with OCI layout build contexts.

### Testing
- Added unit tests
  - Negative test cases
- Added integration test (Linux only)
  - Test requires build functionality which excludes Windows platform testing.

### Additional references
- https://docs.docker.com/reference/cli/docker/buildx/build/#source-oci-layout
- https://github.com/opencontainers/image-spec/blob/main/image-layout.md
- https://docs.docker.com/build/exporters/oci-docker/
- https://docs.docker.com/build/builders/drivers/docker-container/