### PR TITLE
Relax error on network annotation read failure

### DIFF
--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -143,7 +143,8 @@ func cleanupNetwork(ctx context.Context, container containerd.Container, globalO
 		networksJSON := spec.Annotations[labels.Networks]
 		var networks []string
 		if err := json.Unmarshal([]byte(networksJSON), &networks); err != nil {
-			return err
+			log.G(ctx).WithError(err).WithField("container", container.ID()).Infof("unable to retrieve networking information for that container")
+			return nil
 		}
 		netType, err := nettype.Detect(networks)
 		if err != nil {

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -191,19 +191,18 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		}
 
 		netOpts, err := containerutil.NetworkOptionsFromSpec(spec)
-		if err != nil {
-			retErr = fmt.Errorf("failed to load container networking options from specs: %s", err)
-			return
-		}
+		if err == nil {
+			networkManager, err := containerutil.NewNetworkingOptionsManager(globalOptions, netOpts, client)
+			if err != nil {
+				retErr = fmt.Errorf("failed to instantiate network options manager: %s", err)
+				return
+			}
 
-		networkManager, err := containerutil.NewNetworkingOptionsManager(globalOptions, netOpts, client)
-		if err != nil {
-			retErr = fmt.Errorf("failed to instantiate network options manager: %s", err)
-			return
-		}
-
-		if err := networkManager.CleanupNetworking(ctx, c); err != nil {
-			log.G(ctx).WithError(err).Warnf("failed to clean up container networking: %q", id)
+			if err := networkManager.CleanupNetworking(ctx, c); err != nil {
+				log.G(ctx).WithError(err).Warnf("failed to clean up container networking: %q", id)
+			}
+		} else {
+			log.G(ctx).WithError(err).WithField("container", id).Infof("unable to retrieve networking information for that container")
 		}
 
 		// Delete the container now. If it fails, try again without snapshot cleanup


### PR DESCRIPTION
Fix #3765

Killing or stopping a container that does not have a nerdctl network annotation is currently a hard fail.

Suggesting we change that to a soft error, warning the user that they are (very likely) doing something that will lead to trouble (eg: managing containers with different tools).

@mathias-ioki I you can test this patch and confirm it fixes your issue, that would be really helpful (I am reading tea-leaves here).