### PR TITLE
Ensure all layers are here when tagging, committing, saving, or converting

### DIFF
--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -26,69 +26,52 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
-func TestImageInspectContainsSomeStuff(t *testing.T) {
-	base := testutil.NewBase(t)
+func TestImageInspectSimpleCases(t *testing.T) {
+	nerdtest.Setup()
 
-	base.Cmd("pull", testutil.CommonImage).AssertOK()
-	inspect := base.InspectImage(testutil.CommonImage)
-
-	assert.Assert(base.T, len(inspect.RootFS.Layers) > 0)
-	assert.Assert(base.T, inspect.RootFS.Type != "")
-	assert.Assert(base.T, inspect.Architecture != "")
-	assert.Assert(base.T, inspect.Size > 0)
-}
-
-func TestImageInspectWithFormat(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	base.Cmd("pull", testutil.CommonImage).AssertOK()
-
-	// test RawFormat support
-	base.Cmd("image", "inspect", testutil.CommonImage, "--format", "{{.Id}}").AssertOK()
-
-	// test typedFormat support
-	base.Cmd("image", "inspect", testutil.CommonImage, "--format", "{{.ID}}").AssertOK()
-}
-
-func inspectImageHelper(base *testutil.Base, identifier ...string) []dockercompat.Image {
-	args := append([]string{"image", "inspect"}, identifier...)
-	cmdResult := base.Cmd(args...).Run()
-	assert.Equal(base.T, cmdResult.ExitCode, 0)
-	var dc []dockercompat.Image
-	if err := json.Unmarshal([]byte(cmdResult.Stdout()), &dc); err != nil {
-		base.T.Fatal(err)
+	testCase := &test.Case{
+		Description: "TestImageInspect",
+		Setup: func(data test.Data, helpers test.Helpers) {
+			helpers.Ensure("pull", testutil.CommonImage)
+		},
+		SubTests: []*test.Case{
+			{
+				Description: "Contains some stuff",
+				Command:     test.RunCommand("image", "inspect", testutil.CommonImage),
+				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+					var dc []dockercompat.Image
+					err := json.Unmarshal([]byte(stdout), &dc)
+					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+					assert.Assert(t, len(dc[0].RootFS.Layers) > 0, info)
+					assert.Assert(t, dc[0].Architecture != "", info)
+					assert.Assert(t, dc[0].Size > 0, info)
+				}),
+			},
+			{
+				Description: "RawFormat support (.Id)",
+				Command:     test.RunCommand("image", "inspect", testutil.CommonImage, "--format", "{{.Id}}"),
+				Expected:    test.Expects(0, nil, nil),
+			},
+			{
+				Description: "typedFormat support (.ID)",
+				Command:     test.RunCommand("image", "inspect", testutil.CommonImage, "--format", "{{.ID}}"),
+				Expected:    test.Expects(0, nil, nil),
+			},
+		},
 	}
-	return dc
+
+	testCase.Run(t)
 }
 
 func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
-	testutil.DockerIncompatible(t)
+	nerdtest.Setup()
 
-	if runtime.GOOS == "windows" {
-		t.Skip("Windows is not supported for this test right now")
-	}
-
-	base := testutil.NewBase(t)
-
-	// Overall, we need a clean slate before doing these lookups.
-	// More specifically, because we trigger https://github.com/containerd/nerdctl/issues/3016
-	// we cannot do selective rmi, so, just nuke everything
-	ids := base.Cmd("image", "list", "-q").Out()
-	allIDs := strings.Split(ids, "\n")
-	for _, id := range allIDs {
-		id = strings.TrimSpace(id)
-		if id != "" {
-			base.Cmd("rmi", "-f", id).Run()
-		}
-	}
-
-	base.Cmd("pull", "alpine", "--platform", "linux/amd64").AssertOK()
-	base.Cmd("pull", "busybox", "--platform", "linux/amd64").AssertOK()
-	base.Cmd("pull", "busybox:stable", "--platform", "linux/amd64").AssertOK()
-	base.Cmd("pull", "registry-1.docker.io/library/busybox", "--platform", "linux/amd64").AssertOK()
-	base.Cmd("pull", "registry-1.docker.io/library/busybox:stable", "--platform", "linux/amd64").AssertOK()
+	platform := runtime.GOOS + "/" + runtime.GOARCH
 
 	tags := []string{
 		"",
@@ -102,76 +85,141 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 		"registry-1.docker.io/library/busybox",
 	}
 
