### PR TITLE
3771 follow up: use %w consistently when wrapping errors

### DIFF
--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -443,7 +443,7 @@ func createAction(cmd *cobra.Command, args []string) error {
 
 	netFlags, err := loadNetworkFlags(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to load networking flags: %s", err)
+		return fmt.Errorf("failed to load networking flags: %w", err)
 	}
 
 	netManager, err := containerutil.NewNetworkingOptionsManager(createOpt.GOptions, netFlags, client)

--- a/cmd/nerdctl/container/container_logs.go
+++ b/cmd/nerdctl/container/container_logs.go
@@ -127,7 +127,7 @@ func getTailArgAsUint(arg string) (uint, error) {
 	}
 	num, err := strconv.Atoi(arg)
 	if err != nil {
-		return 0, fmt.Errorf("failed to parse `-n/--tail` argument %q: %s", arg, err)
+		return 0, fmt.Errorf("failed to parse `-n/--tail` argument %q: %w", arg, err)
 	}
 	if num < 0 {
 		return 0, fmt.Errorf("`-n/--tail` argument must be positive, got: %d", num)

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -357,7 +357,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 
 	netFlags, err := loadNetworkFlags(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to load networking flags: %s", err)
+		return fmt.Errorf("failed to load networking flags: %w", err)
 	}
 
 	netManager, err := containerutil.NewNetworkingOptionsManager(createOpt.GOptions, netFlags, client)

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -386,7 +386,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 				return
 			}
 			if err := netManager.CleanupNetworking(ctx, c); err != nil {
-				log.L.Warnf("failed to clean up container networking: %s", err)
+				log.L.WithError(err).Warnf("failed to clean up container networking")
 			}
 			if err := container.RemoveContainer(ctx, c, createOpt.GOptions, true, true, client); err != nil {
 				log.L.WithError(err).Warnf("failed to remove container %s", id)

--- a/cmd/nerdctl/container/container_run_network_windows_test.go
+++ b/cmd/nerdctl/container/container_run_network_windows_test.go
@@ -73,7 +73,7 @@ func listHnsEndpointsRegex(hnsEndpointNameRegex string) ([]hcsshim.HNSEndpoint, 
 	}
 	hnsEndpoints, err := hcsshim.HNSListEndpointRequest()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list HNS endpoints for request: %s", err)
+		return nil, fmt.Errorf("failed to list HNS endpoints for request: %w", err)
 	}
 
 	res := []hcsshim.HNSEndpoint{}

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -120,7 +120,7 @@ func Build(ctx context.Context, client *containerd.Client, options types.Builder
 		imageService := client.ImageService()
 		image, err := imageService.Get(ctx, tags[0])
 		if err != nil {
-			return fmt.Errorf("unable to tag image: %s", err)
+			return fmt.Errorf("unable to tag image: %w", err)
 		}
 		for _, targetRef := range tags[1:] {
 			image.Name = targetRef
@@ -135,7 +135,7 @@ func Build(ctx context.Context, client *containerd.Client, options types.Builder
 					}
 					continue
 				}
-				return fmt.Errorf("unable to tag image: %s", err)
+				return fmt.Errorf("unable to tag image: %w", err)
 			}
 		}
 	}

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -230,19 +230,19 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	cOpts = append(cOpts, restartOpts...)
 
 	if err = netManager.VerifyNetworkOptions(ctx); err != nil {
-		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), fmt.Errorf("failed to verify networking settings: %s", err)
+		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), fmt.Errorf("failed to verify networking settings: %w", err)
 	}
 
 	netOpts, netNewContainerOpts, err := netManager.ContainerNetworkingOpts(ctx, id)
 	if err != nil {
-		return nil, generateRemoveOrphanedDirsFunc(ctx, id, dataStore, internalLabels), fmt.Errorf("failed to generate networking spec options: %s", err)
+		return nil, generateRemoveOrphanedDirsFunc(ctx, id, dataStore, internalLabels), fmt.Errorf("failed to generate networking spec options: %w", err)
 	}
 	opts = append(opts, netOpts...)
 	cOpts = append(cOpts, netNewContainerOpts...)
 
 	netLabelOpts, err := netManager.InternalNetworkingOptionLabels(ctx)
 	if err != nil {
-		return nil, generateRemoveOrphanedDirsFunc(ctx, id, dataStore, internalLabels), fmt.Errorf("failed to generate internal networking labels: %s", err)
+		return nil, generateRemoveOrphanedDirsFunc(ctx, id, dataStore, internalLabels), fmt.Errorf("failed to generate internal networking labels: %w", err)
 	}
 
 	envs = append(envs, "HOSTNAME="+netLabelOpts.Hostname)

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -85,7 +85,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 					} else {
 						waitCh, err := task.Wait(ctx)
 						if err != nil {
-							return fmt.Errorf("failed to get wait channel for task %#v: %s", task, err)
+							return fmt.Errorf("failed to get wait channel for task %#v: %w", task, err)
 						}
 
 						// Setup goroutine to send stop event if container task finishes:

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -194,7 +194,7 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		if err == nil {
 			networkManager, err := containerutil.NewNetworkingOptionsManager(globalOptions, netOpts, client)
 			if err != nil {
-				retErr = fmt.Errorf("failed to instantiate network options manager: %s", err)
+				retErr = fmt.Errorf("failed to instantiate network options manager: %w", err)
 				return
 			}
 

--- a/pkg/cmd/container/top_unix.go
+++ b/pkg/cmd/container/top_unix.go
@@ -232,7 +232,7 @@ func parsePSOutput(output []byte, procs []uint32) (*ContainerTopOKBody, error) {
 		}
 		p, err = strconv.Atoi(fields[pidIndex])
 		if err != nil {
-			return nil, fmt.Errorf("unexpected pid '%s': %s", fields[pidIndex], err)
+			return nil, fmt.Errorf("unexpected pid '%s': %w", fields[pidIndex], err)
 		}
 
 		if hasPid(procs, p) {

--- a/pkg/composer/create.go
+++ b/pkg/composer/create.go
@@ -159,7 +159,7 @@ func (c *Composer) createServiceContainer(ctx context.Context, service *servicep
 	// check if container already exists
 	exists, err := c.containerExists(ctx, container.Name, service.Unparsed.Name)
 	if err != nil {
-		return "", fmt.Errorf("error while checking for containers with name %q: %s", container.Name, err)
+		return "", fmt.Errorf("error while checking for containers with name %q: %w", container.Name, err)
 	}
 
 	// delete container if it already exists and force-recreate is enabled
@@ -172,7 +172,7 @@ func (c *Composer) createServiceContainer(ctx context.Context, service *servicep
 		log.G(ctx).Debugf("Container %q already exists and force-created is enabled, deleting", container.Name)
 		delCmd := c.createNerdctlCmd(ctx, "rm", "-f", container.Name)
 		if err = delCmd.Run(); err != nil {
-			return "", fmt.Errorf("could not delete container %q: %s", container.Name, err)
+			return "", fmt.Errorf("could not delete container %q: %w", container.Name, err)
 		}
 		log.G(ctx).Infof("Re-creating container %s", container.Name)
 	} else {

--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -57,12 +57,12 @@ func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
 	}
 	orphans, err := c.getOrphanContainers(ctx, parsedServices)
 	if err != nil && downOptions.RemoveOrphans {
-		return fmt.Errorf("error getting orphaned containers: %s", err)
+		return fmt.Errorf("error getting orphaned containers: %w", err)
 	}
 	if len(orphans) > 0 {
 		if downOptions.RemoveOrphans {
 			if err := c.removeContainers(ctx, orphans, RemoveOptions{Stop: true, Volumes: downOptions.RemoveVolumes}); err != nil {
-				return fmt.Errorf("error removeing orphaned containers: %s", err)
+				return fmt.Errorf("error removeing orphaned containers: %w", err)
 			}
 		} else {
 			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -51,7 +51,7 @@ type ExecOptions struct {
 func (c *Composer) Exec(ctx context.Context, eo ExecOptions) error {
 	containers, err := c.Containers(ctx, eo.ServiceName)
 	if err != nil {
-		return fmt.Errorf("fail to get containers for service %s: %s", eo.ServiceName, err)
+		return fmt.Errorf("fail to get containers for service %s: %w", eo.ServiceName, err)
 	}
 	if len(containers) == 0 {
 		return fmt.Errorf("no running containers from service %s", eo.ServiceName)

--- a/pkg/composer/orphans.go
+++ b/pkg/composer/orphans.go
@@ -45,7 +45,7 @@ func (c *Composer) getOrphanContainers(ctx context.Context, parsedServices []*se
 		// to any name of given services.
 		containerLabels, err := container.Labels(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("error getting container labels: %s", err)
+			return nil, fmt.Errorf("error getting container labels: %w", err)
 		}
 		containerSvc := containerLabels[labels.ComposeService]
 		if inServices := parsedSvcNames[containerSvc]; !inServices {

--- a/pkg/composer/port.go
+++ b/pkg/composer/port.go
@@ -38,7 +38,7 @@ type PortOptions struct {
 func (c *Composer) Port(ctx context.Context, writer io.Writer, po PortOptions) error {
 	containers, err := c.Containers(ctx, po.ServiceName)
 	if err != nil {
-		return fmt.Errorf("fail to get containers for service %s: %s", po.ServiceName, err)
+		return fmt.Errorf("fail to get containers for service %s: %w", po.ServiceName, err)
 	}
 	if len(containers) == 0 {
 		return fmt.Errorf("no running containers from service %s", po.ServiceName)

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -167,7 +167,7 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 			for _, p := range ro.Publish {
 				pc, err := types.ParsePortConfig(p)
 				if err != nil {
-					return fmt.Errorf("error parse --publish: %s", err)
+					return fmt.Errorf("error parse --publish: %w", err)
 				}
 				targetSvc.Ports = append(targetSvc.Ports, pc...)
 			}
@@ -193,12 +193,12 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 	// FYI: https://github.com/docker/compose/blob/v2.3.4/pkg/compose/create.go#L91-L112
 	orphans, err := c.getOrphanContainers(ctx, parsedServices)
 	if err != nil && ro.RemoveOrphans {
-		return fmt.Errorf("error getting orphaned containers: %s", err)
+		return fmt.Errorf("error getting orphaned containers: %w", err)
 	}
 	if len(orphans) > 0 {
 		if ro.RemoveOrphans {
 			if err := c.removeContainers(ctx, orphans, RemoveOptions{Stop: true, Volumes: true}); err != nil {
-				return fmt.Errorf("error removing orphaned containers: %s", err)
+				return fmt.Errorf("error removing orphaned containers: %w", err)
 			}
 		} else {
 			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -106,12 +106,12 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 	// FYI: https://github.com/docker/compose/blob/v2.3.4/pkg/compose/create.go#L91-L112
 	orphans, err := c.getOrphanContainers(ctx, parsedServices)
 	if err != nil && uo.RemoveOrphans {
-		return fmt.Errorf("error getting orphaned containers: %s", err)
+		return fmt.Errorf("error getting orphaned containers: %w", err)
 	}
 	if len(orphans) > 0 {
 		if uo.RemoveOrphans {
 			if err := c.removeContainers(ctx, orphans, RemoveOptions{Stop: true, Volumes: true}); err != nil {
-				return fmt.Errorf("error removing orphaned containers: %s", err)
+				return fmt.Errorf("error removing orphaned containers: %w", err)
 			}
 		} else {
 			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)

--- a/pkg/composer/up_service.go
+++ b/pkg/composer/up_service.go
@@ -129,7 +129,7 @@ func (c *Composer) upServiceContainer(ctx context.Context, service *serviceparse
 	// check if container already exists
 	existingCid, err := c.containerID(ctx, container.Name, service.Unparsed.Name)
 	if err != nil {
-		return "", fmt.Errorf("error while checking for containers with name %q: %s", container.Name, err)
+		return "", fmt.Errorf("error while checking for containers with name %q: %w", container.Name, err)
 	}
 
 	// FIXME
@@ -157,7 +157,7 @@ func (c *Composer) upServiceContainer(ctx context.Context, service *serviceparse
 		log.G(ctx).Debugf("Container %q already exists, deleting", container.Name)
 		delCmd := c.createNerdctlCmd(ctx, "rm", "-f", container.Name)
 		if err = delCmd.Run(); err != nil {
-			return "", fmt.Errorf("could not delete container %q: %s", container.Name, err)
+			return "", fmt.Errorf("could not delete container %q: %w", container.Name, err)
 		}
 		log.G(ctx).Infof("Re-creating container %s", container.Name)
 	} else {

--- a/pkg/containerutil/container_network_manager_windows.go
+++ b/pkg/containerutil/container_network_manager_windows.go
@@ -69,7 +69,7 @@ func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
 func (m *cniNetworkManager) getCNI() (cni.CNI, error) {
 	e, err := netutil.NewCNIEnv(m.globalOptions.CNIPath, m.globalOptions.CNINetConfPath, netutil.WithNamespace(m.globalOptions.Namespace), netutil.WithDefaultNetwork(m.globalOptions.BridgeIP))
 	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate CNI env: %s", err)
+		return nil, fmt.Errorf("failed to instantiate CNI env: %w", err)
 	}
 
 	cniOpts := []cni.Opt{
@@ -92,7 +92,7 @@ func (m *cniNetworkManager) getCNI() (cni.CNI, error) {
 func (m *cniNetworkManager) SetupNetworking(ctx context.Context, containerID string) error {
 	cni, err := m.getCNI()
 	if err != nil {
-		return fmt.Errorf("failed to get container networking for setup: %s", err)
+		return fmt.Errorf("failed to get container networking for setup: %w", err)
 	}
 
 	netNs, err := m.setupNetNs()
@@ -110,12 +110,12 @@ func (m *cniNetworkManager) CleanupNetworking(ctx context.Context, container con
 	containerID := container.ID()
 	cni, err := m.getCNI()
 	if err != nil {
-		return fmt.Errorf("failed to get container networking for cleanup: %s", err)
+		return fmt.Errorf("failed to get container networking for cleanup: %w", err)
 	}
 
 	spec, err := container.Spec(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to get container specs for networking cleanup: %s", err)
+		return fmt.Errorf("failed to get container specs for networking cleanup: %w", err)
 	}
 
 	netNsID, found := spec.Annotations[ocihook.NetworkNamespace]

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -160,13 +160,13 @@ func ServerSemVer(ctx context.Context, client *containerd.Client) (*semver.Versi
 func buildctlVersion() dockercompat.ComponentVersion {
 	buildctlBinary, err := buildkitutil.BuildctlBinary()
 	if err != nil {
-		log.L.Warnf("unable to determine buildctl version: %s", err.Error())
+		log.L.WithError(err).Warnf("unable to determine buildctl version")
 		return dockercompat.ComponentVersion{Name: "buildctl"}
 	}
 
 	stdout, err := exec.Command(buildctlBinary, "--version").Output()
 	if err != nil {
-		log.L.Warnf("unable to determine buildctl version: %s", err.Error())
+		log.L.WithError(err).Warnf("unable to determine buildctl version")
 		return dockercompat.ComponentVersion{Name: "buildctl"}
 	}
 
@@ -205,7 +205,7 @@ func parseBuildctlVersion(buildctlVersionStdout []byte) (*dockercompat.Component
 func runcVersion() dockercompat.ComponentVersion {
 	stdout, err := exec.Command("runc", "--version").Output()
 	if err != nil {
-		log.L.Warnf("unable to determine runc version: %s", err.Error())
+		log.L.WithError(err).Warnf("unable to determine runc version")
 		return dockercompat.ComponentVersion{Name: "runc"}
 	}
 	v, err := parseRuncVersion(stdout)

--- a/pkg/logging/fluentd_logger.go
+++ b/pkg/logging/fluentd_logger.go
@@ -219,20 +219,20 @@ func parseFluentdConfig(config map[string]string) (fluent.Config, error) {
 	result := fluent.Config{}
 	location, err := parseAddress(config[fluentAddress])
 	if err != nil {
-		return result, fmt.Errorf("error occurs %v,invalid fluentd address (%s)", err, config[fluentAddress])
+		return result, fmt.Errorf("error occurs %w,invalid fluentd address (%s)", err, config[fluentAddress])
 	}
 	bufferLimit := defaultBufferLimit
 	if config[fluentdBufferLimit] != "" {
 		bufferLimit, err = strconv.Atoi(config[fluentdBufferLimit])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid buffer limit (%s)", err, config[fluentdBufferLimit])
+			return result, fmt.Errorf("error occurs %w,invalid buffer limit (%s)", err, config[fluentdBufferLimit])
 		}
 	}
 	retryWait := int(defaultRetryWait)
 	if config[fluentdRetryWait] != "" {
 		temp, err := time.ParseDuration(config[fluentdRetryWait])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid retry wait (%s)", err, config[fluentdRetryWait])
+			return result, fmt.Errorf("error occurs %w,invalid retry wait (%s)", err, config[fluentdRetryWait])
 		}
 		retryWait = int(temp.Milliseconds())
 	}
@@ -240,21 +240,21 @@ func parseFluentdConfig(config map[string]string) (fluent.Config, error) {
 	if config[fluentdMaxRetries] != "" {
 		maxRetries, err = strconv.Atoi(config[fluentdMaxRetries])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid max retries (%s)", err, config[fluentdMaxRetries])
+			return result, fmt.Errorf("error occurs %w,invalid max retries (%s)", err, config[fluentdMaxRetries])
 		}
 	}
 	async := false
 	if config[fluentdAsync] != "" {
 		async, err = strconv.ParseBool(config[fluentdAsync])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid async (%s)", err, config[fluentdAsync])
+			return result, fmt.Errorf("error occurs %w,invalid async (%s)", err, config[fluentdAsync])
 		}
 	}
 	asyncReconnectInterval := 0
 	if config[fluentdAsyncReconnectInterval] != "" {
 		tempDuration, err := time.ParseDuration(config[fluentdAsyncReconnectInterval])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid async connect interval (%s)", err, config[fluentdAsyncReconnectInterval])
+			return result, fmt.Errorf("error occurs %w,invalid async connect interval (%s)", err, config[fluentdAsyncReconnectInterval])
 		}
 		if tempDuration != 0 && (tempDuration < minReconnectInterval || tempDuration > maxReconnectInterval) {
 			return result, fmt.Errorf("invalid async connect interval (%s), must be between %d and %d", config[fluentdAsyncReconnectInterval], minReconnectInterval.Milliseconds(), maxReconnectInterval.Milliseconds())
@@ -265,14 +265,14 @@ func parseFluentdConfig(config map[string]string) (fluent.Config, error) {
 	if config[fluentdSubSecondPrecision] != "" {
 		subSecondPrecision, err = strconv.ParseBool(config[fluentdSubSecondPrecision])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid sub second precision (%s)", err, config[fluentdSubSecondPrecision])
+			return result, fmt.Errorf("error occurs %w,invalid sub second precision (%s)", err, config[fluentdSubSecondPrecision])
 		}
 	}
 	requestAck := false
 	if config[fluentRequestAck] != "" {
 		requestAck, err = strconv.ParseBool(config[fluentRequestAck])
 		if err != nil {
-			return result, fmt.Errorf("error occurs %v,invalid request ack (%s)", err, config[fluentRequestAck])
+			return result, fmt.Errorf("error occurs %w,invalid request ack (%s)", err, config[fluentRequestAck])
 		}
 	}
 	result = fluent.Config{

--- a/pkg/logging/journald_logger.go
+++ b/pkg/logging/journald_logger.go
@@ -161,7 +161,7 @@ func (journaldLogger *JournaldLogger) PostProcess() error {
 func FetchLogs(stdout, stderr io.Writer, journalctlArgs []string, stopChannel chan os.Signal) error {
 	journalctl, err := exec.LookPath("journalctl")
 	if err != nil {
-		return fmt.Errorf("could not find `journalctl` executable in PATH: %s", err)
+		return fmt.Errorf("could not find `journalctl` executable in PATH: %w", err)
 	}
 
 	cmd := exec.Command(journalctl, journalctlArgs...)
@@ -169,7 +169,7 @@ func FetchLogs(stdout, stderr io.Writer, journalctlArgs []string, stopChannel ch
 	cmd.Stderr = stderr
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start journalctl command with args %#v: %s", journalctlArgs, err)
+		return fmt.Errorf("failed to start journalctl command with args %#v: %w", journalctlArgs, err)
 	}
 
 	// Setup killing goroutine:

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -192,12 +192,12 @@ func viewLogsJSONFileDirect(lvopts LogViewOptions, jsonLogFilePath string, stdou
 					time.Sleep(5 * time.Millisecond)
 					if retryTimes == 0 {
 						log.L.Infof("finished parsing log JSON filefile, path: %s, line: %s", jsonLogFilePath, string(line))
-						return fmt.Errorf("error occurred while doing read of JSON logfile %q: %s, retryTimes: %d", jsonLogFilePath, err, retryTimes)
+						return fmt.Errorf("error occurred while doing read of JSON logfile %q: %w, retryTimes: %d", jsonLogFilePath, err, retryTimes)
 					}
 					retryTimes--
 					backBytes = len(line)
 				} else {
-					return fmt.Errorf("error occurred while doing read of JSON logfile %q: %s", jsonLogFilePath, err)
+					return fmt.Errorf("error occurred while doing read of JSON logfile %q: %w", jsonLogFilePath, err)
 				}
 			} else {
 				retryTimes = 2

--- a/pkg/logging/jsonfile/jsonfile.go
+++ b/pkg/logging/jsonfile/jsonfile.go
@@ -146,7 +146,7 @@ func Decode(stdout, stderr io.Writer, r io.Reader, timestamps bool, since string
 		// Write out the entry directly
 		err := writeEntry(&e, stdout, stderr, now, timestamps, since, until)
 		if err != nil {
-			log.L.Errorf("error while writing log entry to output stream: %s", err)
+			log.L.WithError(err).Errorf("error while writing log entry to output stream")
 		}
 	}
 

--- a/pkg/logging/log_viewer.go
+++ b/pkg/logging/log_viewer.go
@@ -122,12 +122,12 @@ func InitContainerLogViewer(containerLabels map[string]string, lvopts LogViewOpt
 		lcfg.Driver = "cri"
 	} else {
 		if err := lvopts.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid LogViewOptions provided (%#v): %s", lvopts, err)
+			return nil, fmt.Errorf("invalid LogViewOptions provided (%#v): %w", lvopts, err)
 		}
 
 		lcfg, err = LoadLogConfig(lvopts.DatastoreRootPath, lvopts.Namespace, lvopts.ContainerID)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load logging config: %s", err)
+			return nil, fmt.Errorf("failed to load logging config: %w", err)
 		}
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -139,12 +139,12 @@ func LoadLogConfig(dataStore, ns, id string) (LogConfig, error) {
 	logConfigFilePath := LogConfigFilePath(dataStore, ns, id)
 	logConfigData, err := os.ReadFile(logConfigFilePath)
 	if err != nil {
-		return logConfig, fmt.Errorf("failed to read log config file %q: %s", logConfigFilePath, err)
+		return logConfig, fmt.Errorf("failed to read log config file %q: %w", logConfigFilePath, err)
 	}
 
 	err = json.Unmarshal(logConfigData, &logConfig)
 	if err != nil {
-		return logConfig, fmt.Errorf("failed to load JSON logging config file %q: %s", logConfigFilePath, err)
+		return logConfig, fmt.Errorf("failed to load JSON logging config file %q: %w", logConfigFilePath, err)
 	}
 	return logConfig, nil
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -264,7 +264,7 @@ func startTail(ctx context.Context, logName string, w *fsnotify.Watcher) (bool, 
 				log.L.Debugf("Received unexpected fsnotify event: %v, retrying", e)
 			}
 		case err := <-w.Errors:
-			log.L.Debugf("Received fsnotify watch error, retrying unless no more retries left, retries: %d, error: %s", errRetry, err)
+			log.L.WithError(err).Debugf("Received fsnotify watch error, retrying unless no more retries left, retries: %d", errRetry)
 			if errRetry == 0 {
 				return false, err
 			}

--- a/pkg/mountutil/mountutil_windows.go
+++ b/pkg/mountutil/mountutil_windows.go
@@ -139,7 +139,7 @@ func splitVolumeSpec(raw string) ([]string, error) {
 
 	compiledRegex, err := regexp.Compile(rxWindows)
 	if err != nil {
-		return nil, fmt.Errorf("error compiling regex: %s", err)
+		return nil, fmt.Errorf("error compiling regex: %w", err)
 	}
 	return splitRawSpec(raw, compiledRegex)
 }

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -408,11 +408,11 @@ func (e *CNIEnv) GetDefaultNetworkConfig() (*NetworkConfig, error) {
 func (e *CNIEnv) ensureDefaultNetworkConfig(bridgeIP string) error {
 	defaultNet, err := e.GetDefaultNetworkConfig()
 	if err != nil {
-		return fmt.Errorf("failed to check for default network: %s", err)
+		return fmt.Errorf("failed to check for default network: %w", err)
 	}
 	if defaultNet == nil {
 		if err := e.createDefaultNetworkConfig(bridgeIP); err != nil {
-			return fmt.Errorf("failed to create default network: %s", err)
+			return fmt.Errorf("failed to create default network: %w", err)
 		}
 	}
 	return nil
@@ -429,7 +429,7 @@ func (e *CNIEnv) createDefaultNetworkConfig(bridgeIP string) error {
 	if bridgeIP != "" {
 		bIP, bCIDR, err := net.ParseCIDR(bridgeIP)
 		if err != nil {
-			return fmt.Errorf("invalid bridge ip %s: %s", bridgeIP, err)
+			return fmt.Errorf("invalid bridge ip %s: %w", bridgeIP, err)
 		}
 		bridgeGatewayIP = bIP.String()
 		bridgeCIDR = bCIDR.String()

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -503,7 +503,7 @@ func applyNetworkSettings(opts *handlerOpts) error {
 		}
 		if !b4nnBindEnabled && len(opts.ports) > 0 {
 			if err := exposePortsRootless(ctx, opts.rootlessKitClient, opts.ports); err != nil {
-				return fmt.Errorf("failed to expose ports in rootless mode: %s", err)
+				return fmt.Errorf("failed to expose ports in rootless mode: %w", err)
 			}
 		}
 	}
@@ -590,7 +590,7 @@ func onPostStop(opts *handlerOpts) error {
 			}
 			if !b4nnBindEnabled && len(opts.ports) > 0 {
 				if err := unexposePortsRootless(ctx, opts.rootlessKitClient, opts.ports); err != nil {
-					return fmt.Errorf("failed to unexpose ports in rootless mode: %s", err)
+					return fmt.Errorf("failed to unexpose ports in rootless mode: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION
As pointed out in https://github.com/containerd/nerdctl/pull/3771#pullrequestreview-2566004032, we are not currently consistent with the way we wrap errors.

This PR remediates that.

Note this is on top of #3771.