### PR TITLE
[ON HOLD] Disable TestIPFSComposeUp

### DIFF
--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestIPFSComposeUp(t *testing.T) {
+	t.Skip("This is currently broken and failing very often. It is unclear if the test or the code is faulty.")
+
 	testutil.DockerIncompatible(t)
 	base := testutil.NewBase(t)
 


### PR DESCRIPTION
This test is failing a lot.

Even despite the fact that we do retry all tests, it still regularly fail builds, with a variety of different errors (`cannot start a stopped container`, `reuse of closed network connections`, etc).

While it is unclear whether the test or the underlying code is faulty, and despite some time spent investigating it with no success, this test serves no purpose given its current condition, and there does not seem to be interest in fixing it.

Suggesting we disable it.