### PR TITLE
Add support for writing to ptys

### DIFF
--- a/cmd/nerdctl/container/container_attach_linux_test.go
+++ b/cmd/nerdctl/container/container_attach_linux_test.go
@@ -17,9 +17,11 @@
 package container
 
 import (
-	"bytes"
+	"errors"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
 
@@ -28,133 +30,189 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
-// skipAttachForDocker should be called by attach-related tests that assert 'read detach keys' in stdout.
-func skipAttachForDocker(t *testing.T) {
-	t.Helper()
-	if testutil.GetTarget() == testutil.Docker {
-		t.Skip("When detaching from a container, for a session started with 'docker attach'" +
-			", it prints 'read escape sequence', but for one started with 'docker (run|start)', it prints nothing." +
-			" However, the flag is called '--detach-keys' in all cases" +
-			", so nerdctl prints 'read detach keys' for all cases" +
-			", and that's why this test is skipped for Docker.")
-	}
-}
-
-// prepareContainerToAttach spins up a container (entrypoint = shell) with `-it` and detaches from it
-// so that it can be re-attached to later.
-func prepareContainerToAttach(base *testutil.Base, containerName string) {
-	opts := []func(*testutil.Cmd){
-		testutil.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader(
-			[]byte{16, 17}, // ctrl+p,ctrl+q, see https://www.physics.udel.edu/~watson/scen103/ascii.html
-		))),
-	}
-	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
-	// unbuffer(1) can be installed with `apt-get install expect`.
-	//
-	// "-p" is needed because we need unbuffer to read from stdin, and from [1]:
-	// "Normally, unbuffer does not read from stdin. This simplifies use of unbuffer in some situations.
-	//  To use unbuffer in a pipeline, use the -p flag."
-	//
-	// [1] https://linux.die.net/man/1/unbuffer
-	base.CmdWithHelper([]string{"unbuffer", "-p"}, "run", "-it", "--name", containerName, testutil.CommonImage).
-		CmdOption(opts...).AssertOutContains("read detach keys")
-	container := base.InspectContainer(containerName)
-	assert.Equal(base.T, container.State.Running, true)
-}
+/*
+Important notes:
+- for both docker and nerdctl, you can run+detach of a container and exit 0, while the container would actually fail starting
+- nerdctl (not docker): on run, detach will race anything on stdin before the detach sequence from reaching the container
+- nerdctl AND docker: on attach ^
+- exit code variants: https://github.com/containerd/nerdctl/issues/3571
+*/
 
 func TestAttach(t *testing.T) {
-	t.Parallel()
-
-	t.Skip("This test is very unstable and currently skipped. See https://github.com/containerd/nerdctl/issues/3558")
-
-	skipAttachForDocker(t)
-
-	base := testutil.NewBase(t)
-	containerName := testutil.Identifier(t)
-
-	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
-	prepareContainerToAttach(base, containerName)
-
-	opts := []func(*testutil.Cmd){
-		testutil.WithStdin(testutil.NewDelayOnceReader(strings.NewReader("expr 1 + 1\nexit\n"))),
+	// In nerdctl the detach return code from the container after attach is 0, but in docker the return code is 1.
+	// This behaviour is reported in https://github.com/containerd/nerdctl/issues/3571
+	ex := 0
+	if nerdtest.IsDocker() {
+		ex = 1
 	}
-	// `unbuffer -p` returns 0 even if the underlying nerdctl process returns a non-zero exit code,
-	// so the exit code cannot be easily tested here.
-	base.CmdWithHelper([]string{"unbuffer", "-p"}, "attach", containerName).CmdOption(opts...).AssertOutContains("2")
-	container := base.InspectContainer(containerName)
-	assert.Equal(base.T, container.State.Running, false)
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cmd := helpers.Command("run", "--rm", "-it", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			// ctrl+p and ctrl+q (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{16, 17})
+			return err
+		})
+
+		cmd.Run(&test.Expected{
+			ExitCode: 0,
+			Errors:   []error{errors.New("read detach keys")},
+			Output: func(stdout string, info string, t *testing.T) {
+				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+			},
+		})
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Run interactively and detach
+		cmd := helpers.Command("attach", data.Identifier())
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, _ = f.WriteString("echo mark${NON}mark\n")
+			// Interestingly, and unlike with run, on attach, docker (like nerdctl) ALSO needs a pause so that the
+			// container can read stdin before we detach
+			time.Sleep(time.Second)
+			// ctrl+p and ctrl+q (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{16, 17})
+
+			return err
+		})
+
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: ex,
+			Errors:   []error{errors.New("read detach keys")},
+			Output: test.All(
+				test.Contains("markmark"),
+				func(stdout string, info string, t *testing.T) {
+					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+				},
+			),
+		}
+	}
+
+	testCase.Run(t)
 }
 
 func TestAttachDetachKeys(t *testing.T) {
-	t.Parallel()
-
-	skipAttachForDocker(t)
-
-	base := testutil.NewBase(t)
-	containerName := testutil.Identifier(t)
-
-	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
-	prepareContainerToAttach(base, containerName)
-
-	opts := []func(*testutil.Cmd){
-		testutil.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader(
-			[]byte{1, 2}, // https://www.physics.udel.edu/~watson/scen103/ascii.html
-		))),
+	// In nerdctl the detach return code from the container after attach is 0, but in docker the return code is 1.
+	// This behaviour is reported in https://github.com/containerd/nerdctl/issues/3571
+	ex := 0
+	if nerdtest.IsDocker() {
+		ex = 1
 	}
