### PR TITLE
docs: Fix incorrect parameter description in documentation of nydus

### DIFF
--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -30,7 +30,7 @@ For the list of pre-converted Nydus images, see https://github.com/orgs/dragonfl
 
 Nerdctl supports to convert an OCI image or docker format v2 image to Nydus image by using the `nerdctl image convert` command.
 
-Before the conversion, you should have the `nydus-image` binary installed, which is contained in the ["nydus static package"](https://github.com/dragonflyoss/image-service/releases). You can run the command like `nerdctl image convert --nydus --oci --nydus-image <the_path_of_nydus_image> <source_image> <target_image>` to convert the `<source_image>` to a Nydus image whose tag is `<target_image>`.
+Before the conversion, you should have the `nydus-image` binary installed, which is contained in the ["nydus static package"](https://github.com/dragonflyoss/image-service/releases). You can run the command like `nerdctl image convert --nydus --oci --nydus-builder-path <the_path_of_nydus_image_binary> <source_image> <target_image>` to convert the `<source_image>` to a Nydus image whose tag is `<target_image>`.
 
 By now, the converted Nydus image cannot be run directly. It shoud be unpacked to nydus snapshotter before `nerdctl run`, which is a part of the processing flow of `nerdctl image pull`. So you need to push the converted image to a registry after the conversion and use `nerdctl --snapshotter nydus image pull` to unpack it to the nydus snapshotter before running the image.
 


### PR DESCRIPTION
The _--nydus-image_ parameter flag is not available in the nerdctl image convert command, as indicated by the output of the help command. 
```
bravey@bravey-server:~/community/nerdctl$ sudo nerdctl image convert --help | grep nydus
      --nydus                               Convert an OCI image to Nydus image. Should be used in conjunction with '--oci'
      --nydus-builder-path string           The nydus-image binary path, if unset, search in PATH environment (default "nydus-image")
      --nydus-compressor none               Nydus blob compression algorithm, possible values: none, `lz4_block`, `zstd`, default is `lz4_block` (default "lz4_block")
      --nydus-prefetch-patterns string      The file path pattern list want to prefetch
      --nydus-work-dir string               Work directory path for image conversion, default is the nerdctl data root directory
```
When using the _--nydus-image_ flag, nerdctl returns an error ("FATA"). 
```
bravey@bravey-server:~/community/nerdctl$ sudo nerdctl image convert --nydus --oci --nydus-image /usr/local/bin/nydus-image alpine alpine-nydus
FATA[0000] unknown flag: --nydus-image
```
The correct parameter flag should be _--nydus-builder-path_.
```
bravey@bravey-server:~/community/nerdctl$ sudo nerdctl image convert --nydus --oci --nydus-builder-path /usr/local/bin/nydus-image alpine alpine-nydus
sha256:5f4b783127cd39647b1712f01653f4f085f67798eebac016eca60c6f45bfc222
```
