### PR TITLE
Fix pull image process output from stderr to stdout

### DIFF
--- a/cmd/nerdctl/image/image_pull.go
+++ b/cmd/nerdctl/image/image_pull.go
@@ -129,8 +129,9 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 		RFlags: types.RemoteSnapshotterFlags{
 			SociIndexDigest: sociIndexDigest,
 		},
-		Stdout: cmd.OutOrStdout(),
-		Stderr: cmd.OutOrStderr(),
+		Stdout:                 cmd.OutOrStdout(),
+		Stderr:                 cmd.OutOrStderr(),
+		ProgressOutputToStdout: true,
 	}, nil
 }
 

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -236,3 +236,36 @@ func TestImagePullSoci(t *testing.T) {
 
 	testCase.Run(t)
 }
+
+func TestImagePullProcessOutput(t *testing.T) {
+	nerdtest.Setup()
+
+	testCase := &test.Case{
+		SubTests: []*test.Case{
+			{
+				Description: "Pull Image - output should be in stdout",
+				NoParallel:  true,
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rmi", "-f", testutil.BusyboxImage)
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					return helpers.Command("pull", testutil.BusyboxImage)
+				},
+				Expected: test.Expects(0, nil, test.Contains(testutil.BusyboxImage)),
+			},
+			{
+				Description: "Run Container with image pull - output should be in stderr",
+				NoParallel:  true,
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rmi", "-f", testutil.BusyboxImage)
+				},
+				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+					return helpers.Command("run", "--rm", testutil.BusyboxImage)
+				},
+				Expected: test.Expects(0, nil, test.DoesNotContain(testutil.BusyboxImage)),
+			},
+		},
+	}
+
+	testCase.Run(t)
+}

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -189,8 +189,11 @@ type RemoteSnapshotterFlags struct {
 
 // ImagePullOptions specifies options for `nerdctl (image) pull`.
 type ImagePullOptions struct {
-	Stdout        io.Writer
-	Stderr        io.Writer
+	Stdout io.Writer
+	Stderr io.Writer
+	// ProgressOutputToStdout directs progress output to stdout instead of stderr
+	ProgressOutputToStdout bool
+
 	GOptions      GlobalCommandOptions
 	VerifyOptions ImageVerifyOptions
 	// Unpack the image for the current single platform.

--- a/pkg/imgutil/imgutil.go
+++ b/pkg/imgutil/imgutil.go
@@ -207,6 +207,9 @@ func PullImage(ctx context.Context, client *containerd.Client, resolver remotes.
 	}
 	if !options.Quiet {
 		config.ProgressOutput = options.Stderr
+		if options.ProgressOutputToStdout {
+			config.ProgressOutput = options.Stdout
+		}
 	}
 
 	// unpack(B) if given 1 platform unless specified by `unpack`


### PR DESCRIPTION
Fix pull image process output by changing the output stream from stderr to stdout

fix: #3395 
fix: #3772