### PR TITLE
Enable other containers to join network namespace of the none network

### DIFF
--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -24,7 +24,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -513,35 +512,197 @@ func TestRunNetworkHost2613(t *testing.T) {
 	base.Cmd("run", "--rm", "--add-host", "foo:1.2.3.4", testutil.CommonImage, "getent", "hosts", "foo").AssertOutExactly("1.2.3.4           foo  foo\n")
 }
 
-func TestSharedNetworkStack(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("--network=container:<container name|id> only supports linux now")
+func TestSharedNetworkSetup(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier("-container1"))
+			containerName1 := data.Get("containerName1")
+			helpers.Ensure("run", "-d", "--name", containerName1,
+				testutil.NginxAlpineImage)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier("-container1"))
+		},
+		SubTests: []*test.Case{
+			{
+				Description: "Test network is shared",
+				NoParallel:  true, // The validation involves starting of the main container: container1
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "-d", "--name", containerName2,
+						"--network=container:"+data.Get("containerName1"),
+						testutil.NginxAlpineImage)
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							containerName2 := data.Identifier()
+							assert.Assert(t, strings.Contains(helpers.Capture("exec", containerName2, "wget", "-qO-", "http://127.0.0.1:80"), testutil.NginxAlpineIndexHTMLSnippet), info)
+							helpers.Ensure("restart", data.Get("containerName1"))
+							helpers.Ensure("stop", "--time=1", containerName2)
+							helpers.Ensure("start", containerName2)
+							assert.Assert(t, strings.Contains(helpers.Capture("exec", containerName2, "wget", "-qO-", "http://127.0.0.1:80"), testutil.NginxAlpineIndexHTMLSnippet), info)
+						},
+					}
+				},
+			},
+			{
+				Description: "Test uts is supported in shared network",
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "-d", "--name", containerName2, "--uts", "host",
+						"--network=container:"+data.Get("containerName1"),
+						testutil.AlpineImage)
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 0,
+					}
+				},
+			},
+			{
+				Description: "Test dns is not supported",
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "-d", "--name", containerName2, "--dns", "0.1.2.3",
+						"--network=container:"+data.Get("containerName1"),
+						testutil.AlpineImage)
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					if nerdtest.IsDocker() {
+						return &test.Expected{
+							ExitCode: 125,
+						}
+
+					}
+					return &test.Expected{
+						ExitCode: 1,
+					}
+				},
+			},
+			{
+				Description: "Test dns options is not  supported",
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "--name", containerName2, "--dns-option", "attempts:5",
+						"--network=container:"+data.Get("containerName1"),
+						testutil.AlpineImage, "cat", "/etc/resolv.conf")
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					// The Option doesnt throw an error but is never inserted to the resolv.conf
+					return &test.Expected{
+						ExitCode: 0,
+						Output: func(stdout string, info string, t *testing.T) {
+							assert.Assert(t, !strings.Contains(stdout, "attempts:5"), info)
+						},
+					}
+				},
+			},
+			{
+				Description: "Test publish is not supported",
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "-d", "--name", containerName2, "--publish", "80:8080",
+						"--network=container:"+data.Get("containerName1"),
+						testutil.AlpineImage)
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					if nerdtest.IsDocker() {
+						return &test.Expected{
+							ExitCode: 125,
+						}
+
+					}
+					return &test.Expected{
+						ExitCode: 1,
+					}
+				},
+			},
+			{
+				Description: "Test hostname is not supported",
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					containerName2 := data.Identifier()
+					cmd := helpers.Command()
+					cmd.WithArgs("run", "-d", "--name", containerName2, "--hostname", "test",
+						"--network=container:"+data.Get("containerName1"),
+						testutil.AlpineImage)
+					return cmd
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					if nerdtest.IsDocker() {
+						return &test.Expected{
+							ExitCode: 125,
+						}
+
+					}
+					return &test.Expected{
+						ExitCode: 1,
+					}
+				},
+			},
+		},
 	}
-	base := testutil.NewBase(t)
+	testCase.Run(t)
+}
 