-	base.CmdWithHelper([]string{"unbuffer", "-p"}, "attach", "--detach-keys=ctrl-a,ctrl-b", containerName).
-		CmdOption(opts...).AssertOutContains("read detach keys")
-	container := base.InspectContainer(containerName)
-	assert.Equal(base.T, container.State.Running, true)
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cmd := helpers.Command("run", "--rm", "-it", "--detach-keys=ctrl-q", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, err := f.Write([]byte{17})
+			return err
+		})
+
+		cmd.Run(&test.Expected{
+			ExitCode: 0,
+			Errors:   []error{errors.New("read detach keys")},
+			Output: func(stdout string, info string, t *testing.T) {
+				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+			},
+		})
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Run interactively and detach
+		cmd := helpers.Command("attach", "--detach-keys=ctrl-a,ctrl-b", data.Identifier())
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, _ = f.WriteString("echo mark${NON}mark\n")
+			// Interestingly, and unlike with run, on attach, docker (like nerdctl) ALSO needs a pause so that the
+			// container can read stdin before we detach
+			time.Sleep(time.Second)
+			// ctrl+a and ctrl+b (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{1, 2})
+
+			return err
+		})
+
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: ex,
+			Errors:   []error{errors.New("read detach keys")},
+			Output: test.All(
+				test.Contains("markmark"),
+				func(stdout string, info string, t *testing.T) {
+					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+				},
+			),
+		}
+	}
+
+	testCase.Run(t)
 }
 
 // TestIssue3568 tests https://github.com/containerd/nerdctl/issues/3568
