### PR TITLE
[release/1.7] fix: default json-file log size to 100MB

### DIFF
--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -83,10 +83,11 @@ func (jsonLogger *JSONLogger) PreProcess(dataStore string, config *logging.Confi
 	l := &logrotate.Logger{
 		Filename: jsonFilePath,
 	}
-	//maxSize Defaults to unlimited.
-	var capVal int64
-	capVal = -1
+	// MaxBytes is the maximum size in bytes of the log file before it gets
+	// rotated. If not set, it defaults to 100 MiB.
+	// see: https://github.com/fahedouch/go-logrotate/blob/6a8beddaea39b2b9c77109d7fa2fe92053c063e5/logrotate.go#L500
 	if capacity, ok := jsonLogger.Opts[MaxSize]; ok {
+		var capVal int64
 		var err error
 		capVal, err = units.FromHumanSize(capacity)
 		if err != nil {
@@ -95,8 +96,8 @@ func (jsonLogger *JSONLogger) PreProcess(dataStore string, config *logging.Confi
 		if capVal <= 0 {
 			return fmt.Errorf("max-size must be a positive number")
 		}
+		l.MaxBytes = capVal
 	}
-	l.MaxBytes = capVal
 	maxFile := 1
 	if maxFileString, ok := jsonLogger.Opts[MaxFile]; ok {
 		var err error


### PR DESCRIPTION
cherry-pick #3670 to 1.7