### PR TITLE
Add support for running container from OCI archive

### DIFF
--- a/cmd/nerdctl/image/image_load.go
+++ b/cmd/nerdctl/image/image_load.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
-	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/load"
 )
 
 func NewLoadCommand() *cobra.Command {
@@ -94,5 +94,5 @@ func loadAction(cmd *cobra.Command, _ []string) error {
 	}
 	defer cancel()
 
-	return image.Load(ctx, client, options)
+	return load.Load(ctx, client, options)
 }

--- a/cmd/nerdctl/image/image_load.go
+++ b/cmd/nerdctl/image/image_load.go
@@ -94,5 +94,6 @@ func loadAction(cmd *cobra.Command, _ []string) error {
 	}
 	defer cancel()
 
-	return load.Load(ctx, client, options)
+	_, err = load.FromArchive(ctx, client, options)
+	return err
 }

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -134,6 +134,7 @@ Run a command in a new container.
 Usage: `nerdctl run [OPTIONS] IMAGE [COMMAND] [ARG...]`
 
 :nerd_face: `ipfs://` prefix can be used for `IMAGE` to pull it from IPFS. See [`ipfs.md`](./ipfs.md) for details.
+:nerd_face: `oci-archive://` prefix can be used for `IMAGE` to specify a local file system path to an OCI formatted tarball.
 
 Basic flags:
 
@@ -423,6 +424,7 @@ Create a new container.
 Usage: `nerdctl create [OPTIONS] IMAGE [COMMAND] [ARG...]`
 
 :nerd_face: `ipfs://` prefix can be used for `IMAGE` to pull it from IPFS. See [`ipfs.md`](./ipfs.md) for details.
+:nerd_face: `oci-archive://` prefix can be used for `IMAGE` to specify a local file system path to an OCI formatted tarball.
 
 The `nerdctl create` command similar to `nerdctl run -d` except the container is never started. You can then use the `nerdctl start <container_id>` command to start the container at any point.
 

--- a/pkg/imgutil/load/load.go
+++ b/pkg/imgutil/load/load.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package image
+package load
 
 import (
 	"context"
@@ -98,6 +98,7 @@ func loadImage(ctx context.Context, client *containerd.Client, in io.Reader, pla
 		if !options.Quiet {
 			fmt.Fprintf(options.Stdout, "unpacking %s (%s)...\n", img.Name, img.Target.Digest)
 		}
+
 		err = image.Unpack(ctx, options.GOptions.Snapshotter)
 		if err != nil {
 			return err

--- a/pkg/referenceutil/referenceutil.go
+++ b/pkg/referenceutil/referenceutil.go
@@ -17,6 +17,7 @@
 package referenceutil
 
 import (
+	"errors"
 	"path"
 	"strings"
 
@@ -30,6 +31,8 @@ type Protocol string
 const IPFSProtocol Protocol = "ipfs"
 const IPNSProtocol Protocol = "ipns"
 const shortIDLength = 5
+
+var ErrLoadOCIArchiveRequired = errors.New("image must be loaded from archive before parsing image reference")
 
 type ImageReference struct {
 	Protocol    Protocol
@@ -97,6 +100,10 @@ func Parse(rawRef string) (*ImageReference, error) {
 	} else if strings.HasPrefix(rawRef, "ipns://") {
 		ir.Protocol = IPNSProtocol
 		rawRef = rawRef[7:]
+	} else if strings.HasPrefix(rawRef, "oci-archive://") {
+		// The image must be loaded from the specified archive path first
+		// before parsing the image reference specified in its OCI image manifest.
+		return nil, ErrLoadOCIArchiveRequired
 	}
 	if decodedCID, err := cid.Decode(rawRef); err == nil {
 		ir.Protocol = IPFSProtocol

--- a/pkg/referenceutil/referenceutil_test.go
+++ b/pkg/referenceutil/referenceutil_test.go
@@ -273,6 +273,9 @@ func TestReferenceUtil(t *testing.T) {
 			Tag:          "latest",
 			ExplicitTag:  "",
 		},
+		"oci-archive:///tmp/build/saved-image.tar": {
+			Error: "image must be loaded from archive before parsing image reference",
+		},
 	}
 
 	for k, v := range needles {


### PR DESCRIPTION
### Issue
Proposal for https://github.com/containerd/nerdctl/issues/3536

### Description
This change adds the ability to create and run containers from OCI archive without performing separate load step.

### Testing
As this behavior is not provided by Docker, this change adds a nerdctl-only test for this behavior.