### PR TITLE
GHA cache image build dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,47 @@ env:
   LONG_TIMEOUT: 60
 
 jobs:
+  # This job builds the dependency target of the test docker image for all supported architectures and cache it in GHA
+  build-dependencies:
+    timeout-minutes: 10
+    name: dependencies |  ${{ matrix.containerd }} | ${{ matrix.arch }}
+    runs-on: "${{ matrix.runner }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            containerd: v1.6.36
+            arch: amd64
+          - runner: ubuntu-24.04
+            containerd: v1.7.23
+            arch: amd64
+          - runner: ubuntu-24.04
+            containerd: v2.0.0-rc.5
+            arch: amd64
+          - runner: arm64-8core-32gb
+            containerd: v2.0.0-rc.5
+            arch: arm64
+    env:
+      CONTAINERD_VERSION: "${{ matrix.containerd }}"
+      ARCH: "${{ matrix.arch }}"
+    steps:
+      - uses: actions/checkout@v4.2.1
+        with:
+          fetch-depth: 1
+      - name: "Expose GitHub Runtime variables for gha"
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: "Build dependencies for the integration test environment image"
+        run: |
+          docker buildx create --name with-gha --use
+          docker buildx build \
+            --output=type=docker \
+            --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+
   test-unit:
+    # FIXME:
     # Supposed to work: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-data-type
     # Apparently does not
     # timeout-minutes: ${{ fromJSON(env.SHORT_TIMEOUT) }}
@@ -56,7 +96,8 @@ jobs:
         run: make test-unit
 
   test-integration:
-    timeout-minutes: 60
+    needs: build-dependencies
+    timeout-minutes: 30
     name: rootful | ${{ matrix.containerd }} | ${{ matrix.runner }}
     runs-on: "${{ matrix.runner }}"
     strategy:
@@ -67,24 +108,36 @@ jobs:
           - ubuntu: 20.04
             containerd: v1.6.36
             runner: "ubuntu-20.04"
+            arch: amd64
           - ubuntu: 22.04
             containerd: v1.7.23
             runner: "ubuntu-22.04"
+            arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.0-rc.5
             runner: "ubuntu-24.04"
+            arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.0-rc.5
-            runner: github-arm64-2c-8gb
+            runner: arm64-8core-32gb
+            arch: arm64
     env:
-      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
+      ARCH: "${{ matrix.arch }}"
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
     steps:
       - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 1
+      - name: "Expose GitHub Runtime variables for gha"
+        uses: crazy-max/ghaction-github-runtime@v3
       - name: "Prepare integration test environment"
-        run: docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: |
+          docker buildx create --name with-gha --use
+          docker buildx build \
+            --output=type=docker \
+            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -106,19 +159,21 @@ jobs:
         run: docker run -t --rm --privileged test-integration ./hack/test-integration.sh -test.only-flaky=true
 
   test-integration-ipv6:
-    timeout-minutes: 60
+    needs: build-dependencies
+    timeout-minutes: 10
     name: ipv6 | ${{ matrix.containerd }} | ${{ matrix.ubuntu }}
     runs-on: "ubuntu-${{ matrix.ubuntu }}"
     strategy:
       fail-fast: false
       matrix:
-        # ubuntu-20.04: cgroup v1, ubuntu-22.04 and later: cgroup v2
         include:
           - ubuntu: 24.04
             containerd: v2.0.0-rc.5
+            arch: amd64
     env:
-      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
+      ARCH: "${{ matrix.arch }}"
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -127,13 +182,20 @@ jobs:
         run: |
           sudo sysctl -w net.ipv6.conf.all.forwarding=1
           sudo sysctl -w net.ipv4.ip_forward=1
-      - name: Enable IPv6 for Docker
+      - name: "Expose GitHub Runtime variables for gha"
+        uses: crazy-max/ghaction-github-runtime@v3
+      - name: Enable IPv6 for Docker, and configure docker to use containerd for gha
         run: |
           sudo mkdir -p /etc/docker
           echo '{"ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64", "experimental": true, "ip6tables": true}' | sudo tee /etc/docker/daemon.json
           sudo systemctl restart docker
       - name: "Prepare integration test environment"
-        run: docker build -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
+        run: |
+          docker buildx create --name with-gha --use
+          docker buildx build \
+            --output=type=docker \
+            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
           sudo systemctl disable --now snapd.service snapd.socket
@@ -158,7 +220,8 @@ jobs:
         run: docker run --network host -t --rm --privileged test-integration ./hack/test-integration.sh -test.only-ipv6
 
   test-integration-rootless:
