### PR TITLE
Test rework, part 3

### DIFF
--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -206,14 +206,16 @@ func TestIssue2993(t *testing.T) {
 	testCase := &test.Group{
 		{
 			Description: "Issue #2993 - nerdctl no longer leaks containers and etchosts directories and files when container creation fails.",
-			Require:     nerdtest.Private,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				dataRoot := data.TempDir()
 
-				dataRoot := string(data.ReadConfig(nerdtest.DataRoot))
+				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+
 				h := getAddrHash(defaults.DefaultAddress)
 				dataStore := filepath.Join(dataRoot, h)
-				namespace := data.Identifier()
+
+				// FIXME: update with next tooling iteration to retrieve from the command
+				namespace := "nerdctl-test"
 
 				containersPath := filepath.Join(dataStore, "containers", namespace)
 				containersDirs, err := os.ReadDir(containersPath)
@@ -229,10 +231,10 @@ func TestIssue2993(t *testing.T) {
 				data.Set(etchostsPathKey, etchostsPath)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
+				helpers.Anyhow("rm", "--data-root", data.TempDir(), "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.Command {
-				return helpers.Command("run", "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				return helpers.Command("run", "--data-root", data.TempDir(), "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -252,14 +254,16 @@ func TestIssue2993(t *testing.T) {
 		},
 		{
 			Description: "Issue #2993 - nerdctl no longer leaks containers and etchosts directories and files when containers are removed.",
-			Require:     nerdtest.Private,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				dataRoot := data.TempDir()
 
-				dataRoot := string(data.ReadConfig(nerdtest.DataRoot))
+				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+
 				h := getAddrHash(defaults.DefaultAddress)
 				dataStore := filepath.Join(dataRoot, h)
-				namespace := data.Identifier()
+
+				// FIXME: update with next tooling iteration to retrieve from the command
+				namespace := "nerdctl-test"
 
 				containersPath := filepath.Join(dataStore, "containers", namespace)
 				containersDirs, err := os.ReadDir(containersPath)
@@ -275,10 +279,10 @@ func TestIssue2993(t *testing.T) {
 				data.Set(etchostsPathKey, etchostsPath)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
+				helpers.Anyhow("--data-root", data.TempDir(), "rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.Command {
-				return helpers.Command("rm", "-f", data.Identifier())
+				return helpers.Command("--data-root", data.TempDir(), "rm", "-f", data.Identifier())
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{

--- a/cmd/nerdctl/network/network_prune_linux_test.go
+++ b/cmd/nerdctl/network/network_prune_linux_test.go
@@ -27,45 +27,50 @@ import (
 func TestNetworkPrune(t *testing.T) {
 	nerdtest.Setup()
 
-	testGroup := &test.Group{
-		{
-			Description: "Prune does not collect started container network",
-			Require:     nerdtest.Private,
-			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
+	testCase := &test.Case{
+		Description: "TestNetworkPrune",
+		Require:     nerdtest.Private,
+
+		SubTests: []*test.Case{
+			{
+				Description: "Prune does not collect started container network",
+				NoParallel:  true,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Command: test.RunCommand("network", "prune", "-f"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: test.DoesNotContain(data.Identifier()),
+					}
+				},
 			},
-			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("network", "rm", data.Identifier())
-			},
-			Command: test.RunCommand("network", "prune", "-f"),
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					Output: test.DoesNotContain(data.Identifier()),
-				}
-			},
-		},
-		{
-			Description: "Prune does collect stopped container network",
-			Require:     nerdtest.Private,
-			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
-				helpers.Ensure("stop", data.Identifier())
-			},
-			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("network", "rm", data.Identifier())
-			},
-			Command: test.RunCommand("network", "prune", "-f"),
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					Output: test.Contains(data.Identifier()),
-				}
+			{
+				Description: "Prune does collect stopped container network",
+				NoParallel:  true,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
+					helpers.Ensure("stop", data.Identifier())
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("network", "rm", data.Identifier())
+				},
+				Command: test.RunCommand("network", "prune", "-f"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: test.Contains(data.Identifier()),
+					}
+				},
 			},
 		},
 	}
 
-	testGroup.Run(t)
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/system/system_prune_linux_test.go
+++ b/cmd/nerdctl/system/system_prune_linux_test.go
@@ -32,75 +32,79 @@ import (
 func TestSystemPrune(t *testing.T) {
 	nerdtest.Setup()
 
-	testGroup := &test.Group{
-		{
-			Description: "volume prune all success",
-			// Private because of prune evidently
-			Require: nerdtest.Private,
-			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("volume", "create", data.Identifier())
-				anonIdentifier := helpers.Capture("volume", "create")
-				helpers.Ensure("run", "-v", fmt.Sprintf("%s:/volume", data.Identifier()),
-					"--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
+	testCase := &test.Case{
+		Description: "TestSystemPrune",
+		NoParallel:  true,
+		SubTests: []*test.Case{
+			{
+				Description: "volume prune all success",
+				// Private because of prune evidently
+				Require: nerdtest.Private,
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("network", "create", data.Identifier())
+					helpers.Ensure("volume", "create", data.Identifier())
+					anonIdentifier := helpers.Capture("volume", "create")
+					helpers.Ensure("run", "-v", fmt.Sprintf("%s:/volume", data.Identifier()),
+						"--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
 
-				data.Set("anonIdentifier", anonIdentifier)
+					data.Set("anonIdentifier", anonIdentifier)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("network", "rm", data.Identifier())
+					helpers.Anyhow("volume", "rm", data.Identifier())
+					helpers.Anyhow("volume", "rm", data.Get("anonIdentifier"))
+					helpers.Anyhow("rm", "-f", data.Identifier())
+				},
+				Command: test.RunCommand("system", "prune", "-f", "--volumes", "--all"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						ExitCode: 0,
+						Output: func(stdout string, info string, t *testing.T) {
+							volumes := helpers.Capture("volume", "ls")
+							networks := helpers.Capture("network", "ls")
+							images := helpers.Capture("images")
+							containers := helpers.Capture("ps", "-a")
+							assert.Assert(t, strings.Contains(volumes, data.Identifier()), volumes)
+							assert.Assert(t, !strings.Contains(volumes, data.Get("anonIdentifier")), volumes)
+							assert.Assert(t, !strings.Contains(containers, data.Identifier()), containers)
+							assert.Assert(t, !strings.Contains(networks, data.Identifier()), networks)
+							assert.Assert(t, !strings.Contains(images, testutil.CommonImage), images)
+						},
+					}
+				},
 			},
-			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("network", "rm", data.Identifier())
-				helpers.Anyhow("volume", "rm", data.Identifier())
-				helpers.Anyhow("volume", "rm", data.Get("anonIdentifier"))
-				helpers.Anyhow("rm", "-f", data.Identifier())
-			},
-			Command: test.RunCommand("system", "prune", "-f", "--volumes", "--all"),
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
-						volumes := helpers.Capture("volume", "ls")
-						networks := helpers.Capture("network", "ls")
-						images := helpers.Capture("images")
-						containers := helpers.Capture("ps", "-a")
-						assert.Assert(t, strings.Contains(volumes, data.Identifier()), volumes)
-						assert.Assert(t, !strings.Contains(volumes, data.Get("anonIdentifier")), volumes)
-						assert.Assert(t, !strings.Contains(containers, data.Identifier()), containers)
-						assert.Assert(t, !strings.Contains(networks, data.Identifier()), networks)
-						assert.Assert(t, !strings.Contains(images, testutil.CommonImage), images)
-					},
-				}
-			},
-		},
-		{
-			Description: "buildkit",
-			// FIXME: using a dedicated namespace does not work with rootful (because of buildkitd)
-			NoParallel: true,
-			// buildkitd is not available with docker
-			Require: test.Require(nerdtest.Build, test.Not(nerdtest.Docker)),
-			// FIXME: this test will happily say "green" even if the command actually fails to do its duty
-			// if there is nothing in the build cache.
-			// Ensure with setup here that we DO build something first
-			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("system", "prune", "-f", "--volumes", "--all")
-			},
-			Command: func(data test.Data, helpers test.Helpers) test.Command {
-				buildctlBinary, err := buildkitutil.BuildctlBinary()
-				if err != nil {
-					t.Fatal(err)
-				}
+			{
+				Description: "buildkit",
+				// FIXME: using a dedicated namespace does not work with rootful (because of buildkitd)
+				NoParallel: true,
+				// buildkitd is not available with docker
+				Require: test.Require(nerdtest.Build, test.Not(nerdtest.Docker)),
+				// FIXME: this test will happily say "green" even if the command actually fails to do its duty
+				// if there is nothing in the build cache.
+				// Ensure with setup here that we DO build something first
+				Setup: func(data test.Data, helpers test.Helpers) {
+					helpers.Ensure("system", "prune", "-f", "--volumes", "--all")
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.Command {
+					buildctlBinary, err := buildkitutil.BuildctlBinary()
+					if err != nil {
+						t.Fatal(err)
+					}
 
-				host, err := buildkitutil.GetBuildkitHost(testutil.Namespace)
-				if err != nil {
-					t.Fatal(err)
-				}
+					host, err := buildkitutil.GetBuildkitHost(testutil.Namespace)
+					if err != nil {
+						t.Fatal(err)
+					}
 
-				buildctlArgs := buildkitutil.BuildctlBaseArgs(host)
-				buildctlArgs = append(buildctlArgs, "du")
+					buildctlArgs := buildkitutil.BuildctlBaseArgs(host)
+					buildctlArgs = append(buildctlArgs, "du")
 
-				return helpers.CustomCommand(buildctlBinary, buildctlArgs...)
+					return helpers.CustomCommand(buildctlBinary, buildctlArgs...)
+				},
+				Expected: test.Expects(0, nil, test.Contains("Total:\t\t0B")),
 			},
-			Expected: test.Expects(0, nil, test.Contains("Total:\t\t0B")),
 		},
 	}
 
-	testGroup.Run(t)
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/volume/volume_prune_linux_test.go
+++ b/cmd/nerdctl/volume/volume_prune_linux_test.go
@@ -56,54 +56,58 @@ func TestVolumePrune(t *testing.T) {
 	}
 
 	// This set must be marked as private, since we cannot prune without interacting with other tests.
-	testGroup := &test.Group{
-		{
-			Description: "prune anonymous only",
-			Require:     nerdtest.Private,
-			Command:     test.RunCommand("volume", "prune", "-f"),
-			Setup:       setup,
-			Cleanup:     cleanup,
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					Output: test.All(
-						test.DoesNotContain(data.Get("anonIDBusy")),
-						test.Contains(data.Get("anonIDDangling")),
-						test.DoesNotContain(data.Get("namedBusy")),
-						test.DoesNotContain(data.Get("namedDangling")),
-						func(stdout string, info string, t *testing.T) {
-							helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
-							helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
-							helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
-							helpers.Ensure("volume", "inspect", data.Get("namedDangling"))
-						},
-					),
-				}
+	testCase := &test.Case{
+		Description: "Prune",
+		Require:     nerdtest.Private,
+		SubTests: []*test.Case{
+			{
+				Description: "prune anonymous only",
+				NoParallel:  true,
+				Command:     test.RunCommand("volume", "prune", "-f"),
+				Setup:       setup,
+				Cleanup:     cleanup,
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: test.All(
+							test.DoesNotContain(data.Get("anonIDBusy")),
+							test.Contains(data.Get("anonIDDangling")),
+							test.DoesNotContain(data.Get("namedBusy")),
+							test.DoesNotContain(data.Get("namedDangling")),
+							func(stdout string, info string, t *testing.T) {
+								helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
+								helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
+								helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
+								helpers.Ensure("volume", "inspect", data.Get("namedDangling"))
+							},
+						),
+					}
+				},
 			},
-		},
-		{
-			Description: "prune all",
-			Require:     nerdtest.Private,
-			Command:     test.RunCommand("volume", "prune", "-f", "--all"),
-			Setup:       setup,
-			Cleanup:     cleanup,
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					Output: test.All(
-						test.DoesNotContain(data.Get("anonIDBusy")),
-						test.Contains(data.Get("anonIDDangling")),
-						test.DoesNotContain(data.Get("namedBusy")),
-						test.Contains(data.Get("namedDangling")),
-						func(stdout string, info string, t *testing.T) {
-							helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
-							helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
-							helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
-							helpers.Fail("volume", "inspect", data.Get("namedDangling"))
-						},
-					),
-				}
+			{
+				Description: "prune all",
+				NoParallel:  true,
+				Command:     test.RunCommand("volume", "prune", "-f", "--all"),
+				Setup:       setup,
+				Cleanup:     cleanup,
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: test.All(
+							test.DoesNotContain(data.Get("anonIDBusy")),
+							test.Contains(data.Get("anonIDDangling")),
+							test.DoesNotContain(data.Get("namedBusy")),
+							test.Contains(data.Get("namedDangling")),
+							func(stdout string, info string, t *testing.T) {
+								helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
+								helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
+								helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
+								helpers.Fail("volume", "inspect", data.Get("namedDangling"))
+							},
+						),
+					}
+				},
 			},
 		},
 	}
 
-	testGroup.Run(t)
+	testCase.Run(t)
 }

--- a/pkg/testutil/nerdtest/helpers.go
+++ b/pkg/testutil/nerdtest/helpers.go
@@ -1,0 +1,119 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nerdtest
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
+)
+
+// InspectContainer is a helper that can be used inside custom commands or Setup
+func InspectContainer(helpers test.Helpers, name string) dockercompat.Container {
+	var dc []dockercompat.Container
+	cmd := helpers.Command("container", "inspect", name)
+	cmd.Run(&test.Expected{
+		ExitCode: 0,
+		Output: func(stdout string, info string, t *testing.T) {
+			err := json.Unmarshal([]byte(stdout), &dc)
+			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+		},
+	})
+	return dc[0]
+}
+
+func InspectVolume(helpers test.Helpers, name string, args ...string) native.Volume {
+	var dc []native.Volume
+	cmdArgs := append([]string{"volume", "inspect"}, args...)
+	cmdArgs = append(cmdArgs, name)
+
+	cmd := helpers.Command(cmdArgs...)
+	cmd.Run(&test.Expected{
+		ExitCode: 0,
+		Output: func(stdout string, info string, t *testing.T) {
+			err := json.Unmarshal([]byte(stdout), &dc)
+			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+		},
+	})
+	return dc[0]
+}
+
+func InspectNetwork(helpers test.Helpers, name string, args ...string) dockercompat.Network {
+	var dc []dockercompat.Network
+	cmdArgs := append([]string{"network", "inspect"}, args...)
+	cmdArgs = append(cmdArgs, name)
+
+	cmd := helpers.Command(cmdArgs...)
+	cmd.Run(&test.Expected{
+		ExitCode: 0,
+		Output: func(stdout string, info string, t *testing.T) {
+			err := json.Unmarshal([]byte(stdout), &dc)
+			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+		},
+	})
+	return dc[0]
+}
+
+func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
+	var dc []dockercompat.Image
+	cmd := helpers.Command("image", "inspect", name)
+	cmd.Run(&test.Expected{
+		ExitCode: 0,
+		Output: func(stdout string, info string, t *testing.T) {
+			err := json.Unmarshal([]byte(stdout), &dc)
+			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+		},
+	})
+	return dc[0]
+}
+
+func EnsureContainerStarted(helpers test.Helpers, con string) {
+	const (
+		maxRetry = 5
+		sleep    = time.Second
+	)
+	for i := 0; i < maxRetry; i++ {
+		count := i
+		cmd := helpers.Command("container", "inspect", con)
+		cmd.Run(&test.Expected{
+			ExitCode: 0,
+			Output: func(stdout string, info string, t *testing.T) {
+				var dc []dockercompat.Container
+				err := json.Unmarshal([]byte(stdout), &dc)
+				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				if dc[0].State.Running {
+					return
+				}
+				if count == maxRetry-1 {
+					t.Fatalf("conainer %s not running", con)
+				}
+				time.Sleep(sleep)
+			},
+		})
+	}
+}

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -1,0 +1,143 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nerdtest
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
+)
+
+var ipv6 test.ConfigKey = "IPv6Test"
+var only test.ConfigValue = "Only"
+var mode test.ConfigKey = "Mode"
+var modePrivate test.ConfigValue = "Private"
+
+var OnlyIPv6 = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	ret = testutil.GetEnableIPv6()
+	if !ret {
+		mess = "runner skips IPv6 compatible tests in the non-IPv6 environment"
+	}
+	data.WithConfig(ipv6, only)
+	return ret, mess
+})
+
+var Private = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	data.WithConfig(mode, modePrivate)
+	return true, "private mode"
+})
+
+var Soci = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	ret = false
+	mess = "soci is not enabled"
+	(&test.GenericCommand{}).
+		WithT(t).
+		WithBinary(testutil.GetTarget()).
+		WithArgs("info", "--format", "{{ json . }}").
+		Run(&test.Expected{
+			Output: func(stdout string, info string, t *testing.T) {
+				var dinf dockercompat.Info
+				err := json.Unmarshal([]byte(stdout), &dinf)
+				assert.NilError(t, err, "failed to parse docker info")
+				for _, p := range dinf.Plugins.Storage {
+					if p == "soci" {
+						ret = true
+						mess = "soci is enabled"
+					}
+				}
+			},
+		})
+
+	return ret, mess
+})
+
+var Docker = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	ret = testutil.GetTarget() == testutil.Docker
+	if ret {
+		mess = "current target is docker"
+	} else {
+		mess = "current target is not docker"
+	}
+	return ret, mess
+})
+
+var NerdctlNeedsFixing = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	ret = testutil.GetTarget() == testutil.Docker
+	if ret {
+		mess = "current target is docker"
+	} else {
+		mess = "current target is nerdctl, but it is currently broken and not working for this"
+	}
+	return ret, mess
+})
+
+var Rootless = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	// Make sure we DO not return "IsRootless true" for docker
+	ret = testutil.GetTarget() != testutil.Docker && rootlessutil.IsRootless()
+	if ret {
+		mess = "environment is rootless"
+	} else {
+		mess = "environment is rootful"
+	}
+	return ret, mess
+})
+
+var Build = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	// FIXME: shouldn't we run buildkitd in a container? At least for testing, that would be so much easier than
+	// against the host install
+	ret = true
+	mess = "buildkitd is enabled"
+	if testutil.GetTarget() == testutil.Nerdctl {
+		_, err := buildkitutil.GetBuildkitHost(testutil.Namespace)
+		if err != nil {
+			ret = false
+			mess = fmt.Sprintf("buildkitd is not enabled: %+v", err)
+		}
+	}
+	return ret, mess
+})
+
+var CGroup = test.MakeRequirement(func(data test.Data, t *testing.T) (ret bool, mess string) {
+	ret = true
+	mess = "cgroup is enabled"
+	(&test.GenericCommand{}).
+		WithT(t).
+		WithBinary(testutil.GetTarget()).
+		WithArgs("info", "--format", "{{ json . }}").
+		Run(&test.Expected{
+			Output: func(stdout string, info string, t *testing.T) {
+				var dinf dockercompat.Info
+				err := json.Unmarshal([]byte(stdout), &dinf)
+				assert.NilError(t, err, "failed to parse docker info")
+				switch dinf.CgroupDriver {
+				case "none", "":
+					ret = false
+					mess = "cgroup is none"
+				}
+			},
+		})
+
+	return ret, mess
+})

