### PR TITLE
Regression: fix convert unable to find image

### DIFF
--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -76,7 +76,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 	convertOpts = append(convertOpts, converter.WithPlatform(platMC))
 
 	// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
-	err = EnsureAllContent(ctx, client, srcRawRef, options.GOptions)
+	err = EnsureAllContent(ctx, client, srcRef, options.GOptions)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Convert using non fully qualified images will fail. Likely a regression with the refutil cleanup.

Spotted by @GrigoryEvko on unrelated #3623 