### PR TITLE
Cleanup XDGRuntime

### DIFF
--- a/pkg/buildkitutil/buildkitutil_freebsd.go
+++ b/pkg/buildkitutil/buildkitutil_freebsd.go
@@ -16,7 +16,7 @@
 
 package buildkitutil
 
-func getRuntimeVariableDataDir() string {
+func getRuntimeVariableDataDir() (string, error) {
 	// Per hier(7) dated July 6, 2023.
-	return "/var/run"
+	return "/var/run", nil
 }

--- a/pkg/buildkitutil/buildkitutil_linux.go
+++ b/pkg/buildkitutil/buildkitutil_linux.go
@@ -18,13 +18,12 @@ package buildkitutil
 
 import (
 	"fmt"
-
-	"github.com/containerd/log"
+	"os"
 
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func getRuntimeVariableDataDir() string {
+func getRuntimeVariableDataDir() (string, error) {
 	// Per Linux Foundation "Filesystem Hierarchy Standard" version 3.0 section 3.15.
 	// Under version 2.3, this was "/var/run".
 	run := "/run"
@@ -32,9 +31,11 @@ func getRuntimeVariableDataDir() string {
 		var err error
 		run, err = rootlessutil.XDGRuntimeDir()
 		if err != nil {
-			log.L.Warn(err)
-			run = fmt.Sprintf("/run/user/%d", rootlessutil.ParentEUID())
+			if rootlessutil.IsRootlessChild() {
+				return "", err
+			}
+			run = fmt.Sprintf("/run/user/%d", os.Geteuid())
 		}
 	}
-	return run
+	return run, nil
 }

--- a/pkg/buildkitutil/buildkitutil_unix.go
+++ b/pkg/buildkitutil/buildkitutil_unix.go
@@ -28,7 +28,10 @@ func getBuildkitHostCandidates(namespace string) ([]string, error) {
 		return []string{}, fmt.Errorf("namespace must be specified")
 	}
 	// Try candidate locations of the current containerd namespace.
-	run := getRuntimeVariableDataDir()
+	run, err := getRuntimeVariableDataDir()
+	if err != nil {
+		return []string{}, err
+	}
 	var candidates []string
 	if namespace != "default" {
 		candidates = append(candidates, "unix://"+filepath.Join(run, fmt.Sprintf("buildkit-%s/buildkitd.sock", namespace)))

--- a/pkg/bypass4netnsutil/bypass4netnsutil.go
+++ b/pkg/bypass4netnsutil/bypass4netnsutil.go
@@ -18,7 +18,6 @@ package bypass4netnsutil
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -30,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/oci"
 
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
 func generateSecurityOpt(listenerPath string) (oci.SpecOpts, error) {
@@ -83,15 +83,8 @@ func GenerateBypass4netnsOpts(securityOptsMaps map[string]string, annotationsMap
 	return opts, nil
 }
 
-func getXDGRuntimeDir() (string, error) {
-	if xrd := os.Getenv("XDG_RUNTIME_DIR"); xrd != "" {
-		return xrd, nil
-	}
-	return "", fmt.Errorf("environment variable XDG_RUNTIME_DIR is not set")
-}
-
 func CreateSocketDir() error {
-	xdgRuntimeDir, err := getXDGRuntimeDir()
+	xdgRuntimeDir, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
 		return err
 	}
@@ -107,7 +100,7 @@ func CreateSocketDir() error {
 }
 
 func GetBypass4NetnsdDefaultSocketPath() (string, error) {
-	xdgRuntimeDir, err := getXDGRuntimeDir()
+	xdgRuntimeDir, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
 		return "", err
 	}
@@ -116,7 +109,7 @@ func GetBypass4NetnsdDefaultSocketPath() (string, error) {
 }
 
 func GetSocketPathByID(id string) (string, error) {
-	xdgRuntimeDir, err := getXDGRuntimeDir()
+	xdgRuntimeDir, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
 		return "", err
 	}
@@ -126,7 +119,7 @@ func GetSocketPathByID(id string) (string, error) {
 }
 
 func GetPidFilePathByID(id string) (string, error) {
-	xdgRuntimeDir, err := getXDGRuntimeDir()
+	xdgRuntimeDir, err := rootlessutil.XDGRuntimeDir()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/defaults/defaults_freebsd.go
+++ b/pkg/defaults/defaults_freebsd.go
@@ -39,8 +39,8 @@ func CNINetConfPath() string {
 	return cni.DefaultNetDir
 }
 
-func CNIRuntimeDir() string {
-	return "/run/cni"
+func CNIRuntimeDir() (string, error) {
+	return "/run/cni", nil
 }
 
 func CgroupManager() string {

--- a/pkg/defaults/defaults_windows.go
+++ b/pkg/defaults/defaults_windows.go
@@ -39,8 +39,8 @@ func CNINetConfPath() string {
 	return filepath.Join(os.Getenv("ProgramFiles"), "containerd", "cni", "conf")
 }
 
-func CNIRuntimeDir() string {
-	return ""
+func CNIRuntimeDir() (string, error) {
+	return "", nil
 }
 
 func IsSystemdAvailable() bool {

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -206,7 +206,11 @@ func (e *CNIEnv) generateIPAM(driver string, subnets []string, gatewayStr, ipRan
 		ipamConfig = ipamConf
 	case "dhcp":
 		ipamConf := newDHCPIPAMConfig()
-		ipamConf.DaemonSocketPath = filepath.Join(defaults.CNIRuntimeDir(), "dhcp.sock")
+		crd, err := defaults.CNIRuntimeDir()
+		if err != nil {
+			return nil, err
+		}
+		ipamConf.DaemonSocketPath = filepath.Join(crd, "dhcp.sock")
 		if err := systemutil.IsSocketAccessible(ipamConf.DaemonSocketPath); err != nil {
 			log.L.Warnf("cannot access dhcp socket %q (hint: try running with `dhcp daemon --socketpath=%s &` in CNI_PATH to launch the dhcp daemon)", ipamConf.DaemonSocketPath, ipamConf.DaemonSocketPath)
 		}


### PR DESCRIPTION
From reading code, it seems to me like:

1. `XDGRuntimeDir()` should check the value of `ROOTLESSKIT_PARENT_EUID` (like `ParentEUID` does)
2. `getXDGRuntimeDir()` in bypass4netns is essentially duplicating `XDGRuntimeDir()`
3. `getRuntimeVariableDataDir` and `CNIRuntimeDir` should not ignore errors, and they seem to have faulty logic (relying on `Geteuid` regardless of conditions), or calling `rootlessutil.ParentEUID` which will redo stuff done already in `XDGRuntimeDir()`

PR addresses these.