### PR TITLE
Fix CNIEnv concurrency issue

### DIFF
--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -215,7 +215,15 @@ func NewCNIEnv(cniPath, cniConfPath string, opts ...CNIEnvOpt) (*CNIEnv, error) 
 }
 
 func (e *CNIEnv) NetworkList() ([]*NetworkConfig, error) {
-	return e.networkConfigList()
+	var netConfigList []*NetworkConfig
+	var err error
+	fn := func() error {
+		netConfigList, err = e.networkConfigList()
+		return err
+	}
+	err = lockutil.WithDirLock(e.NetconfPath, fn)
+
+	return netConfigList, err
 }
 
 func (e *CNIEnv) NetworkMap() (map[string]*NetworkConfig, error) { //nolint:revive


### PR DESCRIPTION
This is very similar to #3522, and addresses another facet of the same underlying problem (CNIEnv not being safe to use concurrently).

Failure is typically showing-up with `images` in integration tests (on my laptop, shows up after 20+ runs).

This is not a good long-term solution (the right solution is to rewrite CNIEnv with concurrency in mind) - but it will alleviate the problem in a bunch of cases for now.