### PR TITLE
`referenceutil` cleanup

### DIFF
--- a/cmd/nerdctl/image/image_list.go
+++ b/cmd/nerdctl/image/image_list.go
@@ -70,49 +70,47 @@ Properties:
 	return imagesCommand
 }
 
-func processImageListOptions(cmd *cobra.Command, args []string) (types.ImageListOptions, error) {
+func processImageListOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
 	var filters []string
-
 	if len(args) > 0 {
-		canonicalRef, err := referenceutil.ParseAny(args[0])
+		parsedReference, err := referenceutil.Parse(args[0])
 		if err != nil {
-			return types.ImageListOptions{}, err
+			return nil, err
 		}
-		filters = append(filters, fmt.Sprintf("name==%s", canonicalRef.String()))
-		filters = append(filters, fmt.Sprintf("name==%s", args[0]))
+		filters = []string{fmt.Sprintf("name==%s", parsedReference)}
 	}
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
 	noTrunc, err := cmd.Flags().GetBool("no-trunc")
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
 	format, err := cmd.Flags().GetString("format")
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
 	var inputFilters []string
 	if cmd.Flags().Changed("filter") {
 		inputFilters, err = cmd.Flags().GetStringSlice("filter")
 		if err != nil {
-			return types.ImageListOptions{}, err
+			return nil, err
 		}
 	}
 	digests, err := cmd.Flags().GetBool("digests")
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
 	names, err := cmd.Flags().GetBool("names")
 	if err != nil {
-		return types.ImageListOptions{}, err
+		return nil, err
 	}
-	return types.ImageListOptions{
+	return &types.ImageListOptions{
 		GOptions:         globalOptions,
 		Quiet:            quiet,
 		NoTrunc:          noTrunc,

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -28,7 +28,6 @@ import (
 	"strconv"
 	"strings"
 
-	distributionref "github.com/distribution/reference"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -42,6 +41,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
+	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
@@ -235,19 +235,19 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 	}
 	if tags = strutil.DedupeStrSlice(options.Tag); len(tags) > 0 {
 		ref := tags[0]
-		named, err := distributionref.ParseNormalizedNamed(ref)
+		parsedReference, err := referenceutil.Parse(ref)
 		if err != nil {
 			return "", nil, false, "", nil, nil, err
 		}
-		output += ",name=" + distributionref.TagNameOnly(named).String()
+		output += ",name=" + parsedReference.String()
 
 		// pick the first tag and add it to output
 		for idx, tag := range tags {
-			named, err := distributionref.ParseNormalizedNamed(tag)
+			parsedReference, err = referenceutil.Parse(tag)
 			if err != nil {
 				return "", nil, false, "", nil, nil, err
 			}
-			tags[idx] = distributionref.TagNameOnly(named).String()
+			tags[idx] = parsedReference.String()
 		}
 	} else if len(tags) == 0 {
 		output = output + ",dangling-name-prefix=<none>"

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -81,11 +81,11 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 	options.VolumeExists = volStore.Exists
 
 	options.ImageExists = func(ctx context.Context, rawRef string) (bool, error) {
-		refNamed, err := referenceutil.ParseAny(rawRef)
+		parsedReference, err := referenceutil.Parse(rawRef)
 		if err != nil {
 			return false, err
 		}
-		ref := refNamed.String()
+		ref := parsedReference.String()
 		if _, err := client.ImageService().Get(ctx, ref); err != nil {
 			if errors.Is(err, errdefs.ErrNotFound) {
 				return false, nil
@@ -116,8 +116,12 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 			Stderr:          stderr,
 		}
 
-		// IPFS reference
-		if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(imageName); err == nil {
+		parsedReference, err := referenceutil.Parse(imageName)
+		if err != nil {
+			return err
+		}
+
+		if parsedReference.Protocol != "" {
 			var ipfsPath string
 			if ipfsAddress := options.IPFSAddress; ipfsAddress != "" {
 				dir, err := os.MkdirTemp("", "apidirtmp")
@@ -130,7 +134,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 				}
 				ipfsPath = dir
 			}
-			_, err = ipfs.EnsureImage(ctx, client, scheme, ref, ipfsPath, imgPullOpts)
+			_, err = ipfs.EnsureImage(ctx, client, string(parsedReference.Protocol), parsedReference.String(), ipfsPath, imgPullOpts)
 			return err
 		}
 

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -33,7 +33,7 @@ import (
 
 // Commit will commit a container’s file changes or settings into a new image.
 func Commit(ctx context.Context, client *containerd.Client, rawRef string, req string, options types.ContainerCommitOptions) error {
-	named, err := referenceutil.ParseDockerRef(rawRef)
+	parsedReference, err := referenceutil.Parse(rawRef)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func Commit(ctx context.Context, client *containerd.Client, rawRef string, req s
 	opts := &commit.Opts{
 		Author:  options.Author,
 		Message: options.Message,
-		Ref:     named.String(),
+		Ref:     parsedReference.String(),
 		Pause:   options.Pause,
 		Changes: changes,
 	}

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -272,7 +272,12 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		if ensuredImage != nil {
 			imageRef = ensuredImage.Ref
 		}
-		options.Name = referenceutil.SuggestContainerName(imageRef, id)
+		parsedReference, err := referenceutil.Parse(imageRef)
+		// Ignore cases where the imageRef is ""
+		if err != nil && imageRef != "" {
+			return nil, generateRemoveOrphanedDirsFunc(ctx, id, dataStore, internalLabels), err
+		}
+		options.Name = parsedReference.SuggestContainerName(id)
 	}
 	if options.Name != "" {
 		containerNameStore, err = namestore.New(dataStore, options.GOptions.Namespace)

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -57,17 +57,17 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 		return errors.New("src and target image need to be specified")
 	}
 
-	srcNamed, err := referenceutil.ParseAny(srcRawRef)
+	parsedReference, err := referenceutil.Parse(srcRawRef)
 	if err != nil {
 		return err
 	}
-	srcRef := srcNamed.String()
+	srcRef := parsedReference.String()
 
-	targetNamed, err := referenceutil.ParseDockerRef(targetRawRef)
+	parsedReference, err = referenceutil.Parse(targetRawRef)
 	if err != nil {
 		return err
 	}
-	targetRef := targetNamed.String()
+	targetRef := parsedReference.String()
 
 	platMC, err := platformutil.NewMatchComparer(options.AllPlatforms, options.Platforms)
 	if err != nil {

--- a/pkg/cmd/image/crypt.go
+++ b/pkg/cmd/image/crypt.go
@@ -40,17 +40,17 @@ func Crypt(ctx context.Context, client *containerd.Client, srcRawRef, targetRawR
 		return errors.New("src and target image need to be specified")
 	}
 
-	srcNamed, err := referenceutil.ParseAny(srcRawRef)
+	parsedRerefence, err := referenceutil.Parse(srcRawRef)
 	if err != nil {
 		return err
 	}
-	srcRef := srcNamed.String()
+	srcRef := parsedRerefence.String()
 
-	targetNamed, err := referenceutil.ParseDockerRef(targetRawRef)
+	parsedRerefence, err = referenceutil.Parse(targetRawRef)
 	if err != nil {
 		return err
 	}
-	targetRef := targetNamed.String()
+	targetRef := parsedRerefence.String()
 
 	platMC, err := platformutil.NewMatchComparer(options.AllPlatforms, options.Platforms)
 	if err != nil {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -47,7 +47,7 @@ import (
 )
 
 // ListCommandHandler `List` and print images matching filters in `options`.
-func ListCommandHandler(ctx context.Context, client *containerd.Client, options types.ImageListOptions) error {
+func ListCommandHandler(ctx context.Context, client *containerd.Client, options *types.ImageListOptions) error {
 	imageList, err := List(ctx, client, options.Filters, options.NameAndRefFilter)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ type imagePrintable struct {
 	Platform string // nerdctl extension
 }
 
-func printImages(ctx context.Context, client *containerd.Client, imageList []images.Image, options types.ImageListOptions) error {
+func printImages(ctx context.Context, client *containerd.Client, imageList []images.Image, options *types.ImageListOptions) error {
 	w := options.Stdout
 	digestsFlag := options.Digests
 	if options.Format == "wide" {

--- a/pkg/cmd/image/pull.go
+++ b/pkg/cmd/image/pull.go
@@ -45,7 +45,12 @@ func Pull(ctx context.Context, client *containerd.Client, rawRef string, options
 func EnsureImage(ctx context.Context, client *containerd.Client, rawRef string, options types.ImagePullOptions) (*imgutil.EnsuredImage, error) {
 	var ensured *imgutil.EnsuredImage
 
-	if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(rawRef); err == nil {
+	parsedReference, err := referenceutil.Parse(rawRef)
+	if err != nil {
+		return nil, err
+	}
+
+	if parsedReference.Protocol != "" {
 		if options.VerifyOptions.Provider != "none" {
 			return nil, errors.New("--verify flag is not supported on IPFS as of now")
 		}
@@ -63,7 +68,7 @@ func EnsureImage(ctx context.Context, client *containerd.Client, rawRef string, 
 			ipfsPath = dir
 		}
 
-		ensured, err = ipfs.EnsureImage(ctx, client, scheme, ref, ipfsPath, options)
+		ensured, err = ipfs.EnsureImage(ctx, client, string(parsedReference.Protocol), parsedReference.String(), ipfsPath, options)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"path/filepath"
 
-	distributionref "github.com/distribution/reference"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -55,19 +54,20 @@ import (
 
 // Push pushes an image specified by `rawRef`.
 func Push(ctx context.Context, client *containerd.Client, rawRef string, options types.ImagePushOptions) error {
-	if scheme, ref, err := referenceutil.ParseIPFSRefWithScheme(rawRef); err == nil {
-		if scheme != "ipfs" {
-			return fmt.Errorf("ipfs scheme is only supported but got %q", scheme)
-		}
-		log.G(ctx).Infof("pushing image %q to IPFS", ref)
+	parsedReference, err := referenceutil.Parse(rawRef)
+	if err != nil {
+		return err
+	}
 
-		parsedRef, err := distributionref.ParseDockerRef(ref)
-		if err != nil {
-			return err
+	if parsedReference.Protocol != "" {
+		if parsedReference.Protocol != referenceutil.IPFSProtocol {
+			return fmt.Errorf("ipfs scheme is only supported but got %q", parsedReference.Protocol)
 		}
+		log.G(ctx).Infof("pushing image %q to IPFS", parsedReference)
 
 		// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3489
-		err = EnsureAllContent(ctx, client, parsedRef.String(), options.GOptions)
+		// XXX what if the image is a CID, or only otherwise available on ipfs?
+		err = EnsureAllContent(ctx, client, parsedReference.String(), options.GOptions)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		if options.Estargz {
 			layerConvert = eStargzConvertFunc()
 		}
-		c, err := ipfs.Push(ctx, client, parsedRef.String(), layerConvert, options.AllPlatforms, options.Platforms, options.IpfsEnsureImage, ipfsPath)
+		c, err := ipfs.Push(ctx, client, parsedReference.String(), layerConvert, options.AllPlatforms, options.Platforms, options.IpfsEnsureImage, ipfsPath)
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("ipfs push failed")
 			return err
@@ -98,12 +98,12 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		return nil
 	}
 
-	named, err := distributionref.ParseDockerRef(rawRef)
+	parsedReference, err = referenceutil.Parse(rawRef)
 	if err != nil {
 		return err
 	}
-	ref := named.String()
-	refDomain := distributionref.Domain(named)
+	ref := parsedReference.String()
+	refDomain := parsedReference.Domain
 
 	platMC, err := platformutil.NewMatchComparer(options.AllPlatforms, options.Platforms)
 	if err != nil {

--- a/pkg/cmd/image/tag.go
+++ b/pkg/cmd/image/tag.go
@@ -49,7 +49,7 @@ func Tag(ctx context.Context, client *containerd.Client, options types.ImageTagO
 		return fmt.Errorf("%s: not found", options.Source)
 	}
 
-	target, err := referenceutil.ParseDockerRef(options.Target)
+	parsedReference, err := referenceutil.Parse(options.Target)
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func Tag(ctx context.Context, client *containerd.Client, options types.ImageTagO
 		return err
 	}
 
-	img.Name = target.String()
+	img.Name = parsedReference.String()
 	if _, err = imageService.Create(ctx, img); err != nil {
 		if errdefs.IsAlreadyExists(err) {
 			if err = imageService.Delete(ctx, img.Name); err != nil {

--- a/pkg/idutil/imagewalker/imagewalker.go
+++ b/pkg/idutil/imagewalker/imagewalker.go
@@ -50,8 +50,8 @@ type ImageWalker struct {
 // Returns the number of the found entries.
 func (w *ImageWalker) Walk(ctx context.Context, req string) (int, error) {
 	var filters []string
-	if canonicalRef, err := referenceutil.ParseAny(req); err == nil {
-		filters = append(filters, fmt.Sprintf("name==%s", canonicalRef.String()))
+	if parsedReference, err := referenceutil.Parse(req); err == nil {
+		filters = append(filters, fmt.Sprintf("name==%s", parsedReference.String()))
 	}
 	filters = append(filters,
 		fmt.Sprintf("name==%s", req),

--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -24,8 +24,6 @@ import (
 	"strings"
 	"time"
 
-	distributionref "github.com/distribution/reference"
-
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 
@@ -80,19 +78,19 @@ func ParseFilters(filters []string) (*Filters, error) {
 				}
 				f.Dangling = &isDangling
 			} else if tempFilterToken[0] == FilterBeforeType {
-				canonicalRef, err := referenceutil.ParseAny(tempFilterToken[1])
+				parsedReference, err := referenceutil.Parse(tempFilterToken[1])
 				if err != nil {
 					return nil, err
 				}
 
-				f.Before = append(f.Before, fmt.Sprintf("name==%s", canonicalRef.String()))
+				f.Before = append(f.Before, fmt.Sprintf("name==%s", parsedReference.String()))
 				f.Before = append(f.Before, fmt.Sprintf("name==%s", tempFilterToken[1]))
 			} else if tempFilterToken[0] == FilterSinceType {
-				canonicalRef, err := referenceutil.ParseAny(tempFilterToken[1])
+				parsedReference, err := referenceutil.Parse(tempFilterToken[1])
 				if err != nil {
 					return nil, err
 				}
-				f.Since = append(f.Since, fmt.Sprintf("name==%s", canonicalRef.String()))
+				f.Since = append(f.Since, fmt.Sprintf("name==%s", parsedReference.String()))
 				f.Since = append(f.Since, fmt.Sprintf("name==%s", tempFilterToken[1]))
 			} else if tempFilterToken[0] == FilterUntilType {
 				if len(tempFilterToken[0]) == 0 {
@@ -311,13 +309,13 @@ func matchesAllLabels(imageCfgLabels map[string]string, filterLabels map[string]
 func matchesReferences(image images.Image, referencePatterns []string) (bool, error) {
 	var matches int
 
-	reference, err := distributionref.ParseAnyReference(image.Name)
+	parsedReference, err := referenceutil.Parse(image.Name)
 	if err != nil {
 		return false, err
 	}
 
 	for _, pattern := range referencePatterns {
-		familiarMatch, err := distributionref.FamiliarMatch(pattern, reference)
+		familiarMatch, err := parsedReference.FamiliarMatch(pattern)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/referenceutil/referenceutil_test.go
+++ b/pkg/referenceutil/referenceutil_test.go
@@ -19,17 +19,299 @@ package referenceutil
 import (
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	"gotest.tools/v3/assert"
 )
 
-func TestSuggestContainerName(t *testing.T) {
-	const containerID = "16f6d167d4f4743e48affb86e7097222b7992b34a29dab5f8c10cd6a90cdd990"
-	assert.Equal(t, "alpine-16f6d", SuggestContainerName("alpine", containerID))
-	assert.Equal(t, "alpine-16f6d", SuggestContainerName("alpine:3.15", containerID))
-	assert.Equal(t, "alpine-16f6d", SuggestContainerName("docker.io/library/alpine:3.15", containerID))
-	assert.Equal(t, "alpine-16f6d", SuggestContainerName("docker.io/library/alpine:latest", containerID))
-	assert.Equal(t, "ipfs-bafkr-16f6d", SuggestContainerName("bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze", containerID))
-	assert.Equal(t, "ipfs-bafkr-16f6d", SuggestContainerName("ipfs://bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze", containerID))
-	assert.Equal(t, "untitled-16f6d", SuggestContainerName("invalid://alpine", containerID))
-	assert.Equal(t, "untitled-16f6d", SuggestContainerName("", containerID))
+func TestReferenceUtil(t *testing.T) {
+	needles := map[string]struct {
+		Error         string
+		String        string
+		Normalized    string
+		Suggested     string
+		FamiliarName  string
+		FamiliarMatch map[string]bool
+		Protocol      Protocol
+		Digest        digest.Digest
+		Path          string
+		Domain        string
+		Tag           string
+		ExplicitTag   string
+	}{
+		"": {
+			Error: "invalid reference format",
+		},
+		"∞": {
+			Error: "invalid reference format",
+		},
+		"abcd:∞": {
+			Error: "invalid reference format",
+		},
+		"abcd@sha256:∞": {
+			Error: "invalid reference format",
+		},
+		"abcd@∞": {
+			Error: "invalid reference format",
+		},
+		"abcd:foo@sha256:∞": {
+			Error: "invalid reference format",
+		},
+		"abcd:foo@∞": {
+			Error: "invalid reference format",
+		},
+		"sha256:whatever": {
+			Error:        "",
+			String:       "docker.io/library/sha256:whatever",
+			Suggested:    "sha256-abcde",
+			FamiliarName: "sha256",
+			FamiliarMatch: map[string]bool{
+				"*a*":                      true,
+				"?ha25?":                   true,
+				"[s-z]ha25[0-9]":           true,
+				"[^a]ha25[^a-z]":           true,
+				"*6:whatever":              true,
+				"docker.io/library/sha256": false,
+			},
+			Protocol:    "",
+			Digest:      "",
+			Path:        "library/sha256",
+			Domain:      "docker.io",
+			Tag:         "whatever",
+			ExplicitTag: "whatever",
+		},
+		"sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
+			Error:        "",
+			String:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Normalized:   "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Suggested:    "untitled-abcde",
+			FamiliarName: "",
+			Protocol:     "",
+			Digest:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Path:         "",
+			Domain:       "",
+			Tag:          "",
+		},
+		"4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
+			Error:        "",
+			String:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Normalized:   "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Suggested:    "untitled-abcde",
+			FamiliarName: "",
+			Protocol:     "",
+			Digest:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Path:         "",
+			Domain:       "",
+			Tag:          "",
+		},
+		"image_name": {
+			Error:        "",
+			String:       "docker.io/library/image_name:latest",
+			Normalized:   "docker.io/library/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"library/image_name": {
+			Error:        "",
+			String:       "docker.io/library/image_name:latest",
+			Normalized:   "docker.io/library/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"something/image_name": {
+			Error:        "",
+			String:       "docker.io/something/image_name:latest",
+			Normalized:   "docker.io/something/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "something/image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "something/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"docker.io/library/image_name": {
+			Error:        "",
+			String:       "docker.io/library/image_name:latest",
+			Normalized:   "docker.io/library/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"image_name:latest": {
+			Error:        "",
+			String:       "docker.io/library/image_name:latest",
+			Normalized:   "docker.io/library/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "latest",
+		},
+		"image_name:foo": {
+			Error:        "",
+			String:       "docker.io/library/image_name:foo",
+			Normalized:   "docker.io/library/image_name:foo",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "foo",
+			ExplicitTag:  "foo",
+		},
+		"image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
+			Error:        "",
+			String:       "docker.io/library/image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Normalized:   "docker.io/library/image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "",
+			ExplicitTag:  "",
+		},
+		"image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
+			Error:        "",
+			String:       "docker.io/library/image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Normalized:   "docker.io/library/image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "image_name",
+			Protocol:     "",
+			Digest:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
+			Path:         "library/image_name",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "latest",
+		},
+		"ghcr.io:1234/image_name": {
+			Error:        "",
+			String:       "ghcr.io:1234/image_name:latest",
+			Normalized:   "ghcr.io:1234/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "ghcr.io:1234/image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "image_name",
+			Domain:       "ghcr.io:1234",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"ghcr.io/sub_name/image_name": {
+			Error:        "",
+			String:       "ghcr.io/sub_name/image_name:latest",
+			Normalized:   "ghcr.io/sub_name/image_name:latest",
+			Suggested:    "image_name-abcde",
+			FamiliarName: "ghcr.io/sub_name/image_name",
+			Protocol:     "",
+			Digest:       "",
+			Path:         "sub_name/image_name",
+			Domain:       "ghcr.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+		"bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze": {
+			Error:        "",
+			String:       "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Normalized:   "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Suggested:    "ipfs-bafkr-abcde",
+			FamiliarName: "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Protocol:     "ipfs",
+			Digest:       "",
+			Path:         "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Domain:       "",
+			Tag:          "",
+			ExplicitTag:  "",
+		},
+		"ipfs://bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze": {
+			Error:        "",
+			String:       "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Normalized:   "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Suggested:    "ipfs-bafkr-abcde",
+			FamiliarName: "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Protocol:     "ipfs",
+			Digest:       "",
+			Path:         "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
+			Domain:       "",
+			Tag:          "",
+			ExplicitTag:  "",
+		},
+		"ipfs://ghcr.io/stargz-containers/alpine:3.13-org": {
+			Error:        "",
+			String:       "ghcr.io/stargz-containers/alpine:3.13-org",
+			Normalized:   "ghcr.io/stargz-containers/alpine:3.13-org",
+			Suggested:    "alpine-abcde",
+			FamiliarName: "ghcr.io/stargz-containers/alpine",
+			FamiliarMatch: map[string]bool{
+				"ghcr.io/stargz-containers/alpine": true,
+				"*/*/*":                            true,
+				"*/*/*:3.13-org":                   true,
+			},
+			Protocol:    "ipfs",
+			Digest:      "",
+			Path:        "stargz-containers/alpine",
+			Domain:      "ghcr.io",
+			Tag:         "3.13-org",
+			ExplicitTag: "3.13-org",
+		},
+		"ipfs://alpine": {
+			Error:        "",
+			String:       "docker.io/library/alpine:latest",
+			Normalized:   "docker.io/library/alpine:latest",
+			Suggested:    "alpine-abcde",
+			FamiliarName: "alpine",
+			Protocol:     "ipfs",
+			Digest:       "",
+			Path:         "library/alpine",
+			Domain:       "docker.io",
+			Tag:          "latest",
+			ExplicitTag:  "",
+		},
+	}
+
+	for k, v := range needles {
+		parsed, err := Parse(k)
+		if v.Error != "" || err != nil {
+			assert.Error(t, err, v.Error)
+			continue
+		}
+		assert.Equal(t, parsed.String(), v.String, k)
+		assert.Equal(t, parsed.SuggestContainerName("abcdefghij"), v.Suggested, k)
+		assert.Equal(t, parsed.FamiliarName(), v.FamiliarName, k)
+		for needle, result := range v.FamiliarMatch {
+			res, err := parsed.FamiliarMatch(needle)
+			assert.NilError(t, err)
+			assert.Equal(t, res, result, k)
+		}
+
+		assert.Equal(t, parsed.Protocol, v.Protocol, k)
+		assert.Equal(t, parsed.Digest, v.Digest, k)
+		assert.Equal(t, parsed.Path, v.Path, k)
+		assert.Equal(t, parsed.Domain, v.Domain, k)
+		assert.Equal(t, parsed.Tag, v.Tag, k)
+		assert.Equal(t, parsed.ExplicitTag, v.ExplicitTag, k)
+	}
 }


### PR DESCRIPTION
This is a first step at enhancing and fixing issues in imgutil (#3531) - focusing specifically on `referenceutil`.

We currently use a mix of `nerdctl/referenceutil` and `github.com/distribution/reference` as far as I can tell without much consistency.

We obviously introduced our own "helpers" in `referenceutil` (primarily to accommodate for ipfs images), sometimes with identical names to the upstream API:
- ParseDockerRef
- ParseAny
- ParseAnyReference
- ParseIPFSRefWithScheme

... in addition to the existing:
- ParseNormalizedNamed
- ParseDockerRef
- ParseAnyReference
- etc

This abundance of methods that are doing _almost_ exactly the same thing - with subtle differences - seems hard to justify - be it on our side, or on the distribution side.
The distribution ref code was designed ten years ago now (fall 2014), with different notions about images names, backward compatibility requirements with the old python registry (prior to the go implem), and quite frankly, a questionable design (the whole "cast it to `XYZ` if you want to access properties"), and a number of embarrassing bugs (specifically around tags+digests), that IIRC have been creeping far out (into buildkit), causing hard-to-figure-out caching issues.
It seems like `reference` has been barely touched since then. 

At this point, it is doubtful that anyone could say _top of the head_ what are the differences between all of these or what are the ramifications if you use one rather than the other.

While this is challenging already for long-timers (_I certainly do need to read the source multiple times every time I touch these_), it is just plain bad for newcomers.

Add to that normalization concerns, the familiarization mechanisms that work only post normalization. This is just not a good API.

Finally, we seem to parse these references multiples times during the same flow as we pass strings around - in a context where `distribution/reference` is notoriously hungry for memory.

This PR is suggesting that we stop using `distributionref` entirely (eg: except inside referenceutil obviously), and replace all of our stuff with a new, _single method_ - `Parse` - and _one_ struct.

The first commit is the implementation of the new referenceutil + tests.
The second commit adapts the codebase - this is not too aggressive of a refactor, and we might want to further clean this up to reduce duplicate parsing - but that would require changing methods signatures, which this PR tries to avoid.

Let me know your thoughts - especially if I am missing something here that would not be in the tests, and that would justify specialized parsing in certain cases.
