### PR TITLE
typo: remove extra colons and whitespaces #3650

### DIFF
--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -154,7 +154,7 @@ func prettyPrintInfoDockerCompat(stdout io.Writer, stderr io.Writer, info *docke
 	// Storage Driver is not really Server concept for nerdctl, but mimics `docker info` output
 	fmt.Fprintf(w, " Storage Driver: %s\n", info.Driver)
 	fmt.Fprintf(w, " Logging Driver: %s\n", info.LoggingDriver)
-	printF(w, " Cgroup Driver:  ", info.CgroupDriver)
+	printF(w, " Cgroup Driver: ", info.CgroupDriver)
 	printF(w, " Cgroup Version: ", info.CgroupVersion)
 	fmt.Fprintf(w, " Plugins:\n")
 	fmt.Fprintf(w, "  Log:     %s\n", strings.Join(info.Plugins.Log, " "))
@@ -183,7 +183,7 @@ func printF(w io.Writer, label string, dockerCompatInfo string) {
 	if dockerCompatInfo == "" {
 		return
 	}
-	fmt.Fprintf(w, " %s: %s\n", label, dockerCompatInfo)
+	fmt.Fprintf(w, " %s%s\n", label, dockerCompatInfo)
 }
 
 func printSecurityOptions(w io.Writer, securityOptions []string) {
@@ -208,7 +208,7 @@ func printSecurityOptions(w io.Writer, securityOptions []string) {
 			if k == "name" {
 				continue
 			}
-			fmt.Fprintf(w, "   %s:\t%s\n", cases.Title(language.English).String(k), v)
+			fmt.Fprintf(w, "   %s: %s\n", cases.Title(language.English).String(k), v)
 		}
 	}
 }


### PR DESCRIPTION
remove extra colons and whitespaces, and be same with `docker info`

![image](https://github.com/user-attachments/assets/b2be4fb0-79ad-4767-99fa-807e285b4f14)

Fixes: #3650 