### PR TITLE
refactor: Use a more direct and less error-prone return value

### DIFF
--- a/pkg/netutil/subnet/subnet.go
+++ b/pkg/netutil/subnet/subnet.go
@@ -111,12 +111,12 @@ func LastIPInSubnet(addr *net.IPNet) (net.IP, error) {
 	}
 	ones, bits := cidr.Mask.Size()
 	if ones == bits {
-		return cidr.IP, err
+		return cidr.IP, nil
 	}
 	for i := range cidr.IP {
 		cidr.IP[i] = cidr.IP[i] | ^cidr.Mask[i]
 	}
-	return cidr.IP, err
+	return cidr.IP, nil
 }
 
 // firstIPInSubnet gets the first IP in a subnet
@@ -129,8 +129,8 @@ func FirstIPInSubnet(addr *net.IPNet) (net.IP, error) {
 	}
 	ones, bits := cidr.Mask.Size()
 	if ones == bits {
-		return cidr.IP, err
+		return cidr.IP, nil
 	}
 	cidr.IP[len(cidr.IP)-1]++
-	return cidr.IP, err
+	return cidr.IP, nil
 }


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

Just like  https://github.com/containerd/nerdctl/blob/8b814ca7fe29cb505a02a3d85ba22860e63d15bf/pkg/netutil/subnet/subnet.go#L76   and  https://github.com/containerd/nerdctl/blob/8b814ca7fe29cb505a02a3d85ba22860e63d15bf/pkg/netutil/subnet/subnet.go#L92