### PR TITLE
Fix improper hooks registration

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -509,12 +509,6 @@ func withNerdctlOCIHook(cmd string, args []string) (oci.SpecOpts, error) {
 			Args: crArgs,
 			Env:  os.Environ(),
 		})
-		scArgs := append(args, "startContainer")
-		s.Hooks.CreateRuntime = append(s.Hooks.StartContainer, specs.Hook{
-			Path: cmd,
-			Args: scArgs,
-			Env:  os.Environ(),
-		})
 		argsCopy := append([]string(nil), args...)
 		psArgs := append(argsCopy, "postStop")
 		s.Hooks.Poststop = append(s.Hooks.Poststop, specs.Hook{

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -99,8 +99,6 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 	switch event {
 	case "createRuntime":
 		return onCreateRuntime(opts)
-	case "startContainer":
-		return onStartContainer(opts)
 	case "postStop":
 		return onPostStop(opts)
 	default:
@@ -486,18 +484,11 @@ func applyNetworkSettings(opts *handlerOpts) error {
 func onCreateRuntime(opts *handlerOpts) error {
 	loadAppArmor()
 
-	if opts.cni != nil {
-		return applyNetworkSettings(opts)
-	}
-	return nil
-}
-
-func onStartContainer(opts *handlerOpts) error {
 	name := opts.state.Annotations[labels.Name]
 	ns := opts.state.Annotations[labels.Namespace]
 	namst, err := namestore.New(opts.dataStore, ns)
 	if err != nil {
-		log.L.WithError(err).Error("failed opening the namestore in onStartContainer")
+		log.L.WithError(err).Error("failed opening the namestore in onCreateRuntime")
 	} else if err := namst.Acquire(name, opts.state.ID); err != nil {
 		log.L.WithError(err).Error("failed re-acquiring name - see https://github.com/containerd/nerdctl/issues/2992")
 	}


### PR DESCRIPTION
On main, we do *override* `s.Hooks.CreateRuntime` with new values, effectively making the prior assignment a no-op.

The effect of this seems to be that `ocihooks.onCreateRuntime` is never run, which looks wrong.

Proposed PR addresses that.

