### PR TITLE
Fix semantic of Fail to not care about exit code

### DIFF
--- a/pkg/testutil/test/helpers.go
+++ b/pkg/testutil/test/helpers.go
@@ -70,7 +70,7 @@ func (help *helpersInternal) Anyhow(args ...string) {
 // Fail will run a command and make sure it does fail
 func (help *helpersInternal) Fail(args ...string) {
 	help.Command(args...).Run(&Expected{
-		ExitCode: 1,
+		ExitCode: -1,
 	})
 }
 


### PR DESCRIPTION
This is a small change broken out of #3550 which is pending review (will rebase once this is in).

`Fail()` is not expected to verify the exitcode, just that the task fail.
This is specifically important as Docker often returns 127 instead of 1 in certain conditions.