### PR TITLE
Fix port forwarding not working for non-127.0.0.1 localhost in rootless

### DIFF
--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
@@ -558,6 +559,48 @@ func TestIssue3568(t *testing.T) {
 						test.Contains("read detach keys"),
 						func(stdout string, info string, t *testing.T) {
 							assert.Assert(t, strings.Contains(helpers.Capture("ps"), data.Identifier()))
+						},
+					),
+				}
+			},
+		},
+	}
+
+	testCase.Run(t)
+}
+
+// TestPortBindingWithCustomHost tests https://github.com/containerd/nerdctl/issues/3539
+func TestPortBindingWithCustomHost(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	const (
+		host     = "127.0.0.2"
+		hostPort = 8080
+	)
+	address := fmt.Sprintf("%s:%d", host, hostPort)
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "Issue #3539 - Access to a container running when 127.0.0.2 is specified in -p in rootless mode.",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(), "-p", fmt.Sprintf("%s:80", address), testutil.NginxAlpineImage)
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Errors:   []error{},
+					Output: test.All(
+						func(stdout string, info string, t *testing.T) {
+							resp, err := nettestutil.HTTPGet(address, 30, false)
+							assert.NilError(t, err)
+
+							respBody, err := io.ReadAll(resp.Body)
+							assert.NilError(t, err)
+							assert.Assert(t, strings.Contains(string(respBody), testutil.NginxAlpineIndexHTMLSnippet))
 						},
 					),
 				}


### PR DESCRIPTION
When running `a rootless container`, specifying an address such as `127.0.0.2` 
for the `-p` option, we will not be able to access the published container 
through that address.

This behavior is reported in the following issue:

- https://github.com/containerd/nerdctl/issues/3539

This behavior is caused by the behavior in `rootlesskit`, and the following 
pull request has been made to improve the behavior.

- https://github.com/rootless-containers/rootlesskit/pull/477

Therefore, this PR adds a test to ensure that the behavior of the 
issue has been improved.

~~Also, this PR updates docs for propagations the address specified in the `-p` option~~