### PR TITLE
fix: default json-file log size to 100MB

### DIFF
--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -88,10 +88,11 @@ func (jsonLogger *JSONLogger) PreProcess(dataStore string, config *logging.Confi
 	l := &logrotate.Logger{
 		Filename: jsonFilePath,
 	}
-	//maxSize Defaults to unlimited.
-	var capVal int64
-	capVal = -1
+	// MaxBytes is the maximum size in bytes of the log file before it gets
+	// rotated. If not set, it defaults to 100 MiB.
+	// see: https://github.com/fahedouch/go-logrotate/blob/6a8beddaea39b2b9c77109d7fa2fe92053c063e5/logrotate.go#L500
 	if capacity, ok := jsonLogger.Opts[MaxSize]; ok {
+		var capVal int64
 		var err error
 		capVal, err = units.FromHumanSize(capacity)
 		if err != nil {
@@ -100,8 +101,8 @@ func (jsonLogger *JSONLogger) PreProcess(dataStore string, config *logging.Confi
 		if capVal <= 0 {
 			return fmt.Errorf("max-size must be a positive number")
 		}
+		l.MaxBytes = capVal
 	}
-	l.MaxBytes = capVal
 	maxFile := 1
 	if maxFileString, ok := jsonLogger.Opts[MaxFile]; ok {
 		var err error


### PR DESCRIPTION
#3661 
This commit makes the json-file logger to default logrotate maxBytes configuration of 100MB.

It is a temporary fix to a bug addressed by this [logrotate PR](https://github.com/fahedouch/go-logrotate/pull/50).

Setting the default values in the config passed to logrotate fixes the issue temporarily but having unlimited size for container logs will be available when the issue is addressed upstream. 

Testing done :

Verified that the logging mechanism works and appends the logs to the same log file and doesn't create a new log file.