### PR TITLE
Increase golangci-lint timeout to 5min

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 ---
 run:
   concurrency: 6
+  timeout: 5m
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
We got quite some CI failure due to golangci-lint timeout.

https://github.com/containerd/nerdctl/actions/runs/10967297843/job/30456799919?pr=3444

Its default timeout is [1m](https://golangci-lint.run/usage/configuration/#:~:text=g.%2030s%2C%205m.-,%23%20Default%3A%201m,-timeout%3A%205m), this PR changes it to 5m.