### PR TITLE
Lock errdefs minor versions for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ version: 2
 updates:
   # Dependencies listed in go.mod
   - package-ecosystem: "gomod"
+    ignore:
+      - dependency-name: "github.com/containerd/errdefs"
+        update-types: ["version-update:semver-minor"]
     directory: "/"  # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
errdefs recent minor updates are breaking compatibility, and since we depend on containerd, which depends on 0.1.0, we are not going to update that anytime soon.

Meanwhile, dependabot keeps trying: #3521 

Hopefully, that should now limit that?