### PR TITLE
Separate lint + enable on other platforms

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,79 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - main
+      - 'release/**'
+  pull_request:
+
+env:
+  GO_VERSION: 1.23.x
+
+jobs:
+  go:
+    timeout-minutes: 5
+    name: "go | ${{ matrix.goos }} | ${{ matrix.canary }}"
+    runs-on: "${{ matrix.os }}"
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            goos: linux
+          - os: ubuntu-24.04
+            goos: freebsd
+          # FIXME: this is currently failing in a non-sensical way, so, running on linux instead...
+          # - os: windows-2022
+          - os: ubuntu-24.04
+            goos: windows
+          - os: ubuntu-24.04
+            goos: linux
+            # This allows the canary script to select any upcoming golang alpha/beta/RC
+            canary: go-canary
+    env:
+      GOOS: "${{ matrix.goos }}"
+    steps:
+      - uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 1
+      - name: Set GO env
+        run: |
+          # If canary is specified, get the latest available golang pre-release instead of the major version
+          if [ "$canary" != "" ]; then
+            . ./hack/build-integration-canary.sh
+            canary::golang::latest
+          fi
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          args: --verbose
+
+  other:
+    timeout-minutes: 5
+    name: yaml | shell | imports order
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: true
+      - name: yaml
+        run: make lint-yaml
+      - name: shell
+        run: make lint-shell
+      - name: go imports ordering
+        run: |
+          go install -v github.com/incu6us/goimports-reviser/v3@latest
+          make lint-imports

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -15,27 +15,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  lint:
-    runs-on: "ubuntu-24.04"
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4.2.1
-        with:
-          fetch-depth: 1
-      - name: Set GO env
-        run: |
-          . ./hack/build-integration-canary.sh
-          canary::golang::latest
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-          cache: true
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.1
-        with:
-          args: --verbose
-
   linux:
     runs-on: "ubuntu-24.04"
     timeout-minutes: 40

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,32 +13,6 @@ env:
   GO_VERSION: 1.23.x
 
 jobs:
-  lint:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@v4.2.1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-          cache: true
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.1.1
-        with:
-          version: v1.60.1
-          args: --verbose
-      - name: yamllint-lint
-        run: make lint-yaml
-      - name: shellcheck
-        run: make lint-shell
-      - name: go imports ordering
-        run: |
-          go install -v github.com/incu6us/goimports-reviser/v3@latest
-          make lint-imports
-
   test-unit:
     timeout-minutes: 5
     name: unit | ${{ matrix.goos }}


### PR DESCRIPTION
Breakout of #3535 

This breaks lint tasks into their own file (others are overcrowded), and enables linting for freebsd and windows. 