### PR TITLE
Fix TestDiff failure with docker

### DIFF
--- a/cmd/nerdctl/container_diff_linux_test.go
+++ b/cmd/nerdctl/container_diff_linux_test.go
@@ -23,7 +23,11 @@ import (
 )
 
 func TestDiff(t *testing.T) {
-	t.Parallel()
+	// It is unclear why this is failing with docker when run in parallel
+	// Obviously some other container test is interfering
+	if testutil.GetTarget() != testutil.Docker {
+		t.Parallel()
+	}
 	base := testutil.NewBase(t)
 	containerName := testutil.Identifier(t)
 	defer base.Cmd("rm", containerName).Run()


### PR DESCRIPTION
TestDiff started failing with target docker after moving `cmd/container` to a subpackage.

The actual reason for the failure is unclear to me, but the bottom-line is that it does not work with Parallel, which suggests it is interacting with another parallelized test.

As for why this is only showing up (more) now, the answer is simply the reduction in size of the parallelized test pool (since we only parallelize per sub-package now), which makes it much more likely that the interacting test is actually running in parallel with TestDiff.

Anyhow, this will unblock #3383 and can / should be merged now.