### PR TITLE
add fields such as CONTAINER_NAME to journald log entries sent to by containers

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -218,7 +218,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// 1, nerdctl run --name demo -it imagename
 	// 2, ctrl + c to stop demo container
 	// 3, nerdctl start/restart demo
-	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace)
+	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address)
 	if err != nil {
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
 	}
@@ -819,12 +819,13 @@ func writeCIDFile(path, id string) error {
 }
 
 // generateLogConfig creates a LogConfig for the current container store
-func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns string) (logConfig logging.LogConfig, err error) {
+func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
 	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
 		logConfig.LogURI = logDriver
 	} else {
 		logConfig.Driver = logDriver
+		logConfig.Address = address
 		logConfig.Opts, err = parseKVStringsMapFromLogOpt(logOpt, logDriver)
 		if err != nil {
 			return logConfig, err
@@ -834,7 +835,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 			logConfigB    []byte
 			lu            *url.URL
 		)
-		logDriverInst, err = logging.GetDriver(logDriver, logConfig.Opts)
+		logDriverInst, err = logging.GetDriver(logDriver, logConfig.Opts, logConfig.Address)
 		if err != nil {
 			return logConfig, err
 		}

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/logging"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
@@ -72,6 +73,7 @@ func Info(ctx context.Context, client *containerd.Client, options types.SystemIn
 		if err != nil {
 			return err
 		}
+		infoCompat.Plugins.Log = logging.Drivers()
 	default:
 		return fmt.Errorf("unknown mode %q", options.Mode)
 	}

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -35,7 +35,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	"github.com/containerd/nerdctl/v2/pkg/logging"
 	"github.com/containerd/nerdctl/v2/pkg/version"
 )
 
