### PR TITLE
Add HostConfig to `nerdctl inspect` response

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -18,14 +18,18 @@ package container
 
 import (
 	"fmt"
+	"os"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/docker/go-connections/nat"
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
@@ -68,13 +72,12 @@ func TestContainerInspectContainsMounts(t *testing.T) {
 		testutil.NginxAlpineImage).AssertOK()
 
 	inspect := base.InspectContainer(testContainer)
-
 	// convert array to map to get by key of Destination
 	actual := make(map[string]dockercompat.MountPoint)
 	for i := range inspect.Mounts {
 		actual[inspect.Mounts[i].Destination] = inspect.Mounts[i]
 	}
-
+	t.Logf("actual in TestContainerInspectContainsMounts: %+v", actual)
 	const localDriver = "local"
 
 	expected := []struct {
@@ -228,4 +231,235 @@ func TestContainerInspectState(t *testing.T) {
 		})
 	}
 
+}
+
+func TestContainerInspectHostConfig(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+	if rootlessutil.IsRootless() && infoutil.CgroupsVersion() == "1" {
+		t.Skip("test skipped for rootless containers on cgroup v1")
+	}
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	// Run a container with various HostConfig options
+	base.Cmd("run", "-d", "--name", testContainer,
+		"--cpuset-cpus", "0-1",
+		"--cpuset-mems", "0",
+		"--blkio-weight", "500",
+		"--cpu-shares", "1024",
+		"--cpu-quota", "100000",
+		"--group-add", "1000",
+		"--group-add", "2000",
+		"--add-host", "host1:10.0.0.1",
+		"--add-host", "host2:10.0.0.2",
+		"--ipc", "host",
+		"--memory", "512m",
+		"--read-only",
+		"--shm-size", "256m",
+		"--uts", "host",
+		"--sysctl", "net.core.somaxconn=1024",
+		"--runtime", "io.containerd.runc.v2",
+		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	assert.Equal(t, "0-1", inspect.HostConfig.CPUSetCPUs)
+	assert.Equal(t, "0", inspect.HostConfig.CPUSetMems)
+	assert.Equal(t, uint16(500), inspect.HostConfig.BlkioWeight)
+	assert.Equal(t, uint64(1024), inspect.HostConfig.CPUShares)
+	assert.Equal(t, int64(100000), inspect.HostConfig.CPUQuota)
+	assert.Assert(t, slices.Contains(inspect.HostConfig.GroupAdd, "1000"), "Expected '1000' to be in GroupAdd")
+	assert.Assert(t, slices.Contains(inspect.HostConfig.GroupAdd, "2000"), "Expected '2000' to be in GroupAdd")
+	expectedExtraHosts := []string{"host1:10.0.0.1", "host2:10.0.0.2"}
+	assert.DeepEqual(t, expectedExtraHosts, inspect.HostConfig.ExtraHosts)
+	assert.Equal(t, "host", inspect.HostConfig.IpcMode)
+	assert.Equal(t, int64(536870912), inspect.HostConfig.Memory)
+	assert.Equal(t, int64(1073741824), inspect.HostConfig.MemorySwap)
+	assert.Equal(t, true, inspect.HostConfig.ReadonlyRootfs)
+	assert.Equal(t, "host", inspect.HostConfig.UTSMode)
+	assert.Equal(t, int64(268435456), inspect.HostConfig.ShmSize)
+}
+
+func TestContainerInspectHostConfigDefaults(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	var hc hostConfigValues
+
+	// Hostconfig default values differ with Docker.
+	// This is because we directly retrieve the configured values instead of using preset defaults.
+	if testutil.GetTarget() == testutil.Docker {
+		hc.Driver = ""
+		hc.GroupAddSize = 0
+		hc.ShmSize = int64(67108864) // Docker default 64M
+		hc.Runtime = "runc"
+	} else {
+		hc.GroupAddSize = 10
+		hc.Driver = "json-file"
+		hc.ShmSize = int64(0)
+		hc.Runtime = "io.containerd.runc.v2"
+	}
+
+	// Run a container without specifying HostConfig options
+	base.Cmd("run", "-d", "--name", testContainer, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+	t.Logf("HostConfig in TestContainerInspectHostConfigDefaults: %+v", inspect.HostConfig)
+	assert.Equal(t, "", inspect.HostConfig.CPUSetCPUs)
+	assert.Equal(t, "", inspect.HostConfig.CPUSetMems)
+	assert.Equal(t, uint16(0), inspect.HostConfig.BlkioWeight)
+	assert.Equal(t, uint64(0), inspect.HostConfig.CPUShares)
+	assert.Equal(t, int64(0), inspect.HostConfig.CPUQuota)
+	assert.Equal(t, hc.GroupAddSize, len(inspect.HostConfig.GroupAdd))
+	assert.Equal(t, 0, len(inspect.HostConfig.ExtraHosts))
+	assert.Equal(t, "private", inspect.HostConfig.IpcMode)
+	assert.Equal(t, hc.Driver, inspect.HostConfig.LogConfig.Driver)
+	assert.Equal(t, int64(0), inspect.HostConfig.Memory)
+	assert.Equal(t, int64(0), inspect.HostConfig.MemorySwap)
+	assert.Equal(t, bool(false), inspect.HostConfig.OomKillDisable)
+	assert.Equal(t, bool(false), inspect.HostConfig.ReadonlyRootfs)
+	assert.Equal(t, "", inspect.HostConfig.UTSMode)
+	assert.Equal(t, hc.ShmSize, inspect.HostConfig.ShmSize)
+	assert.Equal(t, hc.Runtime, inspect.HostConfig.Runtime)
+	assert.Equal(t, 0, len(inspect.HostConfig.Sysctls))
+	assert.Equal(t, 0, len(inspect.HostConfig.Devices))
+}
+
+func TestContainerInspectHostConfigDNS(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	// Run a container with DNS options
+	base.Cmd("run", "-d", "--name", testContainer,
+		"--dns", "8.8.8.8",
+		"--dns", "1.1.1.1",
+		"--dns-search", "example.com",
+		"--dns-search", "test.local",
+		"--dns-option", "ndots:5",
+		"--dns-option", "timeout:3",
+		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	// Check DNS servers
+	expectedDNSServers := []string{"8.8.8.8", "1.1.1.1"}
+	assert.DeepEqual(t, expectedDNSServers, inspect.HostConfig.DNS)
+
+	// Check DNS search domains
+	expectedDNSSearch := []string{"example.com", "test.local"}
+	assert.DeepEqual(t, expectedDNSSearch, inspect.HostConfig.DNSSearch)
+
+	// Check DNS options
+	expectedDNSOptions := []string{"ndots:5", "timeout:3"}
+	assert.DeepEqual(t, expectedDNSOptions, inspect.HostConfig.DNSOptions)
+}
+
+func TestContainerInspectHostConfigDNSDefaults(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	// Run a container without specifying DNS options
+	base.Cmd("run", "-d", "--name", testContainer, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	// Check that DNS settings are empty by default
+	assert.Equal(t, 0, len(inspect.HostConfig.DNS))
+	assert.Equal(t, 0, len(inspect.HostConfig.DNSSearch))
+	assert.Equal(t, 0, len(inspect.HostConfig.DNSOptions))
+}
+
+func TestContainerInspectHostConfigPID(t *testing.T) {
+	testContainer1 := testutil.Identifier(t) + "-container1"
+	testContainer2 := testutil.Identifier(t) + "-container2"
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer1, testContainer2).Run()
+
+	// Run the first container
+	base.Cmd("run", "-d", "--name", testContainer1, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	containerID1 := strings.TrimSpace(base.Cmd("inspect", "-f", "{{.Id}}", testContainer1).Out())
+
+	var hc hostConfigValues
+
+	if testutil.GetTarget() == testutil.Docker {
+		hc.PidMode = "container:" + containerID1
+	} else {
+		hc.PidMode = containerID1
+	}
+
+	base.Cmd("run", "-d", "--name", testContainer2,
+		"--pid", fmt.Sprintf("container:%s", testContainer1),
+		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer2)
+
+	assert.Equal(t, hc.PidMode, inspect.HostConfig.PidMode)
+
+}
+
+func TestContainerInspectHostConfigPIDDefaults(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	base.Cmd("run", "-d", "--name", testContainer, testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	assert.Equal(t, "", inspect.HostConfig.PidMode)
+}
+
+func TestContainerInspectDevices(t *testing.T) {
+	testContainer := testutil.Identifier(t)
+
+	base := testutil.NewBase(t)
+	defer base.Cmd("rm", "-f", testContainer).Run()
+
+	if rootlessutil.IsRootless() && infoutil.CgroupsVersion() == "1" {
+		t.Skip("test skipped for rootless containers on cgroup v1")
+	}
+
+	// Create a temporary directory
+	dir, err := os.MkdirTemp(t.TempDir(), "device-dir")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if testutil.GetTarget() == testutil.Docker {
+		dir = "/dev/zero"
+	}
+
+	// Run the container with the directory mapped as a device
+	base.Cmd("run", "-d", "--name", testContainer,
+		"--device", dir+":/dev/xvda",
+		testutil.AlpineImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(testContainer)
+
+	expectedDevices := []dockercompat.DeviceMapping{
+		{
+			PathOnHost:        dir,
+			PathInContainer:   "/dev/xvda",
+			CgroupPermissions: "rwm",
+		},
+	}
+	assert.DeepEqual(t, expectedDevices, inspect.HostConfig.Devices)
+}
+
+type hostConfigValues struct {
+	Driver       string
+	ShmSize      int64
+	PidMode      string
+	GroupAddSize int
+	Runtime      string
 }

--- a/pkg/cmd/container/run_linux.go
+++ b/pkg/cmd/container/run_linux.go
@@ -56,7 +56,7 @@ func setPlatformOptions(ctx context.Context, client *containerd.Client, id, uts 
 			{Type: "cgroup", Source: "cgroup", Destination: "/sys/fs/cgroup", Options: []string{"ro", "nosuid", "noexec", "nodev"}},
 		}))
 
-	cgOpts, err := generateCgroupOpts(id, options)
+	cgOpts, err := generateCgroupOpts(id, options, internalLabels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/docker/go-units"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
 	containerd "github.com/containerd/containerd/v2/client"
@@ -45,6 +46,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/ocihook/state"
 )
@@ -94,6 +96,13 @@ type ImageMetadata struct {
 	LastTagTime time.Time `json:",omitempty"`
 }
 
+type loggerLogConfig struct {
+	Driver  string            `json:"driver"`
+	Opts    map[string]string `json:"opts,omitempty"`
+	LogURI  string            `json:"-"`
+	Address string            `json:"address"`
+}
+
 // Container mimics a `docker container inspect` object.
 // From https://github.com/moby/moby/blob/v20.10.1/api/types/types.go#L340-L374
 type Container struct {
@@ -116,7 +125,7 @@ type Container struct {
 	// TODO: ProcessLabel    string
 	AppArmorProfile string
 	// TODO: ExecIDs         []string
-	// TODO: HostConfig      *container.HostConfig
+	HostConfig *HostConfig
 	// TODO: GraphDriver     GraphDriverData
 	SizeRw     *int64 `json:",omitempty"`
 	SizeRootFs *int64 `json:",omitempty"`
@@ -124,6 +133,53 @@ type Container struct {
 	Mounts          []MountPoint
 	Config          *Config
 	NetworkSettings *NetworkSettings
+}
+
+// From https://github.com/moby/moby/blob/8dbd90ec00daa26dc45d7da2431c965dec99e8b4/api/types/container/host_config.go#L391
+// HostConfig the non-portable Config structure of a container.
+type HostConfig struct {
+	// Binds           []string      // List of volume bindings for this container
+	ContainerIDFile string          // File (path) where the containerId is written
+	LogConfig       loggerLogConfig // Configuration of the logs for this container
+	// NetworkMode     NetworkMode   // Network mode to use for the container
+	PortBindings nat.PortMap // Port mapping between the exposed port (container) and the host
+	// RestartPolicy   RestartPolicy // Restart policy to be used for the container
+	// AutoRemove      bool          // Automatically remove container when it exits
+	// VolumeDriver    string        // Name of the volume driver used to mount volumes
+	// VolumesFrom     []string      // List of volumes to take from other container
+	// CapAdd          strslice.StrSlice // List of kernel capabilities to add to the container
+	// CapDrop         strslice.StrSlice // List of kernel capabilities to remove from the container
+
+	CgroupnsMode string   // Cgroup namespace mode to use for the container
+	DNS          []string `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions   []string `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch    []string `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts   []string // List of extra hosts
+	GroupAdd     []string // GroupAdd specifies additional groups to join
+	IpcMode      string   `json:"IpcMode"` // IPC namespace to use for the container
+	// Cgroup          CgroupSpec        // Cgroup to use for the container
+	OomScoreAdj int    // specifies the tune container’s OOM preferences (-1000 to 1000, rootless: 100 to 1000)
+	PidMode     string // PID namespace to use for the container
+	// Privileged      bool              // Is the container in privileged mode
+	// PublishAllPorts bool              // Should docker publish all exposed port for the container
+	ReadonlyRootfs bool // Is the container root filesystem in read-only
+	// SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
+	Tmpfs   map[string]string `json:"Tmpfs,omitempty"` // List of tmpfs (mounts) used for the container
+	UTSMode string            // UTS namespace to use for the container
+	// UsernsMode      UsernsMode        // The user namespace to use for the container
+	ShmSize int64             // Size of /dev/shm in bytes. The size must be greater than 0.
+	Sysctls map[string]string // List of Namespaced sysctls used for the container
+	Runtime string            // Runtime to use with this container
+
+	BlkioWeight    uint16          // Block IO weight (relative weight vs. other containers)
+	CPUSetMems     string          `json:"CpusetMems"` // CpusetMems 0-2, 0,1
+	CPUSetCPUs     string          `json:"CpusetCpus"` // CpusetCpus 0-2, 0,1
+	CPUQuota       int64           `json:"CpuQuota"`   // CPU CFS (Completely Fair Scheduler) quota
+	CPUShares      uint64          `json:"CpuShares"`  // CPU shares (relative weight vs. other containers)
+	Memory         int64           // Memory limit (in bytes)
+	MemorySwap     int64           // Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	OomKillDisable bool            // specifies whether to disable OOM Killer
+	Devices        []DeviceMapping // List of devices to map inside the container
 }
 
 // From https://github.com/moby/moby/blob/v20.10.1/api/types/types.go#L416-L427
@@ -191,6 +247,31 @@ type NetworkSettings struct {
 	Networks map[string]*NetworkEndpointSettings
 }
 
+type DNSSettings struct {
+	DNSServers           []string
+	DNSResolvConfOptions []string
+	DNSSearchDomains     []string
+}
+
+type HostConfigLabel struct {
+	BlkioWeight uint16
+	CidFile     string
+	Devices     []DeviceMapping
+}
+
+type DeviceMapping struct {
+	PathOnHost        string
+	PathInContainer   string
+	CgroupPermissions string
+}
+
+type cpuSettings struct {
+	cpuSetCpus string
+	cpuSetMems string
+	cpuShares  uint64
+	cpuQuota   int64
+}
+
 // DefaultNetworkSettings is from https://github.com/moby/moby/blob/v20.10.1/api/types/types.go#L405-L414
 type DefaultNetworkSettings struct {
 	// TODO EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
@@ -234,6 +315,7 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		// XXX is this always right? what if the container OS is NOT the same as the host OS?
 		Platform: runtime.GOOS, // for Docker compatibility, this Platform string does NOT contain arch like "/amd64"
 	}
+	c.HostConfig = new(HostConfig)
 	if n.Labels[restart.StatusLabel] == string(containerd.Running) {
 		c.RestartCount, _ = strconv.Atoi(n.Labels[restart.CountLabel])
 	}
@@ -274,12 +356,73 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		}
 	}
 
+	c.HostConfig.Tmpfs = make(map[string]string)
 	if nerdctlMounts := n.Labels[labels.Mounts]; nerdctlMounts != "" {
 		mounts, err := parseMounts(nerdctlMounts)
 		if err != nil {
 			return nil, err
 		}
 		c.Mounts = mounts
+		for _, mount := range mounts {
+			if mount.Type == "tmpfs" {
+				c.HostConfig.Tmpfs[mount.Destination] = mount.Mode
+			}
+		}
+	}
+
+	if nedctlExtraHosts := n.Labels[labels.ExtraHosts]; nedctlExtraHosts != "" {
+		c.HostConfig.ExtraHosts = parseExtraHosts(nedctlExtraHosts)
+	}
+
+	if nerdctlLoguri := n.Labels[labels.LogURI]; nerdctlLoguri != "" {
+		c.HostConfig.LogConfig.LogURI = nerdctlLoguri
+	}
+	if logConfigJSON, ok := n.Labels[labels.LogConfig]; ok {
+		var logConfig loggerLogConfig
+		err := json.Unmarshal([]byte(logConfigJSON), &logConfig)
+		if err != nil {
+			return nil, fmt.Errorf("failed to unmarshal log config: %v", err)
+		}
+
+		// Assign the parsed LogConfig to c.HostConfig.LogConfig
+		c.HostConfig.LogConfig = logConfig
+	} else {
+		// If LogConfig label is not present, set default values
+		c.HostConfig.LogConfig = loggerLogConfig{
+			Driver: "json-file",
+			Opts:   make(map[string]string),
+		}
+	}
+
+	hostConfigLabel, err := getHostConfigLabelFromNative(n.Labels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch HostConfigLabel: %v", err)
+	}
+
+	c.HostConfig.BlkioWeight = hostConfigLabel.BlkioWeight
+	c.HostConfig.ContainerIDFile = hostConfigLabel.CidFile
+
+	groupAdd, err := groupAddFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to groupAdd from native spec: %v", err)
+	}
+
+	c.HostConfig.GroupAdd = groupAdd
+	c.HostConfig.ShmSize = 0
+
+	if ipcMode := n.Labels[labels.IPC]; ipcMode != "" {
+		ipc, err := ipcutil.DecodeIPCLabel(ipcMode)
+		if err != nil {
+			return nil, fmt.Errorf("failed to Decode IPC Label: %v", err)
+		}
+		c.HostConfig.IpcMode = string(ipc.Mode)
+		if ipc.ShmSize != "" {
+			shmSize, err := units.RAMInBytes(ipc.ShmSize)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse ShmSize: %v", err)
+			}
+			c.HostConfig.ShmSize = shmSize
+		}
 	}
 
 	cs := new(ContainerState)
@@ -308,7 +451,69 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 			return nil, err
 		}
 		c.NetworkSettings = nSettings
+		c.HostConfig.PortBindings = *nSettings.Ports
 	}
+
+	cpuSetting, err := cpuSettingsFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to Decode cpuSettings: %v", err)
+	}
+	c.HostConfig.CPUSetCPUs = cpuSetting.cpuSetCpus
+	c.HostConfig.CPUSetMems = cpuSetting.cpuSetMems
+	c.HostConfig.CPUQuota = cpuSetting.cpuQuota
+	c.HostConfig.CPUShares = cpuSetting.cpuShares
+
+	cgroupNamespace, err := getCgroupnsFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to Decode cgroupNamespace: %v", err)
+	}
+	c.HostConfig.CgroupnsMode = cgroupNamespace
+
+	memorySettings, err := getMemorySettingsFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to Decode memory Settings: %v", err)
+	}
+
+	c.HostConfig.OomKillDisable = memorySettings.DisableOOMKiller
+	c.HostConfig.Memory = memorySettings.Limit
+	c.HostConfig.MemorySwap = memorySettings.Swap
+
+	dnsSettings, err := getDNSFromNative(n.Labels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to Decode dns Settings: %v", err)
+	}
+
+	c.HostConfig.DNS = dnsSettings.DNSServers
+	c.HostConfig.DNSOptions = dnsSettings.DNSResolvConfOptions
+	c.HostConfig.DNSSearch = dnsSettings.DNSSearchDomains
+
+	oomScoreAdj, err := getOomScoreAdjFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OomScoreAdj value: %v", err)
+	}
+	c.HostConfig.OomScoreAdj = oomScoreAdj
+
+	c.HostConfig.ReadonlyRootfs = false
+	if n.Spec.(*specs.Spec).Root != nil && n.Spec.(*specs.Spec).Root.Readonly {
+		c.HostConfig.ReadonlyRootfs = n.Spec.(*specs.Spec).Root.Readonly
+	}
+
+	utsMode, err := getUtsModeFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get UtsMode value: %v", err)
+	}
+	c.HostConfig.UTSMode = utsMode
+
+	sysctls, err := getSysctlFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get UtsMode value: %v", err)
+	}
+	c.HostConfig.Sysctls = sysctls
+
+	if n.Runtime.Name != "" {
+		c.HostConfig.Runtime = n.Runtime.Name
+	}
+
 	c.State = cs
 	c.Config = &Config{
 		Labels: n.Labels,
@@ -322,6 +527,13 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		c.Config.Domainname = n.Labels[labels.Domainname]
 	}
 
+	c.HostConfig.Devices = hostConfigLabel.Devices
+
+	var pidMode string
+	if n.Labels[labels.PIDContainer] != "" {
+		pidMode = n.Labels[labels.PIDContainer]
+	}
+	c.HostConfig.PidMode = pidMode
 	return c, nil
 }
 
@@ -479,6 +691,53 @@ func networkSettingsFromNative(n *native.NetNS, sp *specs.Spec) (*NetworkSetting
 	return res, nil
 }
 
+func cpuSettingsFromNative(sp *specs.Spec) (*cpuSettings, error) {
+	res := &cpuSettings{}
+	if sp.Linux != nil && sp.Linux.Resources != nil && sp.Linux.Resources.CPU != nil {
+		if sp.Linux.Resources.CPU.Cpus != "" {
+			res.cpuSetCpus = sp.Linux.Resources.CPU.Cpus
+		}
+
+		if sp.Linux.Resources.CPU.Mems != "" {
+			res.cpuSetMems = sp.Linux.Resources.CPU.Mems
+		}
+
+		if sp.Linux.Resources.CPU.Shares != nil && *sp.Linux.Resources.CPU.Shares > 0 {
+			res.cpuShares = *sp.Linux.Resources.CPU.Shares
+		}
+
+		if sp.Linux.Resources.CPU.Quota != nil && *sp.Linux.Resources.CPU.Quota > 0 {
+			res.cpuQuota = *sp.Linux.Resources.CPU.Quota
+		}
+	}
+
+	return res, nil
+}
+
+func getCgroupnsFromNative(sp *specs.Spec) (string, error) {
+	res := ""
+	if sp.Linux != nil && len(sp.Linux.Namespaces) != 0 {
+		for _, ns := range sp.Linux.Namespaces {
+			if ns.Type == "cgroup" {
+				res = "private"
+			}
+		}
+	}
+	return res, nil
+}
+
+func groupAddFromNative(sp *specs.Spec) ([]string, error) {
+	res := []string{}
+	if sp.Process != nil && sp.Process.User.AdditionalGids != nil {
+		for _, gid := range sp.Process.User.AdditionalGids {
+			if gid != 0 {
+				res = append(res, strconv.FormatUint(uint64(gid), 10))
+			}
+		}
+	}
+	return res, nil
+}
+
 func convertToNatPort(portMappings []cni.PortMapping) (*nat.PortMap, error) {
 	portMap := make(nat.PortMap)
 	for _, portMapping := range portMappings {
@@ -495,6 +754,83 @@ func convertToNatPort(portMappings []cni.PortMapping) (*nat.PortMap, error) {
 		portMap[newP] = ports
 	}
 	return &portMap, nil
+}
+
+func parseExtraHosts(extraHostsJSON string) []string {
+	var extraHosts []string
+	if err := json.Unmarshal([]byte(extraHostsJSON), &extraHosts); err != nil {
+		// Handle error or return empty slice
+		return []string{}
+	}
+	return extraHosts
+}
+
+func getMemorySettingsFromNative(sp *specs.Spec) (*MemorySetting, error) {
+	res := &MemorySetting{}
+	if sp.Linux != nil && sp.Linux.Resources != nil && sp.Linux.Resources.Memory != nil {
+		if sp.Linux.Resources.Memory.DisableOOMKiller != nil {
+			res.DisableOOMKiller = *sp.Linux.Resources.Memory.DisableOOMKiller
+		}
+
+		if sp.Linux.Resources.Memory.Limit != nil {
+			res.Limit = *sp.Linux.Resources.Memory.Limit
+		}
+
+		if sp.Linux.Resources.Memory.Swap != nil {
+			res.Swap = *sp.Linux.Resources.Memory.Swap
+		}
+	}
+	return res, nil
+}
+
+func getDNSFromNative(Labels map[string]string) (*DNSSettings, error) {
+	res := &DNSSettings{}
+
+	if dnsSettingJSON, ok := Labels[labels.DNSSetting]; ok {
+		if err := json.Unmarshal([]byte(dnsSettingJSON), &res); err != nil {
+			return nil, fmt.Errorf("failed to parse DNS settings: %v", err)
+		}
+	}
+
+	return res, nil
+}
+
+func getHostConfigLabelFromNative(Labels map[string]string) (*HostConfigLabel, error) {
+	res := &HostConfigLabel{}
+
+	if hostConfigLabelJSON, ok := Labels[labels.HostConfigLabel]; ok {
+		if err := json.Unmarshal([]byte(hostConfigLabelJSON), &res); err != nil {
+			return nil, fmt.Errorf("failed to parse DNS servers: %v", err)
+		}
+	}
+	return res, nil
+}
+
+func getOomScoreAdjFromNative(sp *specs.Spec) (int, error) {
+	var res int
+	if sp.Process != nil && sp.Process.OOMScoreAdj != nil {
+		res = *sp.Process.OOMScoreAdj
+	}
+	return res, nil
+}
+
+func getUtsModeFromNative(sp *specs.Spec) (string, error) {
+	if sp.Linux != nil && len(sp.Linux.Namespaces) > 0 {
+		for _, ns := range sp.Linux.Namespaces {
+			if ns.Type == "uts" {
+				return "", nil
+			}
+		}
+	}
+	return "host", nil
+}
+
+func getSysctlFromNative(sp *specs.Spec) (map[string]string, error) {
+	var res map[string]string
+	if sp.Linux != nil && sp.Linux.Sysctl != nil {
+		res = sp.Linux.Sysctl
+	}
+	return res, nil
 }
 
 type IPAMConfig struct {
@@ -525,6 +861,12 @@ type structuredCNI struct {
 			Ranges [][]IPAMConfig `json:"ranges"`
 		} `json:"ipam"`
 	} `json:"plugins"`
+}
+
+type MemorySetting struct {
+	Limit            int64 `json:"limit"`
+	Swap             int64 `json:"swap"`
+	DisableOOMKiller bool  `json:"disableOOMKiller"`
 }
 
 func NetworkFromNative(n *native.Network) (*Network, error) {

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -75,6 +75,16 @@ func TestContainerFromNative(t *testing.T) {
 					Pid:        10000,
 					FinishedAt: "",
 				},
+				HostConfig: &HostConfig{
+					PortBindings: nat.PortMap{},
+					GroupAdd:     []string{},
+					LogConfig: loggerLogConfig{
+						Driver: "json-file",
+						Opts:   map[string]string{},
+					},
+					UTSMode: "host",
+					Tmpfs:   map[string]string{},
+				},
 				Mounts: []MountPoint{
 					{
 						Type:        "bind",
@@ -150,6 +160,16 @@ func TestContainerFromNative(t *testing.T) {
 					Pid:        10000,
 					FinishedAt: "",
 				},
+				HostConfig: &HostConfig{
+					PortBindings: nat.PortMap{},
+					GroupAdd:     []string{},
+					LogConfig: loggerLogConfig{
+						Driver: "json-file",
+						Opts:   map[string]string{},
+					},
+					UTSMode: "host",
+					Tmpfs:   map[string]string{},
+				},
 				Mounts: []MountPoint{
 					{
 						Type:        "bind",
@@ -221,6 +241,16 @@ func TestContainerFromNative(t *testing.T) {
 					Running:    true,
 					Pid:        10000,
 					FinishedAt: "",
+				},
+				HostConfig: &HostConfig{
+					PortBindings: nat.PortMap{},
+					GroupAdd:     []string{},
+					LogConfig: loggerLogConfig{
+						Driver: "json-file",
+						Opts:   map[string]string{},
+					},
+					UTSMode: "host",
+					Tmpfs:   map[string]string{},
 				},
 				Mounts: []MountPoint{
 					{

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -106,4 +106,13 @@ const (
 
 	// ContainerAutoRemove is to check whether the --rm option is specified.
 	ContainerAutoRemove = Prefix + "auto-remove"
+
+	// LogConfig defines the logging configuration passed to the container
+	LogConfig = Prefix + "log-config"
+
+	// HostConfigLabel sets the dockercompat host config values
+	HostConfigLabel = Prefix + "host-config"
+
+	// DNSSettings sets the dockercompat DNS config values
+	DNSSetting = Prefix + "dns"
 )


### PR DESCRIPTION
`nerdctl inspect` currently doesn't report [HostConfig](https://github.com/containerd/nerdctl/blob/b854127dea2f7a23ab6e9638f91f666ca0db6aea/pkg/inspecttypes/dockercompat/dockercompat.go#L119) details in its response. 

Attempting to add this PR as a starting point,  aim is to get the `dockercompat` response closer to the [docker inspect response schema](https://docs.docker.com/reference/api/engine/version/v1.43/#tag/Container/operation/ContainerInspect)