### PR TITLE
Add pseudo tty support for tests

### DIFF
--- a/cmd/nerdctl/issues/main_linux_test.go
+++ b/cmd/nerdctl/issues/main_linux_test.go
@@ -33,30 +33,26 @@ func TestMain(m *testing.M) {
 func TestIssue108(t *testing.T) {
 	testCase := nerdtest.Setup()
 
+	testCase.Require = test.Linux
+
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "-it --net=host",
-			Require:     test.Binary("unbuffer"),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.
-					Command("run", "-it", "--rm", "--net=host", testutil.AlpineImage, "echo", "this was always working")
-				cmd.WithWrapper("unbuffer")
+				cmd := helpers.Command("run", "-it", "--rm", "--net=host", testutil.AlpineImage, "echo", "this was always working")
+				cmd.WithPseudoTTY()
 				return cmd
 			},
-			// Note: unbuffer will merge stdout and stderr, preventing exact match here
-			Expected: test.Expects(0, nil, test.Contains("this was always working")),
+			Expected: test.Expects(0, nil, test.Equals("this was always working\r\n")),
 		},
 		{
 			Description: "--net=host -it",
-			Require:     test.Binary("unbuffer"),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.
-					Command("run", "--rm", "--net=host", "-it", testutil.AlpineImage, "echo", "this was not working due to issue #108")
-				cmd.WithWrapper("unbuffer")
+				cmd := helpers.Command("run", "--rm", "--net=host", "-it", testutil.AlpineImage, "echo", "this was not working due to issue #108")
+				cmd.WithPseudoTTY()
 				return cmd
 			},
-			// Note: unbuffer will merge stdout and stderr, preventing exact match here
-			Expected: test.Expects(0, nil, test.Contains("this was not working due to issue #108")),
+			Expected: test.Expects(0, nil, test.Equals("this was not working due to issue #108\r\n")),
 		},
 	}
 

--- a/pkg/testutil/test/pty.go
+++ b/pkg/testutil/test/pty.go
@@ -1,0 +1,74 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package test
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+// Inspiration from https://github.com/creack/pty/tree/2cde18bfb702199728dd43bf10a6c15c7336da0a
+
+var ErrPTY = errors.New("pty failure")
+
+func Open() (pty, tty *os.File, err error) {
+	defer func() {
+		if err != nil && pty != nil {
+			err = errors.Join(pty.Close(), err)
+		}
+		if err != nil {
+			err = errors.Join(ErrPTY, err)
+		}
+	}()
+
+	pty, err = os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var n uint32
+	err = ioctl(pty, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sname := "/dev/pts/" + strconv.Itoa(int(n))
+
+	var u int32
+	err = ioctl(pty, syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tty, err = os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pty, tty, nil
+}
+
+func ioctl(f *os.File, cmd, ptr uintptr) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), cmd, ptr)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/pkg/testutil/test/pty_freebsd.go
+++ b/pkg/testutil/test/pty_freebsd.go
@@ -16,7 +16,10 @@
 
 package test
 
-import "errors"
+import (
+	"os"
+)
 
-var ErrPTYFailure = errors.New("pty failure")
-var ErrPTYUnsupportedPlatform = errors.New("pty not supported on this platform")
+func Open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrPTYUnsupportedPlatform
+}

--- a/pkg/testutil/test/pty_linux.go
+++ b/pkg/testutil/test/pty_linux.go
@@ -1,0 +1,72 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package test
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"syscall"
+	"unsafe"
+)
+
+// Inspiration from https://github.com/creack/pty/tree/2cde18bfb702199728dd43bf10a6c15c7336da0a
+
+func Open() (pty, tty *os.File, err error) {
+	defer func() {
+		if err != nil && pty != nil {
+			err = errors.Join(pty.Close(), err)
+		}
+		if err != nil {
+			err = errors.Join(ErrPTYFailure, err)
+		}
+	}()
+
+	pty, err = os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var n uint32
+	err = ioctl(pty, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sname := "/dev/pts/" + strconv.Itoa(int(n))
+
+	var u int32
+	err = ioctl(pty, syscall.TIOCSPTLCK, uintptr(unsafe.Pointer(&u)))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tty, err = os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return pty, tty, nil
+}
+
+func ioctl(f *os.File, cmd, ptr uintptr) error {
+	_, _, e := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), cmd, ptr)
+	if e != 0 {
+		return e
+	}
+	return nil
+}

--- a/pkg/testutil/test/pty_windows.go
+++ b/pkg/testutil/test/pty_windows.go
@@ -16,7 +16,10 @@
 
 package test
 
-import "errors"
+import (
+	"os"
+)
 
-var ErrPTYFailure = errors.New("pty failure")
-var ErrPTYUnsupportedPlatform = errors.New("pty not supported on this platform")
+func Open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrPTYUnsupportedPlatform
+}

--- a/pkg/testutil/test/test.go
+++ b/pkg/testutil/test/test.go
@@ -97,6 +97,8 @@ type TestableCommand interface {
 	WithArgs(args ...string)
 	// WithWrapper allows wrapping a command with another command (for example: `time`, `unbuffer`)
 	WithWrapper(binary string, args ...string)
+	// WithPseudoTTY
+	WithPseudoTTY()
 	// WithStdin allows passing a reader to be used for stdin for the command
 	WithStdin(r io.Reader)
 	// WithCwd allows specifying the working directory for the command


### PR DESCRIPTION
Right now we rely on unbuffer.

This is problematic for a couple of reasons:
- unbuffer merges stdout and stderr together
- it is a binary dependency on the host
- in light of #3558 it makes debugging more complicated by having another (blackbox) piece at play

Suggesting we just remove unbuffer.

This PR implements basic pty support for tests, and removes unbuffer from a first test.
