### PR TITLE
fix: network cleanup called twice

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -385,9 +385,6 @@ func runAction(cmd *cobra.Command, args []string) error {
 			if isDetached {
 				return
 			}
-			if err := netManager.CleanupNetworking(ctx, c); err != nil {
-				log.L.WithError(err).Warnf("failed to clean up container networking")
-			}
 			if err := container.RemoveContainer(ctx, c, createOpt.GOptions, true, true, client); err != nil {
 				log.L.WithError(err).Warnf("failed to remove container %s", id)
 			}


### PR DESCRIPTION
Fixes the issue 
```
--net=host prints WARN[0000] failed to clean up container networking: [...] meta.json: no such file or directory on exit #3648
```
Link: https://github.com/containerd/nerdctl/issues/3648#issuecomment-2656141700