### PR TITLE
Ci minor cleanup

### DIFF
--- a/cmd/nerdctl/compose/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose/compose_exec_linux_test.go
@@ -164,9 +164,6 @@ services:
 func TestComposeExecTTY(t *testing.T) {
 	// `-i` in `compose run & exec` is only supported in compose v2.
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
-		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
-	}
 
 	var dockerComposeYAML = fmt.Sprintf(`
 version: '3.1'

--- a/cmd/nerdctl/container/container_exec_linux_test.go
+++ b/cmd/nerdctl/container/container_exec_linux_test.go
@@ -54,9 +54,6 @@ func TestExecWithUser(t *testing.T) {
 func TestExecTTY(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
-		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
-	}
 
 	testContainer := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", testContainer).Run()

--- a/cmd/nerdctl/container/container_exec_test.go
+++ b/cmd/nerdctl/container/container_exec_test.go
@@ -53,9 +53,6 @@ func TestExecWithDoubleDash(t *testing.T) {
 func TestExecStdin(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
-		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
-	}
 
 	testContainer := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", testContainer).Run()

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -311,9 +311,6 @@ func TestRunWithInit(t *testing.T) {
 func TestRunTTY(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
-		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
-	}
 
 	const sttyPartialOutput = "speed 38400 baud"
 	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.

--- a/cmd/nerdctl/container/container_run_stargz_linux_test.go
+++ b/cmd/nerdctl/container/container_run_stargz_linux_test.go
@@ -17,21 +17,25 @@
 package container
 
 import (
-	"runtime"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
 func TestRunStargz(t *testing.T) {
-	testutil.DockerIncompatible(t)
-	if runtime.GOARCH != "amd64" {
-		t.Skip("skipping test as FedoraESGZImage is amd64 only")
-	}
+	testCase := nerdtest.Setup()
 
-	base := testutil.NewBase(t)
-	helpers.RequiresStargz(base)
-	// if stargz snapshotter is functional, "/.stargz-snapshotter" appears
-	base.Cmd("--snapshotter=stargz", "run", "--rm", testutil.FedoraESGZImage, "ls", "/.stargz-snapshotter").AssertOK()
+	testCase.Require = test.Require(
+		nerdtest.Stargz,
+		test.Amd64,
+		test.Not(nerdtest.Docker),
+	)
+
+	testCase.Command = test.Command("--snapshotter=stargz", "run", "--rm", testutil.FedoraESGZImage, "ls", "/.stargz-snapshotter")
+
+	testCase.Expected = test.Expects(0, nil, nil)
+
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -237,9 +237,6 @@ func TestRunHostnameEnv(t *testing.T) {
 func TestRunStdin(t *testing.T) {
 	t.Parallel()
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
-		testutil.RequireDaemonVersion(base, ">= 1.6.0-0")
-	}
 
 	const testStr = "test-run-stdin"
 	opts := []func(*testutil.Cmd){

--- a/cmd/nerdctl/helpers/testing.go
+++ b/cmd/nerdctl/helpers/testing.go
@@ -17,7 +17,6 @@
 package helpers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,12 +26,6 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
-
-	containerd "github.com/containerd/containerd/v2/client"
-	"github.com/containerd/containerd/v2/core/content"
-
-	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
 func CreateBuildContext(t *testing.T, dockerfile string) string {
@@ -40,47 +33,6 @@ func CreateBuildContext(t *testing.T, dockerfile string) string {
 	err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile"), []byte(dockerfile), 0644)
 	assert.NilError(t, err)
 	return tmpDir
-}
-
-func RmiAll(base *testutil.Base) {
-	base.T.Logf("Pruning images")
-	imageIDs := base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
-	// remove empty output line at the end
-	imageIDs = imageIDs[:len(imageIDs)-1]
-	// use `Run` on purpose (same below) because `rmi all` may fail on individual
-	// image id that has an expected running container (e.g. a registry)
-	base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).Run()
-
-	base.T.Logf("Pruning build caches")
-	if _, err := buildkitutil.GetBuildkitHost(testutil.Namespace); err == nil {
-		base.Cmd("builder", "prune", "--force").AssertOK()
-	}
-
-	// For BuildKit >= 0.11, pruning cache isn't enough to remove manifest blobs that are referred by build history blobs
-	// https://github.com/containerd/nerdctl/pull/1833
-	if base.Target == testutil.Nerdctl {
-		base.T.Logf("Pruning all content blobs")
-		addr := base.ContainerdAddress()
-		client, err := containerd.New(addr, containerd.WithDefaultNamespace(testutil.Namespace))
-		assert.NilError(base.T, err)
-		cs := client.ContentStore()
-		ctx := context.TODO()
-		wf := func(info content.Info) error {
-			base.T.Logf("Pruning blob %+v", info)
-			if err := cs.Delete(ctx, info.Digest); err != nil {
-				base.T.Log(err)
-			}
-			return nil
-		}
-		if err := cs.Walk(ctx, wf); err != nil {
-			base.T.Log(err)
-		}
-
-		base.T.Logf("Pruning all images (again?)")
-		imageIDs = base.Cmd("images", "--no-trunc", "-a", "-q").OutLines()
-		base.T.Logf("pruning following images: %+v", imageIDs)
-		base.Cmd(append([]string{"rmi", "-f"}, imageIDs...)...).Run()
-	}
 }
 
 func ExtractDockerArchive(archiveTarPath, rootfsPath string) error {

--- a/cmd/nerdctl/helpers/testing_linux.go
+++ b/cmd/nerdctl/helpers/testing_linux.go
@@ -48,16 +48,6 @@ func FindIPv6(output string) net.IP {
 	return net.ParseIP(ipv6)
 }
 
-func RequiresStargz(base *testutil.Base) {
-	info := base.Info()
-	for _, p := range info.Plugins.Storage {
-		if p == "stargz" {
-			return
-		}
-	}
-	base.T.Skip("test requires stargz")
-}
-
 type JweKeyPair struct {
 	Prv     string
 	Pub     string


### PR DESCRIPTION
Since we officially only support containerd 2.0, 1.7 and 1.6, and since we do not have test rig to test older containerd versions, the requirement tests for containerd < 1.6 does not seem useful anymore.

Second commit is also getting rid of old/depreacted/unused test helpers (also misplaced under cmd).