-func TestDetachAttachKeysForAutoRemovedContainer(t *testing.T) {
+func TestAttachForAutoRemovedContainer(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	testCase.SubTests = []*test.Case{
-		{
-			Description: "Issue #3568 - A container should be deleted when detaching and attaching a container started with the --rm option.",
-			// In nerdctl the detach return code from the container is 0, but in docker the return code is 1.
-			// This behaviour is reported in https://github.com/containerd/nerdctl/issues/3571 so this test is skipped for Docker.
-			Require: test.Require(
-				test.Not(nerdtest.Docker),
+	testCase.Description = "Issue #3568 - A container should be deleted when detaching and attaching a container started with the --rm option."
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cmd := helpers.Command("run", "--rm", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			// ctrl+a and ctrl+b (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{1, 2})
+			return err
+		})
+
+		cmd.Run(&test.Expected{
+			ExitCode: 0,
+			Errors:   []error{errors.New("read detach keys")},
+			Output: func(stdout string, info string, t *testing.T) {
+				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"), info)
+			},
+		})
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Run interactively and detach
+		cmd := helpers.Command("attach", data.Identifier())
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, err := f.WriteString("echo mark${NON}mark\nexit 42\n")
+			return err
+		})
+
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: 42,
+			Output: test.All(
+				test.Contains("markmark"),
+				func(stdout string, info string, t *testing.T) {
+					assert.Assert(t, !strings.Contains(helpers.Capture("ps", "-a"), data.Identifier()))
+				},
 			),
-			Setup: func(data test.Data, helpers test.Helpers) {
-				cmd := helpers.Command("run", "--rm", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", data.Identifier(), testutil.CommonImage)
-				// unbuffer(1) can be installed with `apt-get install expect`.
-				//
-				// "-p" is needed because we need unbuffer to read from stdin, and from [1]:
-				// "Normally, unbuffer does not read from stdin. This simplifies use of unbuffer in some situations.
-				//  To use unbuffer in a pipeline, use the -p flag."
-				//
-				// [1] https://linux.die.net/man/1/unbuffer
-				cmd.WithWrapper("unbuffer", "-p")
-				cmd.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader([]byte{1, 2}))) // https://www.physics.udel.edu/~watson/scen103/ascii.html
-				cmd.Run(&test.Expected{
-					ExitCode: 0,
-				})
-			},
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("attach", data.Identifier())
-				cmd.WithWrapper("unbuffer", "-p")
-				cmd.WithStdin(testutil.NewDelayOnceReader(strings.NewReader("exit\n")))
-				return cmd
-			},
-			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-			},
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					ExitCode: 0,
-					Errors:   []error{},
-					Output: test.All(
-						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, !strings.Contains(helpers.Capture("ps", "-a"), data.Identifier()))
-						},
-					),
-				}
-			},
-		},
+		}
 	}
 
 	testCase.Run(t)

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -473,34 +473,47 @@ func TestRunWithOOMScoreAdj(t *testing.T) {
 }
 
 func TestRunWithDetachKeys(t *testing.T) {
-	t.Parallel()
+	testCase := nerdtest.Setup()
 
-	if testutil.GetTarget() == testutil.Docker {
-		t.Skip("When detaching from a container, for a session started with 'docker attach'" +
-			", it prints 'read escape sequence', but for one started with 'docker (run|start)', it prints nothing." +
-			" However, the flag is called '--detach-keys' in all cases" +
-			", so nerdctl prints 'read detach keys' for all cases" +
-			", and that's why this test is skipped for Docker.")
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
 	}
 
-	base := testutil.NewBase(t)
-	containerName := testutil.Identifier(t)
-	opts := []func(*testutil.Cmd){
-		testutil.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader([]byte{1, 2}))), // https://www.physics.udel.edu/~watson/scen103/ascii.html
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Run interactively and detach
+		cmd := helpers.Command("run", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, _ = f.WriteString("echo mark${NON}mark\n")
+			// Because of the way we proxy stdin, we have to wait here, otherwise we detach before
+			// the rest of the input ever reaches the container
+			// Note that this only concerns nerdctl, as docker seems to behave ok LOCALLY.
+			// But then, it fails for docker as well ON THE CI. It is unclear why at this point.
+			// Arbitrary time pauses would not work: what matters is that the container has started.
+			// if !nerdtest.IsDocker() {
+			nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			// }
+			// ctrl+a and ctrl+b (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{1, 2})
+			return err
+		})
+
+		return cmd
 	}
