### PR TITLE
Chore: import cleanup

### DIFF
--- a/cmd/nerdctl/compose/compose_ps.go
+++ b/cmd/nerdctl/compose/compose_ps.go
@@ -29,7 +29,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/errdefs"
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
@@ -323,7 +323,7 @@ type PortPublisher struct {
 // formatPublishers parses and returns docker-compatible []PortPublisher from
 // label map. If an error happens, an empty slice is returned.
 func formatPublishers(labelMap map[string]string) []PortPublisher {
-	mapper := func(pm gocni.PortMapping) PortPublisher {
+	mapper := func(pm cni.PortMapping) PortPublisher {
 		return PortPublisher{
 			URL:           pm.HostIP,
 			TargetPort:    int(pm.ContainerPort),

--- a/cmd/nerdctl/container/container_run_network.go
+++ b/cmd/nerdctl/container/container_run_network.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
@@ -144,7 +144,7 @@ func loadNetworkFlags(cmd *cobra.Command) (types.NetworkOptions, error) {
 		return netOpts, err
 	}
 	portSlice = strutil.DedupeStrSlice(portSlice)
-	portMappings := []gocni.PortMapping{}
+	portMappings := []cni.PortMapping{}
 	for _, p := range portSlice {
 		pm, err := portutil.ParseFlagP(p)
 		if err != nil {

--- a/pkg/api/types/container_network_types.go
+++ b/pkg/api/types/container_network_types.go
@@ -17,7 +17,7 @@
 package types
 
 import (
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 )
 
 // NetworkOptions struct defining networking-related options.
@@ -43,5 +43,5 @@ type NetworkOptions struct {
 	// UTS namespace to use
 	UTSNamespace string
 	// PortMappings specifies a list of ports to publish from the container to the host
-	PortMappings []gocni.PortMapping
+	PortMappings []cni.PortMapping
 }

--- a/pkg/bypass4netnsutil/bypass.go
+++ b/pkg/bypass4netnsutil/bypass.go
@@ -28,7 +28,7 @@ import (
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 
 	"github.com/containerd/errdefs"
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 )
@@ -66,7 +66,7 @@ type Bypass4netnsCNIBypassManager struct {
 	ignoreBind    bool
 }
 
-func (b4nnm *Bypass4netnsCNIBypassManager) StartBypass(ctx context.Context, ports []gocni.PortMapping, id, stateDir string) error {
+func (b4nnm *Bypass4netnsCNIBypassManager) StartBypass(ctx context.Context, ports []cni.PortMapping, id, stateDir string) error {
 	socketPath, err := GetSocketPathByID(id)
 	if err != nil {
 		return err

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -37,7 +37,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
@@ -646,7 +646,7 @@ type internalLabels struct {
 	networks   []string
 	ipAddress  string
 	ip6Address string
-	ports      []gocni.PortMapping
+	ports      []cni.PortMapping
 	macAddress string
 	// volume
 	mountPoints []*mountutil.Processed

--- a/pkg/consoleutil/consoleutil_unix.go
+++ b/pkg/consoleutil/consoleutil_unix.go
@@ -19,7 +19,7 @@
 package consoleutil
 
 import (
-	gocontext "context"
+	"context"
 	"os"
 	"os/signal"
 
@@ -31,7 +31,7 @@ import (
 
 // HandleConsoleResize resizes the console.
 // From https://github.com/containerd/containerd/blob/v1.7.0-rc.2/cmd/ctr/commands/tasks/tasks_unix.go#L43-L68
-func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
+func HandleConsoleResize(ctx context.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console
 	size, err := con.Size()
 	if err != nil {

--- a/pkg/consoleutil/consoleutil_windows.go
+++ b/pkg/consoleutil/consoleutil_windows.go
@@ -17,7 +17,7 @@
 package consoleutil
 
 import (
-	gocontext "context"
+	"context"
 	"time"
 
 	"github.com/containerd/console"
@@ -26,7 +26,7 @@ import (
 
 // HandleConsoleResize resizes the console.
 // From https://github.com/containerd/containerd/blob/v1.7.0-rc.2/cmd/ctr/commands/tasks/tasks_windows.go#L34-L61
-func HandleConsoleResize(ctx gocontext.Context, task resizer, con console.Console) error {
+func HandleConsoleResize(ctx context.Context, task resizer, con console.Console) error {
 	// do an initial resize of the console
 	size, err := con.Size()
 	if err != nil {

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -17,7 +17,7 @@
 package defaults
 
 import (
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 )
 
 const (
@@ -32,11 +32,11 @@ func DataRoot() string {
 
 func CNIPath() string {
 	// default: /opt/cni/bin
-	return gocni.DefaultCNIDir
+	return cni.DefaultCNIDir
 }
 
 func CNINetConfPath() string {
-	return gocni.DefaultNetDir
+	return cni.DefaultNetDir
 }
 
 func CNIRuntimeDir() string {

--- a/pkg/defaults/defaults_linux.go
+++ b/pkg/defaults/defaults_linux.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/containerd/containerd/v2/plugins"
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -48,7 +48,7 @@ func DataRoot() string {
 
 func CNIPath() string {
 	candidates := []string{
-		gocni.DefaultCNIDir, // /opt/cni/bin
+		cni.DefaultCNIDir, // /opt/cni/bin
 		"/usr/local/libexec/cni",
 		"/usr/local/lib/cni",
 		"/usr/libexec/cni", // Fedora
@@ -74,12 +74,12 @@ func CNIPath() string {
 	}
 
 	// default: /opt/cni/bin
-	return gocni.DefaultCNIDir
+	return cni.DefaultCNIDir
 }
 
 func CNINetConfPath() string {
 	if !rootlessutil.IsRootless() {
-		return gocni.DefaultNetDir
+		return cni.DefaultNetDir
 	}
 	xch, err := rootlessutil.XDGConfigHome()
 	if err != nil {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -54,7 +54,7 @@ const (
 	// Currently, the length of the slice must be 1.
 	Networks = Prefix + "networks"
 
-	// Ports is a JSON-marshalled string of []gocni.PortMapping .
+	// Ports is a JSON-marshalled string of []cni.PortMapping .
 	Ports = Prefix + "ports"
 
 	// IPAddress is the static IP address of the container assigned by the user

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -33,7 +33,7 @@ import (
 	b4nndclient "github.com/rootless-containers/bypass4netns/pkg/api/daemon/client"
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/bypass4netnsutil"
@@ -177,18 +177,18 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath, brid
 		if err != nil {
 			return nil, err
 		}
-		cniOpts := []gocni.Opt{
-			gocni.WithPluginDir([]string{cniPath}),
+		cniOpts := []cni.Opt{
+			cni.WithPluginDir([]string{cniPath}),
 		}
 		var netw *netutil.NetworkConfig
 		for _, netstr := range networks {
 			if netw, err = e.NetworkByNameOrID(netstr); err != nil {
 				return nil, err
 			}
-			cniOpts = append(cniOpts, gocni.WithConfListBytes(netw.Bytes))
+			cniOpts = append(cniOpts, cni.WithConfListBytes(netw.Bytes))
 			o.cniNames = append(o.cniNames, netstr)
 		}
-		o.cni, err = gocni.New(cniOpts...)
+		o.cni, err = cni.New(cniOpts...)
 		if err != nil {
 			return nil, err
 		}
@@ -250,8 +250,8 @@ type handlerOpts struct {
 	state             *specs.State
 	dataStore         string
 	rootfs            string
-	ports             []gocni.PortMapping
-	cni               gocni.CNI
+	ports             []cni.PortMapping
+	cni               cni.CNI
 	cniNames          []string
 	fullID            string
 	rootlessKitClient rlkclient.Client
@@ -322,10 +322,10 @@ func getNetNSPath(state *specs.State) (string, error) {
 	return s, nil
 }
 
-func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
+func getPortMapOpts(opts *handlerOpts) ([]cni.NamespaceOpts, error) {
 	if len(opts.ports) > 0 {
 		if !rootlessutil.IsRootlessChild() {
-			return []gocni.NamespaceOpts{gocni.WithCapabilityPortMap(opts.ports)}, nil
+			return []cni.NamespaceOpts{cni.WithCapabilityPortMap(opts.ports)}, nil
 		}
 		var (
 			childIP                            net.IP
@@ -343,7 +343,7 @@ func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 		//
 		// We must NOT modify opts.ports here, because we use the unmodified opts.ports for
 		// interaction with RootlessKit API.
-		ports := make([]gocni.PortMapping, len(opts.ports))
+		ports := make([]cni.PortMapping, len(opts.ports))
 		for i, p := range opts.ports {
 			if hostIP := net.ParseIP(p.HostIP); hostIP != nil && !hostIP.IsUnspecified() {
 				// loopback address is always bindable in the child namespace, but other addresses are unlikely.
@@ -361,56 +361,56 @@ func getPortMapOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
 			}
 			ports[i] = p
 		}
-		return []gocni.NamespaceOpts{gocni.WithCapabilityPortMap(ports)}, nil
+		return []cni.NamespaceOpts{cni.WithCapabilityPortMap(ports)}, nil
 	}
 	return nil, nil
 }
 
-func getIPAddressOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
+func getIPAddressOpts(opts *handlerOpts) ([]cni.NamespaceOpts, error) {
 	if opts.containerIP != "" {
 		if rootlessutil.IsRootlessChild() {
 			log.L.Debug("container IP assignment is not fully supported in rootless mode. The IP is not accessible from the host (but still accessible from other containers).")
 		}
 
-		return []gocni.NamespaceOpts{
-			gocni.WithLabels(map[string]string{
+		return []cni.NamespaceOpts{
+			cni.WithLabels(map[string]string{
 				// Special tick for go-cni. Because go-cni marks all labels and args as same
 				// So, we need add a special label to pass the containerIP to the host-local plugin.
 				// FYI: https://github.com/containerd/go-cni/blob/v1.1.3/README.md?plain=1#L57-L64
 				"IgnoreUnknown": "1",
 			}),
-			gocni.WithArgs("IP", opts.containerIP),
+			cni.WithArgs("IP", opts.containerIP),
 		}, nil
 	}
 	return nil, nil
 }
 
-func getMACAddressOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
+func getMACAddressOpts(opts *handlerOpts) ([]cni.NamespaceOpts, error) {
 	if opts.containerMAC != "" {
-		return []gocni.NamespaceOpts{
-			gocni.WithLabels(map[string]string{
+		return []cni.NamespaceOpts{
+			cni.WithLabels(map[string]string{
 				// allow loose CNI argument verification
 				// FYI: https://github.com/containernetworking/cni/issues/560
 				"IgnoreUnknown": "1",
 			}),
-			gocni.WithArgs("MAC", opts.containerMAC),
+			cni.WithArgs("MAC", opts.containerMAC),
 		}, nil
 	}
 	return nil, nil
 }
 
-func getIP6AddressOpts(opts *handlerOpts) ([]gocni.NamespaceOpts, error) {
+func getIP6AddressOpts(opts *handlerOpts) ([]cni.NamespaceOpts, error) {
 	if opts.containerIP6 != "" {
 		if rootlessutil.IsRootlessChild() {
 			log.L.Debug("container IP6 assignment is not fully supported in rootless mode. The IP6 is not accessible from the host (but still accessible from other containers).")
 		}
-		return []gocni.NamespaceOpts{
-			gocni.WithLabels(map[string]string{
+		return []cni.NamespaceOpts{
+			cni.WithLabels(map[string]string{
 				// allow loose CNI argument verification
 				// FYI: https://github.com/containernetworking/cni/issues/560
 				"IgnoreUnknown": "1",
 			}),
-			gocni.WithCapability("ips", []string{opts.containerIP6}),
+			cni.WithCapability("ips", []string{opts.containerIP6}),
 		}, nil
 	}
 	return nil, nil
@@ -442,16 +442,16 @@ func applyNetworkSettings(opts *handlerOpts) error {
 	if err != nil {
 		return err
 	}
-	var namespaceOpts []gocni.NamespaceOpts
+	var namespaceOpts []cni.NamespaceOpts
 	namespaceOpts = append(namespaceOpts, portMapOpts...)
 	namespaceOpts = append(namespaceOpts, ipAddressOpts...)
 	namespaceOpts = append(namespaceOpts, macAddressOpts...)
 	namespaceOpts = append(namespaceOpts, ip6AddressOpts...)
 	namespaceOpts = append(namespaceOpts,
-		gocni.WithLabels(map[string]string{
+		cni.WithLabels(map[string]string{
 			"IgnoreUnknown": "1",
 		}),
-		gocni.WithArgs("NERDCTL_CNI_DHCP_HOSTNAME", opts.state.Annotations[labels.Hostname]),
+		cni.WithArgs("NERDCTL_CNI_DHCP_HOSTNAME", opts.state.Annotations[labels.Hostname]),
 	)
 	hsMeta := hostsstore.Meta{
 		ID:         opts.state.ID,
@@ -610,7 +610,7 @@ func onPostStop(opts *handlerOpts) error {
 		if err != nil {
 			return err
 		}
-		var namespaceOpts []gocni.NamespaceOpts
+		var namespaceOpts []cni.NamespaceOpts
 		namespaceOpts = append(namespaceOpts, portMapOpts...)
 		namespaceOpts = append(namespaceOpts, ipAddressOpts...)
 		namespaceOpts = append(namespaceOpts, macAddressOpts...)

--- a/pkg/ocihook/rootless_linux.go
+++ b/pkg/ocihook/rootless_linux.go
@@ -21,12 +21,12 @@ import (
 
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {
+func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []cni.PortMapping) error {
 	pm, err := rootlessutil.NewRootlessCNIPortManager(rlkClient)
 	if err != nil {
 		return err
@@ -40,7 +40,7 @@ func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports 
 	return nil
 }
 
-func unexposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {
+func unexposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []cni.PortMapping) error {
 	pm, err := rootlessutil.NewRootlessCNIPortManager(rlkClient)
 	if err != nil {
 		return err

--- a/pkg/ocihook/rootless_other.go
+++ b/pkg/ocihook/rootless_other.go
@@ -24,13 +24,13 @@ import (
 
 	rlkclient "github.com/rootless-containers/rootlesskit/v2/pkg/api/client"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 )
 
-func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {
+func exposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []cni.PortMapping) error {
 	return fmt.Errorf("cannot expose ports rootlessly on non-Linux hosts")
 }
 
-func unexposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []gocni.PortMapping) error {
+func unexposePortsRootless(ctx context.Context, rlkClient rlkclient.Client, ports []cni.PortMapping) error {
 	return fmt.Errorf("cannot unexpose ports rootlessly on non-Linux hosts")
 }

--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/docker/go-connections/nat"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/labels"
@@ -50,7 +50,7 @@ func splitParts(rawport string) (string, string, string) {
 
 // ParseFlagP parse port mapping pair, like "127.0.0.1:3000:8080/tcp",
 // "127.0.0.1:3000-3001:8080-8081/tcp" and "3000:8080" ...
-func ParseFlagP(s string) ([]gocni.PortMapping, error) {
+func ParseFlagP(s string) ([]cni.PortMapping, error) {
 	proto := "tcp"
 	splitBySlash := strings.Split(s, "/")
 	switch len(splitBySlash) {
@@ -67,11 +67,11 @@ func ParseFlagP(s string) ([]gocni.PortMapping, error) {
 		return nil, fmt.Errorf("failed to parse %q, unexpected slashes", s)
 	}
 
-	res := gocni.PortMapping{
+	res := cni.PortMapping{
 		Protocol: proto,
 	}
 
-	mr := []gocni.PortMapping{}
+	mr := []cni.PortMapping{}
 
 	ip, hostPort, containerPort := splitParts(splitBySlash[0])
 
@@ -130,13 +130,13 @@ func ParseFlagP(s string) ([]gocni.PortMapping, error) {
 }
 
 // ParsePortsLabel parses JSON-marshalled string from label map
-// (under `labels.Ports` key) and returns []gocni.PortMapping.
-func ParsePortsLabel(labelMap map[string]string) ([]gocni.PortMapping, error) {
+// (under `labels.Ports` key) and returns []cni.PortMapping.
+func ParsePortsLabel(labelMap map[string]string) ([]cni.PortMapping, error) {
 	portsJSON := labelMap[labels.Ports]
 	if portsJSON == "" {
-		return []gocni.PortMapping{}, nil
+		return []cni.PortMapping{}, nil
 	}
-	var ports []gocni.PortMapping
+	var ports []cni.PortMapping
 	if err := json.Unmarshal([]byte(portsJSON), &ports); err != nil {
 		return nil, fmt.Errorf("failed to parse label %q=%q: %s", labels.Ports, portsJSON, err.Error())
 	}

--- a/pkg/portutil/portutil_test.go
+++ b/pkg/portutil/portutil_test.go
@@ -22,7 +22,7 @@ import (
 	"sort"
 	"testing"
 
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -38,7 +38,7 @@ func TestTestParseFlagPWithPlatformSpec(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []gocni.PortMapping
+		want    []cni.PortMapping
 		wantErr bool
 	}{
 		{
@@ -46,7 +46,7 @@ func TestTestParseFlagPWithPlatformSpec(t *testing.T) {
 			args: args{
 				s: "3000",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 3000,
@@ -61,7 +61,7 @@ func TestTestParseFlagPWithPlatformSpec(t *testing.T) {
 			args: args{
 				s: "3000-3001",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 3000,
@@ -90,7 +90,7 @@ func TestTestParseFlagPWithPlatformSpec(t *testing.T) {
 			args: args{
 				s: "3000-3001/tcp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 3000,
@@ -111,7 +111,7 @@ func TestTestParseFlagPWithPlatformSpec(t *testing.T) {
 			args: args{
 				s: "3000-3001/udp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 3000,
@@ -168,7 +168,7 @@ func TestParsePortsLabel(t *testing.T) {
 	tests := []struct {
 		name     string
 		labelMap map[string]string
-		want     []gocni.PortMapping
+		want     []cni.PortMapping
 		wantErr  bool
 	}{
 		{
@@ -176,7 +176,7 @@ func TestParsePortsLabel(t *testing.T) {
 			labelMap: map[string]string{
 				labels.Ports: "[{\"HostPort\":12345,\"ContainerPort\":10000,\"Protocol\":\"tcp\",\"HostIP\":\"0.0.0.0\"}]",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -191,13 +191,13 @@ func TestParsePortsLabel(t *testing.T) {
 			labelMap: map[string]string{
 				labels.Ports: "",
 			},
-			want:    []gocni.PortMapping{},
+			want:    []cni.PortMapping{},
 			wantErr: false,
 		},
 		{
 			name:     "empty ports (key not exists)",
 			labelMap: map[string]string{},
-			want:     []gocni.PortMapping{},
+			want:     []cni.PortMapping{},
 			wantErr:  false,
 		},
 		{
@@ -251,7 +251,7 @@ func TestParseFlagP(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    []gocni.PortMapping
+		want    []cni.PortMapping
 		wantErr bool
 	}{
 		{
@@ -259,7 +259,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "127.0.0.1:3000:8080/tcp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -274,7 +274,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "127.0.0.1:3000-3001:8080-8081/tcp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -303,7 +303,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "3000:8080/tcp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -318,7 +318,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "3000:8080",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -333,7 +333,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "3000:8080/udp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -348,7 +348,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "3000:8080/sctp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      3000,
 					ContainerPort: 8080,
@@ -363,7 +363,7 @@ func TestParseFlagP(t *testing.T) {
 			args: args{
 				s: "[::0]:8080:80/tcp",
 			},
-			want: []gocni.PortMapping{
+			want: []cni.PortMapping{
 				{
 					HostPort:      8080,
 					ContainerPort: 80,

--- a/pkg/rootlessutil/port_linux.go
+++ b/pkg/rootlessutil/port_linux.go
@@ -24,7 +24,7 @@ import (
 	"github.com/rootless-containers/rootlesskit/v2/pkg/port"
 
 	"github.com/containerd/errdefs"
-	gocni "github.com/containerd/go-cni"
+	"github.com/containerd/go-cni"
 )
 
 func NewRootlessCNIPortManager(client client.Client) (*RootlessCNIPortManager, error) {
@@ -41,7 +41,7 @@ type RootlessCNIPortManager struct {
 	client.Client
 }
 
-func (rlcpm *RootlessCNIPortManager) ExposePort(ctx context.Context, cpm gocni.PortMapping) error {
+func (rlcpm *RootlessCNIPortManager) ExposePort(ctx context.Context, cpm cni.PortMapping) error {
 	// NOTE: When `nerdctl run -p 8080:80` is being launched, cpm.HostPort is set to 8080 and cpm.ContainerPort is set to 80.
 	// We want to forward the port 8080 of the parent namespace into the port 8080 of the child namespace (which is the "host"
 	// from the point of view of CNI). So we do NOT set sp.ChildPort to cpm.ContainerPort here.
@@ -55,7 +55,7 @@ func (rlcpm *RootlessCNIPortManager) ExposePort(ctx context.Context, cpm gocni.P
 	return err
 }
 
-func (rlcpm *RootlessCNIPortManager) UnexposePort(ctx context.Context, cpm gocni.PortMapping) error {
+func (rlcpm *RootlessCNIPortManager) UnexposePort(ctx context.Context, cpm cni.PortMapping) error {
 	pm := rlcpm.Client.PortManager()
 	ports, err := pm.ListPorts(ctx)
 	if err != nil {

--- a/pkg/signalutil/signals.go
+++ b/pkg/signalutil/signals.go
@@ -17,7 +17,7 @@
 package signalutil
 
 import (
-	gocontext "context"
+	"context"
 	"os"
 	"os/signal"
 	"syscall"
@@ -29,12 +29,12 @@ import (
 
 // killer is from https://github.com/containerd/containerd/blob/v1.7.0-rc.2/cmd/ctr/commands/signals.go#L30-L32
 type killer interface {
-	Kill(gocontext.Context, syscall.Signal, ...containerd.KillOpts) error
+	Kill(context.Context, syscall.Signal, ...containerd.KillOpts) error
 }
 
 // ForwardAllSignals forwards signals.
 // From https://github.com/containerd/containerd/blob/v1.7.0-rc.2/cmd/ctr/commands/signals.go#L34-L55
-func ForwardAllSignals(ctx gocontext.Context, task killer) chan os.Signal {
+func ForwardAllSignals(ctx context.Context, task killer) chan os.Signal {
 	sigc := make(chan os.Signal, 128)
 	signal.Notify(sigc)
 	go func() {


### PR DESCRIPTION
Suggesting we remove spurious prefixes for imports that make reading code more confusing than necessary:
- remove `gocni`, and use the expected `cni`
- remove `gocontext`, and use the expected `context`