-	containerName := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", containerName).AssertOK()
-	base.Cmd("run", "-d", "--name", containerName,
-		testutil.NginxAlpineImage).AssertOK()
-	base.EnsureContainerStarted(containerName)
-
-	containerNameJoin := testutil.Identifier(t) + "-network"
-	defer base.Cmd("rm", "-f", containerNameJoin).AssertOK()
-	base.Cmd("run",
-		"-d",
-		"--name", containerNameJoin,
-		"--network=container:"+containerName,
-		testutil.CommonImage,
-		"sleep", nerdtest.Infinity).AssertOK()
-
-	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
-		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
-
-	base.Cmd("restart", containerName).AssertOK()
-	base.Cmd("stop", "--time=1", containerNameJoin).AssertOK()
-	base.Cmd("start", containerNameJoin).AssertOK()
-	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
-		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)
+func TestSharedNetworkWithNone(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier("-container1"))
+			containerName1 := data.Get("containerName1")
+			helpers.Ensure("run", "-d", "--name", containerName1, "--network", "none",
+				testutil.NginxAlpineImage)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Get("containerName1"))
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			containerName2 := data.Identifier()
+			cmd := helpers.Command()
+			cmd.WithArgs("run", "-d", "--name", containerName2,
+				"--network=container:"+data.Get("containerName1"),
+				testutil.NginxAlpineImage)
+			return cmd
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				ExitCode: 0,
+			}
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestRunContainerInExistingNetNS(t *testing.T) {
@@ -669,6 +830,8 @@ func TestHostsFileMounts(t *testing.T) {
 		"sh", "-euxc", "echo >> /etc/hosts").AssertOK()
 	base.Cmd("run", "--rm", "-v", "/etc/hosts:/etc/hosts", "--network", "host", testutil.CommonImage,
 		"sh", "-euxc", "head -n -1 /etc/hosts > temp && cat temp > /etc/hosts").AssertOK()
+	base.Cmd("run", "--rm", "--network", "none", testutil.CommonImage,
+		"sh", "-euxc", "echo >> /etc/hosts").AssertOK()
 
 	base.Cmd("run", "--rm", testutil.CommonImage,
 		"sh", "-euxc", "echo >> /etc/resolv.conf").AssertOK()
@@ -681,6 +844,8 @@ func TestHostsFileMounts(t *testing.T) {
 		"sh", "-euxc", "echo >> /etc/resolv.conf").AssertOK()
 	base.Cmd("run", "--rm", "-v", "/etc/resolv.conf:/etc/resolv.conf", "--network", "host", testutil.CommonImage,
 		"sh", "-euxc", "head -n -1 /etc/resolv.conf > temp && cat temp > /etc/resolv.conf").AssertOK()
+	base.Cmd("run", "--rm", "--network", "host", testutil.CommonImage,
+		"sh", "-euxc", "echo >> /etc/resolv.conf").AssertOK()
 }
 
 func TestRunContainerWithStaticIP6(t *testing.T) {
@@ -751,4 +916,115 @@ func TestRunContainerWithStaticIP6(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestNoneNetworkHostName(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier())
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("run", "-d", "--name", data.Identifier(), "--network", "none", testutil.NginxAlpineImage)
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				Output: func(stdout string, info string, t *testing.T) {
+					hostname := stdout
+					if len(hostname) > 12 {
+						hostname = hostname[:12]
+					}
+					assert.Assert(t, strings.Compare(strings.TrimSpace(helpers.Capture("exec", data.Identifier(), "cat", "/etc/hostname")), hostname) == 0, info)
+				},
+			}
+		},
+	}
+	testCase.Run(t)
+}
+
+func TestHostNetworkHostName(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier())
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Custom("cat", "/etc/hostname")
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				Output: func(stdout string, info string, t *testing.T) {
+					hostname := stdout
+					assert.Assert(t, strings.Compare(strings.TrimSpace(helpers.Capture("run", "--name", data.Identifier(), "--network", "host", testutil.AlpineImage, "cat", "/etc/hostname")), strings.TrimSpace(hostname)) == 0, info)
+				},
+			}
+		},
+	}
+	testCase.Run(t)
+}
+
+func TestNoneNetworkDnsConfigs(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier())
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("run", "-d", "--name", data.Identifier(), "--network", "none", "--dns", "0.1.2.3", "--dns-search", "example.com", "--dns-option", "timeout:3", "--dns-option", "attempts:5", testutil.NginxAlpineImage)
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				Output: func(stdout string, info string, t *testing.T) {
+					out := helpers.Capture("exec", data.Identifier(), "cat", "/etc/resolv.conf")
+					assert.Assert(t, strings.Contains(out, "0.1.2.3"), info)
+					assert.Assert(t, strings.Contains(out, "example.com"), info)
+					assert.Assert(t, strings.Contains(out, "attempts:5"), info)
+					assert.Assert(t, strings.Contains(out, "timeout:3"), info)
+
+				},
+			}
+		},
+	}
+	testCase.Run(t)
+}
+
+func TestHostNetworkDnsConfigs(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Require: test.Not(test.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("containerName1", data.Identifier())
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("run", "-d", "--name", data.Identifier(), "--network", "host", "--dns", "0.1.2.3", "--dns-search", "example.com", "--dns-option", "timeout:3", "--dns-option", "attempts:5", testutil.NginxAlpineImage)
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				Output: func(stdout string, info string, t *testing.T) {
+					out := helpers.Capture("exec", data.Identifier(), "cat", "/etc/resolv.conf")
+					assert.Assert(t, strings.Contains(out, "0.1.2.3"), info)
+					assert.Assert(t, strings.Contains(out, "example.com"), info)
+					assert.Assert(t, strings.Contains(out, "attempts:5"), info)
+					assert.Assert(t, strings.Contains(out, "timeout:3"), info)
+
+				},
+			}
+		},
+	}
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -37,6 +37,12 @@ func TestImagePrune(t *testing.T) {
 	// Cannot use a custom namespace with buildkitd right now, so, no parallel it is
 	testCase.NoParallel = true
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		// Stop and remove all running containers. This is to ensure we can remove all
+		contList := strings.TrimSpace(helpers.Capture("ps", "-aq"))
+		if contList != "" {
+			helpers.Ensure(append([]string{"rm", "-f"}, strings.Split(contList, "\n")...)...)
+		}
+
 		// We need to delete everything here for prune to make any sense
 		imgList := strings.TrimSpace(helpers.Capture("images", "--no-trunc", "-aq"))
 		if imgList != "" {

--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -42,6 +43,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/mountutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
+	"github.com/containerd/nerdctl/v2/pkg/resolvconf"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
@@ -84,6 +86,36 @@ func withCustomHosts(src string) func(context.Context, oci.Client, *containers.C
 		})
 		return nil
 	}
