### PR TITLE
Fix nsenter working dir for child

### DIFF
--- a/pkg/rootlessutil/parent_linux.go
+++ b/pkg/rootlessutil/parent_linux.go
@@ -102,6 +102,7 @@ func ParentMain(hostGatewayIP string) error {
 		log.L.WithError(err).Warn("unable to determine working directory")
 	} else {
 		args = append(args, "-w"+wd)
+		os.Setenv("PWD", wd)
 	}
 
 	args = append(args, "--preserve-credentials",


### PR DESCRIPTION
Currently, we are losing the working directory after we nsenter in some circumstances.

It is not entirely clear to me why.

This is manifest in testing (for example `TestRunVolumeRelativePath`) if you try to change the `Dir` of the `icmd` command to a newly created temp directory, nerdctl will then error when trying to mount the relative path inside https://github.com/containerd/nerdctl/blob/1a55c720256c629371ed092278acf9e1d5bd83c0/pkg/mountutil/mountutil.go#L172 (as Getwd cannot be retrieved).

It is not clear to me either if that would be a bug in nsenter (as I would expect `-w` to still be used as a default?).

Note that @fahedouch clearly had the right intuition as they suggested to change to `-W` in (related) PR: https://github.com/containerd/nerdctl/pull/3329#discussion_r1724736121 

This PR here was triggered by the ongoing refactoring of the `cmd` package, as one of the incidental changes required for tests to pass after the refactoring.