### PR TITLE
Alleviate image --filter missing digest issue

### DIFF
--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -28,6 +28,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
@@ -240,7 +241,10 @@ func FilterByLabel(ctx context.Context, client *containerd.Client, labels map[st
 			clientImage := containerd.NewImage(client, i)
 			imageCfg, _, err := ReadImageConfig(ctx, clientImage)
 			if err != nil {
-				return false, err
+				// Stop-gap measure. Do not hard error if some images config cannot be read.
+				// See https://github.com/containerd/nerdctl/issues/3516
+				log.G(ctx).WithError(err).Errorf("failed reading image config for %s (%s)", clientImage.Name(), clientImage.Platform())
+				return false, nil
 			}
 			return matchesAllLabels(imageCfg.Config.Labels, labels), nil
 		})


### PR DESCRIPTION
See #3512 #3513 #3516 for some context.

In a shell, filtering requires config to be there.
With multi-arch / non-native arch, retrieving the config might fail for specific images, which will fail the entire operation.

Turning this into a soft failure to alleviate the pain.