@@ -82,7 +81,6 @@ func Info(ctx context.Context, client *containerd.Client, snapshotter, cgroupMan
 	info.ID = daemonIntro.UUID
 	// Storage drivers and logging drivers are not really Server concept for nerdctl, but mimics `docker info` output
 	info.Driver = snapshotter
-	info.Plugins.Log = logging.Drivers()
 	info.Plugins.Storage = snapshotterPlugins
 	info.SystemTime = time.Now().Format(time.RFC3339Nano)
 	info.LoggingDriver = "json-file" // hard-coded

--- a/pkg/logging/fluentd_logger.go
+++ b/pkg/logging/fluentd_logger.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/url"
@@ -99,7 +100,7 @@ func (f *FluentdLogger) Init(dataStore, ns, id string) error {
 	return nil
 }
 
-func (f *FluentdLogger) PreProcess(_ string, config *logging.Config) error {
+func (f *FluentdLogger) PreProcess(_ context.Context, _ string, config *logging.Config) error {
 	if runtime.GOOS == "windows" {
 		// TODO: support fluentd on windows
 		return fmt.Errorf("logging to fluentd is not supported on windows")

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -78,7 +78,7 @@ func (jsonLogger *JSONLogger) Init(dataStore, ns, id string) error {
 	return nil
 }
 
-func (jsonLogger *JSONLogger) PreProcess(dataStore string, config *logging.Config) error {
+func (jsonLogger *JSONLogger) PreProcess(ctx context.Context, dataStore string, config *logging.Config) error {
 	var jsonFilePath string
 	if logPath, ok := jsonLogger.Opts[LogPath]; ok {
 		jsonFilePath = logPath

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -38,7 +38,7 @@ func (m *MockDriver) Init(dataStore, ns, id string) error {
 	return nil
 }
 
-func (m *MockDriver) PreProcess(dataStore string, config *logging.Config) error {
+func (m *MockDriver) PreProcess(ctx context.Context, dataStore string, config *logging.Config) error {
 	return nil
 }
 

--- a/pkg/logging/none_logger.go
+++ b/pkg/logging/none_logger.go
@@ -17,6 +17,8 @@
 package logging
 
 import (
+	"context"
+
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 )
 
@@ -28,7 +30,7 @@ func (n *NoneLogger) Init(dataStore, ns, id string) error {
 	return nil
 }
 
-func (n *NoneLogger) PreProcess(dataStore string, config *logging.Config) error {
+func (n *NoneLogger) PreProcess(ctx context.Context, dataStore string, config *logging.Config) error {
 	return nil
 }
 

--- a/pkg/logging/none_logger_test.go
+++ b/pkg/logging/none_logger_test.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 func TestNoneLogger(t *testing.T) {
 	// Create a temporary directory for potential log files
 	tmpDir := t.TempDir()
+	ctx := context.Background()
 
 	logger := &NoneLogger{
 		Opts: map[string]string{},
@@ -40,7 +42,7 @@ func TestNoneLogger(t *testing.T) {
 
 		// Run all logger methods
 		logger.Init(tmpDir, "namespace", "id")
-		logger.PreProcess(tmpDir, &logging.Config{})
+		logger.PreProcess(ctx, tmpDir, &logging.Config{})
 
 		stdout := make(chan string)
 		stderr := make(chan string)

--- a/pkg/logging/syslog_logger.go
+++ b/pkg/logging/syslog_logger.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -122,7 +123,7 @@ func (sy *SyslogLogger) Init(dataStore string, ns string, id string) error {
 	return nil
 }
 
-func (sy *SyslogLogger) PreProcess(dataStore string, config *logging.Config) error {
+func (sy *SyslogLogger) PreProcess(ctx context.Context, dataStore string, config *logging.Config) error {
 	logger, err := parseSyslog(config.ID, sy.Opts)
 	if err != nil {
 		return err


### PR DESCRIPTION
In the current implementation, containers running by `nerdctl` don't 
export entries containing fileds such as `CONTAINER_NAME`, `IMAGE_NAME`
, and etc to the journald log like containers runnging by `docker cli`.

At this time, the journald log entry describes below when sending to the journald log using `nerdctl`.

<details><summary>Details</summary>
<p>

```
> nerdctl run -d --name nginx-nerdctl --log-driver=journald nginx
bb7df47d27fd73426cec286ed88c5abf1443e74df637e2440d2dbca7229a84dc

> nerdctl ps
CONTAINER ID    IMAGE                             COMMAND                   CREATED          STATUS    PORTS    NAMES
bb7df47d27fd    docker.io/library/nginx:latest    "/docker-entrypoint.…"    3 seconds ago    Up                 nginx-nerdctl

> sudo journalctl SYSLOG_IDENTIFIER=bb7df47d27fd -a -n 1 -o json-pretty
{
        "__CURSOR" : "???",
        "__REALTIME_TIMESTAMP" : "1730899940827182",
        "__MONOTONIC_TIMESTAMP" : "10815937979908",
        "_BOOT_ID" : "???",
        "_UID" : "0",
        "_GID" : "0",
        "_CAP_EFFECTIVE" : "1ffffffffff",
        "_MACHINE_ID" : "???",
        "_HOSTNAME" : "???.us-west-2.amazon.com",
        "_TRANSPORT" : "journal",
        "_SYSTEMD_SLICE" : "system.slice",
        "PRIORITY" : "3",
        "_SYSTEMD_CGROUP" : "/system.slice/containerd.service",
        "_SYSTEMD_UNIT" : "containerd.service",
        "_COMM" : "nerdctl",
        "_EXE" : "/usr/local/bin/nerdctl",
        "_CMDLINE" : "/usr/local/bin/nerdctl _NERDCTL_INTERNAL_LOGGING /var/lib/nerdctl/1935db59",
        "SYSLOG_IDENTIFIER" : "bb7df47d27fd",
        "_PID" : "8118",
        "MESSAGE" : "2024/11/06 13:32:20 [notice] 1#1: start worker process 44",
        "_SOURCE_REALTIME_TIMESTAMP" : "1730899940825905"
}
```

</p>
</details> 

On the other hand, the output fields are listed below when we use the journald logging driver with `docker cli`.

- https://docs.docker.com/engine/logging/drivers/journald/

As you can see, some entries are not output by `nerdctl` and are incompatible with `docker cli`.

This feature request is reported in the following:

- https://github.com/containerd/nerdctl/issues/3486

Therefore, in this pull request, we will add the fields to be output in 
the journald log.

After applying this fix, the journald log will output the following 
fields.

<details><summary>Details</summary>
<p>

```
> sudo journalctl SYSLOG_IDENTIFIER=fe22eccbd704 -a -n 1 -o json-pretty
{
  "__CURSOR": "???",
  "__REALTIME_TIMESTAMP": "1731385591671422",
  "__MONOTONIC_TIMESTAMP": "11301588824148",
  "_BOOT_ID": "???",
  "_MACHINE_ID": "???",
  "_HOSTNAME": "???.us-west-2.amazon.com",
  "PRIORITY": "3",
  "_TRANSPORT": "journal",
  "_UID": "0",
  "_GID": "0",
  "_COMM": "nerdctl",
  "_EXE": "/usr/local/bin/nerdctl",
  "_CMDLINE": "/usr/local/bin/nerdctl _NERDCTL_INTERNAL_LOGGING /var/lib/nerdctl/1935db59",
  "_CAP_EFFECTIVE": "1ffffffffff",
  "_SYSTEMD_CGROUP": "/system.slice/containerd.service",
  "_SYSTEMD_UNIT": "containerd.service",
  "_SYSTEMD_SLICE": "system.slice",
  "CONTAINER_NAME": "nginx-nerdctl",
  "IMAGE_NAME": "nginx",
  "CONTAINER_ID_FULL": "fe22eccbd704ba799785999079ac465ed067d5914e9e3f1020e769921d5a83c5",
  "SYSLOG_IDENTIFIER": "fe22eccbd704",
  "CONTAINER_TAG": "fe22eccbd704",
  "CONTAINER_ID": "fe22eccbd704",
  "_PID": "31643",
  "MESSAGE": "2024/11/12 04:26:31 [notice] 1#1: start worker process 44",
  "_SOURCE_REALTIME_TIMESTAMP": "1731385591669765"
}
```

</p>
</details> 

Note that details are described in each commits.