### PR TITLE
Test rework, part 2

### DIFF
--- a/cmd/nerdctl/network/network_list_linux_test.go
+++ b/cmd/nerdctl/network/network_list_linux_test.go
@@ -17,60 +17,77 @@
 package network
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
 func TestNetworkLsFilter(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	tID := testutil.Identifier(t)
+	nerdtest.Setup()
 
-	var net1, net2 = tID + "net-1", tID + "net-2"
-	var label1 = tID + "=label-1"
-	netID1 := base.Cmd("network", "create", "--label="+label1, net1).Out()
-	defer base.Cmd("network", "rm", "-f", netID1).Run()
+	testCase := &test.Case{
+		Description: "Test network list",
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Set("identifier", data.Identifier())
+			data.Set("label", data.Identifier()+"=label-1")
+			data.Set("netID1", helpers.Capture("network", "create", "--label="+data.Get("label"), data.Identifier()+"-1"))
+			data.Set("netID2", helpers.Capture("network", "create", data.Identifier()+"-2"))
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("network", "rm", data.Identifier()+"-1")
+			helpers.Anyhow("network", "rm", data.Identifier()+"-2")
+		},
+		SubTests: []*test.Case{
+			{
+				Description: "filter label",
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "ls", "--quiet", "--filter", "label="+data.Get("label"))
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var lines = strings.Split(strings.TrimSpace(stdout), "\n")
+							assert.Assert(t, len(lines) >= 1, info)
+							netNames := map[string]struct{}{
+								data.Get("netID1")[:12]: {},
+							}
 
-	netID2 := base.Cmd("network", "create", net2).Out()
-	defer base.Cmd("network", "rm", "-f", netID2).Run()
+							for _, name := range lines {
+								_, ok := netNames[name]
+								assert.Assert(t, ok, info)
+							}
+						},
+					}
+				},
+			},
+			{
+				Description: "filter name",
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "ls", "--quiet", "--filter", "name="+data.Get("identifier")+"-2")
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, info string, t *testing.T) {
+							var lines = strings.Split(strings.TrimSpace(stdout), "\n")
+							assert.Assert(t, len(lines) >= 1, info)
+							netNames := map[string]struct{}{
+								data.Get("netID2")[:12]: {},
+							}
 
-	base.Cmd("network", "ls", "--quiet", "--filter", "label="+tID).AssertOutWithFunc(func(stdout string) error {
-		var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-		if len(lines) < 1 {
-			return errors.New("expected at least 1 lines")
-		}
-		netNames := map[string]struct{}{
-			netID1[:12]: {},
-		}
+							for _, name := range lines {
+								_, ok := netNames[name]
+								assert.Assert(t, ok, info)
+							}
+						},
+					}
+				},
+			},
+		},
+	}
 
-		for _, name := range lines {
-			_, ok := netNames[name]
-			if !ok {
-				return fmt.Errorf("unexpected netume %s found", name)
-			}
-		}
-		return nil
-	})
-
-	base.Cmd("network", "ls", "--quiet", "--filter", "name="+net2).AssertOutWithFunc(func(stdout string) error {
-		var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-		if len(lines) < 1 {
-			return errors.New("expected at least 1 lines")
-		}
-		netNames := map[string]struct{}{
-			netID2[:12]: {},
-		}
-
-		for _, name := range lines {
-			_, ok := netNames[name]
-			if !ok {
-				return fmt.Errorf("unexpected netume %s found", name)
-			}
-		}
-		return nil
-	})
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -17,99 +17,124 @@
 package network
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/vishvananda/netlink"
 	"gotest.tools/v3/assert"
 
-	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
 func TestNetworkRemove(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for remove rootless network")
+	nerdtest.Setup()
+
+	testCase := &test.Case{
+		Description: "TestNetworkRemove",
+		Require:     test.Not(nerdtest.Rootless),
+		SubTests: []*test.Case{
+			{
+				Description: "Simple network remove",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
+					helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
+					// Verity the network is here
+					_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+					assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "rm", data.Identifier())
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 0,
+						Output: func(stdout string, info string, t *testing.T) {
+							_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+							assert.Error(t, err, "Link not found", info)
+						},
+					}
+				},
+			},
+			{
+				Description: "Network remove when linked to container",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "rm", data.Identifier())
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 1,
+						Errors:   []error{errors.New("is in use")},
+					}
+				},
+			},
+			{
+				Description: "Network remove by id",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
+					helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
+					// Verity the network is here
+					_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+					assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "rm", data.Get("netID"))
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 0,
+						Output: func(stdout string, info string, t *testing.T) {
+							_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+							assert.Error(t, err, "Link not found", info)
+						},
+					}
+				},
+			},
+			{
+				Description: "Network remove by short id",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
+					helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
+					// Verity the network is here
+					_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+					assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					return helpers.Command("network", "rm", data.Get("netID")[:12])
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 0,
+						Output: func(stdout string, info string, t *testing.T) {
+							_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+							assert.Error(t, err, "Link not found", info)
+						},
+					}
+				},
+			},
+		},
 	}
