### PR TITLE
Fix apparmor test not running

### DIFF
--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -16,6 +16,10 @@
 
 set -eux -o pipefail
 if [[ "$(id -u)" = "0" ]]; then
+  # Ensure securityfs is mounted for apparmor to work
+  if ! mountpoint -q /sys/kernel/security; then
+    mount -tsecurityfs securityfs /sys/kernel/security
+  fi
 	if [ -e /sys/kernel/security/apparmor/profiles ]; then
 		# Load the "nerdctl-default" profile for TestRunApparmor
 		nerdctl apparmor load

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -19,6 +19,13 @@ set -o errexit -o errtrace -o functrace -o nounset -o pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]:-$PWD}")" 2>/dev/null 1>&2 && pwd)"
 readonly root
 
+if [[ "$(id -u)" = "0" ]]; then
+  # Ensure securityfs is mounted for apparmor to work
+  if ! mountpoint -q /sys/kernel/security; then
+    mount -tsecurityfs securityfs /sys/kernel/security
+  fi
+fi
+
 readonly timeout="60m"
 readonly retries="2"
 readonly needsudo="${WITH_SUDO:-}"


### PR DESCRIPTION
Fix #3859 

This PR addresses two underlying issues:
- our test rig did not mount securityfs
- the containerd/pkg hostsupport method is not usable here, as it was specifically designed to not work inside a container

 