### PR TITLE
[fix] fix image filter with nonexist image

### DIFF
--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -17,6 +17,7 @@
 package image
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -258,13 +259,13 @@ RUN echo "actually creating a layer so that docker sets the createdAt time"
 				Description: "since=non-exists-image",
 				Require:     nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3511"),
 				Command:     test.Command("images", "--filter", "since=non-exists-image"),
-				Expected:    test.Expects(-1, nil, nil),
+				Expected:    test.Expects(-1, []error{errors.New("No such image: ")}, nil),
 			},
 			{
 				Description: "before=non-exists-image",
 				Require:     nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3511"),
 				Command:     test.Command("images", "--filter", "before=non-exists-image"),
-				Expected:    test.Expects(-1, nil, nil),
+				Expected:    test.Expects(-1, []error{errors.New("No such image: ")}, nil),
 			},
 		},
 	}


### PR DESCRIPTION
Fix #3511

This commit does not cover this situation `nerdctl images -f since=IMAGE_ID`