-	defer base.Cmd("container", "rm", "-f", containerName).AssertOK()
-	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
-	// unbuffer(1) can be installed with `apt-get install expect`.
-	//
-	// "-p" is needed because we need unbuffer to read from stdin, and from [1]:
-	// "Normally, unbuffer does not read from stdin. This simplifies use of unbuffer in some situations.
-	//  To use unbuffer in a pipeline, use the -p flag."
-	//
-	// [1] https://linux.die.net/man/1/unbuffer
-	base.CmdWithHelper([]string{"unbuffer", "-p"}, "run", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", containerName, testutil.CommonImage).
-		CmdOption(opts...).AssertOutContains("read detach keys")
-	container := base.InspectContainer(containerName)
-	assert.Equal(base.T, container.State.Running, true)
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: 0,
+			Errors:   []error{errors.New("detach keys")},
+			Output: test.All(
+				test.Contains("markmark"),
+				func(stdout string, info string, t *testing.T) {
+					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+				},
+			),
+		}
+	}
+
+	testCase.Run(t)
 }
 
 func TestRunWithTtyAndDetached(t *testing.T) {
@@ -528,43 +541,44 @@ func TestRunWithTtyAndDetached(t *testing.T) {
 func TestIssue3568(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	testCase.SubTests = []*test.Case{
-		{
-			Description: "Issue #3568 - Detaching from a container started by using --rm option causes the container to be deleted.",
-			// When detaching from a container, for a session started with 'docker attach', it prints 'read escape sequence', but for one started with 'docker (run|start)', it prints nothing.
-			// However, the flag is called '--detach-keys' in all cases, so nerdctl prints 'read detach keys' for all cases, and that's why this test is skipped for Docker.
-			Require: test.Require(
-				test.Not(nerdtest.Docker),
+	testCase.Description = "Issue #3568 - Detaching from a container started by using --rm option causes the container to be deleted."
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Run interactively and detach
+		cmd := helpers.Command("run", "--rm", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY(func(f *os.File) error {
+			_, _ = f.WriteString("echo mark${NON}mark\n")
+			// Because of the way we proxy stdin, we have to wait here, otherwise we detach before
+			// the rest of the input ever reaches the container
+			// Note that this only concerns nerdctl, as docker seems to behave ok LOCALLY.
+			// But then, it fails for docker as well ON THE CI. It is unclear why at this point.
+			// Arbitrary time pauses would not work: what matters is that the container has started.
+			// if !nerdtest.IsDocker() {
+			nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			// }
+			// ctrl+a and ctrl+b (see https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
+			_, err := f.Write([]byte{1, 2})
+			return err
+		})
+
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: 0,
+			Errors:   []error{errors.New("detach keys")},
+			Output: test.All(
+				test.Contains("markmark"),
+				func(stdout string, info string, t *testing.T) {
+					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+				},
 			),
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "--rm", "-it", "--detach-keys=ctrl-a,ctrl-b", "--name", data.Identifier(), testutil.CommonImage)
-				// unbuffer(1) can be installed with `apt-get install expect`.
-				//
-				// "-p" is needed because we need unbuffer to read from stdin, and from [1]:
-				// "Normally, unbuffer does not read from stdin. This simplifies use of unbuffer in some situations.
-				//  To use unbuffer in a pipeline, use the -p flag."
-				//
-				// [1] https://linux.die.net/man/1/unbuffer
-				cmd.WithWrapper("unbuffer", "-p")
-				cmd.WithStdin(testutil.NewDelayOnceReader(bytes.NewReader([]byte{1, 2}))) // https://www.physics.udel.edu/~watson/scen103/ascii.html
-				return cmd
-			},
-			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-			},
-			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-				return &test.Expected{
-					ExitCode: 0,
-					Errors:   []error{},
-					Output: test.All(
-						test.Contains("read detach keys"),
-						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, strings.Contains(helpers.Capture("ps"), data.Identifier()))
-						},
-					),
-				}
-			},
-		},
+		}
 	}
 
 	testCase.Run(t)