+}
+
+func fetchDNSResolverConfig(netOpts types.NetworkOptions) ([]string, []string, []string, error) {
+	dns := netOpts.DNSServers
+	dnsSearch := netOpts.DNSSearchDomains
+	dnsOptions := netOpts.DNSResolvConfOptions
+
+	conf, err := resolvconf.Get()
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, nil, nil, err
+		}
+		// if resolvConf file does't exist, using default resolvers
+		conf = &resolvconf.File{}
+		log.L.WithError(err).Debugf("resolvConf file doesn't exist on host")
+	}
+	conf, err = resolvconf.FilterResolvDNS(conf.Content, true)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(netOpts.DNSServers) == 0 {
+		dns = resolvconf.GetNameservers(conf.Content, resolvconf.IP)
+	}
+	if len(netOpts.DNSSearchDomains) == 0 {
+		dnsSearch = resolvconf.GetSearchDomains(conf.Content)
+	}
+	if len(netOpts.DNSResolvConfOptions) == 0 {
+		dnsOptions = resolvconf.GetOptions(conf.Content)
+	}
+	return dns, dnsSearch, dnsOptions, err
 }
 
 // NetworkOptionsManager types.NetworkOptionsManager is an interface for reading/setting networking
@@ -157,31 +189,164 @@ func (m *noneNetworkManager) NetworkOptions() types.NetworkOptions {
 
 // VerifyNetworkOptions Verifies that the internal network settings are correct.
 func (m *noneNetworkManager) VerifyNetworkOptions(_ context.Context) error {
-	// No options to verify if no network settings are provided.
+	err := validateUtsSettings(m.netOpts)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // SetupNetworking Performs setup actions required for the container with the given ID.
-func (m *noneNetworkManager) SetupNetworking(_ context.Context, _ string) error {
+func (m *noneNetworkManager) SetupNetworking(ctx context.Context, containerID string) error {
+	// Retrieve the container
+	container, err := m.client.ContainerService().Get(ctx, containerID)
+	if err != nil {
+		return err
+	}
+
+	// Get the dataStore
+	dataStore, err := clientutil.DataStore(m.globalOptions.DataRoot, m.globalOptions.Address)
+	if err != nil {
+		return err
+	}
+
+	// Get the hostsStore
+	hs, err := hostsstore.New(dataStore, container.Labels[labels.Namespace])
+	if err != nil {
+		return err
+	}
+
+	// Get extra-hosts
+	extraHostsJSON := container.Labels[labels.ExtraHosts]
+	var extraHosts []string
+	if err = json.Unmarshal([]byte(extraHostsJSON), &extraHosts); err != nil {
+		return err
+	}
+
+	hosts := make(map[string]string)
+	for _, host := range extraHosts {
+		if v := strings.SplitN(host, ":", 2); len(v) == 2 {
+			hosts[v[0]] = v[1]
+		}
+	}
+
+	// Prep the meta
+	hsMeta := hostsstore.Meta{
+		ID:         container.ID,
+		Hostname:   container.Labels[labels.Hostname],
+		ExtraHosts: hosts,
+		Name:       container.Labels[labels.Name],
+	}
+
+	// Save the meta information
+	if err = hs.Acquire(hsMeta); err != nil {
+		return err
+	}
+
 	return nil
 }
 
 // CleanupNetworking Performs any required cleanup actions for the given container.
 // Should only be called to revert any setup steps performed in SetupNetworking.
-func (m *noneNetworkManager) CleanupNetworking(_ context.Context, _ containerd.Container) error {
+func (m *noneNetworkManager) CleanupNetworking(ctx context.Context, container containerd.Container) error {
+	// Get the dataStore
+	dataStore, err := clientutil.DataStore(m.globalOptions.DataRoot, m.globalOptions.Address)
+	if err != nil {
+		return err
+	}
+
+	// Get labels
+	lbls, err := container.Labels(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Get the hostsStore
+	hs, err := hostsstore.New(dataStore, lbls[labels.Namespace])
+	if err != nil {
+		return err
+	}
+
+	// Release
+	if err = hs.Release(container.ID()); err != nil {
+		return err
+	}
 	return nil
 }
 
 // InternalNetworkingOptionLabels Returns the set of NetworkingOptions which should be set as labels on the container.
 func (m *noneNetworkManager) InternalNetworkingOptionLabels(_ context.Context) (types.NetworkOptions, error) {
-	return m.netOpts, nil
+	opts := m.netOpts
+	// Cannot have a MAC address in host networking mode.
+	opts.MACAddress = ""
+	return opts, nil
 }
 
 // ContainerNetworkingOpts Returns a slice of `oci.SpecOpts` and `containerd.NewContainerOpts` which represent
 // the network specs which need to be applied to the container with the given ID.
-func (m *noneNetworkManager) ContainerNetworkingOpts(_ context.Context, _ string) ([]oci.SpecOpts, []containerd.NewContainerOpts, error) {
-	// No options to return if no network settings are provided.
-	return []oci.SpecOpts{}, []containerd.NewContainerOpts{}, nil
+func (m *noneNetworkManager) ContainerNetworkingOpts(_ context.Context, containerID string) ([]oci.SpecOpts, []containerd.NewContainerOpts, error) {
+	dataStore, err := clientutil.DataStore(m.globalOptions.DataRoot, m.globalOptions.Address)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	stateDir, err := ContainerStateDirPath(m.globalOptions.Namespace, dataStore, containerID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	resolvConfPath := filepath.Join(stateDir, "resolv.conf")
+	dns, dnsSearch, dnsOptions, err := fetchDNSResolverConfig(m.netOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = resolvconf.Build(resolvConfPath, dns, dnsSearch, dnsOptions)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	hs, err := hostsstore.New(dataStore, m.globalOptions.Namespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	etcHostsPath, err := hs.AllocHostsFile(containerID, []byte{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// `/etc/host` does not exist in FreeBSD minimal rootfs image
+	// `/etc/resolv.conf` does not exist in FreeBSD minimal rootfs image
+	specs := []oci.SpecOpts{}
+	if runtime.GOOS == "linux" {
+		specs = []oci.SpecOpts{
+			withDedupMounts("/etc/resolv.conf", withCustomResolvConf(resolvConfPath)),
+			withDedupMounts("/etc/hosts", withCustomHosts(etcHostsPath)),
+		}
+	}
+
+	// `/etc/hostname` does not exist on FreeBSD
+	if runtime.GOOS == "linux" {
+		// If no hostname is set, default to first 12 characters of the container ID.
+		hostname := m.netOpts.Hostname
+		if hostname == "" {
+			hostname = containerID
+			if len(hostname) > 12 {
+				hostname = hostname[0:12]
+			}
+		}
+		m.netOpts.Hostname = hostname
+
+		hostnameOpts, err := writeEtcHostnameForContainer(m.globalOptions, m.netOpts.Hostname, containerID)
+		if err != nil {
+			return nil, nil, err
+		}
+		if hostnameOpts != nil {
+			specs = append(specs, hostnameOpts...)
+		}
+	}
+	return specs, []containerd.NewContainerOpts{}, nil
 }
 
 // types.NetworkOptionsManager implementation for container networking settings.
@@ -203,8 +368,9 @@ func (m *containerNetworkManager) VerifyNetworkOptions(_ context.Context) error 
 		return errors.New("container networking mode is currently only supported on Linux")
 	}
 
-	if len(m.netOpts.NetworkSlice) > 1 {
-		return errors.New("conflicting options: only one network specification is allowed when using '--network=container:<container>'")
+	err := validateUtsSettings(m.netOpts)
+	if err != nil {
+		return err
 	}
 
 	// Note that mac-address is accepted, though it is a no-op
@@ -330,6 +496,10 @@ func (m *containerNetworkManager) ContainerNetworkingOpts(ctx context.Context, _
 		return nil, nil, err
 	}
 	hostname := s.Hostname
+	// if Utsnamespace is set we should not set the hostname
+	if m.netOpts.UTSNamespace == UtsNamespaceHost {
+		hostname = ""
+	}
 
 	netNSPath, err := ContainerNetNSPath(ctx, container)
 	if err != nil {
@@ -469,24 +639,6 @@ func withDedupMounts(mountPath string, defaultSpec oci.SpecOpts) oci.SpecOpts {
 	}
 }
 
-// copyFileContent copies a file and sets world readable permissions on it, regardless of umask.
-// This is used solely for /etc/resolv.conf and /etc/hosts
-func copyFileContent(src string, dst string) error {
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(dst, data, 0644)
-	if err != nil {
-		return err
-	}
-	err = os.Chmod(dst, 0644)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // getHostNetworkingNamespace Returns an oci.SpecOpts representing the network namespace to
 // be used by the hostNetworkManager. When running with `--network=host` this would be the host's
 // root namespace, but `--network=ns:<path>` can be used to run a container in an existing netns.
@@ -524,7 +676,15 @@ func (m *hostNetworkManager) ContainerNetworkingOpts(_ context.Context, containe
 	}
 
 	resolvConfPath := filepath.Join(stateDir, "resolv.conf")
-	copyFileContent("/etc/resolv.conf", resolvConfPath)
+	dns, dnsSearch, dnsOptions, err := fetchDNSResolverConfig(m.netOpts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, err = resolvconf.Build(resolvConfPath, dns, dnsSearch, dnsOptions)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	hs, err := hostsstore.New(dataStore, m.globalOptions.Namespace)
 	if err != nil {
@@ -548,12 +708,12 @@ func (m *hostNetworkManager) ContainerNetworkingOpts(_ context.Context, containe
 	}
 	specs := []oci.SpecOpts{
 		netNamespace,
-		withDedupMounts("/etc/hosts", withCustomHosts(etcHostsPath)),
 		withDedupMounts("/etc/resolv.conf", withCustomResolvConf(resolvConfPath)),
+		withDedupMounts("/etc/hosts", withCustomHosts(etcHostsPath)),
 	}
 
 	// `/etc/hostname` does not exist on FreeBSD
-	if runtime.GOOS == "linux" && m.netOpts.UTSNamespace != UtsNamespaceHost {
+	if runtime.GOOS == "linux" {
 		hostname := m.netOpts.Hostname
 		if hostname == "" {
 			// Hostname by default should be the host hostname


### PR DESCRIPTION
## Fixes: Unable to attach to container network created with none

## Description

There is a use case with pause containers, where other containers attaches to the pause container network. The pause container is launched with network none. This requires the pause container have a copy of hosts, hostname and resolv conf.
It also seems to share a net namespace, the containers must also share a user namespace.

The solution is to have a copy of the hosts/hostname and resolv.conf. In case of container network, add userns and netns both.

Want to confirm is this an acceptable solution and i can send out an PR for it.
Steps to reproduce the issue

    Create a pause container with network none.
    Create another container with --net container:

## Describe the results you received and expected

It would display errors with resolv.conf not found and once those configs are added would see an error with sys fs.
Expected result is to be able to connect to the network of pause container.
What version of nerdctl are you using?

1.7.5
Are you using a variant of nerdctl? (e.g., Rancher Desktop)

None
Host information

lima vm (fedora image), but can be reproduced in any architecture.


