### PR TITLE
feat: add force-recreate and no-recreate for compose up command

### DIFF
--- a/cmd/nerdctl/compose/compose_create.go
+++ b/cmd/nerdctl/compose/compose_create.go
@@ -65,7 +65,7 @@ func composeCreateAction(cmd *cobra.Command, args []string) error {
 	}
 	noRecreate, err := cmd.Flags().GetBool("no-recreate")
 	if err != nil {
-		return nil
+		return err
 	}
 	if forceRecreate && noRecreate {
 		return errors.New("flag --force-recreate and --no-recreate cannot be specified together")

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1410,8 +1410,10 @@ Flags:
 - :whale: `--quiet-pull`: Pull without printing progress information
 - :whale: `--scale`: Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.
 - :whale: `--remove-orphans`: Remove containers for services not defined in the Compose file
+- :whale: `--force-recreate`: force Compose to stop and recreate all containers
+- :whale: `--no-recreate`: force Compose to reuse existing containers
 
-Unimplemented `docker-compose up` (V1) flags: `--no-deps`, `--force-recreate`, `--always-recreate-deps`, `--no-recreate`,
+Unimplemented `docker-compose up` (V1) flags: `--no-deps`, `--always-recreate-deps`,
 `--no-start`, `--abort-on-container-exit`, `--attach-dependencies`, `--timeout`, `--renew-anon-volumes`, `--exit-code-from`
 
 Unimplemented `docker compose up` (V2) flags: `--environment`

--- a/pkg/composer/container.go
+++ b/pkg/composer/container.go
@@ -63,3 +63,24 @@ func (c *Composer) containerExists(ctx context.Context, name, service string) (b
 	// container doesn't exist
 	return false, nil
 }
+
+func (c *Composer) containerID(ctx context.Context, name, service string) (string, error) {
+	// get list of containers for service
+	containers, err := c.Containers(ctx, service)
+	if err != nil {
+		return "", err
+	}
+
+	for _, container := range containers {
+		containerLabels, err := container.Labels(ctx)
+		if err != nil {
+			return "", err
+		}
+		if name == containerLabels[labels.Name] {
+			// container exists
+			return container.ID(), nil
+		}
+	}
+	// container doesn't exist
+	return "", nil
+}

--- a/pkg/composer/logs.go
+++ b/pkg/composer/logs.go
@@ -41,6 +41,7 @@ type LogsOptions struct {
 	Tail                 string
 	NoColor              bool
 	NoLogPrefix          bool
+	LatestRun            bool
 }
 
 func (c *Composer) Logs(ctx context.Context, lo LogsOptions, services []string) error {
@@ -62,9 +63,10 @@ func (c *Composer) Logs(ctx context.Context, lo LogsOptions, services []string) 
 func (c *Composer) logs(ctx context.Context, containers []containerd.Container, lo LogsOptions) error {
 	var logTagMaxLen int
 	type containerState struct {
-		name   string
-		logTag string
-		logCmd *exec.Cmd
+		name      string
+		logTag    string
+		logCmd    *exec.Cmd
+		startedAt string
 	}
 
 	containerStates := make(map[string]containerState, len(containers)) // key: containerID
@@ -78,9 +80,15 @@ func (c *Composer) logs(ctx context.Context, containers []containerd.Container, 
 		if l := len(logTag); l > logTagMaxLen {
 			logTagMaxLen = l
 		}
+		ts, err := info.UpdatedAt.MarshalText()
+		if err != nil {
+			return err
+		}
+
 		containerStates[container.ID()] = containerState{
-			name:   name,
-			logTag: logTag,
+			name:      name,
+			logTag:    logTag,
+			startedAt: string(ts),
 		}
 	}
 
@@ -101,6 +109,9 @@ func (c *Composer) logs(ctx context.Context, containers []containerd.Container, 
 			} else {
 				args = append(args, lo.Tail)
 			}
+		}
+		if lo.LatestRun {
+			args = append(args, fmt.Sprintf("--since=%s", state.startedAt))
 		}
 
 		args = append(args, id)

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -242,7 +242,7 @@ func (c *Composer) runServices(ctx context.Context, parsedServices []*servicepar
 		container := ps.Containers[0]
 
 		runEG.Go(func() error {
-			id, err := c.upServiceContainer(ctx, ps, container)
+			id, err := c.upServiceContainer(ctx, ps, container, RecreateForce)
 			if err != nil {
 				return err
 			}

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -39,7 +39,20 @@ type UpOptions struct {
 	IPFS                 bool
 	QuietPull            bool
 	RemoveOrphans        bool
+	ForceRecreate        bool
+	NoRecreate           bool
 	Scale                map[string]int // map of service name to replicas
+}
+
+func (opts UpOptions) recreateStrategy() string {
+	switch {
+	case opts.ForceRecreate:
+		return RecreateForce
+	case opts.NoRecreate:
+		return RecreateNever
+	default:
+		return RecreateDiverged
+	}
 }
 
 func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) error {


### PR DESCRIPTION
Enable two missing docker compose up options: --force-recreate and --no-recreate

Also made it so that only logs from the latest run are displayed in the user's terminal (otherwise, all logs will be displayed, which could be confusing to users). This is the same behavior as the docker CLI today.

One issue which I noticed is that my testing container would keep getting a new IP address in its IPAM bridge network. I think as of #2839, the iptables rules should be cleaned up when a container is stopped, but its not happening for me for some reason.