### PR TITLE
Do not load build output if dest is specified

### DIFF
--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -228,7 +228,9 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 			output = fmt.Sprintf("type=local,dest=%s", output)
 		}
 		if strings.Contains(output, "type=docker") || strings.Contains(output, "type=oci") {
-			needsLoading = true
+			if !strings.Contains(output, "dest=") {
+				needsLoading = true
+			}
 		}
 	}
 	if tags = strutil.DedupeStrSlice(options.Tag); len(tags) > 0 {


### PR DESCRIPTION
This is not a great PR.
It merely fix #3386 - but clearly this whole code should be rewritten IMHO (`strings.Contains` does not seem like the right approach to properly parse the option here).

A proper cleanup and handling of corner cases could/should be done in a follow-up PR, and add some tests, but at least this quick fix here does address a couple of issues:
- nerdctl wrongly exits 1 with "no image was built" when dest is specified
- inability to output oci images when dest is set

PTAL at your convenience.

Tagging @MayCXC 