### PR TITLE
fix: nerdctl stats on containers without a memory limit returns host memory limit

### DIFF
--- a/pkg/statsutil/stats_linux.go
+++ b/pkg/statsutil/stats_linux.go
@@ -17,6 +17,10 @@
 package statsutil
 
 import (
+	"bufio"
+	"os"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -35,11 +39,10 @@ func calculateMemPercent(limit float64, usedNo float64) float64 {
 }
 
 func SetCgroupStatsFields(previousStats *ContainerStats, data *v1.Metrics, links []netlink.Link) (StatsEntry, error) {
-
 	cpuPercent := calculateCgroupCPUPercent(previousStats, data)
 	blkRead, blkWrite := calculateCgroupBlockIO(data)
 	mem := calculateCgroupMemUsage(data)
-	memLimit := float64(data.Memory.Usage.Limit)
+	memLimit := getCgroupMemLimit(float64(data.Memory.Usage.Limit))
 	memPercent := calculateMemPercent(memLimit, mem)
 	pidsStatsCurrent := data.Pids.Current
 	netRx, netTx := calculateCgroupNetwork(links)
@@ -59,11 +62,10 @@ func SetCgroupStatsFields(previousStats *ContainerStats, data *v1.Metrics, links
 }
 
 func SetCgroup2StatsFields(previousStats *ContainerStats, metrics *v2.Metrics, links []netlink.Link) (StatsEntry, error) {
-
 	cpuPercent := calculateCgroup2CPUPercent(previousStats, metrics)
 	blkRead, blkWrite := calculateCgroup2IO(metrics)
 	mem := calculateCgroup2MemUsage(metrics)
-	memLimit := float64(metrics.Memory.UsageLimit)
+	memLimit := getCgroupMemLimit(float64(metrics.Memory.UsageLimit))
 	memPercent := calculateMemPercent(memLimit, mem)
 	pidsStatsCurrent := metrics.Pids.Current
 	netRx, netTx := calculateCgroupNetwork(links)
@@ -80,6 +82,36 @@ func SetCgroup2StatsFields(previousStats *ContainerStats, metrics *v2.Metrics, l
 		PidsCurrent:      pidsStatsCurrent,
 	}, nil
 
+}
+
+func getCgroupMemLimit(memLimit float64) float64 {
+	if memLimit == float64(^uint64(0)) {
+		return getHostMemLimit()
+	}
+	return memLimit
+}
+
+func getHostMemLimit() float64 {
+	file, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return float64(^uint64(0))
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		if strings.HasPrefix(scanner.Text(), "MemTotal:") {
+			fields := strings.Fields(scanner.Text())
+			if len(fields) >= 2 {
+				memKb, err := strconv.ParseUint(fields[1], 10, 64)
+				if err == nil {
+					return float64(memKb * 1024) // kB to bytes
+				}
+			}
+			break
+		}
+	}
+	return float64(^uint64(0))
 }
 
 func calculateCgroupCPUPercent(previousStats *ContainerStats, metrics *v1.Metrics) float64 {


### PR DESCRIPTION
Fix: https://github.com/runfinch/finch/issues/45

 - Fixed bug where `nerdctl stats` would show 16 exbibytes of memory limit when memory limit on container was not set.