-	base := testutil.NewBase(t)
-	networkName := testutil.Identifier(t)
 
-	base.Cmd("network", "create", networkName).AssertOK()
-	defer base.Cmd("network", "rm", networkName).Run()
-
-	networkID := base.InspectNetwork(networkName).ID
-
-	tID := testutil.Identifier(t)
-	base.Cmd("run", "--rm", "--net", networkName, "--name", tID, testutil.CommonImage).AssertOK()
-
-	_, err := netlink.LinkByName("br-" + networkID[:12])
-	assert.NilError(t, err)
-
-	base.Cmd("network", "rm", networkName).AssertOK()
-
-	_, err = netlink.LinkByName("br-" + networkID[:12])
-	assert.Error(t, err, "Link not found")
-}
-
-func TestNetworkRemoveWhenLinkWithContainer(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for remove rootless network")
-	}
-	base := testutil.NewBase(t)
-	networkName := testutil.Identifier(t)
-
-	base.Cmd("network", "create", networkName).AssertOK()
-	defer base.Cmd("network", "rm", networkName).AssertOK()
-
-	tID := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--net", networkName, "--name", tID, testutil.AlpineImage, "sleep", "infinity").AssertOK()
-	defer base.Cmd("rm", "-f", tID).Run()
-	base.Cmd("network", "rm", networkName).AssertFail()
-}
-
-func TestNetworkRemoveById(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for remove rootless network")
-	}
-	base := testutil.NewBase(t)
-	networkName := testutil.Identifier(t)
-
-	base.Cmd("network", "create", networkName).AssertOK()
-	defer base.Cmd("network", "rm", networkName).Run()
-
-	networkID := base.InspectNetwork(networkName).ID
-
-	tID := testutil.Identifier(t)
-	base.Cmd("run", "--rm", "--net", networkName, "--name", tID, testutil.CommonImage).AssertOK()
-
-	_, err := netlink.LinkByName("br-" + networkID[:12])
-	assert.NilError(t, err)
-
-	base.Cmd("network", "rm", networkID).AssertOK()
-
-	_, err = netlink.LinkByName("br-" + networkID[:12])
-	assert.Error(t, err, "Link not found")
-}
-
-func TestNetworkRemoveByShortId(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for remove rootless network")
-	}
-	base := testutil.NewBase(t)
-	networkName := testutil.Identifier(t)
-
-	base.Cmd("network", "create", networkName).AssertOK()
-	defer base.Cmd("network", "rm", networkName).Run()
-
-	networkID := base.InspectNetwork(networkName).ID
-
-	tID := testutil.Identifier(t)
-	base.Cmd("run", "--rm", "--net", networkName, "--name", tID, testutil.CommonImage).AssertOK()
-
-	_, err := netlink.LinkByName("br-" + networkID[:12])
-	assert.NilError(t, err)
-
-	base.Cmd("network", "rm", networkID[:12]).AssertOK()
-
-	_, err = netlink.LinkByName("br-" + networkID[:12])
-	assert.Error(t, err, "Link not found")
+	testCase.Run(t)
 }


### PR DESCRIPTION
This is a first follow-up to #3418, rewriting more tests to leverage the new tooling.

In almost all cases, this is "identical" with the previous state of affairs, as these changes are not meant to introduce new tests, and normally do not radically change the existing tests intention.

However, here or in upcoming follow-ups:
- "requirements" have been precisely reviewed
   - some tests that were previously not "private" are now properly isolated
   - some tests that were previously not running for Docker (or other previously overstated requirements) will now run
- all tests are now parallelized by default

I appreciate this is hard to review.
This is a full-on rewrite.
But then, we are talking _solely_ about tests here, with no code or logic change - and the proof is in the pudding: aka green CI.

I am splitting different subfolders tests in different commits.
As I am converting more tests, I will add more commits to this branch.

We should still merge this PR whenever convenient (pending green of course) - and I will just open more PRs - that should help keep this bite-size and avoid conflicting with main.