### PR TITLE
Prevent reference filter from failing on dangling images

### DIFF
--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -325,6 +325,11 @@ func matchesAllLabels(imageCfgLabels map[string]string, filterLabels map[string]
 func matchesReferences(image images.Image, referencePatterns []string) (bool, error) {
 	var matches int
 
+	// Containerd returns ":" for dangling untagged images - see https://github.com/containerd/nerdctl/issues/3852
+	if image.Name == ":" {
+		return false, nil
+	}
+
 	parsedReference, err := referenceutil.Parse(image.Name)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Fix #3852 

It seems likely that the same problem exists in other places.

Solutions:
a. review every code location where we manipulate the result of `imagesservice.List` and account for ":"
b. modify referenceutil to account for it

Thoughts?

~~Also 🍿 on the CI to see if that was a change in containerd 2.0.~~