### PR TITLE
Enable more tests to run on windows

### DIFF
--- a/cmd/nerdctl/container/container_commit_linux_test.go
+++ b/cmd/nerdctl/container/container_commit_linux_test.go
@@ -36,7 +36,7 @@ func TestKubeCommitSave(t *testing.T) {
 		// NOTE: kubectl namespaces are not the same as containerd namespaces.
 		// We still want kube test objects segregated in their own Kube API namespace.
 		nerdtest.KubeCtlCommand(helpers, "create", "namespace", "nerdctl-test-k8s").Run(&test.Expected{})
-		nerdtest.KubeCtlCommand(helpers, "run", "--image", testutil.CommonImage, identifier, "--", "sleep", "Inf").Run(&test.Expected{})
+		nerdtest.KubeCtlCommand(helpers, "run", "--image", testutil.CommonImage, identifier, "--", "sleep", nerdtest.Infinity).Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "wait", "pod", identifier, "--for=condition=ready", "--timeout=1m").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "exec", identifier, "--", "mkdir", "-p", "/tmp/whatever").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "get", "pods", identifier, "-o", "jsonpath={ .status.containerStatuses[0].containerID }").Run(&test.Expected{

--- a/cmd/nerdctl/container/container_commit_test.go
+++ b/cmd/nerdctl/container/container_commit_test.go
@@ -38,7 +38,7 @@ func TestCommit(t *testing.T) {
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
 				identifier := data.Identifier()
-				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("exec", identifier, "sh", "-euxc", `echo hello-test-commit > /foo`)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
@@ -63,7 +63,7 @@ func TestCommit(t *testing.T) {
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
 				identifier := data.Identifier()
-				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", nerdtest.Infinity)
 				nerdtest.EnsureContainerStarted(helpers, identifier)
 				helpers.Ensure("exec", identifier, "sh", "-euxc", `echo hello-test-commit > /foo`)
 			},

--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -200,7 +200,7 @@ func TestIssue2993(t *testing.T) {
 			Setup: func(data test.Data, helpers test.Helpers) {
 				dataRoot := data.TempDir()
 
-				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 
 				h := getAddrHash(defaults.DefaultAddress)
 				dataStore := filepath.Join(dataRoot, h)
@@ -224,7 +224,7 @@ func TestIssue2993(t *testing.T) {
 				helpers.Anyhow("rm", "--data-root", data.TempDir(), "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--data-root", data.TempDir(), "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				return helpers.Command("run", "--data-root", data.TempDir(), "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -247,7 +247,7 @@ func TestIssue2993(t *testing.T) {
 			Setup: func(data test.Data, helpers test.Helpers) {
 				dataRoot := data.TempDir()
 
-				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", "infinity")
+				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 
 				h := getAddrHash(defaults.DefaultAddress)
 				dataStore := filepath.Join(dataRoot, h)

--- a/cmd/nerdctl/container/container_exec_linux_test.go
+++ b/cmd/nerdctl/container/container_exec_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestExecWithUser(t *testing.T) {
@@ -28,7 +29,7 @@ func TestExecWithUser(t *testing.T) {
 	testContainer := testutil.Identifier(t)
 
 	defer base.Cmd("rm", "-f", testContainer).Run()
-	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	base.EnsureContainerStarted(testContainer)
 
 	testCases := map[string]string{
@@ -59,7 +60,7 @@ func TestExecTTY(t *testing.T) {
 
 	testContainer := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", testContainer).Run()
-	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	const sttyPartialOutput = "speed 38400 baud"
 	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.

--- a/cmd/nerdctl/container/container_list_test.go
+++ b/cmd/nerdctl/container/container_list_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // https://github.com/containerd/nerdctl/issues/2598
@@ -35,7 +36,7 @@ func TestContainerListWithFormatLabel(t *testing.T) {
 	base.Cmd("run", "-d",
 		"--name", cID,
 		"--label", labelK+"="+labelV,
-		testutil.CommonImage, "sleep", "infinity").AssertOK()
+		testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", cID).AssertOK()
 	base.Cmd("ps", "-a",
 		"--filter", "label="+labelK,
@@ -53,7 +54,7 @@ func TestContainerListWithJsonFormatLabel(t *testing.T) {
 	base.Cmd("run", "-d",
 		"--name", cID,
 		"--label", labelK+"="+labelV,
-		testutil.CommonImage, "sleep", "infinity").AssertOK()
+		testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", cID).AssertOK()
 	base.Cmd("ps", "-a",
 		"--filter", "label="+labelK,

--- a/cmd/nerdctl/container/container_prune_linux_test.go
+++ b/cmd/nerdctl/container/container_prune_linux_test.go
@@ -35,9 +35,9 @@ func TestPruneContainer(t *testing.T) {
 	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("run", "-d", "--name", data.Identifier("1"), "-v", "/anonymous", testutil.CommonImage, "sleep", "infinity")
+		helpers.Ensure("run", "-d", "--name", data.Identifier("1"), "-v", "/anonymous", testutil.CommonImage, "sleep", nerdtest.Infinity)
 		helpers.Ensure("exec", data.Identifier("1"), "touch", "/anonymous/foo")
-		helpers.Ensure("create", "--name", data.Identifier("2"), testutil.CommonImage, "sleep", "infinity")
+		helpers.Ensure("create", "--name", data.Identifier("2"), testutil.CommonImage, "sleep", nerdtest.Infinity)
 	}
 
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {

--- a/cmd/nerdctl/container/container_remove_test.go
+++ b/cmd/nerdctl/container/container_remove_test.go
@@ -28,7 +28,7 @@ func TestRemoveContainer(t *testing.T) {
 	testCase := nerdtest.Setup()
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "inf")
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/container/container_rename_linux_test.go
+++ b/cmd/nerdctl/container/container_rename_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRename(t *testing.T) {
@@ -28,7 +29,7 @@ func TestRename(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	defer base.Cmd("rm", "-f", testContainerName).Run()
-	base.Cmd("run", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	defer base.Cmd("rm", "-f", testContainerName+"_new").Run()
 	base.Cmd("rename", testContainerName, testContainerName+"_new").AssertOK()
@@ -44,11 +45,11 @@ func TestRenameUpdateHosts(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	defer base.Cmd("rm", "-f", testContainerName).Run()
-	base.Cmd("run", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	base.EnsureContainerStarted(testContainerName)
 
 	defer base.Cmd("rm", "-f", testContainerName+"_1").Run()
-	base.Cmd("run", "-d", "--name", testContainerName+"_1", testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", testContainerName+"_1", testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	base.EnsureContainerStarted(testContainerName + "_1")
 
 	defer base.Cmd("rm", "-f", testContainerName+"_new").Run()

--- a/cmd/nerdctl/container/container_rename_windows_test.go
+++ b/cmd/nerdctl/container/container_rename_windows_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRenameProcessContainer(t *testing.T) {
@@ -27,7 +28,7 @@ func TestRenameProcessContainer(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	defer base.Cmd("rm", "-f", testContainerName).Run()
-	base.Cmd("run", "--isolation", "process", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "--isolation", "process", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	defer base.Cmd("rm", "-f", testContainerName+"_new").Run()
 	base.Cmd("rename", testContainerName, testContainerName+"_new").AssertOK()
@@ -45,7 +46,7 @@ func TestRenameHyperVContainer(t *testing.T) {
 	}
 
 	defer base.Cmd("rm", "-f", testContainerName).Run()
-	base.Cmd("run", "--isolation", "hyperv", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "--isolation", "hyperv", "-d", "--name", testContainerName, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	defer base.Cmd("rm", "-f", testContainerName+"_new").Run()
 	base.Cmd("rename", testContainerName, testContainerName+"_new").AssertOK()

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRestart(t *testing.T) {
@@ -52,11 +53,11 @@ func TestRestartPIDContainer(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	baseContainerName := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", baseContainerName, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", baseContainerName, testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", baseContainerName).Run()
 
 	sharedContainerName := fmt.Sprintf("%s-shared", baseContainerName)
-	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--pid=container:%s", baseContainerName), testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--pid=container:%s", baseContainerName), testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", sharedContainerName).Run()
 
 	base.Cmd("restart", baseContainerName).AssertOK()
@@ -79,11 +80,11 @@ func TestRestartIPCContainer(t *testing.T) {
 	const shmSize = "32m"
 	baseContainerName := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", baseContainerName).Run()
-	base.Cmd("run", "-d", "--shm-size", shmSize, "--ipc", "shareable", "--name", baseContainerName, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--shm-size", shmSize, "--ipc", "shareable", "--name", baseContainerName, testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	sharedContainerName := fmt.Sprintf("%s-shared", baseContainerName)
 	defer base.Cmd("rm", "-f", sharedContainerName).Run()
-	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--ipc=container:%s", baseContainerName), testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", sharedContainerName, fmt.Sprintf("--ipc=container:%s", baseContainerName), testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 
 	base.Cmd("stop", baseContainerName).Run()
 	base.Cmd("stop", sharedContainerName).Run()
@@ -104,7 +105,7 @@ func TestRestartWithTime(t *testing.T) {
 	base := testutil.NewBase(t)
 	tID := testutil.Identifier(t)
 
-	base.Cmd("run", "-d", "--name", tID, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", tID, testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", tID).AssertOK()
 
 	inspect := base.InspectContainer(tID)

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRunCgroupV2(t *testing.T) {
@@ -96,7 +97,7 @@ func TestRunCgroupV2(t *testing.T) {
 		"cpu.weight", "cpuset.cpus", "cpuset.mems").AssertOutExactly(expected2)
 
 	base.Cmd("run", "--name", testutil.Identifier(t)+"-testUpdate1", "-w", "/sys/fs/cgroup", "-d",
-		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", testutil.Identifier(t)+"-testUpdate1").Run()
 	update := []string{"update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000",
 		"--memory", "42m",
@@ -115,7 +116,7 @@ func TestRunCgroupV2(t *testing.T) {
 
 	defer base.Cmd("rm", "-f", testutil.Identifier(t)+"-testUpdate2").Run()
 	base.Cmd("run", "--name", testutil.Identifier(t)+"-testUpdate2", "-w", "/sys/fs/cgroup", "-d",
-		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	base.EnsureContainerStarted(testutil.Identifier(t) + "-testUpdate2")
 
 	base.Cmd("update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000",
@@ -199,7 +200,7 @@ func TestRunDevice(t *testing.T) {
 		"--name", containerName,
 		"--device", lo[0].Device+":r",
 		"--device", lo[1].Device,
-		testutil.AlpineImage, "sleep", "infinity").Run()
+		testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
 
 	base.Cmd("exec", containerName, "cat", lo[0].Device).AssertOutContains(loContent[0])
 	base.Cmd("exec", containerName, "cat", lo[1].Device).AssertOutContains(loContent[1])
@@ -364,7 +365,7 @@ func TestRunBlkioWeightCgroupV2(t *testing.T) {
 	containerName := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", containerName).AssertOK()
 	// when bfq io scheduler is used, the io.weight knob is exposed as io.bfq.weight
-	base.Cmd("run", "--name", containerName, "--blkio-weight", "300", "-w", "/sys/fs/cgroup", testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "--name", containerName, "--blkio-weight", "300", "-w", "/sys/fs/cgroup", testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	base.Cmd("exec", containerName, "cat", "io.bfq.weight").AssertOutExactly("default 300\n")
 	base.Cmd("update", containerName, "--blkio-weight", "400").AssertOK()
 	base.Cmd("exec", containerName, "cat", "io.bfq.weight").AssertOutExactly("default 400\n")

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRunCustomRootfs(t *testing.T) {
@@ -108,7 +109,7 @@ func TestRunIPCContainerNotExists(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	container := testutil.Identifier(t)
-	result := base.Cmd("run", "--name", container, "--ipc", "container:abcd1234", testutil.AlpineImage, "sleep", "infinity").Run()
+	result := base.Cmd("run", "--name", container, "--ipc", "container:abcd1234", testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
 	defer base.Cmd("rm", "-f", container)
 	combined := result.Combined()
 	if !strings.Contains(strings.ToLower(combined), "no such container: abcd1234") {
@@ -121,7 +122,7 @@ func TestRunShmSizeIPCContainer(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	const shmSize = "32m"
-	sharedContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", "infinity").Run()
+	sharedContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
 	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
 	defer base.Cmd("rm", "-f", baseContainerID).Run()
 
@@ -134,7 +135,7 @@ func TestRunIPCContainer(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	const shmSize = "32m"
-	victimContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", "infinity").Run()
+	victimContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
 	victimContainerID := strings.TrimSpace(victimContainerResult.Stdout())
 	defer base.Cmd("rm", "-f", victimContainerID).Run()
 
@@ -169,12 +170,12 @@ func TestRunPidContainer(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
 
-	sharedContainerResult := base.Cmd("run", "-d", testutil.AlpineImage, "sleep", "infinity").Run()
+	sharedContainerResult := base.Cmd("run", "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
 	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
 	defer base.Cmd("rm", "-f", baseContainerID).Run()
 
 	base.Cmd("run", "--rm", fmt.Sprintf("--pid=container:%s", baseContainerID),
-		testutil.AlpineImage, "ps", "ax").AssertOutContains("sleep infinity")
+		testutil.AlpineImage, "ps", "ax").AssertOutContains("sleep " + nerdtest.Infinity)
 }
 
 func TestRunIpcHost(t *testing.T) {
@@ -278,7 +279,7 @@ func TestRunWithInit(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	container := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", container, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--name", container, testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", container).Run()
 
 	base.Cmd("stop", "--time=3", container).AssertOK()
@@ -288,7 +289,7 @@ func TestRunWithInit(t *testing.T) {
 	// Test with --init-path
 	container1 := container + "-1"
 	base.Cmd("run", "-d", "--name", container1, "--init-binary", "tini-custom",
-		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", container1).Run()
 
 	base.Cmd("stop", "--time=3", container1).AssertOK()
@@ -297,7 +298,7 @@ func TestRunWithInit(t *testing.T) {
 	// Test with --init
 	container2 := container + "-2"
 	base.Cmd("run", "-d", "--name", container2, "--init",
-		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("rm", "-f", container2).Run()
 
 	base.Cmd("stop", "--time=3", container2).AssertOK()

--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRunVolume(t *testing.T) {
@@ -242,7 +243,7 @@ RUN echo -n "rev0" > /mnt/file
 
 	base.Cmd("volume", "create", volumeName)
 	runContainer := func() {
-		base.Cmd("run", "-d", "--name", containerName, "-v", volumeName+":/mnt", imageName, "sleep", "infinity").AssertOK()
+		base.Cmd("run", "-d", "--name", containerName, "-v", volumeName+":/mnt", imageName, "sleep", nerdtest.Infinity).AssertOK()
 	}
 	runContainer()
 	base.EnsureContainerStarted(containerName)

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 )
 
@@ -492,7 +493,7 @@ func TestSharedNetworkStack(t *testing.T) {
 		"--name", containerNameJoin,
 		"--network=container:"+containerName,
 		testutil.CommonImage,
-		"sleep", "infinity").AssertOK()
+		"sleep", nerdtest.Infinity).AssertOK()
 
 	base.Cmd("exec", containerNameJoin, "wget", "-qO-", "http://127.0.0.1:80").
 		AssertOutContains(testutil.NginxAlpineIndexHTMLSnippet)

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestRunEntrypointWithBuild(t *testing.T) {
@@ -470,7 +471,7 @@ func TestRunAddHostRemainsWhenAnotherContainerCreated(t *testing.T) {
 
 	containerName := testutil.Identifier(t)
 	hostMapping := "test-add-host:10.0.0.1"
-	base.Cmd("run", "-d", "--add-host", hostMapping, "--name", containerName, testutil.CommonImage, "sleep", "infinity").AssertOK()
+	base.Cmd("run", "-d", "--add-host", hostMapping, "--name", containerName, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
 	defer base.Cmd("container", "rm", "-f", containerName).Run()
 
 	checkEtcHosts := func(stdout string) error {

--- a/cmd/nerdctl/container/container_stats_test.go
+++ b/cmd/nerdctl/container/container_stats_test.go
@@ -47,8 +47,8 @@ func TestStats(t *testing.T) {
 	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("run", "-d", "--name", data.Identifier("container"), testutil.CommonImage, "sleep", "10")
-		helpers.Ensure("run", "-d", "--name", data.Identifier("memlimited"), "--memory", "1g", testutil.CommonImage, "sleep", "10")
+		helpers.Ensure("run", "-d", "--name", data.Identifier("container"), testutil.CommonImage, "sleep", nerdtest.Infinity)
+		helpers.Ensure("run", "-d", "--name", data.Identifier("memlimited"), "--memory", "1g", testutil.CommonImage, "sleep", nerdtest.Infinity)
 		helpers.Ensure("run", "--name", data.Identifier("exited"), testutil.CommonImage, "echo", "'exited'")
 		data.Set("id", data.Identifier("container"))
 	}

--- a/cmd/nerdctl/container/container_top_test.go
+++ b/cmd/nerdctl/container/container_top_test.go
@@ -35,7 +35,7 @@ func TestTop(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		// FIXME: busybox 1.36 on windows still appears to not support sleep inf. Unclear why.
-		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "10")
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 		data.Set("cID", data.Identifier())
 	}
 
@@ -75,7 +75,7 @@ func TestTopHyperVContainer(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		// FIXME: busybox 1.36 on windows still appears to not support sleep inf. Unclear why.
-		helpers.Ensure("run", "--isolation", "hyperv", "-d", "--name", data.Identifier("container"), testutil.CommonImage, "sleep", "10")
+		helpers.Ensure("run", "--isolation", "hyperv", "-d", "--name", data.Identifier("container"), testutil.CommonImage, "sleep", nerdtest.Infinity)
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -31,6 +31,7 @@ func TestImageConvert(t *testing.T) {
 
 	testCase := &test.Case{
 		Require: test.Require(
+			// FIXME: windows does not support stargz
 			test.Not(test.Windows),
 			test.Not(nerdtest.Docker),
 		),

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -87,6 +87,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 	testCase := &test.Case{
 		Require: test.Require(
 			test.Not(nerdtest.Docker),
+			// FIXME: this test depends on hub images that do not have windows versions
 			test.Not(test.Windows),
 			// We need a clean slate
 			nerdtest.Private,

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -43,7 +43,6 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with stopped container - without -f",
 			NoParallel:  true,
 			Require: test.Require(
-				test.Not(test.Windows),
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
@@ -68,7 +67,6 @@ func TestRemove(t *testing.T) {
 		{
 			Description: "Remove image with stopped container - with -f",
 			NoParallel:  true,
-			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("run", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage)
 			},
@@ -90,7 +88,6 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with running container - without -f",
 			NoParallel:  true,
 			Require: test.Require(
-				test.Not(test.Windows),
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
@@ -121,7 +118,6 @@ func TestRemove(t *testing.T) {
 			// untags `imageName` (left a `<none>` image) without deletion; `docker rmi -rf imageID` fails.
 			// In both cases, `nerdctl rmi -f` will fail.
 			Require: test.Require(
-				test.Not(test.Windows),
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
@@ -146,7 +142,6 @@ func TestRemove(t *testing.T) {
 		{
 			Description: "Remove image with created container - without -f",
 			NoParallel:  true,
-			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
@@ -169,7 +164,6 @@ func TestRemove(t *testing.T) {
 		{
 			Description: "Remove image with created container - with -f",
 			NoParallel:  true,
-			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
 				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
@@ -197,7 +191,6 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with paused container - without -f",
 			NoParallel:  true,
 			Require: test.Require(
-				test.Not(test.Windows),
 				test.Not(nerdtest.Docker),
 				nerdtest.CGroup,
 			),
@@ -225,7 +218,6 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with paused container - with -f",
 			NoParallel:  true,
 			Require: test.Require(
-				test.Not(test.Windows),
 				nerdtest.CGroup,
 				// FIXME: nerdctl is broken
 				// https://github.com/containerd/nerdctl/issues/3454
@@ -258,7 +250,6 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with killed container - without -f",
 			NoParallel:  true,
 			Require: test.Require(
-				test.Not(test.Windows),
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
@@ -284,7 +275,6 @@ func TestRemove(t *testing.T) {
 		{
 			Description: "Remove image with killed container - with -f",
 			NoParallel:  true,
-			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("kill", data.Identifier())

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -94,7 +94,7 @@ func TestRemove(t *testing.T) {
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -125,7 +125,7 @@ func TestRemove(t *testing.T) {
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -148,7 +148,7 @@ func TestRemove(t *testing.T) {
 			NoParallel:  true,
 			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -170,7 +170,7 @@ func TestRemove(t *testing.T) {
 			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
-				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("rmi", testutil.NginxAlpineImage)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -200,7 +200,7 @@ func TestRemove(t *testing.T) {
 				nerdtest.CGroup,
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("pause", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -233,7 +233,7 @@ func TestRemove(t *testing.T) {
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("pause", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -260,7 +260,7 @@ func TestRemove(t *testing.T) {
 				test.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("kill", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -284,7 +284,7 @@ func TestRemove(t *testing.T) {
 			NoParallel:  true,
 			Require:     test.Not(test.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("kill", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -153,12 +153,14 @@ func TestRemove(t *testing.T) {
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
 			},
-			Command: test.Command("rmi", "-f", testutil.CommonImage),
+			Command: test.Command("rmi", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
+					ExitCode: 1,
+					Errors:   []error{errors.New("image is being used")},
 					Output: func(stdout string, info string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
-							Output: test.DoesNotContain(repoName),
+							Output: test.Contains(repoName),
 						})
 					},
 				}

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -35,6 +35,7 @@ func TestSaveContent(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
+		// FIXME: move to busybox for windows?
 		Require: test.Not(test.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)

--- a/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
@@ -43,7 +43,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 	)
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("pull", "--quiet", testutil.AlpineImage)
+		helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 
 		ipfsRegistry = registry.NewKuboRegistry(data, helpers, t, nil, 0, nil)
 		ipfsRegistry.Setup(data, helpers)
@@ -62,7 +62,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				ipfsCID := pushToIPFS(helpers, testutil.AlpineImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)))
+				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)))
 				helpers.Ensure("pull", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
 				data.Set(mainImageCIDKey, ipfsCID)
 			},
@@ -85,7 +85,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				ipfsCID := pushToIPFS(helpers, testutil.AlpineImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)), "--estargz")
+				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)), "--estargz")
 				helpers.Ensure("pull", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
 				data.Set(mainImageCIDKey, ipfsCID)
 			},

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -62,7 +62,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 	)
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("pull", "--quiet", testutil.AlpineImage)
+		helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 
 		// Start a local ipfs backed registry
 		ipfsServer = helpers.Command("ipfs", "registry", "serve", "--listen-registry", listenAddr)
@@ -84,7 +84,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.AlpineImage))
+				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
 				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -102,7 +102,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			NoParallel:  true,
 			Require:     nerdtest.Stargz,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.AlpineImage, "--estargz"))
+				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
 				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -126,7 +126,7 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 				}
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.AlpineImage))
+				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
 
 				dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-test-string"]

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -42,7 +42,7 @@ func TestIPFSSimple(t *testing.T) {
 	)
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("pull", "--quiet", testutil.AlpineImage)
+		helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 	}
 
 	testCase.SubTests = []*test.Case{
@@ -50,7 +50,7 @@ func TestIPFSSimple(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.AlpineImage))
+				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
 				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -71,7 +71,7 @@ func TestIPFSSimple(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.AlpineImage, "--estargz"))
+				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
 				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -88,7 +88,7 @@ func TestIPFSSimple(t *testing.T) {
 			Description: "with commit and push",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.AlpineImage))
+				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
 				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
@@ -126,7 +126,7 @@ func TestIPFSSimple(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.AlpineImage, "--estargz"))
+				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
 				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
@@ -161,7 +161,7 @@ func TestIPFSSimple(t *testing.T) {
 			NoParallel:  true,
 			Require:     test.Binary("openssl"),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.AlpineImage))
+				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
 				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Prep a key pair

--- a/cmd/nerdctl/issues/main_linux_test.go
+++ b/cmd/nerdctl/issues/main_linux_test.go
@@ -39,7 +39,7 @@ func TestIssue108(t *testing.T) {
 		{
 			Description: "-it --net=host",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "-it", "--rm", "--net=host", testutil.AlpineImage, "echo", "this was always working")
+				cmd := helpers.Command("run", "-it", "--rm", "--net=host", testutil.CommonImage, "echo", "this was always working")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -48,7 +48,7 @@ func TestIssue108(t *testing.T) {
 		{
 			Description: "--net=host -it",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "--rm", "--net=host", "-it", testutil.AlpineImage, "echo", "this was not working due to issue #108")
+				cmd := helpers.Command("run", "--rm", "--net=host", "-it", testutil.CommonImage, "echo", "this was not working due to issue #108")
 				cmd.WithPseudoTTY()
 				return cmd
 			},

--- a/cmd/nerdctl/issues/main_linux_test.go
+++ b/cmd/nerdctl/issues/main_linux_test.go
@@ -33,8 +33,6 @@ func TestMain(m *testing.M) {
 func TestIssue108(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	testCase.Require = test.Linux
-
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "-it --net=host",

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -49,8 +49,8 @@ func TestNetworkCreate(t *testing.T) {
 				helpers.Anyhow("network", "rm", data.Identifier("1"))
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				data.Set("container2", helpers.Capture("run", "--rm", "--net", data.Identifier("1"), testutil.AlpineImage, "ip", "route"))
-				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.AlpineImage, "ip", "route")
+				data.Set("container2", helpers.Capture("run", "--rm", "--net", data.Identifier("1"), testutil.CommonImage, "ip", "route"))
+				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.CommonImage, "ip", "route")
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -72,7 +72,7 @@ func TestNetworkCreate(t *testing.T) {
 				helpers.Anyhow("network", "rm", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.AlpineImage, "ifconfig", "eth0")
+				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.CommonImage, "ifconfig", "eth0")
 			},
 			Expected: test.Expects(0, nil, test.Contains("MTU:9216")),
 		},

--- a/cmd/nerdctl/network/network_prune_linux_test.go
+++ b/cmd/nerdctl/network/network_prune_linux_test.go
@@ -36,7 +36,7 @@ func TestNetworkPrune(t *testing.T) {
 			Setup: func(data test.Data, helpers test.Helpers) {
 				identifier := data.Identifier()
 				helpers.Ensure("network", "create", identifier)
-				helpers.Ensure("run", "-d", "--net", identifier, "--name", identifier, testutil.NginxAlpineImage)
+				helpers.Ensure("run", "-d", "--net", identifier, "--name", identifier, testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -54,7 +54,7 @@ func TestNetworkPrune(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
+				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("stop", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -65,7 +65,7 @@ func TestNetworkRemove(t *testing.T) {
 			Description: "Network remove when linked to container",
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("network", "rm", data.Identifier())

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -29,6 +29,14 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
+const (
+	// It seems that at this moment, the busybox on windows image we are using has an outdated version of sleep
+	// that does not support inf/infinity.
+	// This constant is provided as a mean for tests to express the intention of sleep infinity without having to
+	// worry about that and get windows compatibility.
+	Infinity = "3600"
+)
+
 func IsDocker() bool {
 	return testutil.GetTarget() == "docker"
 }


### PR DESCRIPTION
On top of #3631 and #3632.

This PR enables tests on Windows, or annotate them to indicate why they can't run there.

The following have been reviewed:
   - root
   - volume
   - system
   - network
   - namespace
   - issues
   - ipfs
   - internal
   - inspect
   - apparmor
   - completion

The following need to be reviewed more thoroughly:
   - image - needs a windows Registry for push and pull, might come with #3636
   - login - needs a windows Registry, might come with #3636
   - builder
   - compose
   - container
