### PR TITLE
Enforce go imports grouping in CI

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,8 @@ linters:
     # - wrapcheck
     # - wsl
 linters-settings:
+  goimports:
+    local-prefixes: github.com/containerd/nerdctl/v2
   gocritic:
     enabled-checks:
       # Diagnostic


### PR DESCRIPTION
By default goimports organize imports into 2 groups

```
import (
  std pkgs

  third-party / non-std pkgs
)
```

The `local-prefixes` option (https://golangci-lint.run/usage/linters/#goimports) in golang-ci (correspond to `-local` flag in goimports CLI https://cs.opensource.google/go/x/tools/+/refs/tags/v0.27.0:cmd/goimports/goimports.go;l=54) will enforce 3 groups instead:

```
import (
  std pkgs

  third-party pkgs

  local pkgs
)
```

I think this will provide a clear/consistent view of dependency import groups.