### PR TITLE
Allow Canary to fail the build

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -65,7 +65,6 @@ jobs:
       - name: "Run unit tests"
         run: go test -v ./pkg/...
       - name: "Run integration tests"
-        continue-on-error: true
         run: docker run -t --rm --privileged test-integration
 
   windows:
@@ -113,5 +112,4 @@ jobs:
           ctrdVersion: ${{ env.CONTAINERD_VERSION }}
         run: powershell hack/configure-windows-ci.ps1
       - name: "Run integration tests"
-        continue-on-error: true
         run: go test -v ./cmd/...


### PR DESCRIPTION
Right now, canary integration test failures are ignored.
This was on-purpose initially, as I was expecting canary to be very unstable.

Although, the effect of `continue-on-error` is that these tasks are reported as green, and failures do go unnoticed.

This PR just remove that, making sure that we are appropriately noticing canary test failures.
If it turns out that canary is just failing too much, well, maybe we fix the issues - or we revert this change.

cc @AkihiroSuda if we can get that soon, that would be lovely!