### PR TITLE
Fix test leaking tagged Alpine image

### DIFF
--- a/cmd/nerdctl/builder/builder_builder_test.go
+++ b/cmd/nerdctl/builder/builder_builder_test.go
@@ -86,6 +86,7 @@ CMD ["echo", "nerdctl-builder-debug-test-string"]`, testutil.CommonImage)
 			},
 			{
 				Description: "WithPull",
+				NoParallel:  true,
 				Setup: func(data test.Data, helpers test.Helpers) {
 					// FIXME: this test should be rewritten to dynamically retrieve the ids, and use images
 					// available on all platforms
@@ -105,6 +106,9 @@ CMD ["echo", "nerdctl-builder-debug-test-string"]`, testutil.CommonImage)
 					data.Set("buildCtx", buildCtx)
 					data.Set("oldImageSha", oldImageSha)
 					data.Set("newImageSha", newImageSha)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rmi", testutil.AlpineImage)
 				},
 				SubTests: []*test.Case{
 					{


### PR DESCRIPTION
This test is/was leaking busybox tagged as alpine.

Further tests that would call `run alpine` would then not pull, since the image is already here.

But then - see #3617 - if said test was to `run -d sleep inf` - it would fail silently, because the version of busybox we are using has an old `sleep` that does not support `inf`, causing cascading errors into unrelated commands.