### PR TITLE
Remove old cni 1.6.1 checksum file

### DIFF
--- a/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.6.1
+++ b/Dockerfile.d/SHA256SUMS.d/cni-plugins-v1.6.1
@@ -1,2 +1,0 @@
-2503ce29ac445715ebe146073f45468153f9e28f45fa173cb060cfd9e735f563  cni-plugins-linux-amd64-v1.6.1.tgz
-f0f440b968ab50ad13d9d42d993ba98ec30b2ec666846f4ef1bddc7646a701cc  cni-plugins-linux-arm64-v1.6.1.tgz


### PR DESCRIPTION
https://github.com/containerd/nerdctl/pull/3797 updated CNI 1.6.1 to 1.6.2, but forgot deleting the old checksum file. This PR deletes that.