### PR TITLE
Fix FATA error when inspecting images in native mode

### DIFF
--- a/cmd/nerdctl/image/image_inspect.go
+++ b/cmd/nerdctl/image/image_inspect.go
@@ -17,6 +17,8 @@
 package image
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
@@ -27,7 +29,7 @@ import (
 )
 
 func newImageInspectCommand() *cobra.Command {
-	var imageInspectCommand = &cobra.Command{
+	imageInspectCommand := &cobra.Command{
 		Use:               "inspect [flags] IMAGE [IMAGE...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Display detailed information on one or more images.",
@@ -87,6 +89,11 @@ func imageInspectAction(cmd *cobra.Command, args []string) error {
 	options, err := ProcessImageInspectOptions(cmd, nil)
 	if err != nil {
 		return err
+	}
+
+	// Verify we have a valid mode
+	if options.Mode != "native" && options.Mode != "dockercompat" {
+		return fmt.Errorf("unknown mode %q", options.Mode)
 	}
 
 	client, ctx, cancel, err := clientutil.NewClientWithPlatform(cmd.Context(), options.GOptions.Namespace, options.GOptions.Address, options.Platform)

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -175,13 +175,11 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, data.Get(mainImageCIDKey), data.Identifier("encrypted"))
 				cmd := helpers.Command("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					ExitCode: 1,
-					Output:   test.Equals("1\n"),
+					Output: test.Equals("1\n"),
 				})
 				cmd = helpers.Command("image", "inspect", "--mode=native", "--format={{json (index .Manifest.Layers 0) }}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
-					ExitCode: 1,
-					Output:   test.Contains("org.opencontainers.image.enc.keys.jwe"),
+					Output: test.Contains("org.opencontainers.image.enc.keys.jwe"),
 				})
 
 				// Push the encrypted image and save the CID

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -88,11 +88,6 @@ func inspectIdentifier(ctx context.Context, client *containerd.Client, identifie
 
 // Inspect prints detailed information of each image in `images`.
 func Inspect(ctx context.Context, client *containerd.Client, identifiers []string, options types.ImageInspectOptions) error {
-	// Verify we have a valid mode
-	// TODO: move this out of here, to Cobra command line arg validation
-	if options.Mode != "native" && options.Mode != "dockercompat" {
-		return fmt.Errorf("unknown mode %q", options.Mode)
-	}
 	// Set a timeout
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -180,15 +175,17 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 		}
 
 		// Done iterating through candidates. Did we find anything that matches?
-		if validatedImage != nil {
+		if options.Mode == "dockercompat" {
+			if validatedImage == nil {
+				errs = append(errs, fmt.Errorf("no such image: %s", identifier))
+				continue
+			}
 			// Then slap in the repoTags and repoDigests we found from the other candidates
 			validatedImage.RepoTags = append(validatedImage.RepoTags, repoTags...)
 			validatedImage.RepoDigests = append(validatedImage.RepoDigests, repoDigests...)
 			// Store our image
 			// foundImages[validatedDigest] = validatedImage
 			entries = append(entries, validatedImage)
-		} else {
-			errs = append(errs, fmt.Errorf("no such image: %s", identifier))
 		}
 	}
 


### PR DESCRIPTION
## Description
This PR fixes an issue where a FATA error is always displayed when inspecting images in native mode.

## Steps to reproduce the issue
```
> nerdctl image inspect --mode native abc
<abc image info>
FATA[0000] 1 errors:
no such image: abc
```

Fix: #3876 
Ref: https://github.com/containerd/nerdctl/pull/3792#issuecomment-2629221450



