### PR TITLE
update:fix update pids-limit=0 error

### DIFF
--- a/cmd/nerdctl/container/container_update.go
+++ b/cmd/nerdctl/container/container_update.go
@@ -266,16 +266,18 @@ func updateContainer(ctx context.Context, client *containerd.Client, id string, 
 		if spec.Linux.Resources == nil {
 			spec.Linux.Resources = &runtimespec.LinuxResources{}
 		}
-		if spec.Linux.Resources.BlockIO == nil {
-			spec.Linux.Resources.BlockIO = &runtimespec.LinuxBlockIO{}
-		}
 		if cmd.Flags().Changed("blkio-weight") {
+			if spec.Linux.Resources.BlockIO == nil {
+				spec.Linux.Resources.BlockIO = &runtimespec.LinuxBlockIO{}
+			}
 			if spec.Linux.Resources.BlockIO.Weight != &opts.BlkioWeight {
 				spec.Linux.Resources.BlockIO.Weight = &opts.BlkioWeight
 			}
 		}
-		if spec.Linux.Resources.CPU == nil {
-			spec.Linux.Resources.CPU = &runtimespec.LinuxCPU{}
+		if cmd.Flags().Changed("cpu-shares") || cmd.Flags().Changed("cpu-quota") || cmd.Flags().Changed("cpu-period") || cmd.Flags().Changed("cpus") || cmd.Flags().Changed("cpuset-mems") || cmd.Flags().Changed("cpuset-cpus") {
+			if spec.Linux.Resources.CPU == nil {
+				spec.Linux.Resources.CPU = &runtimespec.LinuxCPU{}
+			}
 		}
 		if cmd.Flags().Changed("cpu-shares") {
 			if spec.Linux.Resources.CPU.Shares != &opts.CPUShares {
@@ -308,8 +310,10 @@ func updateContainer(ctx context.Context, client *containerd.Client, id string, 
 				spec.Linux.Resources.CPU.Cpus = opts.CpusetCpus
 			}
 		}
-		if spec.Linux.Resources.Memory == nil {
-			spec.Linux.Resources.Memory = &runtimespec.LinuxMemory{}
+		if cmd.Flags().Changed("memory") || cmd.Flags().Changed("memory-reservation") {
+			if spec.Linux.Resources.Memory == nil {
+				spec.Linux.Resources.Memory = &runtimespec.LinuxMemory{}
+			}
 		}
 		if cmd.Flags().Changed("memory") {
 			if spec.Linux.Resources.Memory.Limit != &opts.MemoryLimitInBytes {
@@ -324,10 +328,10 @@ func updateContainer(ctx context.Context, client *containerd.Client, id string, 
 				spec.Linux.Resources.Memory.Reservation = &opts.MemoryReservation
 			}
 		}
-		if spec.Linux.Resources.Pids == nil {
-			spec.Linux.Resources.Pids = &runtimespec.LinuxPids{}
-		}
 		if cmd.Flags().Changed("pids-limit") {
+			if spec.Linux.Resources.Pids == nil {
+				spec.Linux.Resources.Pids = &runtimespec.LinuxPids{}
+			}
 			if spec.Linux.Resources.Pids.Limit != opts.PidsLimit {
 				spec.Linux.Resources.Pids.Limit = opts.PidsLimit
 			}


### PR DESCRIPTION
when try  nerdctl  -n k8s.io update --cpuset-cpus 0-2 ffe
this code 
https://github.com/containerd/nerdctl/blob/c41b394dc2aa8dd05c81f3938a333f25c4076c57/cmd/nerdctl/container/container_update.go#L327-L329
will make  spec.Linux.Resources.Pids =0 it will not work on rust-shim(will cause rshim set pidlimit=0 goshim works well.).
https://github.com/containerd/rust-extensions
will cause 
```
./nerdctl  -n k8s.io  exec  ffe  date
FATA[0000] Others("Other: OCI runtime exec failed: exec failed: unable to start container process: read init-p: connection reset by peer"): unknown

runc log 
runtime/cgo: pthread_create failed: Resource temporarily unavailable

SIGABRT: abort

PC=0x7f128ec969cf m=0 sigcode=18446744073709551610
```

