### PR TITLE
Reduce file permissions

### DIFF
--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -66,7 +66,7 @@ func New(dataStore string, namespace string) (retStore Store, err error) {
 		return nil, store.ErrInvalidArgument
 	}
 
-	st, err := store.New(filepath.Join(dataStore, hostsDirBasename, namespace), 0, 0o644)
+	st, err := store.New(filepath.Join(dataStore, hostsDirBasename, namespace), 0, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mountutil/volumestore/volumestore.go
+++ b/pkg/mountutil/volumestore/volumestore.go
@@ -84,7 +84,7 @@ func New(dataStore, namespace string) (volStore VolumeStore, err error) {
 		return nil, store.ErrInvalidArgument
 	}
 
-	st, err := store.New(filepath.Join(dataStore, volumeDirBasename, namespace), 0, 0o644)
+	st, err := store.New(filepath.Join(dataStore, volumeDirBasename, namespace), 0, 0o600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
```
nerdctl                                                                                    drwx------.
└── 1935db59                                                                               drwx------.
    ├── containers                                                                         drwx------.
    │   └── k8s.io                                                                         drwx------.
    │       ├── 1b0eced10dea9fddab7c66631f0920170121bd996d2845b48468ff119fe40826           drwx------.
    │       │   ├── 1b0eced10dea9fddab7c66631f0920170121bd996d2845b48468ff119fe40826-json.log    -rw-------.
    │       │   ├── hostname                                                               -rw-r--r--.    //same as the host path
    │       │   ├── log-config.json                                                        -rw-------.
    │       │   ├── oci-hook.createRuntime.log                                             -rw-r--r--.    
    │       │   └── resolv.conf                                                            -rw-r--r--.    //same as the host path
    │       └── 398edb6ec491ebbbe5175e9ce7acfadaabac72c4f6de07995d685f452cddae4d           drwx------.
    │           ├── 398edb6ec491ebbbe5175e9ce7acfadaabac72c4f6de07995d685f452cddae4d-json.log    -rw-------.
    │           └── log-config.json                                                        -rw-------.
    ├── etchosts                                                                           drwx------.
    │   └── k8s.io                                                                         drwx------.
    │       └── 1b0eced10dea9fddab7c66631f0920170121bd996d2845b48468ff119fe40826           drwx------.
    │           ├── hosts                                                                  -rw-r--r--.    //same as the host path
    │           └── meta.json                                                              -rw-r--r--.    //644 -> 640
    ├── names                                                                              drwx------.
    │   └── k8s.io                                                                         drwx------.
    │       └── busybox-1b0ec                                                              -rw-------.
    └── volumes                                                                            drwx------.
        └── k8s.io                                                                         drwx------.                                                   
            ├── 48c16a5d59bdaa86a12e39f9f926a2b8d1a79c88545126b43df07a298aa45bc3           drwx------.
            │   ├── _data                                                                  drwxr-xr-x.    //same as the volume-mount path
            │   └── volume.json                                                            -rw-r--r--.    //644 -> 640
            └── 52caf01568a036a1cae077fbd5a8fd5d1c50bc45f1df022bf8e89c1c400ee465           drwx------.
                ├── _data
                └── volume.json
```