--- a/pkg/testutil/test/case.go
+++ b/pkg/testutil/test/case.go
@@ -133,7 +133,7 @@ func (test *Case) seal(t *testing.T) {
 
 	// Check the requirements
 	if test.Require != nil {
-		test.Require(test.Data, t)
+		test.Require(test.Data, true, t)
 	}
 }
 

--- a/pkg/testutil/test/command.go
+++ b/pkg/testutil/test/command.go
@@ -128,7 +128,9 @@ func (gc *GenericCommand) Run(expect *Expected) {
 
 func (gc *GenericCommand) boot() icmd.Cmd {
 	// This is a helper function, not to appear in the debugging output
-	gc.t.Helper()
+	if gc.t != nil {
+		gc.t.Helper()
+	}
 
 	binary := gc.mainBinary
 	args := gc.mainArgs
@@ -153,6 +155,10 @@ func (gc *GenericCommand) boot() icmd.Cmd {
 	icmdCmd.Dir = gc.WorkingDir
 	if icmdCmd.Dir == "" {
 		icmdCmd.Dir = gc.tempDir
+	}
+
+	if gc.stdin != nil {
+		icmdCmd.Stdin = gc.stdin
 	}
 
 	// Attach any extra env we have
@@ -182,8 +188,9 @@ func (gc *GenericCommand) Clear() Command {
 	return gc
 }
 
-func (gc *GenericCommand) WithT(t *testing.T) {
+func (gc *GenericCommand) WithT(t *testing.T) Command {
 	gc.t = t
+	return gc
 }
 
 func (gc *GenericCommand) WithTempDir(tempDir string) {

--- a/pkg/testutil/test/test.go
+++ b/pkg/testutil/test/test.go
@@ -24,7 +24,7 @@ import (
 
 // A Requirement is a function that can evaluate random requirement and possibly skip a test
 // See test.MakeRequirement to make your own
-type Requirement func(data Data, t *testing.T) (bool, string)
+type Requirement func(data Data, skip bool, t *testing.T) (bool, string)
 
 // A Butler is the function signature meant to be attached to a Setup or Cleanup routine for a test.Case
 type Butler func(data Data, helpers Helpers)

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -126,7 +126,7 @@ func NewDelayOnceReader(wrapped io.Reader) io.Reader {
 
 func (r *delayOnceReader) Read(p []byte) (int, error) {
 	// FIXME: this is obviously not exact science. At 1 second, it will fail regularly on the CI under load.
-	r.once.Do(func() { time.Sleep(2 * time.Second) })
+	r.once.Do(func() { time.Sleep(5 * time.Second) })
 	n, err := r.wrapped.Read(p)
 	if errors.Is(err, io.EOF) {
 		time.Sleep(time.Second)


### PR DESCRIPTION
On top of #3455 

Notably:
- first commit has a raft of evolutions to test tooling in preparation for more test rewrites
- second commit tentatively addresses flakyness of TestAttach
- third commit disables parallelism for Docker on prune and rmi tests