### PR TITLE
Skip TestRunBindMountPropagation

### DIFF
--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -500,6 +500,8 @@ func TestRunVolumeBindMode(t *testing.T) {
 }
 
 func TestRunBindMountPropagation(t *testing.T) {
+	t.Skip("This test is currently broken. See https://github.com/containerd/nerdctl/issues/3404")
+
 	tID := testutil.Identifier(t)
 
 	if !isRootfsShareableMount() {


### PR DESCRIPTION
Fix #3404 

It _seems_ that this test never runs on the CI - presumably because of the docker environment.

Furthermore, it does run outside of docker, with rootless - but fails, as the mechanism deciding that the mount is shared is incorrect (possibly because of nsenter or the way rootlesskit starts containerd).

In all cases, suggesting we skip it for now:
- it will not change anything for the CI
- it will allow to run the rootless test suite locally

