### PR TITLE
Fix login persistence regression against Hub

### DIFF
--- a/pkg/imgutil/dockerconfigresolver/credentialsstore.go
+++ b/pkg/imgutil/dockerconfigresolver/credentialsstore.go
@@ -83,7 +83,7 @@ func (cs *CredentialsStore) Store(registryURL *RegistryURL, credentials *Credent
 	if registryURL.Namespace != nil {
 		credentials.ServerAddress = fmt.Sprintf("%s%s?%s", registryURL.Host, registryURL.Path, registryURL.RawQuery)
 	} else {
-		credentials.ServerAddress = registryURL.Host
+		credentials.ServerAddress = registryURL.CanonicalIdentifier()
 	}
 
 	// XXX future namespaced url likely require special handling here

--- a/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
+++ b/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
@@ -393,3 +393,5 @@ func TestWorkingCredentialsStore(t *testing.T) {
 
 	})
 }
+
+// TODO: add more tests that write credentials (specifically to hub locations) to verify they use the canonical id properly

--- a/pkg/imgutil/dockerconfigresolver/registryurl_test.go
+++ b/pkg/imgutil/dockerconfigresolver/registryurl_test.go
@@ -39,6 +39,11 @@ func TestURLParsingAndID(t *testing.T) {
 			error:   ErrUnsupportedScheme,
 		},
 		{
+			address:    "",
+			identifier: "https://index.docker.io/v1/",
+			allIDs:     []string{"https://index.docker.io/v1/"},
+		},
+		{
 			address:    "https://index.docker.io/v1/",
 			identifier: "https://index.docker.io/v1/",
 			allIDs:     []string{"https://index.docker.io/v1/"},


### PR DESCRIPTION
Login no longer persists for Docker Hub, as a mistake in the code was not using the special case Docker Hub key to save in the store.

Incidentally, we should start testing more against Hub generally to avoid things like that.
That implies creating a test account over there, and issuing a read-only token to be added here.