### PR TITLE
fix redundant error checks and comment format

### DIFF
--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -420,11 +420,7 @@ func (m *hostNetworkManager) SetupNetworking(ctx context.Context, containerID st
 	}
 
 	// Save the meta information
-	if err = hs.Acquire(hsMeta); err != nil {
-		return err
-	}
-
-	return nil
+	return hs.Acquire(hsMeta)
 }
 
 // CleanupNetworking Performs any required cleanup actions for the given container.
@@ -449,11 +445,7 @@ func (m *hostNetworkManager) CleanupNetworking(ctx context.Context, container co
 	}
 
 	// Release
-	if err = hs.Release(container.ID()); err != nil {
-		return err
-	}
-
-	return nil
+	return hs.Release(container.ID())
 }
 
 // InternalNetworkingOptionLabels Returns the set of NetworkingOptions which should be set as labels on the container.

--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -72,8 +72,5 @@ func Unlock(locked *os.File) error {
 		_ = locked.Close()
 	}()
 
-	if err := flock(locked, unix.LOCK_UN); err != nil {
-		return err
-	}
-	return nil
+	return flock(locked, unix.LOCK_UN)
 }

--- a/pkg/mountutil/volumestore/volumestore.go
+++ b/pkg/mountutil/volumestore/volumestore.go
@@ -39,7 +39,7 @@ const (
 	volumeJSONFileName = "volume.json"
 )
 
-// ErrNameStore will wrap all errors here
+// ErrVolumeStore will wrap all errors here
 var ErrVolumeStore = errors.New("volume-store error")
 
 type VolumeStore interface {


### PR DESCRIPTION

1. removed redundant if ...; err != nil checks in:
* `pkg/lockutil/lockutil_unix.go`
* `pkg/containerutil/container_network_manager.go`

2. corrected the comment format for the exported variable in `pkg/mountutil/volumestore/volumestore.go`