### PR TITLE
Mark `nerdctl builder debug` as incompatible with Docker

### DIFF
--- a/cmd/nerdctl/builder/builder_builder_test.go
+++ b/cmd/nerdctl/builder/builder_builder_test.go
@@ -71,7 +71,9 @@ CMD ["echo", "nerdctl-test-builder-prune"]`, testutil.CommonImage)
 			},
 			{
 				Description: "Debug",
-				NoParallel:  true,
+				// `nerdctl builder debug` is currently incompatible with `docker buildx debug`.
+				Require:    test.Require(test.Not(nerdtest.Docker)),
+				NoParallel: true,
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-builder-debug-test-string"]`, testutil.CommonImage)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1260,6 +1260,8 @@ This is an [experimental](./experimental.md) feature.
 
 :warning: This command currently doesn't use the host's `buildkitd` daemon but uses the patched version of BuildKit provided by buildg. This should be fixed in the future.
 
+:warning: This command is currently incompatible with `docker buildx debug`.
+
 Usage: `nerdctl builder debug PATH`
 
 Flags:


### PR DESCRIPTION
Close #3652

The command line syntax is different across `nerdctl builder debug` and `docker buildx debug` (w/ `BUILDX_EXPERIMENTAL=1`)