### PR TITLE
fix: enable --env-file flag behavior in nerdctl compose

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1391,6 +1391,7 @@ Flags:
 - :whale: `-p, --project-name`: Specify an alternate project name
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 - :whale: `--profile: Specify a profile to enable
+- :whale: `--env-file` : Specify an alternate environment file
 
 ### :whale: nerdctl compose up
 

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -175,6 +175,10 @@ func (c *Composer) upServiceContainer(ctx context.Context, service *serviceparse
 	defer os.RemoveAll(tempDir)
 	cidFilename := filepath.Join(tempDir, "cid")
 
+	if c.EnvFile != "" {
+		container.RunArgs = append([]string{"--env-file=" + c.EnvFile}, container.RunArgs...)
+	}
+
 	//add metadata labels to container https://github.com/compose-spec/compose-spec/blob/master/spec.md#labels
 	container.RunArgs = append([]string{
 		"--cidfile=" + cidFilename,


### PR DESCRIPTION
While debugging this issue on finch - [Unable to use the "--env-file" option on "finch compose up" command #890](https://github.com/runfinch/finch/issues/890) 
I noticed that nerdctl also fails to set the env variables within the container when using the "--env-file" option.

```
$ sudo nerdctl compose up --env-file .env.test show-env
INFO[0000] Creating network testing_default             
INFO[0000] Ensuring image busybox                       
INFO[0000] Creating container testing-show-env-1        
INFO[0000] Attaching to logs                            
show-env-1 |PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
show-env-1 |HOSTNAME=show-env
show-env-1 |HOME=/root
INFO[0001] Container "testing-show-env-1" exited        
INFO[0001] All the containers have exited               
INFO[0001] Stopping containers (forcibly)               
INFO[0001] Stopping container testing-show-env-1
```
This behavior is also seen on ``nerdctl compose run`` command as well.

Digging around the up_service.go file I noticed that we're not passing the --env-file flag to the run command [here](https://github.com/containerd/nerdctl/blob/3c41efe581fd7291b446709f11c7439594abf347/pkg/composer/up_service.go#L167)
Adding ``--env-file`` to the Run argument fixes the issue for both ``compose up`` and ``compose run`` commands.

Testing done:
Verified that the env variables are available within the container.

```
sudo .././_output/nerdctl compose up --env-file .env.test show-env 
INFO[0000] Ensuring image busybox                       
INFO[0000] Re-creating container testing-show-env-1     
INFO[0000] Running [/local/home/<user>/<project>/nerdctl/_output/nerdctl run --cidfile=/tmp/compose-3618749869/cid -l=com.docker.compose.project=testing -l=com.docker.compose.service=show-env --env-file=.env.test -d --name=testing-show-env-1 --pull=never --net=testing_default --hostname=show-env --restart=no busybox env] 
INFO[0000] Attaching to logs                            
show-env-1 |PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
show-env-1 |A=1
show-env-1 |B=2
show-env-1 |HOSTNAME=show-env
show-env-1 |HOME=/root
INFO[0000] Container "testing-show-env-1" exited        
INFO[0000] All the containers have exited               
INFO[0000] Stopping containers (forcibly)               
INFO[0000] Stopping container testing-show-env-1  
```