### PR TITLE
feat: add support for 'domainname' option in container create

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -131,6 +131,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().String("ip", "", "IPv4 address to assign to the container")
 	cmd.Flags().String("ip6", "", "IPv6 address to assign to the container")
 	cmd.Flags().StringP("hostname", "h", "", "Container host name")
+	cmd.Flags().String("domainname", "", "Container domain name")
 	cmd.Flags().String("mac-address", "", "MAC address to assign to the container")
 	// #endregion
 

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -166,6 +166,8 @@ func TestRunUtsHost(t *testing.T) {
 	base.Cmd("run", "--rm", "--uts=host", testutil.AlpineImage, "hostname").AssertOutContains(hostName)
 	// Validate we can't provide a hostname with uts=host
 	base.Cmd("run", "--rm", "--uts=host", "--hostname=foobar", testutil.AlpineImage, "hostname").AssertFail()
+	// Validate we can't provide a domainname with uts=host
+	base.Cmd("run", "--rm", "--uts=host", "--domainname=example.com", testutil.AlpineImage, "hostname").AssertFail()
 }
 
 func TestRunPidContainer(t *testing.T) {

--- a/cmd/nerdctl/container/container_run_network.go
+++ b/cmd/nerdctl/container/container_run_network.go
@@ -93,6 +93,13 @@ func loadNetworkFlags(cmd *cobra.Command) (types.NetworkOptions, error) {
 	}
 	netOpts.Hostname = hostName
 
+	// --domainname=<container domainname>
+	domainname, err := cmd.Flags().GetString("domainname")
+	if err != nil {
+		return netOpts, err
+	}
+	netOpts.Domainname = domainname
+
 	// --dns=<DNS host> ...
 	dnsSlice, err := cmd.Flags().GetStringSlice("dns")
 	if err != nil {

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -722,3 +722,54 @@ func TestRunFromOCIArchive(t *testing.T) {
 	base.Cmd("build", "--tag", tag, fmt.Sprintf("--output=type=oci,dest=%s", tarPath), buildCtx).AssertOK()
 	base.Cmd("run", "--rm", fmt.Sprintf("oci-archive://%s", tarPath)).AssertOutContainsAll(fmt.Sprintf("Loaded image: %s", tag), sentinel)
 }
+
+func TestRunDomainname(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("run --hostname not implemented on Windows yet")
+	}
+
+	testCases := []struct {
+		name        string
+		hostname    string
+		domainname  string
+		Cmd         string
+		CmdFlag     string
+		expectedOut string
+	}{
+		{
+			name:        "Check domain name",
+			hostname:    "foobar",
+			domainname:  "example.com",
+			Cmd:         "hostname",
+			CmdFlag:     "-d",
+			expectedOut: "example.com",
+		},
+		{
+			name:        "check fqdn",
+			hostname:    "foobar",
+			domainname:  "example.com",
+			Cmd:         "hostname",
+			CmdFlag:     "-f",
+			expectedOut: "foobar.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			base := testutil.NewBase(t)
+
+			base.Cmd("run",
+				"--rm",
+				"--hostname", tc.hostname,
+				"--domainname", tc.domainname,
+				testutil.CommonImage,
+				tc.Cmd,
+				tc.CmdFlag,
+			).AssertOutContains(tc.expectedOut)
+		})
+	}
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -186,6 +186,7 @@ Network flags:
 - :whale: `--dns-search`: Set custom DNS search domains
 - :whale: `--dns-opt, --dns-option`: Set DNS options
 - :whale: `-h, --hostname`: Container host name
+- :whale: `--domainname`: Container domain name
 - :whale: `--add-host`: Add a custom host-to-IP mapping (host:ip). `ip` could be a special string `host-gateway`,
 - which will be resolved to the `host-gateway-ip` in nerdctl.toml or global flag.
 - :whale: `--ip`: Specific static IP address(es) to use. Note that unlike docker, nerdctl allows specifying it with the default bridge network.
@@ -413,7 +414,7 @@ IPFS flags:
 
 Unimplemented `docker run` flags:
     `--blkio-weight-device`, `--cpu-rt-*`, `--device-*`,
-    `--disable-content-trust`, `--domainname`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
+    `--disable-content-trust`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
     `--link*`, `--publish-all`, `--storage-opt`,
     `--userns`, `--volume-driver`
 

--- a/pkg/api/types/container_network_types.go
+++ b/pkg/api/types/container_network_types.go
@@ -32,6 +32,8 @@ type NetworkOptions struct {
 	IP6Address string
 	// Hostname set container host name
 	Hostname string
+	// Domainname specifies the container's domain name
+	Domainname string
 	// DNSServers set custom DNS servers
 	DNSServers []string
 	// DNSResolvConfOptions set DNS options

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -621,8 +621,9 @@ type internalLabels struct {
 	extraHosts []string
 	pidFile    string
 	// labels from cmd options or automatically set
-	name     string
-	hostname string
+	name       string
+	hostname   string
+	domainname string
 	// automatically generated
 	stateDir string
 	// network
@@ -652,6 +653,7 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 		m[labels.Name] = internalLabels.name
 	}
 	m[labels.Hostname] = internalLabels.hostname
+	m[labels.Domainname] = internalLabels.domainname
 	extraHostsJSON, err := json.Marshal(internalLabels.extraHosts)
 	if err != nil {
 		return nil, err
@@ -729,6 +731,7 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 // loadNetOpts loads network options into InternalLabels.
 func (il *internalLabels) loadNetOpts(opts types.NetworkOptions) {
 	il.hostname = opts.Hostname
+	il.domainname = opts.Domainname
 	il.ports = opts.PortMappings
 	il.ipAddress = opts.IPAddress
 	il.ip6Address = opts.IP6Address

--- a/pkg/containerutil/container_network_manager_linux.go
+++ b/pkg/containerutil/container_network_manager_linux.go
@@ -129,6 +129,9 @@ func (m *cniNetworkManager) ContainerNetworkingOpts(_ context.Context, container
 		if hostnameOpts != nil {
 			opts = append(opts, hostnameOpts...)
 		}
+		if m.netOpts.Domainname != "" {
+			opts = append(opts, oci.WithDomainname(m.netOpts.Domainname))
+		}
 	}
 
 	return opts, cOpts, nil

--- a/pkg/containerutil/container_network_manager_windows.go
+++ b/pkg/containerutil/container_network_manager_windows.go
@@ -48,8 +48,9 @@ func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
 	}
 
 	nonZeroArgs := nonZeroMapValues(map[string]interface{}{
-		"--hostname": m.netOpts.Hostname,
-		"--uts":      m.netOpts.UTSNamespace,
+		"--hostname":   m.netOpts.Hostname,
+		"--domainname": m.netOpts.Domainname,
+		"--uts":        m.netOpts.UTSNamespace,
 		// NOTE: IP and MAC settings are currently ignored on Windows.
 		"--ip-address":  m.netOpts.IPAddress,
 		"--mac-address": m.netOpts.MACAddress,

--- a/pkg/dnsutil/hostsstore/hostsstore.go
+++ b/pkg/dnsutil/hostsstore/hostsstore.go
@@ -82,6 +82,7 @@ type Meta struct {
 	Hostname   string
 	ExtraHosts map[string]string // host:ip
 	Name       string
+	Domainname string
 }
 
 type Store interface {

--- a/pkg/dnsutil/hostsstore/updater.go
+++ b/pkg/dnsutil/hostsstore/updater.go
@@ -21,8 +21,11 @@ import (
 )
 
 // createLine returns a line string slice.
-// line is like "foo foo.nw0 bar bar.nw0\n"
-// for `nerdctl --name=foo --hostname=bar --network=n0`.
+// line is like "bar bar.nw0 foo foo.nw0\n"
+// for `nerdctl --name=foo --hostname=bar --network=nw0`.
+//
+// line is line "bar.example.com bar bar.nw0 foo foo.nw0\n"
+// for  `nerdctl --name=foo --hostname=bar --domainname=example.com --network=n0`.
 //
 // May return an empty string slice
 func createLine(thatNetwork string, meta *Meta, myNetworks map[string]struct{}) []string {
@@ -31,7 +34,13 @@ func createLine(thatNetwork string, meta *Meta, myNetworks map[string]struct{}) 
 		// Do not add lines for other networks
 		return line
 	}
+
+	if meta.Domainname != "" {
+		line = append(line, meta.Hostname+"."+meta.Domainname)
+	}
+
 	baseHostnames := []string{meta.Hostname}
+
 	if meta.Name != "" {
 		baseHostnames = append(baseHostnames, meta.Name)
 	}

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -142,8 +142,8 @@ type MountPoint struct {
 
 // config is from https://github.com/moby/moby/blob/8dbd90ec00daa26dc45d7da2431c965dec99e8b4/api/types/container/config.go#L37-L69
 type Config struct {
-	Hostname string `json:",omitempty"` // Hostname
-	// TODO: Domainname   string      // Domainname
+	Hostname    string `json:",omitempty"` // Hostname
+	Domainname  string `json:",omitempty"` // Domainname
 	User        string `json:",omitempty"` // User that will run the command(s) inside the container, also support user:group
 	AttachStdin bool   // Attach the standard input, makes possible user interaction
 	// TODO: AttachStdout bool        // Attach the standard output
@@ -317,6 +317,10 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		hostname = n.Labels[labels.Hostname]
 	}
 	c.Config.Hostname = hostname
+
+	if n.Labels[labels.Domainname] != "" {
+		c.Config.Domainname = n.Labels[labels.Domainname]
+	}
 
 	return c, nil
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -44,6 +44,9 @@ const (
 	// Hostname
 	Hostname = Prefix + "hostname"
 
+	// Domainname
+	Domainname = Prefix + "domainname"
+
 	// ExtraHosts are HostIPs to appended to /etc/hosts
 	ExtraHosts = Prefix + "extraHosts"
 

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -457,6 +457,7 @@ func applyNetworkSettings(opts *handlerOpts) error {
 		ID:         opts.state.ID,
 		Networks:   make(map[string]*types100.Result, len(opts.cniNames)),
 		Hostname:   opts.state.Annotations[labels.Hostname],
+		Domainname: opts.state.Annotations[labels.Domainname],
 		ExtraHosts: opts.extraHosts,
 		Name:       opts.state.Annotations[labels.Name],
 	}


### PR DESCRIPTION
Adds support for `--domainname` in container create and run. 

A domainname fied has been added to the OCI spec and runc has added [support](https://github.com/opencontainers/runc/pull/3600) for it. 

This field should set mainly set the NIS domain name of the container. Though, docker is currently using the `domainname` option to also set the FQDN in /etc/hosts. I have tried to preserve the same behavior, since some users may choose to pass a unqualified hostname and the domain name separately, instead of passing the full FQDN in the hostname.

### Testing:
```
dev-dsk-sbora-2c-038007b3 % sudo nerdctl run -it --hostname myhost --domainname example.com ubuntu  domainname
example.com

(25-02-14 19:49:14) <0> [~/nerdctl]  
dev-dsk-sbora-2c-038007b3 % sudo nerdctl run -it --hostname myhost --domainname example.com ubuntu hostname
myhost

(25-02-14 19:49:19) <0> [~/nerdctl]  
dev-dsk-sbora-2c-038007b3 % sudo nerdctl run -it --hostname myhost --domainname example.com ubuntu hostname -f
myhost.example.com

(25-02-14 19:49:22) <0> [~/nerdctl]  
dev-dsk-sbora-2c-038007b3 % sudo nerdctl run -it --hostname myhost --domainname example.com ubuntu hostname --nis
example.com
```

Closes: #1772