### PR TITLE
Fix image inspect exit code on image not found error

### DIFF
--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -18,6 +18,8 @@ package image
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"runtime"
 	"strings"
 	"testing"
@@ -60,6 +62,14 @@ func TestImageInspectSimpleCases(t *testing.T) {
 				Description: "typedFormat support (.ID)",
 				Command:     test.Command("image", "inspect", testutil.CommonImage, "--format", "{{.ID}}"),
 				Expected:    test.Expects(0, nil, nil),
+			},
+			{
+				Description: "Error for image not found",
+				Command:     test.Command("image", "inspect", "dne:latest", "dne2:latest"),
+				Expected: test.Expects(1, []error{
+					errors.New("no such image: dne:latest"),
+					errors.New("no such image: dne2:latest"),
+				}, nil),
 			},
 		},
 	}
@@ -171,7 +181,8 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 							for _, id := range []string{"doesnotexist", "doesnotexist:either", "busybox:bogustag"} {
 								cmd := helpers.Command("image", "inspect", id+"@sha256:"+sha)
 								cmd.Run(&test.Expected{
-									Output: test.Equals(""),
+									ExitCode: 1,
+									Errors:   []error{fmt.Errorf("no such image: %s@sha256:%s", id, sha)},
 								})
 							}
 						},
@@ -192,7 +203,8 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 							for _, id := range []string{"∞∞∞∞∞∞∞∞∞∞", "busybox:∞∞∞∞∞∞∞∞∞∞"} {
 								cmd := helpers.Command("image", "inspect", id)
 								cmd.Run(&test.Expected{
-									Output: test.Equals(""),
+									ExitCode: 1,
+									Errors:   []error{fmt.Errorf("invalid reference format: %s", id)},
 								})
 							}
 						},

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -175,11 +175,13 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, data.Get(mainImageCIDKey), data.Identifier("encrypted"))
 				cmd := helpers.Command("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					Output: test.Equals("1\n"),
+					ExitCode: 1,
+					Output:   test.Equals("1\n"),
 				})
 				cmd = helpers.Command("image", "inspect", "--mode=native", "--format={{json (index .Manifest.Layers 0) }}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					Output: test.Contains("org.opencontainers.image.enc.keys.jwe"),
+					ExitCode: 1,
+					Output:   test.Contains("org.opencontainers.image.enc.keys.jwe"),
 				})
 
 				// Push the encrypted image and save the CID


### PR DESCRIPTION
### Issue
Fixes regression inadvertently introduced with https://github.com/containerd/nerdctl/pull/3017 for image inspect command exit code when image does not exist.

### Description
This change updates the image inspect utility function to serialize an array of encountered errors. This aligns with the behavior of `nerdctl inspect`.

### Testing
Adds simple test case for image inspect on images that do not exist.
Required updates to test cases which assumed exit code 0 for image inspects on images that do not exist.