### PR TITLE
CI: go install action

### DIFF
--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -64,7 +64,10 @@ runs:
       with:
         go-version: ${{ env.GO_VERSION }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
-        cache: true
+        # See https://github.com/containerd/nerdctl/issues/3733
+        # GitHub cache is very limited. We currently depend on it for the (more important) build dependencies caching.
+        # Disabling this here will slow down the setup a bit.
+        cache: false
     - name: "Cleanup go version string"
       shell: bash
       # Remove possible trailing .x

--- a/.github/actions/install-go/action.yml
+++ b/.github/actions/install-go/action.yml
@@ -1,0 +1,72 @@
+name: "Go install"
+description: "This action will install go (currently supported version by default). Operator may optionally require the `strategy` input:
+ - 'canary', for the latest RC/beta
+ - 'latest-stable', for the latest patch release for the currently supported version (this is normally the default, unless nerdctl is lagging)
+ - 'old-stable' for the latest patch release of the minimum minor go version nerdctl is supporting"
+inputs:
+  cache-dependency-path:
+    description: 'Used to specify the path to a dependency file - go.sum'
+  strategy:
+    default: ""
+    description: "You may set this to `canary`, `latest-stable`, or `old-stable`. Otherwise defauls to the explicitly supported version."
+  # These below are technically not input variables (that we expect people to specific or change).
+  # We are just abusing the system here for convenience, since a composite action does not let you define env.
+  # This here is the one, central location where we would update go versions when there is a newly supported go version.
+  _current:
+    default: "1.23.4"
+    description: "What we consider the current blessed go version (typically the latest patch release of the last major.minor version)"
+  _stable:
+    default: "1.23.x"
+    description: "The latest major.minor version we support"
+  _old_stable:
+    default: "1.22.x"
+    description: "The minimum major.minor go version that we still support"
+
+runs:
+  using: composite
+  steps:
+    - name: "Set GO_VERSION environment variable from user strategy"
+      shell: bash
+      run: |
+        golang::canary(){
+          # Enable extended globbing features to use advanced pattern matching
+          shopt -s extglob
+          # Get latest golang version and split it in components
+          norm=()
+          while read -r line; do
+            line_trimmed="${line//+([[:space:]])/}"
+            norm+=("$line_trimmed")
+          done < \
+            <(sed -E 's/^go([0-9]+)[.]([0-9]+)([.]([0-9]+))?(([a-z]+)([0-9]+))?/\1.\2\n\4\n\6\n\7/i' \
+              <(curl -fsSL "https://go.dev/dl/?mode=json&include=all" | jq -rc .[0].version) \
+            )
+          # Serialize version, making sure we have a patch version, and separate possible rcX into .rc-X
+          [ "${norm[1]}" != "" ] || norm[1]="0"
+          norm[1]=".${norm[1]}"
+          [ "${norm[2]}" == "" ] || norm[2]="-${norm[2]}"
+          [ "${norm[3]}" == "" ] || norm[3]=".${norm[3]}"
+          # Save it
+          IFS=
+          echo "GO_VERSION=${norm[*]}" >> "$GITHUB_ENV"
+        }
+
+        if [ "${{ inputs.strategy }}" == "canary" ]; then
+          golang::canary
+        elif [ "${{ inputs.strategy }}" == "latest-stable" ]; then
+          echo "GO_VERSION=${{ inputs._stable }}" >> "$GITHUB_ENV"
+        elif [ "${{ inputs.strategy }}" == "old-stable" ]; then
+          echo "GO_VERSION=${{ inputs._old_stable }}" >> "$GITHUB_ENV"
+        else
+          echo "GO_VERSION=${{ inputs._current }}" >> "$GITHUB_ENV"
+        fi
+    - name: "Setup Go"
+      uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        cache: true
+    - name: "Cleanup go version string"
+      shell: bash
+      # Remove possible trailing .x
+      run: |
+        echo "GO_VERSION=${GO_VERSION%.x*}" >> "$GITHUB_ENV"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,10 @@ on:
       - 'release/**'
   pull_request:
 
-env:
-  GO_VERSION: 1.23.x
-
 jobs:
   go:
     timeout-minutes: 5
-    name: "go | ${{ matrix.goos }} | ${{ matrix.canary }}"
+    name: "go | ${{ matrix.goos }} | ${{ matrix.goversion }}"
     runs-on: "${{ matrix.os }}"
     defaults:
       run:
@@ -23,33 +20,28 @@ jobs:
         include:
           - os: ubuntu-24.04
             goos: linux
+            goversion: latest-stable
           - os: ubuntu-24.04
             goos: freebsd
+            goversion: latest-stable
           # FIXME: this is currently failing in a non-sensical way, so, running on linux instead...
           # - os: windows-2022
           - os: ubuntu-24.04
             goos: windows
+            goversion: latest-stable
           - os: ubuntu-24.04
             goos: linux
-            # This allows the canary script to select any upcoming golang alpha/beta/RC
-            canary: go-canary
+            goversion: canary
     env:
       GOOS: "${{ matrix.goos }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - name: Set GO env
-        run: |
-          # If canary is specified, get the latest available golang pre-release instead of the major version
-          if [ "$canary" != "" ]; then
-            . ./hack/build-integration-canary.sh
-            canary::golang::latest
-          fi
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - name: "Install go"
+        uses: ./.github/actions/install-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+          strategy: ${{ matrix.goversion }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@774c35bcccffb734694af9e921f12f57d882ef74  # v6.1.1
         with:
@@ -62,10 +54,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - name: "Install go"
+        uses: ./.github/actions/install-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+          strategy: latest-stable
       - name: yaml
         run: make lint-yaml
       - name: shell

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -17,14 +17,12 @@ jobs:
         with:
           path: src/github.com/containerd/nerdctl
           fetch-depth: 100
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - uses: ./src/github.com/containerd/nerdctl/.github/actions/install-go
         with:
-          go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: src/github.com/containerd/nerdctl
       - uses: containerd/project-checks@434a07157608eeaa1d5c8d4dd506154204cd9401  # v1.1.0
         with:
           working-directory: src/github.com/containerd/nerdctl
-          repo-access-token: ${{ secrets.GITHUB_TOKEN }}
       - run: ./hack/verify-no-patent.sh
         working-directory: src/github.com/containerd/nerdctl
       - run: ./hack/verify-pkg-isolation.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     timeout-minutes: 40
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
-      with:
-        go-version: 1.23.x
+    - name: "Install golang"
+      uses: ./.github/actions/install-go
+      strategy: latest-stable
     - name: "Compile binaries"
       run: make artifacts
     - name: "SHA256SUMS"

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - name: Set GO env
+      - name: Set Containerd version
         run: |
           # Get latest containerd
           args=(curl --proto '=https' --tlsv1.2 -fsSL -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
@@ -67,13 +67,10 @@ jobs:
           } || args+=(-H "Authorization: Bearer $GITHUB_TOKEN")
           ctd_v="$("${args[@]}" https://api.github.com/repos/containerd/containerd/tags | jq -rc .[0].name)"
           echo "CONTAINERD_VERSION=${ctd_v:1}" >> "$GITHUB_ENV"
-
-          . ./hack/build-integration-canary.sh
-          canary::golang::latest
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - name: "Install go"
+        uses: ./.github/actions/install-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+          strategy: canary
       - run: go install ./cmd/nerdctl
       - run: go install -v gotest.tools/gotestsum@v1
       # This here is solely to get the cni install script, which has not been modified in 3+ years.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
       - '**.md'
 
 env:
-  GO_VERSION: 1.23.x
   SHORT_TIMEOUT: 5
   LONG_TIMEOUT: 60
 
@@ -76,10 +75,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - name: "Install go"
+        uses: ./.github/actions/install-go
         with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+          strategy: latest-stable
       - if: ${{ matrix.goos=='windows' }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -310,17 +309,17 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        go-version: ["1.22.x", "1.23.x"]
+        go-version: ["old-stable", "latest-stable"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
+      - name: "Install go"
+        uses: ./.github/actions/install-go
         with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
+          strategy: ${{ matrix.go-version }}
       - name: "build"
-        run: GO_VERSION="$(echo ${{ matrix.go-version }} | sed -e s/.x//)" make binaries
+        run: make binaries
 
   test-integration-docker-compatibility:
     timeout-minutes: 30
@@ -330,10 +329,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+      - name: "Install go"
+        uses: ./.github/actions/install-go
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
           # `--install all` will only install emulation for architectures that cannot be natively executed
@@ -365,10 +362,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a  # v5.2.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
+      - name: "Install go"
+        uses: ./.github/actions/install-go
       - run: go install ./cmd/nerdctl
       - run: go install -v gotest.tools/gotestsum@v1
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/hack/build-integration-canary.sh
+++ b/hack/build-integration-canary.sh
@@ -322,27 +322,3 @@ canary::golang::hublatest(){
 
   printf "%s" "$available_version"
 }
-
-canary::golang::latest(){
-  # Enable extended globbing features to use advanced pattern matching
-  shopt -s extglob
-
-  # Get latest golang version and split it in components
-  norm=()
-  while read -r line; do
-    line_trimmed="${line//+([[:space:]])/}"
-    norm+=("$line_trimmed")
-  done < \
-    <(sed -E 's/^go([0-9]+)[.]([0-9]+)([.]([0-9]+))?(([a-z]+)([0-9]+))?/\1.\2\n\4\n\6\n\7/i' \
-      <(curl -fsSL "https://go.dev/dl/?mode=json&include=all" | jq -rc .[0].version) \
-    )
-
-  # Serialize version, making sure we have a patch version, and separate possible rcX into .rc-X
-  [ "${norm[1]}" != "" ] || norm[1]="0"
-  norm[1]=".${norm[1]}"
-  [ "${norm[2]}" == "" ] || norm[2]="-${norm[2]}"
-  [ "${norm[3]}" == "" ] || norm[3]=".${norm[3]}"
-  # Save it
-  IFS=
-  echo "GO_VERSION=${norm[*]}" >> "$GITHUB_ENV"
-}


### PR DESCRIPTION
Currently, we carry GO_VERSION around in a bunch of files, along with calls to `actions/setup-go`, which also comes with it pinned version.

This here suggests we centralize all of that inside a new, in-tree github action that also bundles in the logic for canary and simplify pulling go for the consumer:
- default strategy is to get the explicitly pinned go version (currently 1.23.4)
- `strategy latest-stable` will retrieve the latest patch for the main go version (eg: 1.23.x)
- `strategy old-stable` will retrieve the latest patch for the previous go version (eg: 1.22.x)
- `strategy canary` will retrieve the latest RC
 
That should clean-up our CI files a tad, and allow for much simpler / centralized maintenance, and also better control over usage of cache.