### PR TITLE
fix: not to be deleted a container created with --rm when detaching

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -340,6 +340,8 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		}
 	}
 
+	internalLabels.rm = containerutil.EncodeContainerRmOptLabel(options.Rm)
+
 	// TODO: abolish internal labels and only use annotations
 	ilOpt, err := withInternalLabels(internalLabels)
 	if err != nil {
@@ -655,6 +657,8 @@ type internalLabels struct {
 	ipc string
 	// log
 	logURI string
+	// a label to check whether the --rm option is specified.
+	rm string
 }
 
 // WithInternalLabels sets the internal labels for a container.
@@ -730,6 +734,10 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 
 	if internalLabels.ipc != "" {
 		m[labels.IPC] = internalLabels.ipc
+	}
+
+	if internalLabels.rm != "" {
+		m[labels.ContainerAutoRemove] = internalLabels.rm
 	}
 
 	return containerd.WithAdditionalContainerLabels(m), nil

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -600,3 +600,13 @@ func GetContainerName(containerLabels map[string]string) string {
 	}
 	return ""
 }
+
+// EncodeContainerRmOptLabel encodes bool value for the --rm option into string value for a label.
+func EncodeContainerRmOptLabel(rmOpt bool) string {
+	return fmt.Sprintf("%t", rmOpt)
+}
+
+// DecodeContainerRmOptLabel decodes bool value for the --rm option from string value for a label.
+func DecodeContainerRmOptLabel(rmOptLabel string) (bool, error) {
+	return strconv.ParseBool(rmOptLabel)
+}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -100,4 +100,7 @@ const (
 	// Boolean value which can be parsed with strconv.ParseBool() is required.
 	// (like "nerdctl/default-network=true" or "nerdctl/default-network=false")
 	NerdctlDefaultNetwork = Prefix + "default-network"
+
+	// ContainerAutoRemove is to check whether the --rm option is specified.
+	ContainerAutoRemove = Prefix + "auto-remove"
 )


### PR DESCRIPTION
In the current implementation, detaching from a container started with
`nerdctl run --rm ...` unexpectedly removes it.

The behaviour before this modification is as follows.

```
> nerdctl run --rm -it --detach-keys=ctrl-a,ctrl-b --name test alpine
/ # INFO[0002] read detach keys

> nerdctl ps
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
```

When the same operation is performed in the Docker CLI, the container will
not be deleted.

This issue is reported in the following:

- https://github.com/containerd/nerdctl/issues/3568

Therefore, this commit resolves this behaviour of a container not being
deleted on detachment.

Note that the behaviour after this modification is as follows.

```
> nerdctl run --rm -it --detach-keys=ctrl-a,ctrl-b --name test alpine
/ # INFO[0010] read detach keys

> nerdctl ps
CONTAINER ID    IMAGE                                        COMMAND      CREATED           STATUS    PORTS    NAMES
46f4c829e5cc    docker.io/library/alpine:latest              "/bin/sh"    15 seconds ago    Up                 test
```

This PR has also been modified to remove a container when detaching and
attaching a container started with the --rm option.
The detailed behaviour is as follows.

```
> nerdctl attach test

/ # exit

> nerdctl ps -a
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES

```