### PR TITLE
Fix Docker Hub push regression

### DIFF
--- a/pkg/imgutil/dockerconfigresolver/registryurl.go
+++ b/pkg/imgutil/dockerconfigresolver/registryurl.go
@@ -102,8 +102,10 @@ func (rn *RegistryURL) AllIdentifiers() []string {
 
 	// Docker behavior: if the domain was index.docker.io over 443, we are allowed to additionally read the canonical
 	// docker credentials
-	if rn.Hostname() == "index.docker.io" && rn.Port() == standardHTTPSPort {
-		fullList = append(fullList, dockerIndexServer)
+	if rn.Port() == standardHTTPSPort {
+		if rn.Hostname() == "index.docker.io" || rn.Hostname() == "registry-1.docker.io" {
+			fullList = append(fullList, dockerIndexServer)
+		}
 	}
 
 	// Add legacy variants


### PR DESCRIPTION
Docker Hub push is currently broken (regression from #3293).

This fixes it.

Same as the other regression - we need to test against Hub with a dummy account and actual content for push and pull.