### PR TITLE
Chores

### DIFF
--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -131,6 +131,8 @@ func TestCreateWithMACAddress(t *testing.T) {
 				// res = base.Cmd("start", "-i", containerName).
 				//	CmdOption(testutil.WithStdin(strings.NewReader("ip addr show eth0 | grep ether | awk '{printf $2}'"))).Run()
 				res = base.Cmd("start", "-a", containerName).Run()
+				// FIXME: flaky - this has failed on the CI once, with the output NOT containing anything
+				// https://github.com/containerd/nerdctl/actions/runs/11392051487/job/31697214002?pr=3535#step:7:271
 				assert.Assert(t, strings.Contains(res.Stdout(), expect), fmt.Sprintf("expected output to contain %q: %q", expect, res.Stdout()))
 				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded")
 			} else {

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -82,6 +82,7 @@ func TestLogsOutStreamsSeparated(t *testing.T) {
 }
 
 func TestLogsWithInheritedFlags(t *testing.T) {
+	// Seen flaky with Docker
 	t.Parallel()
 	base := testutil.NewBase(t)
 	for k, v := range base.Args {

--- a/cmd/nerdctl/container/container_stop_linux_test.go
+++ b/cmd/nerdctl/container/container_stop_linux_test.go
@@ -73,6 +73,8 @@ func TestStopStart(t *testing.T) {
 
 func TestStopWithStopSignal(t *testing.T) {
 	t.Parallel()
+	// There may be issues with logs in Docker.
+	// This test is flaky with Docker. Might be related to https://github.com/containerd/nerdctl/pull/3557
 	base := testutil.NewBase(t)
 	testContainerName := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", testContainerName).Run()

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -61,6 +62,10 @@ func TestImageInspectSimpleCases(t *testing.T) {
 				Expected:    test.Expects(0, nil, nil),
 			},
 		},
+	}
+
+	if runtime.GOOS == "windows" {
+		testCase.Require = nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3524")
 	}
 
 	testCase.Run(t)

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"fmt"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -117,6 +118,13 @@ func TestImages(t *testing.T) {
 		},
 	}
 
+	if runtime.GOOS == "windows" {
+		testCase.Require = test.Require(
+			testCase.Require,
+			nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3524"),
+		)
+	}
+
 	testCase.Run(t)
 }
 
@@ -189,7 +197,6 @@ RUN echo "actually creating a layer so that docker sets the createdAt time"
 			},
 			{
 				Description: "label=version",
-				Require:     nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3512"),
 				Command:     test.Command("images", "--filter", "label=version"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -179,7 +179,7 @@ RUN echo "actually creating a layer so that docker sets the createdAt time"
 				},
 			},
 			{
-				Description: "label=foo=bar label=version=0.1",
+				Description: "label=foo=bar label=version=0.2",
 				Command:     test.Command("images", "--filter", "label=foo=bar", "--filter", "label=version=0.2"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -19,6 +19,7 @@ package image
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -69,6 +70,10 @@ func TestSave(t *testing.T) {
 	// Further note though, that this will hide the fact this the save command could fail if some layers are missing.
 	// See https://github.com/containerd/nerdctl/issues/3425 and others for details.
 	testCase.Require = nerdtest.Private
+
+	if runtime.GOOS == "windows" {
+		testCase.Require = nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3524")
+	}
 
 	testCase.SubTests = []*test.Case{
 		{

--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -46,6 +46,7 @@ func TestIPFSCompNoBuild(t *testing.T) {
 		test.Not(nerdtest.Docker),
 		nerdtest.Registry,
 		nerdtest.IPFS,
+		nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3510"),
 		// See note below
 		// nerdtest.Private,
 	)
@@ -153,6 +154,7 @@ services:
       WORDPRESS_DB_USER: exampleuser
       WORDPRESS_DB_PASSWORD: examplepass
       WORDPRESS_DB_NAME: exampledb
+    # FIXME: this is flaky and will make the container fail on occasions
     volumes:
       - wordpress:/var/www/html
 

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -35,8 +35,6 @@ func TestNetworkCreate(t *testing.T) {
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "vanilla",
-			// #3491 and #3508 may have helped - commenting this out for now
-			// Require:     nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3086"),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier())
 				netw := nerdtest.InspectNetwork(helpers, data.Identifier())
@@ -66,8 +64,6 @@ func TestNetworkCreate(t *testing.T) {
 		},
 		{
 			Description: "with MTU",
-			// #3491 and #3508 may have helped - commenting this out for now
-			// Require:     nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3086"),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier(), "--driver", "bridge", "--opt", "com.docker.network.driver.mtu=9216")
 			},
@@ -81,9 +77,7 @@ func TestNetworkCreate(t *testing.T) {
 		},
 		{
 			Description: "with ipv6",
-			// #3491 and #3508 may have helped - commenting this out for now
-			// Require:     nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3086"),
-			Require: nerdtest.OnlyIPv6,
+			Require:     nerdtest.OnlyIPv6,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				subnetStr := "2001:db8:8::/64"
 				data.Set("subnetStr", subnetStr)

--- a/cmd/nerdctl/network/network_list_linux_test.go
+++ b/cmd/nerdctl/network/network_list_linux_test.go
@@ -29,9 +29,6 @@ import (
 func TestNetworkLsFilter(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	// #3491 and #3508 may have helped - commenting this out for now
-	// testCase.Require =     nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3086"),
-
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		data.Set("identifier", data.Identifier())
 		data.Set("label", "mylabel=label-1")

--- a/pkg/cmd/image/ensure.go
+++ b/pkg/cmd/image/ensure.go
@@ -65,9 +65,6 @@ func ensureOne(ctx context.Context, client *containerd.Client, rawRef string, ta
 	if err != nil {
 		return err
 	}
-	// if platform == nil {
-	//	platform = platforms.DefaultSpec()
-	//}
 	pltf := []ocispec.Platform{platform}
 	platformComparer := platformutil.NewMatchComparerFromOCISpecPlatformSlice(pltf)
 

--- a/pkg/referenceutil/referenceutil_test.go
+++ b/pkg/referenceutil/referenceutil_test.go
@@ -27,7 +27,6 @@ func TestReferenceUtil(t *testing.T) {
 	needles := map[string]struct {
 		Error         string
 		String        string
-		Normalized    string
 		Suggested     string
 		FamiliarName  string
 		FamiliarMatch map[string]bool
@@ -82,7 +81,6 @@ func TestReferenceUtil(t *testing.T) {
 		"sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
 			Error:        "",
 			String:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
-			Normalized:   "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
 			Suggested:    "untitled-abcde",
 			FamiliarName: "",
 			Protocol:     "",
@@ -94,7 +92,6 @@ func TestReferenceUtil(t *testing.T) {
 		"4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
 			Error:        "",
 			String:       "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
-			Normalized:   "sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
 			Suggested:    "untitled-abcde",
 			FamiliarName: "",
 			Protocol:     "",
@@ -106,7 +103,6 @@ func TestReferenceUtil(t *testing.T) {
 		"image_name": {
 			Error:        "",
 			String:       "docker.io/library/image_name:latest",
-			Normalized:   "docker.io/library/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -119,7 +115,6 @@ func TestReferenceUtil(t *testing.T) {
 		"library/image_name": {
 			Error:        "",
 			String:       "docker.io/library/image_name:latest",
-			Normalized:   "docker.io/library/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -132,7 +127,6 @@ func TestReferenceUtil(t *testing.T) {
 		"something/image_name": {
 			Error:        "",
 			String:       "docker.io/something/image_name:latest",
-			Normalized:   "docker.io/something/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "something/image_name",
 			Protocol:     "",
@@ -145,7 +139,6 @@ func TestReferenceUtil(t *testing.T) {
 		"docker.io/library/image_name": {
 			Error:        "",
 			String:       "docker.io/library/image_name:latest",
-			Normalized:   "docker.io/library/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -158,7 +151,6 @@ func TestReferenceUtil(t *testing.T) {
 		"image_name:latest": {
 			Error:        "",
 			String:       "docker.io/library/image_name:latest",
-			Normalized:   "docker.io/library/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -171,7 +163,6 @@ func TestReferenceUtil(t *testing.T) {
 		"image_name:foo": {
 			Error:        "",
 			String:       "docker.io/library/image_name:foo",
-			Normalized:   "docker.io/library/image_name:foo",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -184,7 +175,6 @@ func TestReferenceUtil(t *testing.T) {
 		"image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
 			Error:        "",
 			String:       "docker.io/library/image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
-			Normalized:   "docker.io/library/image_name@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -197,7 +187,6 @@ func TestReferenceUtil(t *testing.T) {
 		"image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50": {
 			Error:        "",
 			String:       "docker.io/library/image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
-			Normalized:   "docker.io/library/image_name:latest@sha256:4b826db5f1f14d1db0b560304f189d4b17798ddce2278b7822c9d32313fe3f50",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "image_name",
 			Protocol:     "",
@@ -210,7 +199,6 @@ func TestReferenceUtil(t *testing.T) {
 		"ghcr.io:1234/image_name": {
 			Error:        "",
 			String:       "ghcr.io:1234/image_name:latest",
-			Normalized:   "ghcr.io:1234/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "ghcr.io:1234/image_name",
 			Protocol:     "",
@@ -223,7 +211,6 @@ func TestReferenceUtil(t *testing.T) {
 		"ghcr.io/sub_name/image_name": {
 			Error:        "",
 			String:       "ghcr.io/sub_name/image_name:latest",
-			Normalized:   "ghcr.io/sub_name/image_name:latest",
 			Suggested:    "image_name-abcde",
 			FamiliarName: "ghcr.io/sub_name/image_name",
 			Protocol:     "",
@@ -236,7 +223,6 @@ func TestReferenceUtil(t *testing.T) {
 		"bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze": {
 			Error:        "",
 			String:       "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
-			Normalized:   "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
 			Suggested:    "ipfs-bafkr-abcde",
 			FamiliarName: "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
 			Protocol:     "ipfs",
@@ -249,7 +235,6 @@ func TestReferenceUtil(t *testing.T) {
 		"ipfs://bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze": {
 			Error:        "",
 			String:       "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
-			Normalized:   "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
 			Suggested:    "ipfs-bafkr-abcde",
 			FamiliarName: "bafkreicq4dg6nkef5ju422ptedcwfz6kcvpvvhuqeykfrwq5krazf3muze",
 			Protocol:     "ipfs",
@@ -262,7 +247,6 @@ func TestReferenceUtil(t *testing.T) {
 		"ipfs://ghcr.io/stargz-containers/alpine:3.13-org": {
 			Error:        "",
 			String:       "ghcr.io/stargz-containers/alpine:3.13-org",
-			Normalized:   "ghcr.io/stargz-containers/alpine:3.13-org",
 			Suggested:    "alpine-abcde",
 			FamiliarName: "ghcr.io/stargz-containers/alpine",
 			FamiliarMatch: map[string]bool{
@@ -280,7 +264,6 @@ func TestReferenceUtil(t *testing.T) {
 		"ipfs://alpine": {
 			Error:        "",
 			String:       "docker.io/library/alpine:latest",
-			Normalized:   "docker.io/library/alpine:latest",
 			Suggested:    "alpine-abcde",
 			FamiliarName: "alpine",
 			Protocol:     "ipfs",

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -180,9 +180,7 @@ func (b *Base) EnsureDaemonActive() {
 		sleep    = 3 * time.Second
 	)
 	for i := 0; i < maxRetry; i++ {
-		cmd := exec.Command("systemctl",
-			append(systemctlArgs,
-				[]string{"is-active", target}...)...)
+		cmd := exec.Command("systemctl", append(systemctlArgs, "is-active", target)...)
 		out, err := cmd.CombinedOutput()
 		b.T.Logf("(retry=%d) %s", i, string(out))
 		if err == nil {
@@ -204,10 +202,7 @@ func (b *Base) DumpDaemonLogs(minutes int) {
 	b.T.Helper()
 	target := b.systemctlTarget()
 	cmd := exec.Command("journalctl",
-		append(b.systemctlArgs(),
-			[]string{"-u", target,
-				"--no-pager",
-				"-S", fmt.Sprintf("%d min ago", minutes)}...)...)
+		append(b.systemctlArgs(), "-u", target, "--no-pager", "-S", fmt.Sprintf("%d min ago", minutes))...)
 	b.T.Logf("===== %v =====", cmd.Args)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
- duplicated title test fixed
- marking / unmarking tests as flaky based on recent runs
- spurious comments
- (useless) leftovers from previous iteration in referenceutils_tests

This contains some changes broken out of #3550 (while it is being reviewed, we can still get these in and I will rebase)