### PR TITLE
[fix] filter images panic

### DIFF
--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -110,6 +110,8 @@ LABEL version=0.1`, testutil.CommonImage)
 		base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage)).AssertOutNotContains(testutil.ImageRepo(testutil.CommonImage))
 		base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage), testutil.CommonImage).AssertOutNotContains(testutil.ImageRepo(testutil.CommonImage))
 		base.Cmd("images", "--filter", fmt.Sprintf("since=%s", testutil.CommonImage), testutil.CommonImage).AssertOutNotContains(tempName)
+		base.Cmd("images", "--filter", fmt.Sprintf("since=%s:%s", "non-exists-image", "non-exists-image")).AssertOutContains(tempName)
+		base.Cmd("images", "--filter", fmt.Sprintf("before=%s:%s", "non-exists-image", "non-exists-image")).AssertOutContains(tempName)
 	}
 	base.Cmd("images", "--filter", "label=foo=bar").AssertOutContains(tempName)
 	base.Cmd("images", "--filter", "label=foo=bar1").AssertOutNotContains(tempName)

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -150,10 +150,12 @@ func FilterByCreatedAt(ctx context.Context, client *containerd.Client, before []
 			if err != nil {
 				return []images.Image{}, err
 			}
-			maxTime = beforeImages[0].CreatedAt
-			for _, image := range beforeImages {
-				if image.CreatedAt.After(maxTime) {
-					maxTime = image.CreatedAt
+			if len(beforeImages) > 0 {
+				maxTime = beforeImages[0].CreatedAt
+				for _, image := range beforeImages {
+					if image.CreatedAt.After(maxTime) {
+						maxTime = image.CreatedAt
+					}
 				}
 			}
 		}
@@ -163,10 +165,12 @@ func FilterByCreatedAt(ctx context.Context, client *containerd.Client, before []
 			if err != nil {
 				return []images.Image{}, err
 			}
-			minTime = sinceImages[0].CreatedAt
-			for _, image := range sinceImages {
-				if image.CreatedAt.Before(minTime) {
-					minTime = image.CreatedAt
+			if len(sinceImages) > 0 {
+				minTime = sinceImages[0].CreatedAt
+				for _, image := range sinceImages {
+					if image.CreatedAt.Before(minTime) {
+						minTime = image.CreatedAt
+					}
 				}
 			}
 		}


### PR DESCRIPTION
`nerdctl images --filter before=not-exist-image` will panic.

Fix: #3467