-	// Build reference values for comparison
-	reference := inspectImageHelper(base, "busybox")
-	assert.Equal(base.T, 1, len(reference))
-	// Extract image sha
-	sha := strings.TrimPrefix(reference[0].RepoDigests[0], "busybox@sha256:")
+	testCase := &test.Case{
+		Description: "TestImageInspectDifferentValidReferencesForTheSameImage",
+		Require: test.Require(
+			test.Not(nerdtest.Docker),
+			test.Not(test.Windows),
+			// We need a clean slate
+			nerdtest.Private,
+		),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			helpers.Ensure("pull", "alpine", "--platform", platform)
+			helpers.Ensure("pull", "busybox", "--platform", platform)
+			helpers.Ensure("pull", "busybox:stable", "--platform", platform)
+			helpers.Ensure("pull", "registry-1.docker.io/library/busybox", "--platform", platform)
+			helpers.Ensure("pull", "registry-1.docker.io/library/busybox:stable", "--platform", platform)
+		},
+		SubTests: []*test.Case{
+			{
+				Description: "name and tags +/- sha combinations",
+				Command:     test.RunCommand("image", "inspect", "busybox"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var dc []dockercompat.Image
+							err := json.Unmarshal([]byte(stdout), &dc)
+							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							reference := dc[0].ID
+							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
 
-	differentReference := inspectImageHelper(base, "alpine")
-	assert.Equal(base.T, 1, len(differentReference))
+							for _, name := range names {
+								for _, tag := range tags {
+									it := nerdtest.InspectImage(helpers, name+tag)
+									assert.Equal(t, it.ID, reference)
+									it = nerdtest.InspectImage(helpers, name+tag+"@sha256:"+sha)
+									assert.Equal(t, it.ID, reference)
+								}
+							}
+						},
+					}
+				},
+			},
+			{
+				Description: "by digest, short or long, with or without prefix",
+				Command:     test.RunCommand("image", "inspect", "busybox"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var dc []dockercompat.Image
+							err := json.Unmarshal([]byte(stdout), &dc)
+							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							reference := dc[0].ID
+							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
 
-	// Testing all name and tags variants
-	for _, name := range names {
-		for _, tag := range tags {
-			t.Logf("Testing %s", name+tag)
-			result := inspectImageHelper(base, name+tag)
-			assert.Equal(base.T, 1, len(result))
-			assert.Equal(base.T, reference[0].ID, result[0].ID)
-		}
+							for _, id := range []string{"sha256:" + sha, sha, sha[0:8], "sha256:" + sha[0:8]} {
+								it := nerdtest.InspectImage(helpers, id)
+								assert.Equal(t, it.ID, reference)
+							}
+
+							// Now, tag alpine with a short id
+							// Build reference values for comparison
+							alpine := nerdtest.InspectImage(helpers, "alpine")
+
+							// Demonstrate image name precedence over digest lookup
+							// Using the shortened sha should no longer get busybox, but rather the newly tagged Alpine
+							helpers.Ensure("tag", "alpine", sha[0:8])
+							it := nerdtest.InspectImage(helpers, sha[0:8])
+							assert.Equal(t, it.ID, alpine.ID, alpine.ID+" vs "+it.ID)
+						},
+					}
+				},
+			},
+			{
+				Description: "prove that wrong references with correct digest do not get resolved",
+				Command:     test.RunCommand("image", "inspect", "busybox"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var dc []dockercompat.Image
+							err := json.Unmarshal([]byte(stdout), &dc)
+							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
+
+							for _, id := range []string{"doesnotexist", "doesnotexist:either", "busybox:bogustag"} {
+								cmd := helpers.Command("image", "inspect", id+"@sha256:"+sha)
+								cmd.Run(&test.Expected{
+									Output: test.Equals(""),
+								})
+							}
+						},
+					}
+				},
+			},
+			{
+				Description: "prove that invalid reference return no result without crashing",
+				Command:     test.RunCommand("image", "inspect", "busybox"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var dc []dockercompat.Image
+							err := json.Unmarshal([]byte(stdout), &dc)
+							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+
+							for _, id := range []string{"∞∞∞∞∞∞∞∞∞∞", "busybox:∞∞∞∞∞∞∞∞∞∞"} {
+								cmd := helpers.Command("image", "inspect", id)
+								cmd.Run(&test.Expected{
+									Output: test.Equals(""),
+								})
+							}
+						},
+					}
+				},
+			},
+			{
+				Description: "retrieving multiple entries at once",
+				Command:     test.RunCommand("image", "inspect", "busybox", "busybox", "busybox:stable"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var dc []dockercompat.Image
+							err := json.Unmarshal([]byte(stdout), &dc)
+							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+							assert.Equal(t, 3, len(dc), "Unexpectedly did not get 3 results\n"+info)
+							reference := nerdtest.InspectImage(helpers, "busybox")
+							assert.Equal(t, dc[0].ID, reference.ID)
+							assert.Equal(t, dc[1].ID, reference.ID)
+							assert.Equal(t, dc[2].ID, reference.ID)
+						},
+					}
+				},
+			},
+		},
 	}
 
