### PR TITLE
Remove old build tag syntax

### DIFF
--- a/pkg/logging/logs_other.go
+++ b/pkg/logging/logs_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /*
    Copyright The containerd Authors.

--- a/pkg/logging/logs_windows.go
+++ b/pkg/logging/logs_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /*
    Copyright The containerd Authors.


### PR DESCRIPTION
`// +build` is out since go 1.18 IIRC