### PR TITLE
Fix and enable CI unit testing for windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,19 @@ jobs:
           make lint-imports
 
   test-unit:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 5
+    name: unit | ${{ matrix.goos }}
+    runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            goos: windows
+          - os: ubuntu-24.04
+            goos: linux
     steps:
       - uses: actions/checkout@v4.2.1
         with:
@@ -51,6 +62,17 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: true
+      - if: ${{ matrix.goos=='windows' }}
+        uses: actions/checkout@v4.2.1
+        with:
+          repository: containerd/containerd
+          ref: v1.7.23
+          path: containerd
+          fetch-depth: 1
+      - if: ${{ matrix.goos=='windows' }}
+        name: "Set up CNI"
+        working-directory: containerd
+        run: GOPATH=$(go env GOPATH) script/setup/install-cni-windows
       - name: "Run unit tests"
         run: go test -v ./pkg/...
 

--- a/pkg/cmd/builder/build_test.go
+++ b/pkg/cmd/builder/build_test.go
@@ -17,7 +17,10 @@
 package builder
 
 import (
+	"fmt"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
@@ -211,6 +214,15 @@ func TestParseBuildctlArgsForOCILayout(t *testing.T) {
 			expectedArgs:  []string{},
 			expectedErr:   "open /tmp/oci-layout/index.json: no such file or directory",
 		},
+	}
+
+	if runtime.GOOS == "windows" {
+		abspath, err := filepath.Abs("/tmp/oci-layout")
+		assert.NilError(t, err)
+		tests[1].expectedErr = fmt.Sprintf(
+			"open %s\\index.json: The system cannot find the path specified.",
+			abspath,
+		)
 	}
 
 	for _, test := range tests {

--- a/pkg/composer/serviceparser/build_test.go
+++ b/pkg/composer/serviceparser/build_test.go
@@ -17,6 +17,7 @@
 package serviceparser
 
 import (
+	"runtime"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -30,6 +31,11 @@ func lastOf(ss []string) string {
 
 func TestParseBuild(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test is not compatible with windows")
+	}
+
 	const dockerComposeYAML = `
 services:
   foo:

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -79,6 +80,11 @@ var in = strutil.InStringSlice
 
 func TestParse(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test is not compatible with windows")
+	}
+
 	const dockerComposeYAML = `
 version: '3.1'
 
@@ -333,6 +339,10 @@ services:
 
 func TestParseRelative(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("test is not compatible with windows")
+	}
 	const dockerComposeYAML = `
 services:
   foo:
@@ -408,6 +418,9 @@ services:
 
 func TestParseConfigs(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("test is not compatible with windows")
+	}
 	const dockerComposeYAML = `
 services:
   foo:

--- a/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
+++ b/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
@@ -46,6 +46,10 @@ func TestBrokenCredentialsStore(t *testing.T) {
 		// Anyhow, this test is about extreme cases & conditions (filesystem errors wrt credentials loading).
 		t.Skip("skipping broken credential store tests for freebsd")
 	}
+	if runtime.GOOS == "windows" {
+		// Same as above
+		t.Skip("test is not compatible with windows")
+	}
 
 	testCases := []struct {
 		description string

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -68,7 +68,7 @@ func TestContainerFromNative(t *testing.T) {
 			expected: &Container{
 				Created:        "0001-01-01T00:00:00Z",
 				Platform:       runtime.GOOS,
-				ResolvConfPath: tempStateDir + "/resolv.conf",
+				ResolvConfPath: filepath.Join(tempStateDir, "resolv.conf"),
 				State: &ContainerState{
 					Status:     "running",
 					Running:    true,

--- a/pkg/logging/cri_logger_test.go
+++ b/pkg/logging/cri_logger_test.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -234,6 +235,9 @@ func TestReadLogsLimitsWithTimestamps(t *testing.T) {
 
 func TestReadRotatedLog(t *testing.T) {
 	tmpDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows implementation does not seem to work right now and should be fixed: https://github.com/containerd/nerdctl/issues/3554")
+	}
 	file, err := os.CreateTemp(tmpDir, "logfile")
 	if err != nil {
 		t.Errorf("unable to create temp file, error: %s", err.Error())

--- a/pkg/logging/json_logger_test.go
+++ b/pkg/logging/json_logger_test.go
@@ -22,12 +22,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
 
 func TestReadRotatedJSONLog(t *testing.T) {
 	tmpDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("windows implementation does not seem to work right now and should be fixed: https://github.com/containerd/nerdctl/issues/3554")
+	}
 	file, err := os.CreateTemp(tmpDir, "logfile")
 	if err != nil {
 		t.Errorf("unable to create temp file, error: %s", err.Error())

--- a/pkg/mountutil/mountutil_windows_test.go
+++ b/pkg/mountutil/mountutil_windows_test.go
@@ -38,7 +38,7 @@ func TestParseVolumeOptions(t *testing.T) {
 			vType:   "bind",
 			src:     "dummy",
 			optsRaw: "rw",
-			wants:   []string{},
+			wants:   nil,
 		},
 		{
 			vType:   "volume",


### PR DESCRIPTION
Reopening erroneously closed previous PR.

This one no longer depends on other pending CI changes and can be merged now.

Take-away:
- couple of tests marked as not compatible
- one test that is blatantly disagreeing with code has been adapted
- error output specialization
- filepath.Join
- enforcing windows-unit on CI