### PR TITLE
fix: Cleaning up orphaned directories and files when containers creat…

### DIFF
--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -233,7 +233,7 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		hs, err := hostsstore.New(dataStore, containerNamespace)
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("failed to instantiate hostsstore for %q", containerNamespace)
-		} else if err = hs.DeallocHostsFile(id); err != nil {
+		} else if err = hs.Delete(id); err != nil {
 			// De-allocate hosts file - soft failure
 			log.G(ctx).WithError(err).Warnf("failed to remove hosts file for container %q", id)
 		}

--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -89,7 +89,7 @@ type Store interface {
 	Release(id string) error
 	Update(id, newName string) error
 	HostsPath(id string) (location string, err error)
-	DeallocHostsFile(id string) (err error)
+	Delete(id string) (err error)
 	AllocHostsFile(id string, content []byte) (location string, err error)
 }
 
@@ -185,14 +185,13 @@ func (x *hostsStore) AllocHostsFile(id string, content []byte) (location string,
 	return x.safeStore.Location(id, hostsFile)
 }
 
-func (x *hostsStore) DeallocHostsFile(id string) (err error) {
-	defer func() {
-		if err != nil {
-			err = errors.Join(ErrHostsStore, err)
-		}
-	}()
+func (x *hostsStore) Delete(id string) (err error) {
+	err = x.safeStore.WithLock(func() error { return x.safeStore.Delete(id) })
+	if err != nil {
+		err = errors.Join(ErrHostsStore, err)
+	}
 
-	return x.safeStore.WithLock(func() error { return x.safeStore.Delete(id, hostsFile) })
+	return err
 }
 
 func (x *hostsStore) HostsPath(id string) (location string, err error) {


### PR DESCRIPTION
…ion fails

When trying to create new containers, the following directories are created based on the new container ID:

  - `/var/lib/nerdctl/1935db59/containers/<namespace>/<container id>`
  - `/var/lib/nerdctl/1935db59/etchosts/<namespace>/<container id>`

If containers with existing names are attempted to be created, the processes fail.
However, in the events of failures, these directories are not cleaned up.

This issue is reported in the following:

 - https://github.com/containerd/nerdctl/issues/2993

This commit resolves the issue by cleaning up the mentioned directories when containers creation fails.