### PR TITLE
CI/test fixing

### DIFF
--- a/cmd/nerdctl/container/container_run_security_linux_test.go
+++ b/cmd/nerdctl/container/container_run_security_linux_test.go
@@ -182,8 +182,8 @@ func TestRunApparmor(t *testing.T) {
 	attrCurrentEnforceExpected := fmt.Sprintf("%s (enforce)\n", defaultProfile)
 	base.Cmd("run", "--rm", testutil.AlpineImage, "cat", attrCurrentPath).AssertOutExactly(attrCurrentEnforceExpected)
 	base.Cmd("run", "--rm", "--security-opt", "apparmor="+defaultProfile, testutil.AlpineImage, "cat", attrCurrentPath).AssertOutExactly(attrCurrentEnforceExpected)
-	base.Cmd("run", "--rm", "--security-opt", "apparmor=unconfined", testutil.AlpineImage, "cat", attrCurrentPath).AssertOutExactly("unconfined\n")
-	base.Cmd("run", "--rm", "--privileged", testutil.AlpineImage, "cat", attrCurrentPath).AssertOutExactly("unconfined\n")
+	base.Cmd("run", "--rm", "--security-opt", "apparmor=unconfined", testutil.AlpineImage, "cat", attrCurrentPath).AssertOutContains("unconfined")
+	base.Cmd("run", "--rm", "--privileged", testutil.AlpineImage, "cat", attrCurrentPath).AssertOutContains("unconfined")
 }
 
 // TestRunSeccompCapSysPtrace tests https://github.com/containerd/nerdctl/issues/976


### PR DESCRIPTION
Tiny commits enhancing our test situation - making sure we do cleanup resources once done, to avoid polluting other tests expecting a clean slate.

Fix #3403

@AkihiroSuda can we get this in? (see question inline though)