### PR TITLE
Cosmetic tests

### DIFF
--- a/cmd/nerdctl/completion/completion_test.go
+++ b/cmd/nerdctl/completion/completion_test.go
@@ -34,14 +34,16 @@ func TestCompletion(t *testing.T) {
 	testCase := &test.Case{
 		Require: test.Not(nerdtest.Docker),
 		Setup: func(data test.Data, helpers test.Helpers) {
+			identifier := data.Identifier()
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
-			helpers.Ensure("network", "create", data.Identifier())
-			helpers.Ensure("volume", "create", data.Identifier())
-			data.Set("identifier", data.Identifier())
+			helpers.Ensure("network", "create", identifier)
+			helpers.Ensure("volume", "create", identifier)
+			data.Set("identifier", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
-			helpers.Anyhow("network", "rm", data.Identifier())
-			helpers.Anyhow("volume", "rm", data.Identifier())
+			identifier := data.Identifier()
+			helpers.Anyhow("network", "rm", identifier)
+			helpers.Anyhow("volume", "rm", identifier)
 		},
 		SubTests: []*test.Case{
 			{

--- a/cmd/nerdctl/container/container_commit_linux_test.go
+++ b/cmd/nerdctl/container/container_commit_linux_test.go
@@ -31,14 +31,15 @@ func TestKubeCommitSave(t *testing.T) {
 	testCase.Require = nerdtest.OnlyKubernetes
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		identifier := data.Identifier()
 		containerID := ""
 		// NOTE: kubectl namespaces are not the same as containerd namespaces.
 		// We still want kube test objects segregated in their own Kube API namespace.
 		nerdtest.KubeCtlCommand(helpers, "create", "namespace", "nerdctl-test-k8s").Run(&test.Expected{})
-		nerdtest.KubeCtlCommand(helpers, "run", "--image", testutil.CommonImage, data.Identifier(), "--", "sleep", "Inf").Run(&test.Expected{})
-		nerdtest.KubeCtlCommand(helpers, "wait", "pod", data.Identifier(), "--for=condition=ready", "--timeout=1m").Run(&test.Expected{})
-		nerdtest.KubeCtlCommand(helpers, "exec", data.Identifier(), "--", "mkdir", "-p", "/tmp/whatever").Run(&test.Expected{})
-		nerdtest.KubeCtlCommand(helpers, "get", "pods", data.Identifier(), "-o", "jsonpath={ .status.containerStatuses[0].containerID }").Run(&test.Expected{
+		nerdtest.KubeCtlCommand(helpers, "run", "--image", testutil.CommonImage, identifier, "--", "sleep", "Inf").Run(&test.Expected{})
+		nerdtest.KubeCtlCommand(helpers, "wait", "pod", identifier, "--for=condition=ready", "--timeout=1m").Run(&test.Expected{})
+		nerdtest.KubeCtlCommand(helpers, "exec", identifier, "--", "mkdir", "-p", "/tmp/whatever").Run(&test.Expected{})
+		nerdtest.KubeCtlCommand(helpers, "get", "pods", identifier, "-o", "jsonpath={ .status.containerStatuses[0].containerID }").Run(&test.Expected{
 			Output: func(stdout string, info string, t *testing.T) {
 				containerID = strings.TrimPrefix(stdout, "containerd://")
 			},

--- a/cmd/nerdctl/container/container_commit_test.go
+++ b/cmd/nerdctl/container/container_commit_test.go
@@ -32,21 +32,24 @@ func TestCommit(t *testing.T) {
 			Description: "with pause",
 			Require:     nerdtest.CGroup,
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("rmi", "-f", data.Identifier())
+				identifier := data.Identifier()
+				helpers.Anyhow("rm", "-f", identifier)
+				helpers.Anyhow("rmi", "-f", identifier)
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
-				helpers.Ensure("exec", data.Identifier(), "sh", "-euxc", `echo hello-test-commit > /foo`)
+				identifier := data.Identifier()
+				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", "infinity")
+				helpers.Ensure("exec", identifier, "sh", "-euxc", `echo hello-test-commit > /foo`)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				identifier := data.Identifier()
 				helpers.Ensure(
 					"commit",
 					"-c", `CMD ["/foo"]`,
 					"-c", `ENTRYPOINT ["cat"]`,
 					"--pause=true",
-					data.Identifier(), data.Identifier())
-				return helpers.Command("run", "--rm", data.Identifier())
+					identifier, identifier)
+				return helpers.Command("run", "--rm", identifier)
 			},
 			Expected: test.Expects(0, nil, test.Equals("hello-test-commit\n")),
 		},
@@ -54,26 +57,29 @@ func TestCommit(t *testing.T) {
 			Description: "no pause",
 			Require:     test.Not(test.Windows),
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("rmi", "-f", data.Identifier())
+				identifier := data.Identifier()
+				helpers.Anyhow("rm", "-f", identifier)
+				helpers.Anyhow("rmi", "-f", identifier)
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
+				identifier := data.Identifier()
 				// See note above about docker failing.
 				if nerdtest.IsDocker() {
 					helpers.Ensure("pull", testutil.CommonImage)
 				}
-				helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
-				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
-				helpers.Ensure("exec", data.Identifier(), "sh", "-euxc", `echo hello-test-commit > /foo`)
+				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", "infinity")
+				nerdtest.EnsureContainerStarted(helpers, identifier)
+				helpers.Ensure("exec", identifier, "sh", "-euxc", `echo hello-test-commit > /foo`)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				identifier := data.Identifier()
 				helpers.Ensure(
 					"commit",
 					"-c", `CMD ["/foo"]`,
 					"-c", `ENTRYPOINT ["cat"]`,
 					"--pause=false",
-					data.Identifier(), data.Identifier())
-				return helpers.Command("run", "--rm", data.Identifier())
+					identifier, identifier)
+				return helpers.Command("run", "--rm", identifier)
 			},
 			Expected: test.Expects(0, nil, test.Equals("hello-test-commit\n")),
 		},

--- a/cmd/nerdctl/container/container_commit_test.go
+++ b/cmd/nerdctl/container/container_commit_test.go
@@ -63,10 +63,6 @@ func TestCommit(t *testing.T) {
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
 				identifier := data.Identifier()
-				// See note above about docker failing.
-				if nerdtest.IsDocker() {
-					helpers.Ensure("pull", testutil.CommonImage)
-				}
 				helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "sleep", "infinity")
 				nerdtest.EnsureContainerStarted(helpers, identifier)
 				helpers.Ensure("exec", identifier, "sh", "-euxc", `echo hello-test-commit > /foo`)

--- a/cmd/nerdctl/container/container_remove_test.go
+++ b/cmd/nerdctl/container/container_remove_test.go
@@ -36,13 +36,14 @@ func TestRemoveContainer(t *testing.T) {
 	}
 
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
-		helpers.Fail("rm", data.Identifier())
+		containerID := data.Identifier()
+		helpers.Fail("rm", containerID)
 
 		// FIXME: should (re-)evaluate this
 		// `kill` seems to return before the container actually stops
-		helpers.Ensure("stop", data.Identifier())
+		helpers.Ensure("stop", containerID)
 
-		return helpers.Command("rm", data.Identifier())
+		return helpers.Command("rm", containerID)
 	}
 
 	testCase.Expected = test.Expects(0, nil, nil)

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -37,10 +37,11 @@ func TestLoadStdinFromPipe(t *testing.T) {
 		Description: "TestLoadStdinFromPipe",
 		Require:     test.Linux,
 		Setup: func(data test.Data, helpers test.Helpers) {
+			identifier := data.Identifier()
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
-			helpers.Ensure("tag", testutil.CommonImage, data.Identifier())
-			helpers.Ensure("save", data.Identifier(), "-o", filepath.Join(data.TempDir(), "common.tar"))
-			helpers.Ensure("rmi", "-f", data.Identifier())
+			helpers.Ensure("tag", testutil.CommonImage, identifier)
+			helpers.Ensure("save", identifier, "-o", filepath.Join(data.TempDir(), "common.tar"))
+			helpers.Ensure("rmi", "-f", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rmi", "-f", data.Identifier())
@@ -53,11 +54,12 @@ func TestLoadStdinFromPipe(t *testing.T) {
 			return cmd
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			identifier := data.Identifier()
 			return &test.Expected{
 				Output: test.All(
-					test.Contains(fmt.Sprintf("Loaded image: %s:latest", data.Identifier())),
+					test.Contains(fmt.Sprintf("Loaded image: %s:latest", identifier)),
 					func(stdout string, info string, t *testing.T) {
-						assert.Assert(t, strings.Contains(helpers.Capture("images"), data.Identifier()))
+						assert.Assert(t, strings.Contains(helpers.Capture("images"), identifier))
 					},
 				),
 			}
@@ -86,10 +88,11 @@ func TestLoadQuiet(t *testing.T) {
 	testCase := &test.Case{
 		Description: "TestLoadQuiet",
 		Setup: func(data test.Data, helpers test.Helpers) {
+			identifier := data.Identifier()
 			helpers.Ensure("pull", testutil.CommonImage)
-			helpers.Ensure("tag", testutil.CommonImage, data.Identifier())
-			helpers.Ensure("save", data.Identifier(), "-o", filepath.Join(data.TempDir(), "common.tar"))
-			helpers.Ensure("rmi", "-f", data.Identifier())
+			helpers.Ensure("tag", testutil.CommonImage, identifier)
+			helpers.Ensure("save", identifier, "-o", filepath.Join(data.TempDir(), "common.tar"))
+			helpers.Ensure("rmi", "-f", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rmi", "-f", data.Identifier())

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -56,6 +56,7 @@ func TestImagePrune(t *testing.T) {
 				helpers.Anyhow("rmi", "-f", data.Identifier())
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
+				identifier := data.Identifier()
 				dockerfile := fmt.Sprintf(`FROM %s
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
@@ -64,22 +65,23 @@ func TestImagePrune(t *testing.T) {
 				helpers.Ensure("build", buildCtx)
 				// After we rebuild with tag, docker will no longer show the <none> version from above
 				// Swapping order does not change anything.
-				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
+				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, "<none>"), "Missing <none>")
-				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())
+				assert.Assert(t, strings.Contains(imgList, identifier), "Missing "+identifier)
 			},
 			Command: test.Command("image", "prune", "--force"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				identifier := data.Identifier()
 				return &test.Expected{
 					Output: test.All(
 						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, !strings.Contains(stdout, data.Identifier()), info)
+							assert.Assert(t, !strings.Contains(stdout, identifier), info)
 						},
 						func(stdout string, info string, t *testing.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
-							assert.Assert(t, strings.Contains(imgList, data.Identifier()), info)
+							assert.Assert(t, strings.Contains(imgList, identifier), info)
 						},
 					),
 				}
@@ -95,21 +97,23 @@ func TestImagePrune(t *testing.T) {
 			// Cannot use a custom namespace with buildkitd right now, so, no parallel it is
 			NoParallel: true,
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rmi", "-f", data.Identifier())
-				helpers.Anyhow("rm", "-f", data.Identifier())
+				identifier := data.Identifier()
+				helpers.Anyhow("rmi", "-f", identifier)
+				helpers.Anyhow("rm", "-f", identifier)
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
+				identifier := data.Identifier()
 				dockerfile := fmt.Sprintf(`FROM %s
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
 
 				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
 				helpers.Ensure("build", buildCtx)
-				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
+				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, "<none>"), "Missing <none>")
-				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())
-				helpers.Ensure("run", "--name", data.Identifier(), data.Identifier())
+				assert.Assert(t, strings.Contains(imgList, identifier), "Missing "+identifier)
+				helpers.Ensure("run", "--name", identifier, identifier)
 			},
 			Command: test.Command("image", "prune", "--force", "--all"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {

--- a/cmd/nerdctl/issues/issues_linux_test.go
+++ b/cmd/nerdctl/issues/issues_linux_test.go
@@ -49,15 +49,17 @@ func TestIssue3425(t *testing.T) {
 				Description: "with tag",
 				Require:     nerdtest.Private,
 				Setup: func(data test.Data, helpers test.Helpers) {
+					identifier := data.Identifier()
 					helpers.Ensure("image", "pull", testutil.CommonImage)
-					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
+					helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage)
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
 					helpers.Ensure("image", "pull", testutil.CommonImage)
-					helpers.Ensure("tag", testutil.CommonImage, fmt.Sprintf("localhost:%d/%s", reg.Port, data.Identifier()))
+					helpers.Ensure("tag", testutil.CommonImage, fmt.Sprintf("localhost:%d/%s", reg.Port, identifier))
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					helpers.Anyhow("rm", "-f", data.Identifier())
-					helpers.Anyhow("rmi", "-f", fmt.Sprintf("localhost:%d/%s", reg.Port, data.Identifier()))
+					identifier := data.Identifier()
+					helpers.Anyhow("rm", "-f", identifier)
+					helpers.Anyhow("rmi", "-f", fmt.Sprintf("localhost:%d/%s", reg.Port, identifier))
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					return helpers.Command("push", fmt.Sprintf("localhost:%d/%s", reg.Port, data.Identifier()))
@@ -68,11 +70,12 @@ func TestIssue3425(t *testing.T) {
 				Description: "with commit",
 				Require:     nerdtest.Private,
 				Setup: func(data test.Data, helpers test.Helpers) {
+					identifier := data.Identifier()
 					helpers.Ensure("image", "pull", testutil.CommonImage)
-					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "touch", "/something")
+					helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "touch", "/something")
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
 					helpers.Ensure("image", "pull", testutil.CommonImage)
-					helpers.Ensure("commit", data.Identifier(), fmt.Sprintf("localhost:%d/%s", reg.Port, data.Identifier()))
+					helpers.Ensure("commit", identifier, fmt.Sprintf("localhost:%d/%s", reg.Port, identifier))
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rm", "-f", data.Identifier())

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -36,8 +36,9 @@ func TestNetworkCreate(t *testing.T) {
 		{
 			Description: "vanilla",
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				netw := nerdtest.InspectNetwork(helpers, data.Identifier())
+				identifier := data.Identifier()
+				helpers.Ensure("network", "create", identifier)
+				netw := nerdtest.InspectNetwork(helpers, identifier)
 				assert.Equal(t, len(netw.IPAM.Config), 1)
 				data.Set("subnet", netw.IPAM.Config[0].Subnet)
 

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -200,8 +200,9 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "with namespace",
 			Require:     test.Not(nerdtest.Docker),
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("network", "rm", data.Identifier())
-				helpers.Anyhow("namespace", "remove", data.Identifier())
+				identifier := data.Identifier()
+				helpers.Anyhow("network", "rm", identifier)
+				helpers.Anyhow("namespace", "remove", identifier)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("network", "create", data.Identifier())

--- a/cmd/nerdctl/network/network_prune_linux_test.go
+++ b/cmd/nerdctl/network/network_prune_linux_test.go
@@ -34,8 +34,9 @@ func TestNetworkPrune(t *testing.T) {
 			Description: "Prune does not collect started container network",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				helpers.Ensure("run", "-d", "--net", data.Identifier(), "--name", data.Identifier(), testutil.NginxAlpineImage)
+				identifier := data.Identifier()
+				helpers.Ensure("network", "create", identifier)
+				helpers.Ensure("run", "-d", "--net", identifier, "--name", identifier, testutil.NginxAlpineImage)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -37,9 +37,10 @@ func TestNetworkRemove(t *testing.T) {
 		{
 			Description: "Simple network remove",
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("network", "create", data.Identifier())
-				data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
-				helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
+				identifier := data.Identifier()
+				helpers.Ensure("network", "create", identifier)
+				data.Set("netID", nerdtest.InspectNetwork(helpers, identifier).ID)
+				helpers.Ensure("run", "--rm", "--net", identifier, "--name", identifier, testutil.CommonImage)
 				// Verity the network is here
 				_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
 				assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")


### PR DESCRIPTION
This PR does
- reduce the number of unnecessary calls to `data.Identifier()` 
- cleanup remnants of fixed-bug workaround