### PR TITLE
Correct `compose logs` command reference

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1443,7 +1443,7 @@ Unimplemented `docker compose up` (V2) flags: `--environment`
 
 ### :whale: nerdctl compose logs
 
-Create and start containers
+Show logs of running containers
 
 Usage: `nerdctl compose logs [OPTIONS] [SERVICE...]`
 


### PR DESCRIPTION
I think this was copy-pasted from `compose up` so wasn't quite right. 