### PR TITLE
Experimental: add a proxy to increase CI resiliency to third party services failures

### DIFF
--- a/.github/workflows/proxy_cache/Caddyfile.conf
+++ b/.github/workflows/proxy_cache/Caddyfile.conf
@@ -1,0 +1,164 @@
+# Caddy global config
+{
+    https_port 443
+    http_port 80
+
+    default_sni localhost
+    admin :2024
+    storage file_system {
+        root "{$HOME}/proxy/certs"
+    }
+    skip_install_trust
+    auto_https ignore_loaded_certs
+    order cache before rewrite
+
+    acme_ca internal
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    cache {
+        log_level "warn"
+
+        cache_keys {
+            disable_body
+        }
+
+        key {
+            disable_body
+        }
+
+        stale 31536000s
+        ttl 31536000s
+
+        nuts {
+            configuration {
+                Dir "{$HOME}/proxy/cache"
+                EntryIdxMode 1
+                RWMode 0
+                SegmentSize 1024
+                NodeNum 42
+                SyncEnable true
+                StartFileLoadingMode 1
+            }
+        }
+    }
+
+    servers {
+        metrics
+    }
+}
+
+https://index.docker.io {
+    tls internal
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy https://index.docker.io {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+        # Be sure to back out if Docker Hub gives us the 429 treatment
+        unhealthy_status 429
+    }
+}
+
+https://registry-1.docker.io {
+    tls internal
+
+    # Not enabling cache for Hub - doing this would require to be path specific
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy https://registry-1.docker.io {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+        # Be sure to back out if Docker Hub gives us the 429 treatment
+        unhealthy_status 429
+    }
+}
+
+http://deb.debian.org {
+    cache
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy http://deb.debian.org {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+    }
+}
+
+https://deb.debian.org {
+    tls internal
+
+    cache
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy http://deb.debian.org {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+    }
+}
+
+http://ports.ubuntu.com {
+    cache
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy http://ports.ubuntu.com {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+    }
+}
+
+https://ports.ubuntu.com {
+    tls internal
+
+    cache
+
+    log {
+        output stdout
+        format json
+        level "info"
+    }
+
+    reverse_proxy http://ports.ubuntu.com {
+        # Try up to 5 times
+        lb_retries 5
+        # Wait one second between each try
+        lb_try_interval 1s
+    }
+}

--- a/.github/workflows/proxy_cache/Dockerfile
+++ b/.github/workflows/proxy_cache/Dockerfile
@@ -1,0 +1,5 @@
+FROM golang:bookworm
+RUN go install github.com/caddyserver/xcaddy/cmd/xcaddy@v0.4.2
+RUN "$(go env GOPATH)"/bin/xcaddy build --with github.com/caddyserver/cache-handler --with github.com/darkweak/storages/nuts/caddy
+COPY ./Caddyfile.conf /config/Caddyfile.conf
+CMD ["./caddy", "run", "--config", "/config/Caddyfile.conf", "--adapter", "caddyfile"]

--- a/.github/workflows/proxy_cache/setup.sh
+++ b/.github/workflows/proxy_cache/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2015
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+root="$(cd "$(dirname "${BASH_SOURCE[0]:-$PWD}")" 2>/dev/null 1>&2 && pwd)"
+readonly root
+
+# Cleanup for repeat local development
+docker rmi -f caddy
+docker rm -f proxy
+# Build the caddy image
+docker build -t caddy -f "$root"/Dockerfile "$root"
+# Run it, exposing 80 and 443 (+2024 for the admin / trust)
+docker run -d --restart always --name proxy -p 80:80 -p 443:443 -p 2024:2024 caddy
+# Copy caddy here and trust the generated certificate
+docker cp proxy:/go/caddy .
+./caddy trust --address localhost:2024
+# Point docker registry to our proxy
+echo "127.0.0.1 registry-1.docker.io" | sudo tee -a /etc/hosts >/dev/null
+echo "127.0.0.1 ports.ubuntu.com" | sudo tee -a /etc/hosts >/dev/null
+echo "127.0.0.1 deb.debian.org" | sudo tee -a /etc/hosts >/dev/null
+# Restart docker to take into account the newly trusted certificate
+sudo systemctl restart docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,8 +77,10 @@ jobs:
       - uses: actions/checkout@v4.2.1
         with:
           fetch-depth: 1
+      - name: "Setup proxy"
+        run: ./.github/workflows/proxy_cache/setup.sh
       - name: "Prepare integration test environment"
-        run: docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: docker build --network host --add-host=ports.ubuntu.com:127.0.0.1 --add-host=deb.debian.org:127.0.0.1 -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -128,8 +130,10 @@ jobs:
           sudo mkdir -p /etc/docker
           echo '{"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
+      - name: "Setup proxy"
+        run: ./.github/workflows/proxy_cache/setup.sh
       - name: "Prepare integration test environment"
-        run: docker build -t test-integration-ipv6 --target test-integration-ipv6 --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: docker build --network host --add-host=ports.ubuntu.com:127.0.0.1 --add-host=deb.debian.org:127.0.0.1 -t test-integration-ipv6 --target test-integration-ipv6 --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -215,8 +219,10 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
+      - name: "Setup proxy"
+        run: ./.github/workflows/proxy_cache/setup.sh
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
-        run: docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
+        run: docker build --network host --add-host=ports.ubuntu.com:127.0.0.1 --add-host=deb.debian.org:127.0.0.1 -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
         run: |
           # https://github.com/containerd/nerdctl/issues/622


### PR DESCRIPTION
CI fails regularly because of third-party services transient errors.

Most typically, debian or ubuntu servers, or Docker Hub, returning a 500 during the build phase.

This PR is an experimental proposal to alleviate a bit of the pain with this problem, by adding a local proxy that will retry backends requests on such failures.

The proxy also provisionally does caching for debian and ubuntu domains. Currently, this is not going to do much, although it is good practice IMHO to minimize hammering debian servers.

Besides this PR, we might want to rethink our strategy with building the test image though.
Right now, we build everything once per target.
This is happening in parallel, but this is (obviously) significantly increasing the chances of failures against these services.

Note that this proxy will intercept requests done from the host and from the build phase - not for the tests themselves.