-    timeout-minutes: 60
+    needs: build-dependencies
+    timeout-minutes: 30
     name: "${{ matrix.target }} | ${{ matrix.containerd }} | ${{ matrix.rootlesskit }} | ${{ matrix.ubuntu }}"
     runs-on: "ubuntu-${{ matrix.ubuntu }}"
     strategy:
@@ -170,21 +233,26 @@ jobs:
             containerd: v1.6.36
             rootlesskit: v1.1.1  # Deprecated
             target: rootless
+            arch: amd64
           - ubuntu: 22.04
             containerd: v1.7.23
             rootlesskit: v2.3.1
             target: rootless
+            arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.0-rc.5
             rootlesskit: v2.3.1
             target: rootless
+            arch: amd64
           - ubuntu: 24.04
             containerd: v1.7.23
             rootlesskit: v2.3.1
             target: rootless-port-slirp4netns
+            arch: amd64
     env:
-      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
+      ARCH: "${{ matrix.arch }}"
+      UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       ROOTLESSKIT_VERSION: "${{ matrix.rootlesskit }}"
       TEST_TARGET: "test-integration-${{ matrix.target }}"
     steps:
@@ -215,8 +283,15 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
+      - name: "Expose GitHub Runtime variables for gha"
+        uses: crazy-max/ghaction-github-runtime@v3
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
-        run: docker build -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
+        run: |
+          docker buildx create --name with-gha --use
+          docker buildx build \
+            --output=type=docker \
+            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
         run: |
           # https://github.com/containerd/nerdctl/issues/622
@@ -250,7 +325,7 @@ jobs:
         run: GO_VERSION="$(echo ${{ matrix.go-version }} | sed -e s/.x//)" make binaries
 
   test-integration-docker-compatibility:
-    timeout-minutes: 60
+    timeout-minutes: 30
     name: docker
     runs-on: ubuntu-24.04
     steps:
@@ -262,11 +337,6 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
           check-latest: true
-      - name: "Print docker info"
-        run: |
-          set -eux -o pipefail
-          docker info
-          docker version
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
           # `--install all` will only install emulation for architectures that cannot be natively executed
@@ -324,13 +394,14 @@ jobs:
         run: ./hack/test-integration.sh -test.only-flaky=true
 
   test-integration-freebsd:
-    timeout-minutes: 60
+    timeout-minutes: 30
     name: FreeBSD
     # ubuntu-24.04 lacks the vagrant package
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 1
       - uses: actions/cache@v4
         with:
           path: /root/.vagrant.d


### PR DESCRIPTION
Folllow-on to discussion in #3580

What this does:
- enable the use of github actions cache for docker build of the integration image
- in the Dockerfile, separate third-party dependency build stage and nerdctl stage
- in github workflows, separate out the step that builds these dependencies (read-write to cache) from the steps that prepare the final integration image (read-only from cache)

The result is:
- with a cold cache, instead of building everything 9 times (4 rootful, 4 rootless, ipv6) , we only build the dependencies stage 4 times
- the dependencies stage is then cached, and _subsequent runs on the same branch_ will not rebuild it (unless the dependencies versions have changed, or the Dockerfile has been altered)
- note that we SHOULD also get the cache from the main branch as well, so, once it is merged and the cache is hot, new PRs should benefit from the cache as well on their first run (eg: not build)

The key benefit here is about reducing the network traffic required to produce out test images (hence reducing the opportunity for failure due to third-party server hiccups). It is similar in intent to #3580 .

Incidentally, we will also get a small speed boost for the overall run.
Obviously, GHA cache is not "free": it takes time to retrieve and time to store - so, part of the speed gains from not-building are negated by the cache r/w.

Nevertheless, this looks promising for increased reliability (and reduced transactions with docker hub / debian / ubuntu).

This PR also has a couple of minor changes to the workflow file (reduced timeouts, cosmetic comments, along with bumping the size of the arm64 instance as previously discussed). If preferable, I can split these out.

Further refactoring / changes to the Dockerfile could bring more stuff in the dependencies stage.
This PR has been conservative on that front and staid with the minimal possible changes to the Dockerfile, so that we can decide separately if we want a more in-depth restructuring of it or not.

Finally note that GHA cache is rather limited (10G), and going over the limit will prune prior entries indiscriminately - we might want to keep an eye on that and check that this proposed implementation here stays under the limit to fully benefit from it.