--- a/cmd/nerdctl/system/system_events_linux_test.go
+++ b/cmd/nerdctl/system/system_events_linux_test.go
@@ -42,7 +42,8 @@ func TestEventFilters(t *testing.T) {
 			Command:     testEventFilterExecutor,
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: test.Contains(data.Get("output")),
+					ExitCode: test.ExitCodeTimeout,
+					Output:   test.Contains(data.Get("output")),
 				}
 			},
 			Data: test.WithData("filter", "event=START").
@@ -53,7 +54,8 @@ func TestEventFilters(t *testing.T) {
 			Command:     testEventFilterExecutor,
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: test.Contains(data.Get("output")),
+					ExitCode: test.ExitCodeTimeout,
+					Output:   test.Contains(data.Get("output")),
 				}
 			},
 			Data: test.WithData("filter", "event=start").
@@ -65,7 +67,8 @@ func TestEventFilters(t *testing.T) {
 			Command:     testEventFilterExecutor,
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: test.Contains(data.Get("output")),
+					ExitCode: test.ExitCodeTimeout,
+					Output:   test.Contains(data.Get("output")),
 				}
 			},
 			Data: test.WithData("filter", "event=unknown").
@@ -76,7 +79,8 @@ func TestEventFilters(t *testing.T) {
 			Command:     testEventFilterExecutor,
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: test.Contains(data.Get("output")),
+					ExitCode: test.ExitCodeTimeout,
+					Output:   test.Contains(data.Get("output")),
 				}
 			},
 			Data: test.WithData("filter", "status=start").
@@ -88,7 +92,8 @@ func TestEventFilters(t *testing.T) {
 			Command:     testEventFilterExecutor,
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: test.Contains(data.Get("output")),
+					ExitCode: test.ExitCodeTimeout,
+					Output:   test.Contains(data.Get("output")),
 				}
 			},
 			Data: test.WithData("filter", "status=unknown").

--- a/pkg/testutil/test/internal/pty/pty.go
+++ b/pkg/testutil/test/internal/pty/pty.go
@@ -14,12 +14,11 @@
    limitations under the License.
 */
 
-package test
+package pty
 
-import (
-	"os"
+import "errors"
+
+var (
+	ErrPTYFailure             = errors.New("pty failure")
+	ErrPTYUnsupportedPlatform = errors.New("pty not supported on this platform")
 )
-
-func Open() (pty, tty *os.File, err error) {
-	return nil, nil, ErrPTYUnsupportedPlatform
-}

--- a/pkg/testutil/test/internal/pty/pty_freebsd.go
+++ b/pkg/testutil/test/internal/pty/pty_freebsd.go
@@ -14,9 +14,12 @@
    limitations under the License.
 */
 
-package test
+package pty
 
-import "errors"
+import (
+	"os"
+)
 
-var ErrPTYFailure = errors.New("pty failure")
-var ErrPTYUnsupportedPlatform = errors.New("pty not supported on this platform")
+func Open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrPTYUnsupportedPlatform
+}

--- a/pkg/testutil/test/internal/pty/pty_windows.go
+++ b/pkg/testutil/test/internal/pty/pty_windows.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-package test
+package pty
 
 import (
 	"os"

--- a/pkg/testutil/test/test.go
+++ b/pkg/testutil/test/test.go
@@ -18,6 +18,7 @@ package test
 
 import (
 	"io"
+	"os"
 	"testing"
 	"time"
 )
@@ -98,7 +99,7 @@ type TestableCommand interface {
 	// WithWrapper allows wrapping a command with another command (for example: `time`, `unbuffer`)
 	WithWrapper(binary string, args ...string)
 	// WithPseudoTTY
-	WithPseudoTTY()
+	WithPseudoTTY(writers ...func(*os.File) error)
 	// WithStdin allows passing a reader to be used for stdin for the command
 	WithStdin(r io.Reader)
 	// WithCwd allows specifying the working directory for the command


### PR DESCRIPTION
This is the next step in removing `unbuffer` from our testing, adding the ability to write to stdin with ptys.