### PR TITLE
Do not print an error message on non-0 exec exit code

### DIFF
--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -133,12 +133,9 @@ func execActionWithContainer(ctx context.Context, client *containerd.Client, con
 		return nil
 	}
 	status := <-statusC
-	code, _, err := status.Result()
+	_, _, err := status.Result()
 	if err != nil {
 		return err
-	}
-	if code != 0 {
-		return fmt.Errorf("exec failed with exit code %d", code)
 	}
 	return nil
 }


### PR DESCRIPTION
This was added with an earlier exec, and it is very confusing. the error had nothing to do with Containerd; it was the executable we ran inside the container that errored, and per task run convention we should set the Containerd exit code to the process's exit code and print no error.

ctr exec
```
 ctr --debug -n k8s.io task exec -t --exec-id nginx XXX bash -c  'bash ./faketime.sh 2024 9 22 22';echo $?
tomcat: stopped
tomcat: started
1
```

nerdctl exec
```
nerdctl -n k8s.io exec  xxx bash -c  'bash ./faketime.sh 2024 9 22 22';echo $?
tomcat: stopped
tomcat: started
FATA[0005] exec failed with exit code 1
1
```