### PR TITLE
Login refactor (small breakout): add support for explicitly setting --insecure-registry=false

### DIFF
--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 )
 
 func ProcessImageVerifyOptions(cmd *cobra.Command) (opt types.ImageVerifyOptions, err error) {
@@ -84,6 +85,8 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 		return types.GlobalCommandOptions{}, err
 	}
 	insecureRegistry, err := cmd.Flags().GetBool("insecure-registry")
+	// Store whether the insecure-registry flag was provided explicitly or not
+	explicitInsecureRegistry := cmd.Flags().Changed("insecure-registry")
 	if err != nil {
 		return types.GlobalCommandOptions{}, err
 	}
@@ -100,19 +103,22 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 		return types.GlobalCommandOptions{}, err
 	}
 	return types.GlobalCommandOptions{
-		Debug:            debug,
-		DebugFull:        debugFull,
-		Address:          address,
-		Namespace:        namespace,
-		Snapshotter:      snapshotter,
-		CNIPath:          cniPath,
-		CNINetConfPath:   cniConfigPath,
-		DataRoot:         dataRoot,
-		CgroupManager:    cgroupManager,
-		InsecureRegistry: insecureRegistry,
-		HostsDir:         hostsDir,
-		Experimental:     experimental,
-		HostGatewayIP:    hostGatewayIP,
+		Config: config.Config{
+			Debug:            debug,
+			DebugFull:        debugFull,
+			Address:          address,
+			Namespace:        namespace,
+			Snapshotter:      snapshotter,
+			CNIPath:          cniPath,
+			CNINetConfPath:   cniConfigPath,
+			DataRoot:         dataRoot,
+			CgroupManager:    cgroupManager,
+			InsecureRegistry: insecureRegistry,
+			HostsDir:         hostsDir,
+			Experimental:     experimental,
+			HostGatewayIP:    hostGatewayIP,
+		},
+		ExplicitInsecureRegistry: explicitInsecureRegistry,
 	}, nil
 }
 

--- a/pkg/api/types/global.go
+++ b/pkg/api/types/global.go
@@ -18,4 +18,8 @@ package types
 
 import "github.com/containerd/nerdctl/v2/pkg/config"
 
-type GlobalCommandOptions config.Config
+type GlobalCommandOptions struct {
+	config.Config
+
+	ExplicitInsecureRegistry bool
+}


### PR DESCRIPTION
This is the ground work for fixing #3046.

See commit message for details.

TL;DR:
`docker login --insecure-registry false localhost` should NOT treat localhost as insecure.