### PR TITLE
Rename `containerd-rootless-setuptool.sh`

### DIFF
--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -30,17 +30,17 @@ if [[ "$(id -u)" = "0" ]]; then
 	systemctl start ssh
 	exec ssh -o StrictHostKeyChecking=no rootless@localhost "$0" "$@"
 else
-	containerd-rootless-setuptool.sh install
+	containerd-rootless-systemd.sh install
 	if grep -q "options use-vc" /etc/resolv.conf; then
-		containerd-rootless-setuptool.sh nsenter -- sh -euc 'echo "options use-vc" >>/etc/resolv.conf'
+		containerd-rootless-systemd.sh nsenter -- sh -euc 'echo "options use-vc" >>/etc/resolv.conf'
 	fi
 
 	if [[ -e /workaround-issue-622 ]]; then
 		echo "WORKAROUND_ISSUE_622: Not enabling BuildKit (https://github.com/containerd/nerdctl/issues/622)" >&2
 	else
-		CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-setuptool.sh install-buildkit-containerd
+		CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-systemd.sh install-buildkit-containerd
 	fi
-	containerd-rootless-setuptool.sh install-stargz
+	containerd-rootless-systemd.sh install-stargz
 	if [ ! -f "/home/rootless/.config/containerd/config.toml" ] ; then
 		echo "version = 2" > /home/rootless/.config/containerd/config.toml
 	fi
@@ -51,11 +51,11 @@ else
     address = "/run/user/$(id -u)/containerd-stargz-grpc/containerd-stargz-grpc.sock"
 EOF
 	systemctl --user restart containerd.service
-	containerd-rootless-setuptool.sh -- install-ipfs --init --offline # offline ipfs daemon for testing
+	containerd-rootless-systemd.sh -- install-ipfs --init --offline # offline ipfs daemon for testing
 	echo "ipfs = true" >>/home/rootless/.config/containerd-stargz-grpc/config.toml
 	systemctl --user restart stargz-snapshotter.service
 	export IPFS_PATH="/home/rootless/.local/share/ipfs"
-	containerd-rootless-setuptool.sh install-bypass4netnsd
+	containerd-rootless-systemd.sh install-bypass4netnsd
 	# Once ssh-ed, we lost the Dockerfile working dir, so, get back in the nerdctl checkout
 	cd /go/src/github.com/containerd/nerdctl
 	# We also lose the PATH (and SendEnv=PATH would require sshd config changes)

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ binaries: nerdctl
 install:
 	install -D -m 755 $(CURDIR)/_output/nerdctl $(DESTDIR)$(BINDIR)/nerdctl
 	install -D -m 755 $(MAKEFILE_DIR)/extras/rootless/containerd-rootless.sh $(DESTDIR)$(BINDIR)/containerd-rootless.sh
