### PR TITLE
Remove no-op description from top-level tests

### DIFF
--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -30,7 +30,6 @@ func TestImageConvert(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "Test image conversion",
 		Require: test.Require(
 			test.Not(test.Windows),
 			test.Not(nerdtest.Docker),
@@ -101,7 +100,6 @@ func TestImageConvertNydusVerify(t *testing.T) {
 	var registry *testregistry.RegistryServer
 
 	testCase := &test.Case{
-		Description: "TestImageConvertNydusVerify",
 		Require: test.Require(
 			test.Linux,
 			test.Binary("nydus-image"),

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -37,8 +37,7 @@ func TestImages(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "TestImages",
-		Require:     test.Not(nerdtest.Docker),
+		Require: test.Not(nerdtest.Docker),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
@@ -133,8 +132,7 @@ func TestImagesFilter(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "TestImagesFilter",
-		Require:     nerdtest.Build,
+		Require: nerdtest.Build,
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, "taggedimage:one-fragment-one")

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -38,7 +38,6 @@ func TestImagePullWithCosign(t *testing.T) {
 	var keyPair *testhelpers.CosignKeyPair
 
 	testCase := &test.Case{
-		Description: "TestImagePullWithCosign",
 		Require: test.Require(
 			test.Linux,
 			nerdtest.Build,
@@ -107,7 +106,6 @@ func TestImagePullPlainHttpWithDefaultPort(t *testing.T) {
 	var registry *testregistry.RegistryServer
 
 	testCase := &test.Case{
-		Description: "TestImagePullPlainHttpWithDefaultPort",
 		Require: test.Require(
 			test.Linux,
 			test.Not(nerdtest.Docker),
@@ -150,7 +148,6 @@ func TestImagePullSoci(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "TestImagePullSoci",
 		Require: test.Require(
 			test.Linux,
 			test.Not(nerdtest.Docker),

--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -37,8 +37,6 @@ func TestPush(t *testing.T) {
 	var registryNoAuthHTTPRandom, registryNoAuthHTTPDefault, registryTokenAuthHTTPSRandom *testregistry.RegistryServer
 
 	testCase := &test.Case{
-		Description: "Test push",
-
 		Require: test.Linux,
 
 		Setup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -35,8 +35,7 @@ func TestSaveContent(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "Test content (linux only)",
-		Require:     test.Not(test.Windows),
+		Require: test.Not(test.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 		},


### PR DESCRIPTION
`Description` was mandatory previously with the early version of the new test toolkit.
Top-level tests do relax that (since it is a no-op), and these serve no purpose now.