### PR TITLE
Update busybox image (support sleep inf)

### DIFF
--- a/cmd/nerdctl/builder/builder_builder_test.go
+++ b/cmd/nerdctl/builder/builder_builder_test.go
@@ -90,7 +90,7 @@ CMD ["echo", "nerdctl-builder-debug-test-string"]`, testutil.CommonImage)
 					// FIXME: this test should be rewritten to dynamically retrieve the ids, and use images
 					// available on all platforms
 					oldImage := testutil.BusyboxImage
-					oldImageSha := "141c253bc4c3fd0a201d32dc1f493bcf3fff003b6df416dea4f41046e0f37d47"
+					oldImageSha := "7b3ccabffc97de872a30dfd234fd972a66d247c8cfc69b0550f276481852627c"
 					newImage := testutil.AlpineImage
 					newImageSha := "ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a"
 

--- a/pkg/testutil/testutil_freebsd.go
+++ b/pkg/testutil/testutil_freebsd.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	BusyboxImage     = mirrorOf("busybox:1.28")
+	BusyboxImage     = "ghcr.io/containerd/busybox:1.36"
 	AlpineImage      = mirrorOf("alpine:3.13")
 	NginxAlpineImage = mirrorOf("nginx:1.19-alpine")
 	GolangImage      = mirrorOf("golang:1.18")

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -30,7 +30,7 @@ func mirrorOf(s string) string {
 }
 
 var (
-	BusyboxImage                = "ghcr.io/containerd/busybox:1.28"
+	BusyboxImage                = "ghcr.io/containerd/busybox:1.36"
 	AlpineImage                 = mirrorOf("alpine:3.13")
 	NginxAlpineImage            = mirrorOf("nginx:1.19-alpine")
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"

--- a/pkg/testutil/testutil_windows.go
+++ b/pkg/testutil/testutil_windows.go
@@ -29,23 +29,22 @@ import (
 )
 
 const (
-	WindowsNano = "gcr.io/k8s-staging-e2e-test-images/busybox:1.29-2"
-
 	// CommonImage.
 	//
 	// More work needs to be done to support windows containers in test framework
 	// for the tests that are run now this image (used in k8s upstream testing) meets the needs
-	// use gcr.io/k8s-staging-e2e-test-images/busybox:1.29-2-windows-amd64-ltsc2022 locally on windows 11
+	// use gcr.io/k8s-staging-e2e-test-images/busybox:1.36-1-windows-amd64-ltsc2022 locally on windows 11
 	// https://github.com/microsoft/Windows-Containers/issues/179
-	CommonImage = WindowsNano
+	BusyboxImage = "gcr.io/k8s-staging-e2e-test-images/busybox:1.36.1-1"
+	WindowsNano  = BusyboxImage
+	CommonImage  = WindowsNano
 
 	// NOTE(aznashwan): the upstream e2e Nginx test image is actually based on BusyBox.
 	NginxAlpineImage            = "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"
 
-	GolangImage  = "fixme-test-using-this-image-is-disabled-on-windows"
-	BusyboxImage = "fixme-test-using-this-image-is-disabled-on-windows"
-	AlpineImage  = "fixme-test-using-this-image-is-disabled-on-windows"
+	GolangImage = "fixme-test-using-this-image-is-disabled-on-windows"
+	AlpineImage = "fixme-test-using-this-image-is-disabled-on-windows"
 
 	// This error string is expected when attempting to connect to a TCP socket
 	// for a service which actively refuses the connection.


### PR DESCRIPTION
1.28 does not support inf(inity) as an argument for sleep - which is something we are doing a lot in tests.

This came up while debugging docker failures, due to a different test tagging busybox as alpine.

This PR updates to the latest available containerd busybox image. 
