### PR TITLE
fix: Allow to untag images associated with running or paused containe…

### DIFF
--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -78,6 +78,19 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 			}
 
 			if cid, ok := runningImages[found.Image.Name]; ok {
+				if options.Force {
+					if err = is.Delete(ctx, found.Image.Name); err != nil {
+						return err
+					}
+					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Name)
+					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Target.Digest.String())
+
+					found.Image.Name = ":"
+					if _, err = is.Create(ctx, found.Image); err != nil {
+						return err
+					}
+					return nil
+				}
 				return fmt.Errorf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", found.Req, cid)
 			}
 			if cid, ok := usedImages[found.Image.Name]; ok && !options.Force {


### PR DESCRIPTION
…rs by nerdctl rmi -f <Image Names>

In Docker, running `docker rmi -f <Image Names>` on images associated with running or stopped containers will untag the images, leaving <none> images.

The specific behavior in Docker is as follows.

	```
	> docker images
	REPOSITORY   TAG       IMAGE ID       CREATED       SIZE
	alpine       latest    91ef0af61f39   6 weeks ago   7.8MB

	> docker ps
	CONTAINER ID   IMAGE     COMMAND            CREATED         STATUS         PORTS     NAMES
	fe4caab5cf42   alpine    "sleep infinity"   4 minutes ago   Up 4 minutes             test

	> docker rmi -f  alpine
	Untagged: alpine:latest
	Untagged: alpine@sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d

	> docker images
	REPOSITORY   TAG       IMAGE ID       CREATED       SIZE
	<none>       <none>    91ef0af61f39   6 weeks ago   7.8MB
	```

On the other hand, the same operation described above with nerdctl will result in the following error.

	```
	> nerdctl rmi -f alpine
	FATA[0000] 1 errors:
	conflict: unable to delete alpine (cannot be forced) - image is being used by running container 59261bebc8113ca1ea102203137c32406742c2ec43ca3b108a314e9bfb4657fb
	```

This befavior is reported in the following:

  - https://github.com/containerd/nerdctl/issues/3454

Therefore, this commit fixes it so that `nerdctl rmi -f <Image Names>` can be performed on images associated with running or stopped containers.

The behaviour in nerdctl after this modification is as follows.

```
> nerdctl images
REPOSITORY    TAG       IMAGE ID        CREATED          PLATFORM       SIZE       BLOB SIZE
alpine        latest    beefdbd8a1da    5 seconds ago    linux/amd64    8.458MB    3.626MB

> nerdctl ps
CONTAINER ID    IMAGE                              COMMAND             CREATED          STATUS    PORTS    NAMES
28c9db821576    docker.io/library/alpine:latest    "sleep infinity"    6 seconds ago    Up                 alpine-28c9d

> nerdctl rmi -f alpine
Untagged: docker.io/library/alpine:latest
Untagged: sha256:beefdbd8a1da6d2915566fde36db9db0b524eb737fc57cd1367effd16dc0d06d

> nerdctl images
REPOSITORY    TAG       IMAGE ID        CREATED          PLATFORM       SIZE       BLOB SIZE
<none>        <none>    beefdbd8a1da    3 seconds ago    linux/amd64    8.458MB    3.626MB
```