### PR TITLE
[WIP] Test rework permanent next-target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,9 @@ lint-yaml:
 lint-shell: $(call recursive_wildcard,$(MAKEFILE_DIR)/,*.sh)
 	shellcheck -a -x $^
 
+test-unit:
+	go test -v $(MAKEFILE_DIR)/pkg/...
+
 binaries: nerdctl
 
 install:

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# shellcheck disable=SC2034,SC2015
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]:-$PWD}")" 2>/dev/null 1>&2 && pwd)"
+readonly root
+readonly timeout="60m"
+
+# See https://github.com/containerd/nerdctl/blob/main/docs/testing/README.md#about-parallelization
+args=(--format=testname --jsonfile /tmp/test-integration.log --packages="$root"/../cmd/nerdctl/...)
+
+for arg in "$@"; do
+  if [ "$arg" == "-test.only-flaky" ]; then
+    args+=("--rerun-fails=2")
+    break
+  fi
+done
+
+gotestsum "${args[@]}" -- -timeout="$timeout" -p 1 -args -test.allow-kill-daemon "$@"
+
+echo "These are the tests that took more than 20 seconds:"
+gotestsum tool slowest --threshold 20s --jsonfile /tmp/test-integration.log

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -73,6 +73,11 @@ var OnlyKubernetes = &test.Requirement{
 		} else {
 			mess = "runner skips Kubernetes compatible tests in the non-Kubernetes environment"
 		}
+		_, err := exec.LookPath("kubectl")
+		if err != nil {
+			ret = false
+			mess = fmt.Sprintf("kubectl is not in the path: %+v", err)
+		}
 		return ret, mess
 	},
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -787,6 +787,9 @@ func newBase(t *testing.T, ns string, ipv6Compatible bool, kubernetesCompatible 
 	} else if !base.EnableKubernetes && base.KubernetesCompatible {
 		t.Skip("runner skips Kubernetes compatible tests in the non-Kubernetes environment")
 	}
+	if !GetFlakyEnvironment() && !GetEnableKubernetes() && !GetEnableIPv6() {
+		t.Skip("legacy tests are considered flaky by default and are skipped unless in the flaky environment")
+	}
 	var err error
 	switch base.Target {
 	case Nerdctl:


### PR DESCRIPTION
Note:
This PR is a dump of all next- things for test rework.
It will never be merged, and will be forked-out into smaller PR.

Github actions changes:
- cosmetic efforts on test display titles (more compact, more consistent)
- lint on all platforms instead of just linux
- removal of all nick/retries
- separation of flaky / non-flaky in different steps - non-flaky now run without any retry - flaky do run with gotestsum retry, but no longer nick/retries

Integration test entrypoint:
- now lives inside `./hack/test-integration.sh`
- additionally displays slow tests at the end of the run

Dockerfile changes:
- removed CMD - replaced in favor of a direct call to ./hack/test-integration.sh
- removed useless stages

Currently, test suites have been ran locally (no-flaky, on the host directly) 100 times without failure:
- `./cmd/nerdctl` < 1 sec per run
- `./cmd/nerdctl/completion`  < 1 sec per run
- `./cmd/nerdctl/issues` < 10 secs per run
- `./cmd/nerdctl/system` < 10 secs per run
- `./cmd/nerdctl/volume` < 10 secs per run
- `./cmd/nerdctl/network` < 10 secs per run
- `./cmd/nerdctl/image` < 30 secs per run
- `./cmd/nerdctl/ipfs`

WORK IN PROGRESS rn:
- `./cmd/nerdctl/builder`
- `./cmd/nerdctl/container`

NOT part of this PR:
- `./cmd/nerdctl/login`
- `./cmd/nerdctl/compose`

