### PR TITLE
[fix] avoid escaping '<', '>', '&'

### DIFF
--- a/pkg/formatter/common.go
+++ b/pkg/formatter/common.go
@@ -42,11 +42,16 @@ func FormatSlice(format string, writer io.Writer, x []interface{}) error {
 	var tmpl *template.Template
 	switch format {
 	case "":
-		b, err := json.MarshalIndent(x, "", "    ")
+		// Avoid escaping "<", ">", "&"
+		// https://pkg.go.dev/encoding/json
+		encoder := json.NewEncoder(writer)
+		encoder.SetIndent("", "    ")
+		encoder.SetEscapeHTML(false)
+		err := encoder.Encode(x)
 		if err != nil {
 			return err
 		}
-		fmt.Fprintln(writer, string(b))
+		fmt.Fprint(writer, "\n")
 	case "raw", "table", "wide":
 		return errors.New("unsupported format: \"raw\", \"table\", and \"wide\"")
 	default:


### PR DESCRIPTION
json.Encode will escase characters like '<', '>', '&'

cmd:
`nerdctl  -n k8s.io image inspect nginx/nginx-ingress:edge-alpine `

output:
```
 "Labels": {
                "maintainer": "NGINX Docker Maintainers \u003cdocker-maint@nginx.com\u003e",
                "org.opencontainers.image.vendor": "NGINX Inc \u003ckubernetes@nginx.com\u003e",
            }
```
