### PR TITLE
Add image load and container run quiet mode

### DIFF
--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -409,12 +409,17 @@ func processContainerCreateOptions(cmd *cobra.Command) (types.ContainerCreateOpt
 	if err != nil {
 		return opt, err
 	}
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return opt, err
+	}
 	opt.ImagePullOpt = types.ImagePullOptions{
 		GOptions:      opt.GOptions,
 		VerifyOptions: imageVerifyOpt,
 		IPFSAddress:   opt.IPFSAddress,
 		Stdout:        opt.Stdout,
 		Stderr:        opt.Stderr,
+		Quiet:         quiet,
 	}
 	// #endregion
 

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -92,6 +92,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	})
 	cmd.Flags().Bool("rm", false, "Automatically remove the container when it exits")
 	cmd.Flags().String("pull", "missing", `Pull image before running ("always"|"missing"|"never")`)
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress the pull output")
 	cmd.RegisterFlagCompletionFunc("pull", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"always", "missing", "never"}, cobra.ShellCompDirectiveNoFileComp
 	})

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -631,3 +631,30 @@ func TestRunAttachFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestRunQuiet(t *testing.T) {
+	base := testutil.NewBase(t)
+
+	teardown := func() {
+		base.Cmd("rmi", "-f", testutil.CommonImage).Run()
+	}
+	defer teardown()
+	teardown()
+
+	sentinel := "test run quiet"
+	result := base.Cmd("run", "--rm", "--quiet", testutil.CommonImage, fmt.Sprintf(`echo "%s"`, sentinel)).Run()
+	assert.Assert(t, strings.Contains(result.Combined(), sentinel))
+
+	wasQuiet := func(output, sentinel string) bool {
+		return !strings.Contains(output, sentinel)
+	}
+
+	// Docker and nerdctl image pulls are not 1:1.
+	if testutil.GetTarget() == testutil.Docker {
+		sentinel = "Pull complete"
+	} else {
+		sentinel = "resolved"
+	}
+
+	assert.Assert(t, wasQuiet(result.Combined(), sentinel), "Found %s in container run output", sentinel)
+}

--- a/cmd/nerdctl/image/image_load.go
+++ b/cmd/nerdctl/image/image_load.go
@@ -38,6 +38,7 @@ func NewLoadCommand() *cobra.Command {
 	}
 
 	loadCommand.Flags().StringP("input", "i", "", "Read from tar archive file, instead of STDIN")
+	loadCommand.Flags().BoolP("quiet", "q", false, "Suppress the load output")
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
@@ -66,6 +67,10 @@ func processLoadCommandFlags(cmd *cobra.Command) (types.ImageLoadOptions, error)
 	if err != nil {
 		return types.ImageLoadOptions{}, err
 	}
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return types.ImageLoadOptions{}, err
+	}
 	return types.ImageLoadOptions{
 		GOptions:     globalOptions,
 		Input:        input,
@@ -73,6 +78,7 @@ func processLoadCommandFlags(cmd *cobra.Command) (types.ImageLoadOptions, error)
 		AllPlatforms: allPlatforms,
 		Stdout:       cmd.OutOrStdout(),
 		Stdin:        cmd.InOrStdin(),
+		Quiet:        quiet,
 	}, nil
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -151,6 +151,7 @@ Basic flags:
 - :whale: `--rm`: Automatically remove the container when it exits
 - :whale: `--pull=(always|missing|never)`: Pull image before running
   - Default: "missing"
+- :whale: `-q, --quiet`: Suppress the pull output
 - :whale: `--pid=(host|container:<container>)`: PID namespace to use
 - :whale: `--uts=(host)` : UTS namespace to use
 - :whale: `--stop-signal`: Signal to stop a container (default "SIGTERM")
@@ -815,10 +816,9 @@ Usage: `nerdctl load [OPTIONS]`
 Flags:
 
 - :whale: `-i, --input`: Read from tar archive file, instead of STDIN
+- :whale: `-q, --quiet`: Suppress the load output
 - :nerd_face: `--platform=(amd64|arm64|...)`: Import content for a specific platform
 - :nerd_face: `--all-platforms`: Import content for all platforms
-
-Unimplemented `docker load` flags: `--quiet`
 
 ### :whale: nerdctl save
 

--- a/pkg/api/types/load_types.go
+++ b/pkg/api/types/load_types.go
@@ -29,4 +29,6 @@ type ImageLoadOptions struct {
 	Platform []string
 	// AllPlatforms import content for all platforms
 	AllPlatforms bool
+	// Quiet suppresses the load output.
+	Quiet bool
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -138,7 +138,6 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		options.ImagePullOpt.Mode = options.Pull
 		options.ImagePullOpt.OCISpecPlatform = ocispecPlatforms
 		options.ImagePullOpt.Unpack = nil
-		options.ImagePullOpt.Quiet = false
 
 		ensuredImage, err = image.EnsureImage(ctx, client, rawRef, options.ImagePullOpt)
 		if err != nil {


### PR DESCRIPTION
### Issue
Split from https://github.com/containerd/nerdctl/pull/3537

### Description
This change adds `-q|--quiet` flag on `nerdctl load`, `nerdctl container create`, and `nerdctl container run` commands to suppress image pull and load output.

### Testing
1. Manual tested behavior aligned with Docker 25.
```bash
$ docker load -q -i alpine-latest.tar 
Loaded image: alpine:latest
$ _output/nerdctl load -q -i alpine-latest.tar 
Loaded image: alpine:latest
$ 
```
```bash
$ docker run --rm --quiet alpine:latest echo "test run quiet"
test run quiet
$ _output/nerdctl run --rm --quiet alpine:latest echo "test run quiet"
test run quiet
$ 
```
2. Added integration tests