### PR TITLE
typo: remove extra spaces at the lead #3650 #3651

### DIFF
--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -183,7 +183,7 @@ func printF(w io.Writer, label string, dockerCompatInfo string) {
 	if dockerCompatInfo == "" {
 		return
 	}
-	fmt.Fprintf(w, " %s%s\n", label, dockerCompatInfo)
+	fmt.Fprintf(w, "%s%s\n", label, dockerCompatInfo)
 }
 
 func printSecurityOptions(w io.Writer, securityOptions []string) {


### PR DESCRIPTION
Fixes:  #3650

![image](https://github.com/user-attachments/assets/354054a9-8f12-4bae-9e66-aa3f7d2d0feb)


review: @AkihiroSuda 