### PR TITLE
"ns:" network mode to use existing network namespace

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -112,11 +112,11 @@ func setCreateFlags(cmd *cobra.Command) {
 
 	// #region network flags
 	// network (net) is defined as StringSlice, not StringArray, to allow specifying "--network=cni1,cni2"
-	cmd.Flags().StringSlice("network", []string{netutil.DefaultNetworkName}, `Connect a container to a network ("bridge"|"host"|"none"|"container:<container>"|<CNI>)`)
+	cmd.Flags().StringSlice("network", []string{netutil.DefaultNetworkName}, `Connect a container to a network ("bridge"|"host"|"none"|"container:<container>"|"ns:<path>"|<CNI>)`)
 	cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completion.NetworkNames(cmd, []string{})
 	})
-	cmd.Flags().StringSlice("net", []string{netutil.DefaultNetworkName}, `Connect a container to a network ("bridge"|"host"|"none"|<CNI>)`)
+	cmd.Flags().StringSlice("net", []string{netutil.DefaultNetworkName}, `Connect a container to a network ("bridge"|"host"|"none"|"container:<container>"|"ns:<path>"|<CNI>)`)
 	cmd.RegisterFlagCompletionFunc("net", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return completion.NetworkNames(cmd, []string{})
 	})

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -175,9 +175,10 @@ Isolation flags:
 
 Network flags:
 
-- :whale: `--net, --network=(bridge|host|none|container:<container>|<CNI>)`: Connect a container to a network.
+- :whale: `--net, --network=(bridge|host|none|container:<container>|ns:<path>|<CNI>)`: Connect a container to a network.
   - Default: "bridge"
-  - 'container:<name|id>': reuse another container's network stack, container has to be precreated.
+  - `container:<name|id>`: reuse another container's network stack, container has to be precreated.
+  - :nerd_face: `ns:<path>`: run inside an existing network namespace
   - :nerd_face: Unlike Docker, this flag can be specified multiple times (`--net foo --net bar`)
 - :whale: `-p, --publish`: Publish a container's port(s) to the host
 - :whale: `--dns`: Set custom DNS servers

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -151,7 +151,7 @@ func cleanupNetwork(ctx context.Context, container containerd.Container, globalO
 		}
 
 		switch netType {
-		case nettype.Host, nettype.None, nettype.Container:
+		case nettype.Host, nettype.None, nettype.Container, nettype.Namespace:
 			// NOP
 		case nettype.CNI:
 			e, err := netutil.NewCNIEnv(globalOpts.CNIPath, globalOpts.CNINetConfPath, netutil.WithNamespace(globalOpts.Namespace), netutil.WithDefaultNetwork())

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -385,7 +385,7 @@ func getNetworks(project *types.Project, svc types.ServiceConfig) ([]networkName
 			return nil, errors.New("net and network_mode must not be set together")
 		}
 		if strings.Contains(svc.NetworkMode, ":") {
-			if !strings.HasPrefix(svc.NetworkMode, "container:") {
+			if !strings.HasPrefix(svc.NetworkMode, "container:") && !strings.HasPrefix(svc.NetworkMode, "ns:") {
 				return nil, fmt.Errorf("unsupported network_mode: %q", svc.NetworkMode)
 			}
 		}

--- a/pkg/netutil/nettype/nettype.go
+++ b/pkg/netutil/nettype/nettype.go
@@ -29,6 +29,7 @@ const (
 	Host
 	CNI
 	Container
+	Namespace
 )
 
 var netTypeToName = map[interface{}]string{
@@ -37,6 +38,7 @@ var netTypeToName = map[interface{}]string{
 	Host:      "host",
 	CNI:       "cni",
 	Container: "container",
+	Namespace: "ns",
 }
 
 func Detect(names []string) (Type, error) {
@@ -54,6 +56,8 @@ func Detect(names []string) (Type, error) {
 			tmp = Host
 		case "container":
 			tmp = Container
+		case "ns":
+			tmp = Namespace
 		default:
 			tmp = CNI
 		}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -170,7 +170,7 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath strin
 	}
 
 	switch netType {
-	case nettype.Host, nettype.None, nettype.Container:
+	case nettype.Host, nettype.None, nettype.Container, nettype.Namespace:
 		// NOP
 	case nettype.CNI:
 		e, err := netutil.NewCNIEnv(cniPath, cniNetconfPath, netutil.WithNamespace(namespace), netutil.WithDefaultNetwork())


### PR DESCRIPTION
### Description

Fixes https://github.com/containerd/nerdctl/issues/3246, allowing containers to be run inside existing network namespaces. 

I've read the [contribution guide](https://github.com/containerd/project/blob/main/CONTRIBUTING.md), signed off on my commit, and updated the command reference documentation, but please let me know if there's anything else you'd like me to do. 

### Testing

I first manually create a new Linux network namespace, create a dummy interface in it, and give it an address:

```
> sudo ip netns add nerdctltest
> sudo ip -n nerdctltest link add dm0 type dummy
> sudo ip -n nerdctltest addr add 172.16.1.100/32 dev dm0
> sudo ip -n nerdctltest link set dm0 up
> sudo ip -n nerdctltest link set lo up
```

Then use my build of nerdctl to run an Nginx container in this netns, using the new `ns:` networking mode:

```
> sudo ./nerdctl run -d --name nginx-nerdctltest --net=ns:/run/netns/nerdctltest nginx:latest
ce7939065b7c30e59ffc5c5e55d5cdc7c421098b8dc31beba63044991b6b999f
```

Finally, we can access the Nginx server by curl'ing the dummy interface address inside the netns:

```
> sudo ip netns exec nerdctltest curl http://172.16.1.100
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
html { color-scheme: light dark; }
body { width: 35em; margin: 0 auto;
font-family: Tahoma, Verdana, Arial, sans-serif; }
</style>
</head>
<body>
<h1>Welcome to nginx!</h1>
<p>If you see this page, the nginx web server is successfully installed and
working. Further configuration is required.</p>
...<truncated, you get the idea>
```

The new parameter is supported in Docker Compose, as well. Here's my `docker-compose.yml` file I used for testing:

```
services:
  nginx-nerdctltest:
    container_name: nginx-nerdctltest
    image: nginx:latest
    network_mode: ns:/run/netns/nerdctltest
```

Spin up the container:

```
> sudo ./nerdctl compose up -d
INFO[0000] Ensuring image nginx:latest
INFO[0000] Creating container nginx-nerdctltest
```

And test it again:

```
> sudo ip netns exec nerdctltest curl http://172.16.1.100
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
<style>
...
```