### PR TITLE
update CNI plugins (1.6.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 # Basic deps
 ARG CONTAINERD_VERSION=v2.0.1
 ARG RUNC_VERSION=v1.2.3
-ARG CNI_PLUGINS_VERSION=v1.6.1
+ARG CNI_PLUGINS_VERSION=v1.6.2
 
 # Extra deps: Build
 ARG BUILDKIT_VERSION=v0.18.2
@@ -57,18 +57,18 @@ FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-bookworm AS build-base-debia
 COPY --from=xx / /
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    git \
-    dpkg-dev
+  git \
+  dpkg-dev
 ARG TARGETARCH
 # libbtrfs: for containerd
 # libseccomp: for runc and bypass4netns
 RUN xx-apt-get update -qq && xx-apt-get install -qq --no-install-recommends \
-    binutils \
-    gcc \
-    libc6-dev \
-    libbtrfs-dev \
-    libseccomp-dev \
-    pkg-config
+  binutils \
+  gcc \
+  libc6-dev \
+  libbtrfs-dev \
+  libseccomp-dev \
+  pkg-config
 RUN git config --global advice.detachedHead false
 
 FROM build-base-debian AS build-containerd
@@ -246,12 +246,12 @@ COPY --from=build-full /out /
 FROM ubuntu:${UBUNTU_VERSION} AS base
 # fuse3 is required by stargz snapshotter
 RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
-    apparmor \
-    bash-completion \
-    ca-certificates curl \
-    iproute2 iptables \
-    dbus dbus-user-session systemd systemd-sysv \
-    fuse3
+  apparmor \
+  bash-completion \
+  ca-certificates curl \
+  iproute2 iptables \
+  dbus dbus-user-session systemd systemd-sysv \
+  fuse3
 ARG CONTAINERIZED_SYSTEMD_VERSION
 RUN curl -o /docker-entrypoint.sh -fsSL --proto '=https' --tlsv1.2 https://raw.githubusercontent.com/AkihiroSuda/containerized-systemd/${CONTAINERIZED_SYSTEMD_VERSION}/docker-entrypoint.sh && \
   chmod +x /docker-entrypoint.sh
@@ -278,9 +278,9 @@ FROM base AS test-integration
 ARG DEBIAN_FRONTEND=noninteractive
 # `expect` package contains `unbuffer(1)`, which is used for emulating TTY for testing
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    expect \
-    git \
-    make
+  expect \
+  git \
+  make
 COPY --from=goversion /GOVERSION /GOVERSION
 ARG TARGETARCH
 RUN curl -fsSL --proto '=https' --tlsv1.2 https://golang.org/dl/$(cat /GOVERSION).linux-${TARGETARCH:-amd64}.tar.gz | tar xzvC /usr/local
@@ -325,9 +325,9 @@ FROM test-integration AS test-integration-rootless
 # (`sudo` does not work for this purpose,
 #  OTOH `machinectl shell` can create the session but does not propagate exit code)
 RUN apt-get update -qq && apt-get install -qq --no-install-recommends \
-    uidmap \
-    openssh-server \
-    openssh-client
+  uidmap \
+  openssh-server \
+  openssh-client
 # TODO: update containerized-systemd to enable sshd by default, or allow `systemctl wants <TARGET> ssh` here
 RUN ssh-keygen -q -t rsa -f /root/.ssh/id_rsa -N '' && \
   useradd -m -s /bin/bash rootless && \

--- a/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.6.2
+++ b/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.6.2
@@ -1,0 +1,2 @@
+b8e811578fb66023f90d2e238d80cec3bdfca4b44049af74c374d4fae0f9c090  cni-plugins-linux-amd64-v1.6.2.tgz
+01e0e22acc7f7004e4588c1fe1871cc86d7ab562cd858e1761c4641d89ebfaa4  cni-plugins-linux-arm64-v1.6.2.tgz


### PR DESCRIPTION
https://github.com/containernetworking/plugins/releases/tag/v1.6.2

> (administrative note: release v1.6.1 was somehow double-created in GitHub; v1.6.2 is identical but fixes the duplication.)


Now 1.6.1 only has s390v artifacts and fails our CI:

https://github.com/containernetworking/plugins/releases/tag/v1.6.1

https://github.com/containerd/nerdctl/actions/runs/12641602765/job/35224329459?pr=3796