### PR TITLE
fix: save multiple images for the same image id to a tar archive

### DIFF
--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -56,9 +56,8 @@ func Save(ctx context.Context, client *containerd.Client, images []string, optio
 			}
 
 			imgName := found.Image.Name
-			imgDigest := found.Image.Target.Digest.String()
-			if _, ok := savedImages[imgDigest]; !ok {
-				savedImages[imgDigest] = struct{}{}
+			if _, ok := savedImages[imgName]; !ok {
+				savedImages[imgName] = struct{}{}
 				exportOpts = append(exportOpts, archive.WithImage(imageStore, imgName))
 			}
 			return nil


### PR DESCRIPTION
Suppose we try to save multiple container images with the same image ID but different image names into a tar archive using the nerdctl save command.

When we then try to load container images from this tar archive using the nerdctl load command, not all container images will be loaded.

This behavior is reported and the details are described in the following:

- https://github.com/containerd/nerdctl/issues/3806

Therefore, this PR resolves this issue.