-	install -D -m 755 $(MAKEFILE_DIR)/extras/rootless/containerd-rootless-setuptool.sh $(DESTDIR)$(BINDIR)/containerd-rootless-setuptool.sh
+	install -D -m 755 $(MAKEFILE_DIR)/extras/rootless/containerd-rootless-systemd.sh $(DESTDIR)$(BINDIR)/containerd-rootless-systemd.sh
 	install -D -m 644 -t $(DESTDIR)$(DOCDIR)/nerdctl $(MAKEFILE_DIR)/docs/*.md
 
 # Note that these options will not work on macOS - unless you use gnu-tar instead of tar

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ linux/amd64, go1.18.2, 45b0a11
 To launch rootless containerd:
 
 ```console
-$ containerd-rootless-setuptool.sh install
+$ containerd-rootless-systemd.sh install
 ```
 
 To run a container with rootless containerd:

--- a/docs/build.md
+++ b/docs/build.md
@@ -39,10 +39,10 @@ This limitation can be avoided using containerd worker as mentioned later.
 |-------------------|-----------------------------------|
 
 ```
-$ CONTAINERD_NAMESPACE=default containerd-rootless-setuptool.sh install-buildkit-containerd
+$ CONTAINERD_NAMESPACE=default containerd-rootless-systemd.sh install-buildkit-containerd
 ```
 
-`containerd-rootless-setuptool.sh` is aware of `CONTAINERD_NAMESPACE` and `CONTAINERD_SNAPSHOTTER` envvars.
+`containerd-rootless-systemd.sh` is aware of `CONTAINERD_NAMESPACE` and `CONTAINERD_SNAPSHOTTER` envvars.
 It installs buildkitd to the specified containerd namespace.
 This allows BuildKit using containerd-managed images in that namespace as the base image.
 Note that BuildKit can't use images in other namespaces as of now.
@@ -77,7 +77,7 @@ Then add the following configuration to `/etc/buildkit/buildkitd.toml` to enable
 ### Rootless
 
 ```
-$ containerd-rootless-setuptool.sh install-buildkit
+$ containerd-rootless-systemd.sh install-buildkit
 ```
 
 As mentioned in the above, BuildKit with this configuration cannot use images managed by containerd.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -299,7 +299,7 @@ Using SETUID bit is highly discouraged. Consider using [Rootless mode](#rootless
 ### How to use nerdctl as a non-root user? (Rootless mode)
 
 ```
-containerd-rootless-setuptool.sh install
+containerd-rootless-systemd.sh install
 nerdctl run -d --name nginx -p 8080:80 nginx:alpine
 ```
 
@@ -352,6 +352,6 @@ systemctl --user start dbus
 
 Run the following commands:
 ```
-containerd-rootless-setuptool.sh uninstall
+containerd-rootless-systemd.sh uninstall
 rootlesskit rm -rf ~/.local/share/containerd ~/.local/share/nerdctl ~/.config/containerd
 ```

--- a/docs/ipfs.md
+++ b/docs/ipfs.md
@@ -18,15 +18,15 @@ For example, you can run Kubo using the following command.
 ipfs daemon
 ```
 
-In rootless mode, you need to install ipfs daemon using `containerd-rootless-setuptool.sh`.
+In rootless mode, you need to install ipfs daemon using `containerd-rootless-systemd.sh`.
 
 ```
-containerd-rootless-setuptool.sh -- install-ipfs --init
+containerd-rootless-systemd.sh -- install-ipfs --init
 ```
 
 > NOTE: correctly set IPFS_PATH as described in the output of the above command.
 
-:information_source: If you want to expose some ports of ipfs daemon (e.g. 4001), you can install rootless containerd using `containerd-rootless-setuptool.sh install` with `CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS="--publish=0.0.0.0:4001:4001/tcp"` environment variable.
+:information_source: If you want to expose some ports of ipfs daemon (e.g. 4001), you can install rootless containerd using `containerd-rootless-systemd.sh install` with `CONTAINERD_ROOTLESS_ROOTLESSKIT_FLAGS="--publish=0.0.0.0:4001:4001/tcp"` environment variable.
 
 :information_source: If you don't want IPFS to communicate with nodes on the internet, you can run IPFS daemon in offline mode using `--offline` flag or you can create a private IPFS network as described [here](https://github.com/containerd/stargz-snapshotter/blob/main/docs/ipfs.md#appendix-1-creating-ipfs-private-network).
 

--- a/docs/rootless.md
+++ b/docs/rootless.md
@@ -4,10 +4,10 @@ See https://rootlesscontaine.rs/getting-started/common/ for the prerequisites.
 
 ## Daemon (containerd)
 
-Use [`containerd-rootless-setuptool.sh`](../extras/rootless) to set up rootless containerd.
+Use [`containerd-rootless-systemd.sh`](../extras/rootless) to set up rootless containerd.
 
 ```console
-$ containerd-rootless-setuptool.sh install
+$ containerd-rootless-systemd.sh install
 [INFO] Checking RootlessKit functionality
 [INFO] Checking cgroup v2
 [INFO] Checking overlayfs
@@ -21,7 +21,7 @@ $ containerd-rootless-setuptool.sh install
 [INFO] You do NOT need to specify $CONTAINERD_ADDRESS explicitly.
 ```
 
-The usage of `containerd-rootless-setuptool.sh` is almost same as [`dockerd-rootless-setuptool.sh`](https://rootlesscontaine.rs/getting-started/docker/) .
+The usage of `containerd-rootless-systemd.sh` is almost same as [`dockerd-rootless-setuptool.sh`](https://rootlesscontaine.rs/getting-started/docker/) .
 
 Resource limitation flags such as `nerdctl run --memory` require systemd and cgroup v2: https://rootlesscontaine.rs/getting-started/common/cgroup2/
 
@@ -41,7 +41,7 @@ Depending on your kernel version, you may need to enable FUSE-OverlayFS or set `
 To enable BuildKit, run the following command:
 
 ```console
-$ containerd-rootless-setuptool.sh install-buildkit
+$ containerd-rootless-systemd.sh install-buildkit
 ```
 
 ## Snapshotters
@@ -59,7 +59,7 @@ For other hosts, [`fuse-overlayfs` snapshotter](https://github.com/containerd/fu
 
 To enable `fuse-overlayfs` snapshotter, run the following command:
 ```console
-$ containerd-rootless-setuptool.sh install-fuse-overlayfs
+$ containerd-rootless-systemd.sh install-fuse-overlayfs
 ```
 
 Then, add the following config to `~/.config/containerd/config.toml`, and run `systemctl --user restart containerd.service`:
@@ -84,7 +84,7 @@ If `fuse-overlayfs` does not work, try `export CONTAINERD_SNAPSHOTTER=native`.
 
 To enable Stargz snapshotter, run the following command:
 ```console
-$ containerd-rootless-setuptool.sh install-stargz
+$ containerd-rootless-systemd.sh install-stargz
 ```
 
 Then, add the following config to `~/.config/containerd/config.toml` and run `systemctl --user restart containerd.service`:
@@ -128,7 +128,7 @@ Acceleration with bypass4netns is available with:
 You also need to have `bypass4netnsd` (bypass4netns daemon) to be running.
 Example
 ```console
-$ containerd-rootless-setuptool.sh install-bypass4netnsd
+$ containerd-rootless-systemd.sh install-bypass4netnsd
 $ nerdctl run -it --rm -p 8080:80 --annotation nerdctl/bypass4netns=true alpine
 ```
 
@@ -150,7 +150,7 @@ Rootless containerd recognizes the following environment variables to configure 
   however, there is a relatively minor drawback with BuildKit prior to v0.13:
   the host loopback IP address (127.0.0.1) and abstract sockets are exposed to Dockerfile's "RUN" instructions during `nerdctl build` (not `nerdctl run`).
   The drawback is fixed in BuildKit v0.13. Upgrading from a prior version of BuildKit needs removing the old systemd unit:
-  `containerd-rootless-setuptool.sh uninstall-buildkit && rm -f ~/.config/buildkit/buildkitd.toml`
+  `containerd-rootless-systemd.sh uninstall-buildkit && rm -f ~/.config/buildkit/buildkitd.toml`
 
 To set these variables, create `~/.config/systemd/user/containerd.service.d/override.conf` as follows:
 ```ini

--- a/extras/rootless/containerd-rootless-systemd.sh
+++ b/extras/rootless/containerd-rootless-systemd.sh
@@ -21,10 +21,11 @@
 # NOTICE: https://github.com/moby/moby/blob/v20.10.3/NOTICE
 # -----------------------------------------------------------------------------
 
-# containerd-rootless-setuptool.sh: setup tool for containerd-rootless.sh
+# containerd-rootless-systemd.sh: tool to setup systemd units for
+# starting containerd-rootless.sh on startup and on-demand.
 # Needs to be executed as a non-root user.
 #
-# Typical usage: containerd-rootless-setuptool.sh install
+# Typical usage: containerd-rootless-systemd.sh install
 set -eu
 
 # utility functions

--- a/extras/rootless/containerd-rootless.sh
+++ b/extras/rootless/containerd-rootless.sh
@@ -44,7 +44,7 @@
 #   however, there is a relatively minor drawback with BuildKit prior to v0.13:
 #   the host loopback IP address (127.0.0.1) and abstract sockets are exposed to Dockerfile's "RUN" instructions during `nerdctl build` (not `nerdctl run`).
 #   The drawback is fixed in BuildKit v0.13. Upgrading from a prior version of BuildKit needs removing the old systemd unit:
-#   `containerd-rootless-setuptool.sh uninstall-buildkit && rm -f ~/.config/buildkit/buildkitd.toml`
+#   `containerd-rootless-systemd.sh uninstall-buildkit && rm -f ~/.config/buildkit/buildkitd.toml`
 
 # See also: https://github.com/containerd/nerdctl/blob/main/docs/rootless.md#configuring-rootlesskit
 
@@ -67,7 +67,7 @@ if [ -z "$_CONTAINERD_ROOTLESS_CHILD" ]; then
 	fi
 	case "$1" in
 	"check" | "install" | "uninstall")
-		echo "Did you mean 'containerd-rootless-setuptool.sh $*' ?"
+		echo "Did you mean 'containerd-rootless-systemd.sh $*' ?"
 		exit 1
 		;;
 	esac

--- a/hack/generate-release-note.sh
+++ b/hack/generate-release-note.sh
@@ -73,7 +73,7 @@ $ sudo nerdctl run -d --name nginx -p 80:80 nginx:alpine
 
 ### Rootless
 \`\`\`console
-$ containerd-rootless-setuptool.sh install
+$ containerd-rootless-systemd.sh install
 $ nerdctl run -d --name nginx -p 8080:80 nginx:alpine
 \`\`\`
 

--- a/pkg/buildkitutil/buildkitutil.go
+++ b/pkg/buildkitutil/buildkitutil.go
@@ -117,7 +117,7 @@ func GetWorkerLabels(buildkitHost string) (labels map[string]string, _ error) {
 func getHint() string {
 	hint := "`buildctl` needs to be installed and `buildkitd` needs to be running, see https://github.com/moby/buildkit"
 	if rootlessutil.IsRootless() {
-		hint += " , and `containerd-rootless-setuptool.sh install-buildkit` for OCI worker or `containerd-rootless-setuptool.sh install-buildkit-containerd` for containerd worker"
+		hint += " , and `containerd-rootless-systemd.sh install-buildkit` for OCI worker or `containerd-rootless-systemd.sh install-buildkit-containerd` for containerd worker"
 	}
 	return hint
 }

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -222,7 +222,7 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 			}
 			o.bypassClient, err = b4nndclient.New(socketPath)
 			if err != nil {
-				return nil, fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-setuptool.sh install-bypass4netnsd`): %w", err)
+				return nil, fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-systemd.sh install-bypass4netnsd`): %w", err)
 			}
 		}
 	}
@@ -481,7 +481,7 @@ func applyNetworkSettings(opts *handlerOpts) error {
 			}
 			err = bm.StartBypass(ctx, opts.ports, opts.state.ID, opts.state.Annotations[labels.StateDir])
 			if err != nil {
-				return fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-setuptool.sh install-bypass4netnsd`): %w", err)
+				return fmt.Errorf("bypass4netnsd not running? (Hint: run `containerd-rootless-systemd.sh install-bypass4netnsd`): %w", err)
 			}
 		}
 		if !b4nnBindEnabled && len(opts.ports) > 0 {

--- a/pkg/rootlessutil/parent_linux.go
+++ b/pkg/rootlessutil/parent_linux.go
@@ -70,7 +70,7 @@ func ParentMain(hostGatewayIP string) error {
 	stateDir, err := RootlessKitStateDir()
 	log.L.Debugf("stateDir: %s", stateDir)
 	if err != nil {
-		return fmt.Errorf("rootless containerd not running? (hint: use `containerd-rootless-setuptool.sh install` to start rootless containerd): %w", err)
+		return fmt.Errorf("rootless containerd not running? (hint: use `containerd-rootless-systemd.sh install` to start rootless containerd): %w", err)
 	}
 	childPid, err := RootlessKitChildPid(stateDir)
 	if err != nil {


### PR DESCRIPTION
`containerd-rootless-setuptool.sh` is now `containerd-rootless-systemd.sh`

To clarify what this tool does.

Closes #66.