### PR TITLE
Enhance debug output and readability

### DIFF
--- a/cmd/nerdctl/completion/completion_linux_test.go
+++ b/cmd/nerdctl/completion/completion_linux_test.go
@@ -30,7 +30,7 @@ func TestCompletion(t *testing.T) {
 	testCase := &test.Case{
 		Require: test.Not(nerdtest.Docker),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.AlpineImage)
+			helpers.Ensure("pull", "--quiet", testutil.AlpineImage)
 			helpers.Ensure("network", "create", data.Identifier())
 			helpers.Ensure("volume", "create", data.Identifier())
 			data.Set("identifier", data.Identifier())

--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -108,7 +108,7 @@ func TestImageConvertNydusVerify(t *testing.T) {
 			test.Binary("nydusify"),
 			test.Binary("nydusd"),
 			test.Not(nerdtest.Docker),
-			nerdtest.RootFul,
+			nerdtest.Rootful,
 		),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", testutil.CommonImage)

--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -36,7 +36,7 @@ func TestImageConvert(t *testing.T) {
 			test.Not(nerdtest.Docker),
 		),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 		},
 		SubTests: []*test.Case{
 			{
@@ -111,7 +111,7 @@ func TestImageConvertNydusVerify(t *testing.T) {
 			nerdtest.Rootful,
 		),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			base := testutil.NewBase(t)
 			registry = testregistry.NewWithNoAuth(base, 0, false)
 			data.Set(remoteImageKey, fmt.Sprintf("%s:%d/nydusd-image:test", "localhost", registry.Port))

--- a/cmd/nerdctl/image/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image/image_encrypt_linux_test.go
@@ -57,7 +57,7 @@ func TestImageEncryptJWE(t *testing.T) {
 			base := testutil.NewBase(t)
 			registry = testregistry.NewWithNoAuth(base, 0, false)
 			keyPair = testhelpers.NewJWEKeyPair(t)
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			encryptImageRef := fmt.Sprintf("127.0.0.1:%d/%s:encrypted", registry.Port, data.Identifier())
 			helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, testutil.CommonImage, encryptImageRef)
 			inspector := helpers.Capture("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", encryptImageRef)
@@ -71,7 +71,7 @@ func TestImageEncryptJWE(t *testing.T) {
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 			helpers.Fail("pull", data.Get(remoteImageKey))
-			helpers.Ensure("pull", "--unpack=false", data.Get(remoteImageKey))
+			helpers.Ensure("pull", "--quiet", "--unpack=false", data.Get(remoteImageKey))
 			helpers.Fail("image", "decrypt", "--key="+keyPair.Pub, data.Get(remoteImageKey), data.Identifier("decrypted")) // decryption needs prv key, not pub key
 			return helpers.Command("image", "decrypt", "--key="+keyPair.Prv, data.Get(remoteImageKey), data.Identifier("decrypted"))
 		},

--- a/cmd/nerdctl/image/image_history_test.go
+++ b/cmd/nerdctl/image/image_history_test.go
@@ -81,7 +81,7 @@ func TestImageHistory(t *testing.T) {
 			// https://github.com/containerd/nerdctl/issues/3512
 			// Isolating it into a completely different root is the last ditched attempt at avoiding the issue
 			helpers.Write(nerdtest.DataRoot, test.ConfigValue(data.TempDir()))
-			helpers.Ensure("pull", "--platform", "linux/arm64", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", "--platform", "linux/arm64", testutil.CommonImage)
 		},
 		SubTests: []*test.Case{
 			{

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -33,7 +33,6 @@ func TestImageInspectSimpleCases(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "TestImageInspect",
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", testutil.CommonImage)
 		},

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -87,9 +87,9 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 			nerdtest.Private,
 		),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", "alpine")
-			helpers.Ensure("pull", "busybox")
-			helpers.Ensure("pull", "registry-1.docker.io/library/busybox")
+			helpers.Ensure("pull", "--quiet", "alpine")
+			helpers.Ensure("pull", "--quiet", "busybox")
+			helpers.Ensure("pull", "--quiet", "registry-1.docker.io/library/busybox")
 		},
 		SubTests: []*test.Case{
 			{

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -38,8 +38,8 @@ func TestImages(t *testing.T) {
 		Description: "TestImages",
 		Require:     test.Not(nerdtest.Docker),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
-			helpers.Ensure("pull", testutil.NginxAlpineImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
 		},
 		SubTests: []*test.Case{
 			{
@@ -127,7 +127,7 @@ func TestImagesFilter(t *testing.T) {
 		Description: "TestImagesFilter",
 		Require:     nerdtest.Build,
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, "taggedimage:one-fragment-one")
 			helpers.Ensure("tag", testutil.CommonImage, "taggedimage:two-fragment-two")
 

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -37,7 +37,7 @@ func TestLoadStdinFromPipe(t *testing.T) {
 		Description: "TestLoadStdinFromPipe",
 		Require:     test.Linux,
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, data.Identifier())
 			helpers.Ensure("save", data.Identifier(), "-o", filepath.Join(data.TempDir(), "common.tar"))
 			helpers.Ensure("rmi", "-f", data.Identifier())

--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -64,7 +64,7 @@ func TestPush(t *testing.T) {
 			{
 				Description: "plain http",
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -84,7 +84,7 @@ func TestPush(t *testing.T) {
 				Description: "plain http with insecure",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -103,7 +103,7 @@ func TestPush(t *testing.T) {
 			{
 				Description: "plain http with localhost",
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						"127.0.0.1", registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -118,7 +118,7 @@ func TestPush(t *testing.T) {
 				Description: "plain http with insecure, default port",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s/%s:%s",
 						registryNoAuthHTTPDefault.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -138,7 +138,7 @@ func TestPush(t *testing.T) {
 				Description: "with insecure, with login",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -161,7 +161,7 @@ func TestPush(t *testing.T) {
 				Description: "with hosts dir, with login",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.CommonImage)
+					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -184,7 +184,7 @@ func TestPush(t *testing.T) {
 				Description: "non distributable artifacts",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.NonDistBlobImage)
+					helpers.Ensure("pull", "--quiet", testutil.NonDistBlobImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.NonDistBlobImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -216,7 +216,7 @@ func TestPush(t *testing.T) {
 				Description: "non distributable artifacts (with)",
 				Require:     test.Not(nerdtest.Docker),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.NonDistBlobImage)
+					helpers.Ensure("pull", "--quiet", testutil.NonDistBlobImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.NonDistBlobImage, ":")[1])
 					data.Set("testImageRef", testImageRef)
@@ -251,7 +251,7 @@ func TestPush(t *testing.T) {
 					test.Not(nerdtest.Docker),
 				),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("pull", testutil.UbuntuImage)
+					helpers.Ensure("pull", "--quiet", testutil.UbuntuImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.UbuntuImage, ":")[1])
 					data.Set("testImageRef", testImageRef)

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -166,7 +166,7 @@ func TestRemove(t *testing.T) {
 			NoParallel:  true,
 			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.NginxAlpineImage)
+				helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
 				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
 				helpers.Ensure("rmi", testutil.NginxAlpineImage)
 			},

--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -71,7 +71,6 @@ func TestIPFSCompNoBuild(t *testing.T) {
 		if ipfsRegistry != nil {
 			ipfsRegistry.Cleanup(data, helpers)
 		}
-		// Speeding up repeat tests...
 		helpers.Anyhow("rmi", "-f", testutil.WordpressImage)
 		helpers.Anyhow("rmi", "-f", testutil.MariaDBImage)
 	}
@@ -91,13 +90,15 @@ func subtestTestIPFSCompNoB(t *testing.T, stargz bool, byAddr bool) *test.Case {
 
 	testCase.Description += "with"
 
-	if stargz {
-		testCase.Description += "-stargz"
+	if !stargz {
+		testCase.Description += "-no"
 	}
+	testCase.Description += "-stargz"
 
-	if byAddr {
-		testCase.Description += "-byAddr"
+	if !byAddr {
+		testCase.Description += "-no"
 	}
+	testCase.Description += "-byAddr"
 
 	if stargz {
 		testCase.Require = nerdtest.Stargz

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -85,7 +85,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.AlpineImage))
-				helpers.Ensure("pull", data.Get(ipfsImageURLKey))
+				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				if data.Get(ipfsImageURLKey) != "" {
@@ -103,7 +103,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			Require:     nerdtest.Stargz,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.AlpineImage, "--estargz"))
-				helpers.Ensure("pull", data.Get(ipfsImageURLKey))
+				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				if data.Get(ipfsImageURLKey) != "" {

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -31,7 +31,7 @@ import (
 func TestNetworkRemove(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	testCase.Require = nerdtest.RootFul
+	testCase.Require = nerdtest.Rootful
 
 	testCase.SubTests = []*test.Case{
 		{

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -385,7 +385,7 @@ nerdtest.Docker // a test only run on Docker - normally used with test.Not(nerdt
 nerdtest.Soci // a test requires the soci snapshotter
 nerdtest.Stargz // a test requires the stargz snapshotter
 nerdtest.Rootless // a test requires Rootless
-nerdtest.RootFul // a test requires Rootful
+nerdtest.Rootful // a test requires Rootful
 nerdtest.Build // a test requires buildkit
 nerdtest.CGroup // a test requires cgroup
 nerdtest.NerdctlNeedsFixing // indicates that a test cannot be run on nerdctl yet as a fix is required

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -131,8 +131,8 @@ var BrokenTest = func(message string, req *test.Requirement) *test.Requirement {
 	}
 }
 
-// RootLess marks a test as suitable only for the rootless environment
-var RootLess = &test.Requirement{
+// Rootless marks a test as suitable only for the rootless environment
+var Rootless = &test.Requirement{
 	Check: func(data test.Data, helpers test.Helpers) (ret bool, mess string) {
 		// Make sure we DO not return "IsRootless true" for docker
 		ret = getTarget() == targetNerdctl && rootlessutil.IsRootless()
@@ -145,8 +145,8 @@ var RootLess = &test.Requirement{
 	},
 }
 
-// RootFul marks a test as suitable only for rootful env
-var RootFul = test.Not(RootLess)
+// Rootful marks a test as suitable only for rootful env
+var Rootful = test.Not(Rootless)
 
 // CGroup requires that cgroup is enabled
 var CGroup = &test.Requirement{


### PR DESCRIPTION
Small quality-of-life improvements.

1. `--quiet` ancillary image pull
2. RootFul | RootLess -> Rootful, Rootless (previous discussion in part 4)
3. test title tweak

Forked out of #3535 

@AkihiroSuda PTAL