### PR TITLE
Fix host networking issues and rename incidental issue

### DIFF
--- a/cmd/nerdctl/container_run.go
+++ b/cmd/nerdctl/container_run.go
@@ -377,13 +377,8 @@ func runAction(cmd *cobra.Command, args []string) error {
 	id := c.ID()
 	if createOpt.Rm && !createOpt.Detach {
 		defer func() {
-			// NOTE: OCI hooks (which are used for CNI network setup/teardown on Linux)
-			// are not currently supported on Windows, so we must explicitly call
-			// network setup/cleanup from the main nerdctl executable.
-			if runtime.GOOS == "windows" {
-				if err := netManager.CleanupNetworking(ctx, c); err != nil {
-					log.L.Warnf("failed to clean up container networking: %s", err)
-				}
+			if err := netManager.CleanupNetworking(ctx, c); err != nil {
+				log.L.Warnf("failed to clean up container networking: %s", err)
 			}
 			if err := container.RemoveContainer(ctx, c, createOpt.GOptions, true, true, client); err != nil {
 				log.L.WithError(err).Warnf("failed to remove container %s", id)

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -290,7 +290,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		parts := strings.SplitN(host, ":", 2)
 		// If the IP Address is a string called "host-gateway", replace this value with the IP address stored
 		// in the daemon level HostGateway IP config variable.
-		if parts[1] == dockeropts.HostGatewayName {
+		if len(parts) == 2 && parts[1] == dockeropts.HostGatewayName {
 			if options.GOptions.HostGatewayIP == "" {
 				return nil, nil, fmt.Errorf("unable to derive the IP value for host-gateway")
 			}

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -316,10 +316,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 
 	c, containerErr := client.NewContainer(ctx, id, cOpts...)
 	var netSetupErr error
-	// NOTE: on non-Windows platforms, network setup is performed by OCI hooks.
-	// Seeing as though Windows does not currently support OCI hooks, we must explicitly
-	// perform network setup/teardown in the main nerdctl executable.
-	if containerErr == nil && runtime.GOOS == "windows" {
+	if containerErr == nil {
 		netSetupErr = netManager.SetupNetworking(ctx, id)
 		if netSetupErr != nil {
 			log.G(ctx).WithError(netSetupErr).Warnf("networking setup error has occurred")

--- a/pkg/cmd/container/rename.go
+++ b/pkg/cmd/container/rename.go
@@ -22,6 +22,7 @@ import (
 	"runtime"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -78,7 +79,8 @@ func renameContainer(ctx context.Context, container containerd.Container, newNam
 	}
 	if runtime.GOOS == "linux" {
 		if err := hostst.Update(ns, container.ID(), newName); err != nil {
-			return err
+			log.G(ctx).WithError(err).Warn("failed to update host networking definitions " +
+				"- if your container is using network 'none', this is expected - otherwise, please report this as a bug")
 		}
 	}
 	labels := map[string]string{


### PR DESCRIPTION
Purported to:
- fix #3345
- fix #3341
- fix #2591 
- fix #2613 
- (for the relevant part of) fix #2694 

Does NOT fix yet #355

The take-away are:
1. the modification to make network=host use the host hostname as a default is straightforward
2. host networking previously did not call `Acquire` on the hosts store, causing `Update` to fail during a rename operation. Note that the same is true for `none`. Rename has been modified to not hard fail anymore on hostsstore Update failures. Another PR (#3342) is also making rename able to rollback in case of failure
3. for the same reason as above, extraHosts were not added - this has now been done in SetupNetworking and CleanupNetworking for the hostNetworkManager

Note that calls to CleanupNetworking and SetupNetworking were previously gated by a platform check to apply only on Windows (although not everywhere).
Now, this does not seem to serve much of a purpose, as these methods did nothing for any of the networkManager (with the exception of the Windows implementation of CNI).
Is this some kind of unfinished refactor? 

Anyhow, I did remove the platform checks altogether, since the code decides already if something should happen.