### PR TITLE
Hardening lifecycle-state-store, name-store, and oci-hooks

### DIFF
--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -514,10 +514,9 @@ func onCreateRuntime(opts *handlerOpts) error {
 	// Set StartedAt
 	lf := state.NewLifecycleState(opts.state.Annotations[labels.StateDir])
 	return lf.WithLock(func() error {
-		err := lf.Load()
-		if err != nil {
-			return err
-		}
+		// Errors are voluntarily ignored here, as they should not be fatal.
+		// The lifecycle struct is also already warning about the issue.
+		_ = lf.Load()
 		lf.StartedAt = time.Now()
 		return lf.Save()
 	})

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -505,24 +505,37 @@ func onCreateRuntime(opts *handlerOpts) error {
 		log.L.WithError(err).Error("failed re-acquiring name - see https://github.com/containerd/nerdctl/issues/2992")
 	}
 
+	var netError error
 	if opts.cni != nil {
-		if err = applyNetworkSettings(opts); err != nil {
-			return err
-		}
+		netError = applyNetworkSettings(opts)
 	}
 
-	// Set StartedAt
 	lf := state.NewLifecycleState(opts.state.Annotations[labels.StateDir])
-	return lf.WithLock(func() error {
+
+	return errors.Join(netError, lf.WithLock(func() error {
 		// Errors are voluntarily ignored here, as they should not be fatal.
 		// The lifecycle struct is also already warning about the issue.
 		_ = lf.Load()
 		lf.StartedAt = time.Now()
+		lf.CreateError = netError != nil
 		return lf.Save()
-	})
+	}))
 }
 
 func onPostStop(opts *handlerOpts) error {
+	// See https://github.com/containerd/nerdctl/issues/3357
+	// Check if we actually errored during runtimeCreate
+	// If that is the case, CreateError is set, and we are in postStop while the container will NOT be deleted (see ticket).
+	// In that case, do NOT treat this as a deletion, as the container is still there.
+	// Reset CreateError, and return.
+	lf := state.NewLifecycleState(opts.state.Annotations[labels.StateDir])
+	if lf.WithLock(lf.Load) == nil {
+		if lf.CreateError {
+			lf.CreateError = false
+			return lf.WithLock(lf.Save)
+		}
+	}
+
 	ctx := context.Background()
 	ns := opts.state.Annotations[labels.Namespace]
 	if opts.cni != nil {

--- a/pkg/ocihook/state/state.go
+++ b/pkg/ocihook/state/state.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 )
 
@@ -71,6 +73,8 @@ func (lf *LifecycleState) Load() error {
 	} else {
 		err = json.Unmarshal(data, lf)
 		if err != nil {
+			// Logging an error, as Load errors are generally ignored downstream
+			log.L.Error("unable to unmarshall lifecycle data")
 			return fmt.Errorf("unable to unmarshall lifecycle data: %w", err)
 		}
 	}
@@ -78,11 +82,16 @@ func (lf *LifecycleState) Load() error {
 }
 
 func (lf *LifecycleState) Save() error {
+	// Write atomically (write, then move) to avoid incomplete writes from happening
 	data, err := json.Marshal(lf)
 	if err != nil {
 		return fmt.Errorf("unable to marshall lifecycle data: %w", err)
 	}
-	err = os.WriteFile(filepath.Join(lf.stateDir, lifecycleFile), data, 0600)
+	err = os.WriteFile(filepath.Join(lf.stateDir, "."+lifecycleFile), data, 0600)
+	if err != nil {
+		return fmt.Errorf("unable to write lifecycle file: %w", err)
+	}
+	err = os.Rename(filepath.Join(lf.stateDir, "."+lifecycleFile), filepath.Join(lf.stateDir, lifecycleFile))
 	if err != nil {
 		return fmt.Errorf("unable to write lifecycle file: %w", err)
 	}

--- a/pkg/ocihook/state/state.go
+++ b/pkg/ocihook/state/state.go
@@ -51,8 +51,9 @@ func NewLifecycleState(stateDir string) *LifecycleState {
 }
 
 type LifecycleState struct {
-	stateDir  string
-	StartedAt time.Time `json:"started_at"`
+	stateDir    string
+	StartedAt   time.Time `json:"started_at"`
+	CreateError bool      `json:"create_error"`
 }
 
 func (lf *LifecycleState) WithLock(fun func() error) error {


### PR DESCRIPTION
**First commit**

Although #3350 got closed as a fluke, the error message seen in the logs clearly shows that the lifecycle state file could end-up messed-up, triggering a failure.

This does two things:
- write atomically, so that we never end-up with half-written / hosed JSON in the file
- tolerate load errors: this file is not critical and purely informative and should soft fail with a warning instead

This will make the LifecycleState more robust and resistant to host shutdowns.

Note: we should consider a review of all our filesystem based stores and consider moving to atomic writing for them.

**Second commit**

Fix #3351 by making us resistant to the condition and allowing a container to acquire a "broken" name.

This obviously should never happen, but it does ^.

**Third commit**

Fix #3357 - does not fix the underlying issue, which is possibly upstream - but effectively mitigate it.
Since onPostStop is (wrongly?) called after an error in onCreateRuntime - while the container will NOT be deleted - we inhibit the normal cleanup flow in that case. 