-	// Testing all name and tags variants, with a digest
-	for _, name := range names {
-		for _, tag := range tags {
-			t.Logf("Testing %s", name+tag+"@"+sha)
-			result := inspectImageHelper(base, name+tag+"@sha256:"+sha)
-			assert.Equal(base.T, 1, len(result))
-			assert.Equal(base.T, reference[0].ID, result[0].ID)
-		}
-	}
-
-	// Testing repo digest and short digest with or without prefix
-	for _, id := range []string{"sha256:" + sha, sha, sha[0:8], "sha256:" + sha[0:8]} {
-		t.Logf("Testing %s", id)
-		result := inspectImageHelper(base, id)
-		assert.Equal(base.T, 1, len(result))
-		assert.Equal(base.T, reference[0].ID, result[0].ID)
-	}
-
-	// Demonstrate image name precedence over digest lookup
-	// Using the shortened sha should no longer get busybox, but rather the newly tagged Alpine
-	t.Logf("Testing (alpine tagged) %s", sha[0:8])
-	// Tag a different image with the short id
-	base.Cmd("tag", "alpine", sha[0:8]).AssertOK()
-	result := inspectImageHelper(base, sha[0:8])
-	assert.Equal(base.T, 1, len(result))
-	assert.Equal(base.T, differentReference[0].ID, result[0].ID)
-
-	// Prove that wrong references with an existing digest do not get retrieved when asking by digest
-	for _, id := range []string{"doesnotexist", "doesnotexist:either", "busybox:bogustag"} {
-		t.Logf("Testing %s", id+"@"+sha)
-		args := append([]string{"image", "inspect"}, id+"@"+sha)
-		cmdResult := base.Cmd(args...).Run()
-		assert.Equal(base.T, cmdResult.ExitCode, 0)
-		assert.Equal(base.T, cmdResult.Stdout(), "")
-	}
-
-	// Prove that invalid reference return no result without crashing
-	for _, id := range []string{"∞∞∞∞∞∞∞∞∞∞", "busybox:∞∞∞∞∞∞∞∞∞∞"} {
-		t.Logf("Testing %s", id)
-		args := append([]string{"image", "inspect"}, id)
-		cmdResult := base.Cmd(args...).Run()
-		assert.Equal(base.T, cmdResult.ExitCode, 0)
-		assert.Equal(base.T, cmdResult.Stdout(), "")
-	}
-
-	// Retrieving multiple entries at once
-	t.Logf("Testing %s", "busybox busybox busybox:stable")
-	result = inspectImageHelper(base, "busybox", "busybox", "busybox:stable")
-	assert.Equal(base.T, 3, len(result))
-	assert.Equal(base.T, reference[0].ID, result[0].ID)
-	assert.Equal(base.T, reference[0].ID, result[1].ID)
-	assert.Equal(base.T, reference[0].ID, result[2].ID)
-
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -125,7 +125,8 @@ func TestImagesFilterDangling(t *testing.T) {
 	testutil.RequiresBuild(t)
 	testutil.RegisterBuildCacheCleanup(t)
 	base := testutil.NewBase(t)
-	base.Cmd("images", "prune", "--all").AssertOK()
+	base.Cmd("container", "prune", "-f").AssertOK()
+	base.Cmd("image", "prune", "--all", "-f").AssertOK()
 
 	dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-notag-string"]

--- a/cmd/nerdctl/issues/issues_linux_test.go
+++ b/cmd/nerdctl/issues/issues_linux_test.go
@@ -1,0 +1,133 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package issues is meant to document testing for complex scenarios type of issues that cannot simply be ascribed
+// to a specific package.
+package issues
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
+)
+
+func TestMain(m *testing.M) {
+	testutil.M(m)
+}
+
+func TestIssue3425(t *testing.T) {
+	nerdtest.Setup()
+
+	var registry *testregistry.RegistryServer
+
+	testCase := &test.Case{
+		Description: "TestIssue3425",
+		Setup: func(data test.Data, helpers test.Helpers) {
+			base := testutil.NewBase(t)
+			registry = testregistry.NewWithNoAuth(base, 0, false)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			if registry != nil {
+				registry.Cleanup(nil)
+			}
+		},
+		SubTests: []*test.Case{
+			{
+				Description: "with tag",
+				Require:     nerdtest.Private,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
+					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("tag", testutil.CommonImage, fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("rmi", "-f", fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("push", fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Expected: test.Expects(0, nil, nil),
+			},
+			{
+				Description: "with commit",
+				Require:     nerdtest.Private,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "touch", "/something")
+					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("commit", data.Identifier(), fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("rmi", "-f", fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("push", fmt.Sprintf("localhost:%d/%s", registry.Port, data.Identifier()))
+				},
+				Expected: test.Expects(0, nil, nil),
+			},
+			{
+				Description: "with save",
+				Require:     nerdtest.Private,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
+					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("save", testutil.CommonImage)
+				},
+				Expected: test.Expects(0, nil, nil),
+			},
+			{
+				Description: "with convert",
+				Require: test.Require(
+					nerdtest.Private,
+					test.Not(test.Windows),
+					test.Not(nerdtest.Docker),
+				),
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
+					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
+					helpers.Ensure("image", "pull", testutil.CommonImage)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("rmi", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("image", "convert", "--oci", "--estargz", testutil.CommonImage, data.Identifier())
+				},
+				Expected: test.Expects(0, nil, nil),
+			},
+		},
+	}
+
+	testCase.Run(t)
+}

--- a/hack/kind.yaml
+++ b/hack/kind.yaml
@@ -10,3 +10,5 @@ nodes:
         containerPath: /usr/local/go
       - hostPath: .
         containerPath: /nerdctl-source
+      - hostPath: /opt/cni
+        containerPath: /opt/cni

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -75,6 +75,12 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 	}
 	convertOpts = append(convertOpts, converter.WithPlatform(platMC))
 
+	// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
+	err = EnsureAllContent(ctx, client, srcRawRef, options.GOptions)
+	if err != nil {
+		return err
+	}
+
 	estargz := options.Estargz
 	zstd := options.Zstd
 	zstdchunked := options.ZstdChunked

--- a/pkg/cmd/image/ensure.go
+++ b/pkg/cmd/image/ensure.go
@@ -1,0 +1,127 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+
+	distributionref "github.com/distribution/reference"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
+	"github.com/containerd/nerdctl/v2/pkg/errutil"
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/fetch"
+	"github.com/containerd/nerdctl/v2/pkg/platformutil"
+)
+
+func EnsureAllContent(ctx context.Context, client *containerd.Client, srcName string, options types.GlobalCommandOptions) error {
+	// Get the image from the srcName
+	imageService := client.ImageService()
+	img, err := imageService.Get(ctx, srcName)
+	if err != nil {
+		fmt.Println("Failed getting imageservice")
+		return err
+	}
+
+	provider := containerdutil.NewProvider(client)
+	snapshotter := containerdutil.SnapshotService(client, options.Snapshotter)
+	// Read the image
+	imagesList, _ := read(ctx, provider, snapshotter, img.Target)
+	// Iterate through the list
+	for _, i := range imagesList {
+		err = ensureOne(ctx, client, srcName, img.Target, i.platform, options)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ensureOne(ctx context.Context, client *containerd.Client, rawRef string, target ocispec.Descriptor, platform ocispec.Platform, options types.GlobalCommandOptions) error {
+
+	named, err := distributionref.ParseDockerRef(rawRef)
+	if err != nil {
+		return err
+	}
+	refDomain := distributionref.Domain(named)
+	// if platform == nil {
+	//	platform = platforms.DefaultSpec()
+	//}
+	pltf := []ocispec.Platform{platform}
+	platformComparer := platformutil.NewMatchComparerFromOCISpecPlatformSlice(pltf)
+
+	_, _, _, missing, err := images.Check(ctx, client.ContentStore(), target, platformComparer)
+	if err != nil {
+		return err
+	}
+
+	if len(missing) > 0 {
+		// Get a resolver
+		var dOpts []dockerconfigresolver.Opt
+		if options.InsecureRegistry {
+			log.G(ctx).Warnf("skipping verifying HTTPS certs for %q", refDomain)
+			dOpts = append(dOpts, dockerconfigresolver.WithSkipVerifyCerts(true))
+		}
+		dOpts = append(dOpts, dockerconfigresolver.WithHostsDirs(options.HostsDir))
+		resolver, err := dockerconfigresolver.New(ctx, refDomain, dOpts...)
+		if err != nil {
+			return err
+		}
+		config := &fetch.Config{
+			Resolver:       resolver,
+			RemoteOpts:     []containerd.RemoteOpt{},
+			Platforms:      pltf,
+			ProgressOutput: os.Stderr,
+		}
+
+		err = fetch.Fetch(ctx, client, rawRef, config)
+
+		if err != nil {
+			// In some circumstance (e.g. people just use 80 port to support pure http), the error will contain message like "dial tcp <port>: connection refused".
+			if !errors.Is(err, http.ErrSchemeMismatch) && !errutil.IsErrConnectionRefused(err) {
+				return err
+			}
+			if options.InsecureRegistry {
+				log.G(ctx).WithError(err).Warnf("server %q does not seem to support HTTPS, falling back to plain HTTP", refDomain)
+				dOpts = append(dOpts, dockerconfigresolver.WithPlainHTTP(true))
+				resolver, err = dockerconfigresolver.New(ctx, refDomain, dOpts...)
+				if err != nil {
+					return err
+				}
+				config.Resolver = resolver
+				return fetch.Fetch(ctx, client, rawRef, config)
+			}
+			log.G(ctx).WithError(err).Errorf("server %q does not seem to support HTTPS", refDomain)
+			log.G(ctx).Info("Hint: you may want to try --insecure-registry to allow plain HTTP (if you are in a trusted network)")
+		}
+
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -48,6 +48,13 @@ func Save(ctx context.Context, client *containerd.Client, images []string, optio
 			if found.UniqueImages > 1 {
 				return fmt.Errorf("ambiguous digest ID: multiple IDs found with provided prefix %s", found.Req)
 			}
+
+			// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
+			err = EnsureAllContent(ctx, client, found.Image.Name, options.GOptions)
+			if err != nil {
+				return err
+			}
+
 			imgName := found.Image.Name
 			imgDigest := found.Image.Target.Digest.String()
 			if _, ok := savedImages[imgDigest]; !ok {

--- a/pkg/imgutil/fetch/fetch.go
+++ b/pkg/imgutil/fetch/fetch.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fetch
+
+import (
+	"context"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/jobs"
+	"github.com/containerd/nerdctl/v2/pkg/platformutil"
+)
+
+// Config for content fetch
+type Config struct {
+	// Resolver
+	Resolver remotes.Resolver
+	// ProgressOutput to display progress
+	ProgressOutput io.Writer
+	// RemoteOpts, e.g. containerd.WithPullUnpack.
+	//
+	// Regardless to RemoteOpts, the following opts are always set:
+	// WithResolver, WithImageHandler, WithSchema1Conversion
+	//
+	// RemoteOpts related to unpacking can be set only when len(Platforms) is 1.
+	RemoteOpts []containerd.RemoteOpt
+	Platforms  []ocispec.Platform // empty for all-platforms
+}
+
+func Fetch(ctx context.Context, client *containerd.Client, ref string, config *Config) error {
+	ongoing := jobs.New(ref)
+
+	pctx, stopProgress := context.WithCancel(ctx)
+	progress := make(chan struct{})
+
+	go func() {
+		if config.ProgressOutput != nil {
+			// no progress bar, because it hides some debug logs
+			jobs.ShowProgress(pctx, ongoing, client.ContentStore(), config.ProgressOutput)
+		}
+		close(progress)
+	}()
+
+	h := images.HandlerFunc(func(ctx context.Context, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
+		if desc.MediaType != images.MediaTypeDockerSchema1Manifest {
+			ongoing.Add(desc)
+		}
+		return nil, nil
+	})
+
+	log.G(pctx).WithField("image", ref).Debug("fetching")
+	platformMC := platformutil.NewMatchComparerFromOCISpecPlatformSlice(config.Platforms)
+	opts := []containerd.RemoteOpt{
+		containerd.WithResolver(config.Resolver),
+		containerd.WithImageHandler(h),
+		//nolint:staticcheck
+		containerd.WithSchema1Conversion, //lint:ignore SA1019 nerdctl should support schema1 as well.
+		containerd.WithPlatformMatcher(platformMC),
+	}
+	opts = append(opts, config.RemoteOpts...)
+
+	// Note that client.Fetch does not unpack
+	_, err := client.Fetch(pctx, ref, opts...)
+
+	stopProgress()
+	if err != nil {
+		return err
+	}
+
+	<-progress
+	return nil
+}

--- a/pkg/testutil/nerdtest/test.go
+++ b/pkg/testutil/nerdtest/test.go
@@ -170,6 +170,20 @@ func InspectNetwork(helpers test.Helpers, name string, args ...string) dockercom
 	return dc[0]
 }
 
+func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
+	var dc []dockercompat.Image
+	cmd := helpers.Command("image", "inspect", name)
+	cmd.Run(&test.Expected{
+		ExitCode: 0,
+		Output: func(stdout string, info string, t *testing.T) {
+			err := json.Unmarshal([]byte(stdout), &dc)
+			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+		},
+	})
+	return dc[0]
+}
+
 func nerdctlSetup(testCase *test.Case, t *testing.T) test.Command {
 	t.Helper()
 


### PR DESCRIPTION
See #3425 and linked issues for context.

- fix #3425
- fix #827 (commit)
- fix #2357 (save)
- fix #2327 (convert)
- fix #2506 (tag)
- fix #3026 (commit)

Unconfirmed (no test), but cannot reproduce anymore with the patch:
- fix #3420

Unconfirmed, but probably fixed as well:
- #2588 (untested)

Reviewers, most of this is test wrangling:
- enabling Kube test which was missing a few bits
- fixing broken image inspect tests that are now more likely to show leftovers