### PR TITLE
fix: clean up an orphaned etchosts directory for the container that failed to create

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -888,6 +888,17 @@ func generateGcFunc(ctx context.Context, container containerd.Container, ns, id,
 			if netGcErr != nil {
 				log.G(ctx).WithError(netGcErr).Warnf("failed to revert container %q networking settings", id)
 			}
+		} else {
+			hs, err := hostsstore.New(dataStore, internalLabels.namespace)
+			if err != nil {
+				log.G(ctx).WithError(err).Warnf("failed to instantiate hostsstore for %q", internalLabels.namespace)
+			} else {
+				if _, err := hs.HostsPath(id); err != nil {
+					log.G(ctx).WithError(err).Warnf("an etchosts directory for container %q dosen't exist", id)
+				} else if err = hs.Delete(id); err != nil {
+					log.G(ctx).WithError(err).Warnf("failed to remove an etchosts directory for container %q", id)
+				}
+			}
 		}
 
 		ipc, ipcErr := ipcutil.DecodeIPCLabel(internalLabels.ipc)


### PR DESCRIPTION
When specifying `22200-22299:22200-22299` for `-p` optinn in running nerdctl 
run, the following errors occur.

```
$ nerdctl run --rm -p 22200-22299:22200-22299 alpine sh
FATA[0000] create container failed validation: containers.Labels: label key and value length (7714 bytes) greater than maximum size (4096 bytes), key: nerdctl/ports: invalid argument
```

This error is expected behavior in nerdctl.

However, the **etchosts** directory for this container has not been cleaned 
up, even though the container has not been created.

Specifically, the following directory for the container remains without 
being cleaned up.

```
$ ls ~/.local/share/nerdctl/1935db59/etchosts/default/
ea9c09bfdbc525db0b2cfdf3632ddf7c0e58918044acc626019f2fc4e1167573
```

Therefore, this PR creates the following three commits to clean up an 
orphaned directory when the nerdctl run command fails to create a 
container with an invalid value for the `-p` option.

1. Refactor `TestRunWithInvalidPortThenCleanUp` in 
`cmd/nerdctl/container/container_run_network_linux_test.go` based on the 
Principles in the following document

- https://github.com/containerd/nerdctl/tree/main/docs/testing#principles

2. Add the logic to clean up an orphaned etchosts directory for the 
container that failed to create

3. Add an test for added logic to `TestRunWithInvalidPortThenCleanUp`
