### PR TITLE
Remove Docker incompat from image prune and build tests

### DIFF
--- a/cmd/nerdctl/builder_build_test.go
+++ b/cmd/nerdctl/builder_build_test.go
@@ -462,7 +462,6 @@ RUN ["cat", "/hello_from_dir2.txt"]`, testutil.CommonImage, filename)
 // https://github.com/docker/buildx/pull/1482
 func TestBuildSourceDateEpoch(t *testing.T) {
 	testutil.RequiresBuild(t)
-	testutil.DockerIncompatible(t) // Needs buildx v0.10 (https://github.com/docker/buildx/pull/1489)
 	base := testutil.NewBase(t)
 	imageName := testutil.Identifier(t)
 	defer base.Cmd("rmi", imageName).AssertOK()

--- a/cmd/nerdctl/image_prune_test.go
+++ b/cmd/nerdctl/image_prune_test.go
@@ -102,10 +102,10 @@ func TestImagePruneFilterUntil(t *testing.T) {
 	testutil.RequiresBuild(t)
 	testutil.RegisterBuildCacheCleanup(t)
 
-	// Docker image's created timestamp is set based on base image creation time.
-	testutil.DockerIncompatible(t)
-
 	base := testutil.NewBase(t)
+	// For deterministically testing the filter, set the image's created timestamp to 2 hours in the past.
+	base.Env = append(base.Env, fmt.Sprintf("SOURCE_DATE_EPOCH=%d", time.Now().Add(-2*time.Hour).Unix()))
+
 	imageName := testutil.Identifier(t)
 	teardown := func() {
 		// Image should have been pruned; but cleanup on failure.

--- a/cmd/nerdctl/image_prune_test.go
+++ b/cmd/nerdctl/image_prune_test.go
@@ -107,7 +107,12 @@ func TestImagePruneFilterUntil(t *testing.T) {
 
 	base := testutil.NewBase(t)
 	imageName := testutil.Identifier(t)
-	t.Cleanup(func() { base.Cmd("rmi", "--force", imageName) })
+	teardown := func() {
+		// Image should have been pruned; but cleanup on failure.
+		base.Cmd("rmi", "--force", imageName).Run()
+	}
+	t.Cleanup(teardown)
+	teardown()
 
 	dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-test-image-prune-filter-until"]`, testutil.CommonImage)


### PR DESCRIPTION
### Description
This change is a followup to #3319 to enable image prune filter until integration tests on Docker.

`SOURCE_DATE_EPOCH` is available in buildx since v0.10 which should be available in Docker 23 and greater.

### Testing
- Enables `TestImagePruneFilterUntil` on Docker
- Enables `TestBuildSourceDateEpoch` on Docker