### PR TITLE
Refactor: Encapsulate net opts loading in internalLabels

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -248,7 +248,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	envs = append(envs, "HOSTNAME="+netLabelOpts.Hostname)
 	opts = append(opts, oci.WithEnv(envs))
 
-	internalLabels.LoadNetOpts(netLabelOpts)
+	internalLabels.loadNetOpts(netLabelOpts)
 
 	// NOTE: OCI hooks are currently not supported on Windows so we skip setting them altogether.
 	// The OCI hooks we define (whose logic can be found in pkg/ocihook) primarily
@@ -726,8 +726,8 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 	return containerd.WithAdditionalContainerLabels(m), nil
 }
 
-// LoadNetOpts loads network options into InternalLabels.
-func (il *internalLabels) LoadNetOpts(opts types.NetworkOptions) {
+// loadNetOpts loads network options into InternalLabels.
+func (il *internalLabels) loadNetOpts(opts types.NetworkOptions) {
 	il.hostname = opts.Hostname
 	il.ports = opts.PortMappings
 	il.ipAddress = opts.IPAddress

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -248,13 +248,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	envs = append(envs, "HOSTNAME="+netLabelOpts.Hostname)
 	opts = append(opts, oci.WithEnv(envs))
 
-	// TODO(aznashwan): more formal way to load net opts into internalLabels:
-	internalLabels.hostname = netLabelOpts.Hostname
-	internalLabels.ports = netLabelOpts.PortMappings
-	internalLabels.ipAddress = netLabelOpts.IPAddress
-	internalLabels.ip6Address = netLabelOpts.IP6Address
-	internalLabels.networks = netLabelOpts.NetworkSlice
-	internalLabels.macAddress = netLabelOpts.MACAddress
+	internalLabels.LoadNetOpts(netLabelOpts)
 
 	// NOTE: OCI hooks are currently not supported on Windows so we skip setting them altogether.
 	// The OCI hooks we define (whose logic can be found in pkg/ocihook) primarily
@@ -730,6 +724,16 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 	}
 
 	return containerd.WithAdditionalContainerLabels(m), nil
+}
+
+// LoadNetOpts loads network options into InternalLabels.
+func (il *internalLabels) LoadNetOpts(opts types.NetworkOptions) {
+	il.hostname = opts.Hostname
+	il.ports = opts.PortMappings
+	il.ipAddress = opts.IPAddress
+	il.ip6Address = opts.IP6Address
+	il.networks = opts.NetworkSlice
+	il.macAddress = opts.MACAddress
 }
 
 func dockercompatMounts(mountPoints []*mountutil.Processed) []dockercompat.MountPoint {


### PR DESCRIPTION
### Context
The `create.go` file contained a TODO to formalize the way network 
options are loaded into `internalLabels`. The previous implementation 
manually assigned each field, which made it harder to maintain and extend.

### Solution
- Introduced a new method `LoadNetOpts` in the `internalLabels` struct.
- Encapsulated the logic for loading network options, improving 
  maintainability and extensibility.


### Impact
This change is backward-compatible and does not affect existing functionality.

Signed-off-by: Pedro Aibar <pedroaibarmarco@gmail.com>
