### PR TITLE
Chore: spurious helpers test cleanup

### DIFF
--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -19,6 +19,8 @@ package image
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -26,7 +28,6 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -144,7 +145,9 @@ LABEL foo=bar
 LABEL version=0.1
 RUN echo "actually creating a layer so that docker sets the createdAt time"
 `, testutil.CommonImage)
-			buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+			buildCtx := data.TempDir()
+			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+			assert.NilError(helpers.T(), err)
 			data.Set("buildCtx", buildCtx)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -290,7 +293,9 @@ func TestImagesFilterDangling(t *testing.T) {
 			dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-notag-string"]
 	`, testutil.CommonImage)
-			buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+			buildCtx := data.TempDir()
+			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+			assert.NilError(helpers.T(), err)
 			data.Set("buildCtx", buildCtx)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -18,13 +18,14 @@ package image
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"gotest.tools/v3/assert"
 
-	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
@@ -61,7 +62,9 @@ func TestImagePrune(t *testing.T) {
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
 
-				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+				buildCtx := data.TempDir()
+				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", buildCtx)
 				// After we rebuild with tag, docker will no longer show the <none> version from above
 				// Swapping order does not change anything.
@@ -107,7 +110,9 @@ func TestImagePrune(t *testing.T) {
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
 
-				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+				buildCtx := data.TempDir()
+				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", buildCtx)
 				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
@@ -149,7 +154,9 @@ func TestImagePrune(t *testing.T) {
 CMD ["echo", "nerdctl-test-image-prune-filter-label"]
 LABEL foo=bar
 LABEL version=0.1`, testutil.CommonImage)
-				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+				buildCtx := data.TempDir()
+				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())
@@ -187,7 +194,9 @@ LABEL version=0.1`, testutil.CommonImage)
 				dockerfile := fmt.Sprintf(`FROM %s
 RUN echo "Anything, so that we create actual content for docker to set the current time for CreatedAt"
 CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
-				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+				buildCtx := data.TempDir()
+				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -18,6 +18,8 @@ package image
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -56,7 +58,9 @@ func TestImagePullWithCosign(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-			buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+			buildCtx := data.TempDir()
+			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+			assert.NilError(helpers.T(), err)
 			helpers.Ensure("build", "-t", testImageRef+":one", buildCtx)
 			helpers.Ensure("build", "-t", testImageRef+":two", buildCtx)
 			helpers.Ensure("push", "--sign=cosign", "--cosign-key="+keyPair.PrivateKey, testImageRef+":one")
@@ -120,7 +124,9 @@ func TestImagePullPlainHttpWithDefaultPort(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-			buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+			buildCtx := data.TempDir()
+			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+			assert.NilError(helpers.T(), err)
 			helpers.Ensure("build", "-t", testImageRef, buildCtx)
 			helpers.Ensure("--insecure-registry", "push", testImageRef)
 			helpers.Ensure("rmi", "-f", testImageRef)

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -18,6 +18,8 @@ package ipfs
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -25,7 +27,6 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
@@ -132,7 +133,9 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 CMD ["echo", "nerdctl-build-test-string"]
 	`, data.Get(ipfsImageURLKey))
 
-				buildCtx := testhelpers.CreateBuildContext(t, dockerfile)
+				buildCtx := data.TempDir()
+				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
+				assert.NilError(helpers.T(), err)
 
 				helpers.Ensure("build", "-t", data.Identifier("built-image"), buildCtx)
 			},


### PR DESCRIPTION
Remove dependency on misplaced helper CreateBuildContext  for next-gen tests (use data.TempDir(), assert in the test).