### PR TITLE
CI: make the `test` framework usable standalone in other projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/containerd/go-cni v1.1.12
 	github.com/containerd/imgcrypt/v2 v2.0.0
 	github.com/containerd/log v0.1.0
+	github.com/containerd/nerdctl/v2/pkg/testutil/test v0.0.0
 	github.com/containerd/nydus-snapshotter v0.15.0
 	github.com/containerd/platforms v1.0.0-rc.1
 	github.com/containerd/stargz-snapshotter v0.16.3
@@ -142,3 +143,5 @@ require (
 	tags.cncf.io/container-device-interface v0.8.0 // indirect
 	tags.cncf.io/container-device-interface/specs-go v0.8.0 // indirect
 )
+
+replace github.com/containerd/nerdctl/v2/pkg/testutil/test v0.0.0 => ./pkg/testutil/test

--- a/pkg/testutil/test/LICENSE
+++ b/pkg/testutil/test/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/testutil/test/Makefile
+++ b/pkg/testutil/test/Makefile
@@ -1,0 +1,212 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# project-checks is broken.
+# See https://github.com/containerd/nerdctl/pull/3889
+
+##########################
+# Configuration
+##########################
+ORG_PREFIXES := "github.com/containerd"
+
+MAKEFILE_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+VERSION ?= $(shell git -C $(MAKEFILE_DIR) describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+VERSION_TRIMMED := $(VERSION:v%=%)
+REVISION ?= $(shell git -C $(MAKEFILE_DIR) rev-parse HEAD)$(shell if ! git -C $(MAKEFILE_DIR) diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+LINT_COMMIT_RANGE ?= main..HEAD
+
+##########################
+# Helpers
+##########################
+ifdef VERBOSE
+	VERBOSE_FLAG := -v
+	VERBOSE_FLAG_LONG := --verbose
+endif
+
+ifndef DC_NO_FANCY
+    NC := \033[0m
+    GREEN := \033[1;32m
+    ORANGE := \033[1;33m
+endif
+
+# Helpers
+recursive_wildcard=$(wildcard $1$2) $(foreach e,$(wildcard $1*),$(call recursive_wildcard,$e/,$2))
+
+define title
+	@printf "$(GREEN)____________________________________________________________________________________________________\n"
+	@printf "$(GREEN)%*s\n" $$(( ( $(shell echo "🐯$(1) 🐯" | wc -c ) + 100 ) / 2 )) "🐯$(1) 🐯"
+	@printf "$(GREEN)____________________________________________________________________________________________________\n$(ORANGE)"
+endef
+
+define footer
+	@printf "$(GREEN)> %s: done!\n" "$(1)"
+	@printf "$(GREEN)____________________________________________________________________________________________________\n$(NC)"
+endef
+
+##########################
+# High-level tasks definitions
+##########################
+lint: lint-go-all lint-imports lint-yaml lint-shell lint-commits lint-headers lint-mod lint-licenses-all
+test: test-unit test-unit-race test-unit-bench
+unit: test-unit test-unit-race test-unit-bench
+fix: fix-mod fix-imports fix-go-all
+
+##########################
+# Linting tasks
+##########################
+lint-go:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& golangci-lint run $(VERBOSE_FLAG_LONG) ./...
+	$(call footer, $@)
+
+lint-go-all:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& GOOS=darwin make lint-go \
+		&& GOOS=linux make lint-go \
+		&& GOOS=windows make lint-go
+	$(call footer, $@)
+
+lint-imports:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& goimports-reviser -recursive -list-diff -set-exit-status -output stdout -company-prefixes "github.com/containerd"  ./...
+	$(call footer, $@)
+
+lint-yaml:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& yamllint .
+	$(call footer, $@)
+
+lint-shell: $(call recursive_wildcard,$(MAKEFILE_DIR)/,*.sh)
+	$(call title, $@)
+	@shellcheck -a -x $^
+	$(call footer, $@)
+
+lint-commits:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& git-validation $(VERBOSE_FLAG) -run DCO,short-subject,dangling-whitespace -range "$(LINT_COMMIT_RANGE)"
+	$(call footer, $@)
+
+lint-headers:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& ltag -t "./hack/headers" --check -v
+	$(call footer, $@)
+
+lint-mod:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& go mod tidy --diff
+	$(call footer, $@)
+
+lint-licenses:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& ./hack/make-lint-licenses.sh
+	$(call footer, $@)
+
+lint-licenses-all:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& GOOS=darwin make lint-licenses \
+		&& GOOS=linux make lint-licenses \
+		&& GOOS=windows make lint-licenses
+	$(call footer, $@)
+
+##########################
+# Automated fixing tasks
+##########################
+fix-go:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& golangci-lint run --fix
+	$(call footer, $@)
+
+fix-go-all:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& GOOS=darwin make fix-go \
+		&& GOOS=linux make fix-go \
+		&& GOOS=windows make fix-go
+	$(call footer, $@)
+
+fix-imports:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& goimports-reviser -company-prefixes $(ORG_PREFIXES) ./...
+	$(call footer, $@)
+
+fix-mod:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& go mod tidy
+	$(call footer, $@)
+
+up:
+	$(call title, $@)
+	@cd $(MAKEFILE_DIR) \
+		&& go get -u ./...
+	$(call footer, $@)
+
+##########################
+# Development tools installation
+##########################
+install-dev-tools:
+	$(call title, $@)
+	# golangci: v1.64.5
+	# git-validation: main from 2023/11
+	# ltag: v0.2.5
+	# go-licenses: v2.0.0-alpha.1
+	# goimports-reviser: v3.9.0
+	@cd $(MAKEFILE_DIR) \
+		&& go install github.com/golangci/golangci-lint/cmd/golangci-lint@0a603e49e5e9870f5f9f2035bcbe42cd9620a9d5 \
+		&& go install github.com/vbatts/git-validation@679e5cad8c50f1605ab3d8a0a947aaf72fb24c07 \
+		&& go install github.com/kunalkushwaha/ltag@b0cfa33e4cc9383095dc584d3990b62c95096de0 \
+		&& go install github.com/google/go-licenses/v2@d01822334fba5896920a060f762ea7ecdbd086e8 \
+		&& go install github.com/incu6us/goimports-reviser/v3@698f92d226d50a01731ca8551993ebc1bb7fc788
+	@echo "Remember to add GOROOT/bin to your path"
+	$(call footer, $@)
+
+##########################
+# Testing tasks
+##########################
+test-unit:
+	$(call title, $@)
+	@go test $(VERBOSE_FLAG) $(MAKEFILE_DIR)/...
+	$(call footer, $@)
+
+test-unit-bench:
+	$(call title, $@)
+	@go test $(VERBOSE_FLAG) $(MAKEFILE_DIR)/... -bench=.
+	$(call footer, $@)
+
+test-unit-race:
+	$(call title, $@)
+	@go test $(VERBOSE_FLAG) $(MAKEFILE_DIR)/... -race
+	$(call footer, $@)
+
+.PHONY: \
+	lint \
+	fix \
+	test \
+	up \
+	unit \
+	install-dev-tools \
+	lint-commits lint-go lint-go-all lint-headers lint-imports lint-licenses lint-licenses-all lint-mod lint-shell lint-yaml \
+	fix-go fix-go-all fix-imports fix-mod \
+	test-unit test-unit-race test-unit-bench

--- a/pkg/testutil/test/README.md
+++ b/pkg/testutil/test/README.md
@@ -1,0 +1,77 @@
+# Tigron test framework
+
+>  no-one likes you, `if [ $? -eq 0 ]`
+
+A modern testing framework for command-line applications.
+
+## TL;DR
+
+TBD
+
+## Documentation
+
+TBD
+
+For now, see [nerdctl-specific testing documentation](https://github.com/containerd/nerdctl/blob/main/docs/testing/tools.md).
+
+## Motivation and goals
+
+Testing (go) binaries is a journey fraught with many pitfalls.
+
+While some tooling exist (the venerable [bats](https://github.com/bats-core/bats-core), or the solid work going
+on at [gotestyourself](https://github.com/gotestyourself)), they either focus on relatively low-level testing
+primitives (`assert`, `exec`), or do not integrate well into the natural go environment
+(`bats` requires you to write shell scripts), and routinely require additional third-party tools for advanced scenarios
+(hello `unbuffer`), and for the developer to write a large set of "helpers".
+
+Projects and companies thus routinely end-up growing in-house tooling, that generally suffer from a number of
+rampant issues: lack of structure and expressiveness, helpers spaghetti, unclear test lifecycle (specifically
+cleanup), resource leakage and cross test interaction, ultimately encouraging bad test design leading to degraded
+and un-scalable situations (flakyness being of course the number 1 scourge).
+
+Tigron was developed specifically to address these issues, based on the experience testing nerdctl, a large cli
+with a lot of integration tests.
+
+Tigron does not replace `gotest.tools`, nor `gotestsum`. In fact, it leverages and encourages use of these where
+appropriate.
+
+Tigron ambition is to provide a ready-to-use, clean, simple, go-native framework meant specifically to
+write tests for cli binaries, encouraging good test design and a stronger basis to build tests suite.
+It also comes with a set of helpers to accomodate most advanced scenarios (command backgrounding, stdin manipulation,
+support for pseudo ttys, environment filtering, etc.)
+
+## Hack
+
+### Initial setup
+
+Clone, then:
+
+```
+./hack/dev-setup-linux.sh
+# Or
+# ./hack/dev-setup-macos.sh
+
+make install-dev-tools
+```
+
+### Work
+
+```
+# Update dependencies
+make up
+```
+
+```
+# Re-order imports, gofmt, go mod tidy, etc
+make fix
+```
+
+```
+# Ensure linters are happy
+make lint
+```
+
+```
+# Run tests
+make test
+```

--- a/pkg/testutil/test/go.mod
+++ b/pkg/testutil/test/go.mod
@@ -1,0 +1,14 @@
+module github.com/containerd/nerdctl/v2/pkg/testutil/test
+
+go 1.22.7
+
+require (
+	golang.org/x/sync v0.11.0
+	golang.org/x/term v0.29.0
+	gotest.tools/v3 v3.5.2
+)
+
+require (
+	github.com/google/go-cmp v0.6.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+)

--- a/pkg/testutil/test/go.sum
+++ b/pkg/testutil/test/go.sum
@@ -1,0 +1,10 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
+golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=

--- a/pkg/testutil/test/hack/dev-setup-linux.sh
+++ b/pkg/testutil/test/hack/dev-setup-linux.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+
+sudo apt-get install -qq --no-install-recommends golang make yamllint shellcheck

--- a/pkg/testutil/test/hack/dev-setup-macos.sh
+++ b/pkg/testutil/test/hack/dev-setup-macos.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+
+brew install golang make yamllint shellcheck

--- a/pkg/testutil/test/hack/headers/bash.txt
+++ b/pkg/testutil/test/hack/headers/bash.txt
@@ -1,0 +1,13 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/pkg/testutil/test/hack/headers/dockerfile.txt
+++ b/pkg/testutil/test/hack/headers/dockerfile.txt
@@ -1,0 +1,13 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.

--- a/pkg/testutil/test/hack/headers/go.txt
+++ b/pkg/testutil/test/hack/headers/go.txt
@@ -1,0 +1,15 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/

--- a/pkg/testutil/test/hack/headers/makefile.txt
+++ b/pkg/testutil/test/hack/headers/makefile.txt
@@ -1,0 +1,16 @@
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# project-checks is broken.
+# See https://github.com/containerd/nerdctl/pull/3889

--- a/pkg/testutil/test/hack/make-lint-licenses.sh
+++ b/pkg/testutil/test/hack/make-lint-licenses.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# shellcheck disable=SC2034,SC2015
+set -o errexit -o errtrace -o functrace -o nounset -o pipefail
+
+# FIXME: go-licenses cannot find LICENSE from root of repo when submodule is imported:
+# https://github.com/google/go-licenses/issues/186
+# This is impacting gotest.tools
+# go-licenses is also really broken right now wrt to stdlib: https://github.com/google/go-licenses/issues/244
+# workaround taken from the awesome folks at Pulumi: https://github.com/pulumi/license-check-action/pull/3
+go-licenses check --include_tests --allowed_licenses=Apache-2.0,BSD-2-Clause,BSD-3-Clause,MIT,MPL-2.0 \
+	  --ignore gotest.tools \
+	  --ignore "$(go list std | awk 'NR > 1 { printf(",") } { printf("%s",$0) } END { print "" }')" \
+	  ./...
+
+printf "WARNING: you need to manually verify licenses for:\n- gotest.tools\n"

--- a/pkg/testutil/test/internal/pty/pty_darwin.go
+++ b/pkg/testutil/test/internal/pty/pty_darwin.go
@@ -1,0 +1,25 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pty
+
+import (
+	"os"
+)
+
+func Open() (pty, tty *os.File, err error) {
+	return nil, nil, ErrPTYUnsupportedPlatform
+}


### PR DESCRIPTION
Note this is on top of #3591, which must be merged first.

This PR makes the testing framework usable in other projects as an independent module.

Directory renaming and re-organization of the subpackage will come next.

cc @AkihiroSuda 