### PR TITLE
Refactor: suggesting we normalize all command variables to cmd

### DIFF
--- a/cmd/nerdctl/builder/builder.go
+++ b/cmd/nerdctl/builder/builder.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewBuilderCommand() *cobra.Command {
-	var builderCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "builder",
 		Short:         "Manage builds",
@@ -39,17 +39,17 @@ func NewBuilderCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	builderCommand.AddCommand(
+	cmd.AddCommand(
 		NewBuildCommand(),
 		newBuilderPruneCommand(),
 		newBuilderDebugCommand(),
 	)
-	return builderCommand
+	return cmd
 }
 
 func newBuilderPruneCommand() *cobra.Command {
 	shortHelp := `Clean up BuildKit build cache`
-	var buildPruneCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "prune",
 		Args:          cobra.NoArgs,
 		Short:         shortHelp,
@@ -58,11 +58,11 @@ func newBuilderPruneCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	helpers.AddStringFlag(buildPruneCommand, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
+	helpers.AddStringFlag(cmd, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
 
-	buildPruneCommand.Flags().BoolP("all", "a", false, "Remove all unused build cache, not just dangling ones")
-	buildPruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	return buildPruneCommand
+	cmd.Flags().BoolP("all", "a", false, "Remove all unused build cache, not just dangling ones")
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	return cmd
 }
 
 func builderPruneAction(cmd *cobra.Command, _ []string) error {
@@ -133,7 +133,7 @@ func processBuilderPruneOptions(cmd *cobra.Command) (types.BuilderPruneOptions, 
 
 func newBuilderDebugCommand() *cobra.Command {
 	shortHelp := `Debug Dockerfile`
-	var buildDebugCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "debug",
 		Short:         shortHelp,
 		PreRunE:       helpers.CheckExperimental("`nerdctl builder debug`"),
@@ -141,13 +141,13 @@ func newBuilderDebugCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	buildDebugCommand.Flags().StringP("file", "f", "", "Name of the Dockerfile")
-	buildDebugCommand.Flags().String("target", "", "Set the target build stage to build")
-	buildDebugCommand.Flags().StringArray("build-arg", nil, "Set build-time variables")
-	buildDebugCommand.Flags().String("image", "", "Image to use for debugging stage")
-	buildDebugCommand.Flags().StringArray("ssh", nil, "Allow forwarding SSH agent to the build. Format: default|<id>[=<socket>|<key>[,<key>]]")
-	buildDebugCommand.Flags().StringArray("secret", nil, "Expose secret value to the build. Format: id=secretname,src=filepath")
-	return buildDebugCommand
+	cmd.Flags().StringP("file", "f", "", "Name of the Dockerfile")
+	cmd.Flags().String("target", "", "Set the target build stage to build")
+	cmd.Flags().StringArray("build-arg", nil, "Set build-time variables")
+	cmd.Flags().String("image", "", "Image to use for debugging stage")
+	cmd.Flags().StringArray("ssh", nil, "Allow forwarding SSH agent to the build. Format: default|<id>[=<socket>|<key>[,<key>]]")
+	cmd.Flags().StringArray("secret", nil, "Expose secret value to the build. Format: id=secretname,src=filepath")
+	return cmd
 }
 
 func builderDebugAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/builder/builder_build.go
+++ b/cmd/nerdctl/builder/builder_build.go
@@ -35,7 +35,7 @@ import (
 )
 
 func NewBuildCommand() *cobra.Command {
-	var buildCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:   "build [flags] PATH",
 		Short: "Build an image from a Dockerfile. Needs buildkitd to be running.",
 		Long: `Build an image from a Dockerfile. Needs buildkitd to be running.
@@ -44,44 +44,44 @@ If Dockerfile is not present and -f is not specified, it will look for Container
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	helpers.AddStringFlag(buildCommand, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
-	buildCommand.Flags().StringArray("add-host", nil, "Add a custom host-to-IP mapping (format: \"host:ip\")")
-	buildCommand.Flags().StringArrayP("tag", "t", nil, "Name and optionally a tag in the 'name:tag' format")
-	buildCommand.Flags().StringP("file", "f", "", "Name of the Dockerfile")
-	buildCommand.Flags().String("target", "", "Set the target build stage to build")
-	buildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables")
-	buildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image")
-	buildCommand.Flags().StringP("output", "o", "", "Output destination (format: type=local,dest=path)")
-	buildCommand.Flags().String("progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
-	buildCommand.Flags().String("provenance", "", "Shorthand for \"--attest=type=provenance\"")
-	buildCommand.Flags().Bool("pull", false, "On true, always attempt to pull latest image version from remote. Default uses buildkit's default.")
-	buildCommand.Flags().StringArray("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
-	buildCommand.Flags().StringArray("allow", nil, "Allow extra privileged entitlement, e.g. network.host, security.insecure")
-	buildCommand.RegisterFlagCompletionFunc("allow", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	helpers.AddStringFlag(cmd, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
+	cmd.Flags().StringArray("add-host", nil, "Add a custom host-to-IP mapping (format: \"host:ip\")")
+	cmd.Flags().StringArrayP("tag", "t", nil, "Name and optionally a tag in the 'name:tag' format")
+	cmd.Flags().StringP("file", "f", "", "Name of the Dockerfile")
+	cmd.Flags().String("target", "", "Set the target build stage to build")
+	cmd.Flags().StringArray("build-arg", nil, "Set build-time variables")
+	cmd.Flags().Bool("no-cache", false, "Do not use cache when building the image")
+	cmd.Flags().StringP("output", "o", "", "Output destination (format: type=local,dest=path)")
+	cmd.Flags().String("progress", "auto", "Set type of progress output (auto, plain, tty). Use plain to show container output")
+	cmd.Flags().String("provenance", "", "Shorthand for \"--attest=type=provenance\"")
+	cmd.Flags().Bool("pull", false, "On true, always attempt to pull latest image version from remote. Default uses buildkit's default.")
+	cmd.Flags().StringArray("secret", nil, "Secret file to expose to the build: id=mysecret,src=/local/secret")
+	cmd.Flags().StringArray("allow", nil, "Allow extra privileged entitlement, e.g. network.host, security.insecure")
+	cmd.RegisterFlagCompletionFunc("allow", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"network.host", "security.insecure"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	buildCommand.Flags().StringArray("attest", nil, "Attestation parameters (format: \"type=sbom,generator=image\")")
-	buildCommand.Flags().StringArray("ssh", nil, "SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])")
-	buildCommand.Flags().BoolP("quiet", "q", false, "Suppress the build output and print image ID on success")
-	buildCommand.Flags().String("sbom", "", "Shorthand for \"--attest=type=sbom\"")
-	buildCommand.Flags().StringArray("cache-from", nil, "External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
-	buildCommand.Flags().StringArray("cache-to", nil, "Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)")
-	buildCommand.Flags().Bool("rm", true, "Remove intermediate containers after a successful build")
-	buildCommand.Flags().String("network", "default", "Set type of network for build (format:network=default|none|host)")
-	buildCommand.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringArray("attest", nil, "Attestation parameters (format: \"type=sbom,generator=image\")")
+	cmd.Flags().StringArray("ssh", nil, "SSH agent socket or keys to expose to the build (format: default|<id>[=<socket>|<key>[,<key>]])")
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress the build output and print image ID on success")
+	cmd.Flags().String("sbom", "", "Shorthand for \"--attest=type=sbom\"")
+	cmd.Flags().StringArray("cache-from", nil, "External cache sources (eg. user/app:cache, type=local,src=path/to/dir)")
+	cmd.Flags().StringArray("cache-to", nil, "Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)")
+	cmd.Flags().Bool("rm", true, "Remove intermediate containers after a successful build")
+	cmd.Flags().String("network", "default", "Set type of network for build (format:network=default|none|host)")
+	cmd.RegisterFlagCompletionFunc("network", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"default", "host", "none"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	buildCommand.Flags().StringSlice("platform", []string{}, "Set target platform for build (e.g., \"amd64\", \"arm64\")")
-	buildCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	buildCommand.Flags().StringArray("build-context", []string{}, "Additional build contexts (e.g., name=path)")
+	cmd.Flags().StringSlice("platform", []string{}, "Set target platform for build (e.g., \"amd64\", \"arm64\")")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().StringArray("build-context", []string{}, "Additional build contexts (e.g., name=path)")
 	// #endregion
 
-	buildCommand.Flags().String("iidfile", "", "Write the image ID to the file")
-	buildCommand.Flags().StringArray("label", nil, "Set metadata for an image")
+	cmd.Flags().String("iidfile", "", "Write the image ID to the file")
+	cmd.Flags().StringArray("label", nil, "Set metadata for an image")
 
-	return buildCommand
+	return cmd
 }
 
 func processBuildCommandFlag(cmd *cobra.Command, args []string) (types.BuilderBuildOptions, error) {

--- a/cmd/nerdctl/compose/compose.go
+++ b/cmd/nerdctl/compose/compose.go
@@ -24,7 +24,7 @@ import (
 )
 
 func NewComposeCommand() *cobra.Command {
-	var composeCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:              "compose [flags] COMMAND",
 		Short:            "Compose",
 		RunE:             helpers.UnknownSubcommandAction,
@@ -33,14 +33,14 @@ func NewComposeCommand() *cobra.Command {
 		TraverseChildren: true, // required for global short hands like -f
 	}
 	// `-f` is a nonPersistentAlias, as it conflicts with `nerdctl compose logs --follow`
-	helpers.AddPersistentStringArrayFlag(composeCommand, "file", nil, []string{"f"}, nil, "", "Specify an alternate compose file")
-	composeCommand.PersistentFlags().String("project-directory", "", "Specify an alternate working directory")
-	composeCommand.PersistentFlags().StringP("project-name", "p", "", "Specify an alternate project name")
-	composeCommand.PersistentFlags().String("env-file", "", "Specify an alternate environment file")
-	composeCommand.PersistentFlags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
-	composeCommand.PersistentFlags().StringArray("profile", []string{}, "Specify a profile to enable")
+	helpers.AddPersistentStringArrayFlag(cmd, "file", nil, []string{"f"}, nil, "", "Specify an alternate compose file")
+	cmd.PersistentFlags().String("project-directory", "", "Specify an alternate working directory")
+	cmd.PersistentFlags().StringP("project-name", "p", "", "Specify an alternate project name")
+	cmd.PersistentFlags().String("env-file", "", "Specify an alternate environment file")
+	cmd.PersistentFlags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
+	cmd.PersistentFlags().StringArray("profile", []string{}, "Specify a profile to enable")
 
-	composeCommand.AddCommand(
+	cmd.AddCommand(
 		newComposeUpCommand(),
 		newComposeLogsCommand(),
 		newComposeConfigCommand(),
@@ -66,7 +66,7 @@ func NewComposeCommand() *cobra.Command {
 		newComposeCreateCommand(),
 	)
 
-	return composeCommand
+	return cmd
 }
 
 func getComposeOptions(cmd *cobra.Command, debugFull, experimental bool) (composer.Options, error) {

--- a/cmd/nerdctl/compose/compose_build.go
+++ b/cmd/nerdctl/compose/compose_build.go
@@ -26,18 +26,18 @@ import (
 )
 
 func newComposeBuildCommand() *cobra.Command {
-	var composeBuildCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "build [flags] [SERVICE...]",
 		Short:         "Build or rebuild services",
 		RunE:          composeBuildAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeBuildCommand.Flags().StringArray("build-arg", nil, "Set build-time variables for services.")
-	composeBuildCommand.Flags().Bool("no-cache", false, "Do not use cache when building the image.")
-	composeBuildCommand.Flags().String("progress", "", "Set type of progress output (auto, plain, tty). Use plain to show container output")
+	cmd.Flags().StringArray("build-arg", nil, "Set build-time variables for services.")
+	cmd.Flags().Bool("no-cache", false, "Do not use cache when building the image.")
+	cmd.Flags().String("progress", "", "Set type of progress output (auto, plain, tty). Use plain to show container output")
 
-	return composeBuildCommand
+	return cmd
 }
 
 func composeBuildAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_config.go
+++ b/cmd/nerdctl/compose/compose_config.go
@@ -28,21 +28,21 @@ import (
 )
 
 func newComposeConfigCommand() *cobra.Command {
-	var composeConfigCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "config",
 		Short:         "Validate and view the Compose file",
 		RunE:          composeConfigAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeConfigCommand.Flags().BoolP("quiet", "q", false, "Only validate the configuration, don't print anything.")
-	composeConfigCommand.Flags().Bool("services", false, "Print the service names, one per line.")
-	composeConfigCommand.Flags().Bool("volumes", false, "Print the volume names, one per line.")
-	composeConfigCommand.Flags().String("hash", "", "Print the service config hash, one per line.")
-	composeConfigCommand.RegisterFlagCompletionFunc("hash", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().BoolP("quiet", "q", false, "Only validate the configuration, don't print anything.")
+	cmd.Flags().Bool("services", false, "Print the service names, one per line.")
+	cmd.Flags().Bool("volumes", false, "Print the volume names, one per line.")
+	cmd.Flags().String("hash", "", "Print the service config hash, one per line.")
+	cmd.RegisterFlagCompletionFunc("hash", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"\"*\""}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return composeConfigCommand
+	return cmd
 }
 
 func composeConfigAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_cp.go
+++ b/cmd/nerdctl/compose/compose_cp.go
@@ -31,7 +31,7 @@ import (
 func newComposeCopyCommand() *cobra.Command {
 	usage := `cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-
        nerdctl compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH`
-	var composeCpCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           usage,
 		Short:         "Copy files/folders between a service container and the local filesystem",
 		Args:          cobra.ExactArgs(2),
@@ -39,10 +39,10 @@ func newComposeCopyCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeCpCommand.Flags().Bool("dry-run", false, "Execute command in dry run mode")
-	composeCpCommand.Flags().BoolP("follow-link", "L", false, "Always follow symbol link in SRC_PATH")
-	composeCpCommand.Flags().Int("index", 0, "index of the container if service has multiple replicas")
-	return composeCpCommand
+	cmd.Flags().Bool("dry-run", false, "Execute command in dry run mode")
+	cmd.Flags().BoolP("follow-link", "L", false, "Always follow symbol link in SRC_PATH")
+	cmd.Flags().Int("index", 0, "index of the container if service has multiple replicas")
+	return cmd
 }
 
 func composeCopyAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_create.go
+++ b/cmd/nerdctl/compose/compose_create.go
@@ -28,19 +28,19 @@ import (
 )
 
 func newComposeCreateCommand() *cobra.Command {
-	var composeCreateCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "create [flags] [SERVICE...]",
 		Short:         "Creates containers for one or more services",
 		RunE:          composeCreateAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeCreateCommand.Flags().Bool("build", false, "Build images before starting containers.")
-	composeCreateCommand.Flags().Bool("no-build", false, "Don't build an image even if it's missing, conflict with --build.")
-	composeCreateCommand.Flags().Bool("force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
-	composeCreateCommand.Flags().Bool("no-recreate", false, "Don't recreate containers if they exist, conflict with --force-recreate.")
-	composeCreateCommand.Flags().String("pull", "missing", "Pull images before running. (support always|missing|never)")
-	return composeCreateCommand
+	cmd.Flags().Bool("build", false, "Build images before starting containers.")
+	cmd.Flags().Bool("no-build", false, "Don't build an image even if it's missing, conflict with --build.")
+	cmd.Flags().Bool("force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
+	cmd.Flags().Bool("no-recreate", false, "Don't recreate containers if they exist, conflict with --force-recreate.")
+	cmd.Flags().String("pull", "missing", "Pull images before running. (support always|missing|never)")
+	return cmd
 }
 
 func composeCreateAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_down.go
+++ b/cmd/nerdctl/compose/compose_down.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newComposeDownCommand() *cobra.Command {
-	var composeDownCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "down",
 		Short:         "Remove containers and associated resources",
 		Args:          cobra.NoArgs,
@@ -34,9 +34,9 @@ func newComposeDownCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeDownCommand.Flags().BoolP("volumes", "v", false, "Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
-	composeDownCommand.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
-	return composeDownCommand
+	cmd.Flags().BoolP("volumes", "v", false, "Remove named volumes declared in the `volumes` section of the Compose file and anonymous volumes attached to containers.")
+	cmd.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+	return cmd
 }
 
 func composeDownAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_exec.go
+++ b/cmd/nerdctl/compose/compose_exec.go
@@ -30,7 +30,7 @@ import (
 )
 
 func newComposeExecCommand() *cobra.Command {
-	var composeExecCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "exec [flags] SERVICE COMMAND [ARGS...]",
 		Short:         "Execute a command in a running container of the service",
 		Args:          cobra.MinimumNArgs(2),
@@ -38,27 +38,27 @@ func newComposeExecCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeExecCommand.Flags().SetInterspersed(false)
+	cmd.Flags().SetInterspersed(false)
 
 	_, isTerminal := term.GetFdInfo(os.Stdout)
-	composeExecCommand.Flags().BoolP("no-TTY", "T", !isTerminal, "Disable pseudo-TTY allocation. By default nerdctl compose exec allocates a TTY.")
-	composeExecCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
-	composeExecCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
+	cmd.Flags().BoolP("no-TTY", "T", !isTerminal, "Disable pseudo-TTY allocation. By default nerdctl compose exec allocates a TTY.")
+	cmd.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
+	cmd.Flags().StringP("workdir", "w", "", "Working directory inside the container")
 	// env needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}
-	composeExecCommand.Flags().StringArrayP("env", "e", nil, "Set environment variables")
-	composeExecCommand.Flags().Bool("privileged", false, "Give extended privileges to the command")
-	composeExecCommand.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
-	composeExecCommand.Flags().Int("index", 1, "index of the container if the service has multiple instances.")
+	cmd.Flags().StringArrayP("env", "e", nil, "Set environment variables")
+	cmd.Flags().Bool("privileged", false, "Give extended privileges to the command")
+	cmd.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	cmd.Flags().Int("index", 1, "index of the container if the service has multiple instances.")
 
-	composeExecCommand.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached")
-	composeExecCommand.Flags().MarkHidden("interactive")
+	cmd.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached")
+	cmd.Flags().MarkHidden("interactive")
 	// The -t does not has effect to keep the compatibility with docker.
 	// The proposal of -t is to keep "muscle memory" with compose v1: https://github.com/docker/compose/issues/9207
 	// FYI: https://github.com/docker/compose/blob/v2.23.1/cmd/compose/exec.go#L77
-	composeExecCommand.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY")
-	composeExecCommand.Flags().MarkHidden("tty")
+	cmd.Flags().BoolP("tty", "t", true, "Allocate a pseudo-TTY")
+	cmd.Flags().MarkHidden("tty")
 
-	return composeExecCommand
+	return cmd
 }
 
 func composeExecAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_images.go
+++ b/cmd/nerdctl/compose/compose_images.go
@@ -39,16 +39,16 @@ import (
 )
 
 func newComposeImagesCommand() *cobra.Command {
-	var composeImagesCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "images [flags] [SERVICE...]",
 		Short:         "List images used by created containers in services",
 		RunE:          composeImagesAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeImagesCommand.Flags().String("format", "", "Format the output. Supported values: [json]")
-	composeImagesCommand.Flags().BoolP("quiet", "q", false, "Only show numeric image IDs")
-	return composeImagesCommand
+	cmd.Flags().String("format", "", "Format the output. Supported values: [json]")
+	cmd.Flags().BoolP("quiet", "q", false, "Only show numeric image IDs")
+	return cmd
 }
 
 func composeImagesAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_kill.go
+++ b/cmd/nerdctl/compose/compose_kill.go
@@ -26,15 +26,15 @@ import (
 )
 
 func newComposeKillCommand() *cobra.Command {
-	var composeKillCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "kill [flags] [SERVICE...]",
 		Short:         "Force stop service containers",
 		RunE:          composeKillAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeKillCommand.Flags().StringP("signal", "s", "SIGKILL", "SIGNAL to send to the container.")
-	return composeKillCommand
+	cmd.Flags().StringP("signal", "s", "SIGKILL", "SIGNAL to send to the container.")
+	return cmd
 }
 
 func composeKillAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_logs.go
+++ b/cmd/nerdctl/compose/compose_logs.go
@@ -26,19 +26,19 @@ import (
 )
 
 func newComposeLogsCommand() *cobra.Command {
-	var composeLogsCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "logs [flags] [SERVICE...]",
 		Short:         "Show logs of running containers",
 		RunE:          composeLogsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeLogsCommand.Flags().BoolP("follow", "f", false, "Follow log output.")
-	composeLogsCommand.Flags().BoolP("timestamps", "t", false, "Show timestamps")
-	composeLogsCommand.Flags().String("tail", "all", "Number of lines to show from the end of the logs")
-	composeLogsCommand.Flags().Bool("no-color", false, "Produce monochrome output")
-	composeLogsCommand.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
-	return composeLogsCommand
+	cmd.Flags().BoolP("follow", "f", false, "Follow log output.")
+	cmd.Flags().BoolP("timestamps", "t", false, "Show timestamps")
+	cmd.Flags().String("tail", "all", "Number of lines to show from the end of the logs")
+	cmd.Flags().Bool("no-color", false, "Produce monochrome output")
+	cmd.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
+	return cmd
 }
 
 func composeLogsAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_pause.go
+++ b/cmd/nerdctl/compose/compose_pause.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newComposePauseCommand() *cobra.Command {
-	var composePauseCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "pause [SERVICE...]",
 		Short:                 "Pause all processes within containers of service(s). They can be unpaused with nerdctl compose unpause",
 		RunE:                  composePauseAction,
@@ -33,7 +33,7 @@ func newComposePauseCommand() *cobra.Command {
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 	}
-	return composePauseCommand
+	return cmd
 }
 
 func composePauseAction(cmd *cobra.Command, args []string) error {
@@ -60,7 +60,7 @@ func composePauseAction(cmd *cobra.Command, args []string) error {
 }
 
 func newComposeUnpauseCommand() *cobra.Command {
-	var composeUnpauseCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "unpause [SERVICE...]",
 		Short:                 "Unpause all processes within containers of service(s).",
 		RunE:                  composeUnpauseAction,
@@ -68,7 +68,7 @@ func newComposeUnpauseCommand() *cobra.Command {
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 	}
-	return composeUnpauseCommand
+	return cmd
 }
 
 func composeUnpauseAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_port.go
+++ b/cmd/nerdctl/compose/compose_port.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newComposePortCommand() *cobra.Command {
-	var composePortCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "port [flags] SERVICE PRIVATE_PORT",
 		Short:         "Print the public port for a port binding",
 		Args:          cobra.ExactArgs(2),
@@ -37,10 +37,10 @@ func newComposePortCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composePortCommand.Flags().Int("index", 1, "index of the container if the service has multiple instances.")
-	composePortCommand.Flags().String("protocol", "tcp", "protocol of the port (tcp|udp)")
+	cmd.Flags().Int("index", 1, "index of the container if the service has multiple instances.")
+	cmd.Flags().String("protocol", "tcp", "protocol of the port (tcp|udp)")
 
-	return composePortCommand
+	return cmd
 }
 
 func composePortAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_ps.go
+++ b/cmd/nerdctl/compose/compose_ps.go
@@ -42,20 +42,20 @@ import (
 )
 
 func newComposePsCommand() *cobra.Command {
-	var composePsCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "ps [flags] [SERVICE...]",
 		Short:         "List containers of services",
 		RunE:          composePsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composePsCommand.Flags().String("format", "table", "Format the output. Supported values: [table|json]")
-	composePsCommand.Flags().String("filter", "", "Filter matches containers based on given conditions")
-	composePsCommand.Flags().StringArray("status", []string{}, "Filter services by status. Values: [paused | restarting | removing | running | dead | created | exited]")
-	composePsCommand.Flags().BoolP("quiet", "q", false, "Only display container IDs")
-	composePsCommand.Flags().Bool("services", false, "Display services")
-	composePsCommand.Flags().BoolP("all", "a", false, "Show all containers (default shows just running)")
-	return composePsCommand
+	cmd.Flags().String("format", "table", "Format the output. Supported values: [table|json]")
+	cmd.Flags().String("filter", "", "Filter matches containers based on given conditions")
+	cmd.Flags().StringArray("status", []string{}, "Filter services by status. Values: [paused | restarting | removing | running | dead | created | exited]")
+	cmd.Flags().BoolP("quiet", "q", false, "Only display container IDs")
+	cmd.Flags().Bool("services", false, "Display services")
+	cmd.Flags().BoolP("all", "a", false, "Show all containers (default shows just running)")
+	return cmd
 }
 
 type composeContainerPrintable struct {

--- a/cmd/nerdctl/compose/compose_pull.go
+++ b/cmd/nerdctl/compose/compose_pull.go
@@ -26,15 +26,15 @@ import (
 )
 
 func newComposePullCommand() *cobra.Command {
-	var composePullCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "pull [flags] [SERVICE...]",
 		Short:         "Pull service images",
 		RunE:          composePullAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composePullCommand.Flags().BoolP("quiet", "q", false, "Pull without printing progress information")
-	return composePullCommand
+	cmd.Flags().BoolP("quiet", "q", false, "Pull without printing progress information")
+	return cmd
 }
 
 func composePullAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_push.go
+++ b/cmd/nerdctl/compose/compose_push.go
@@ -26,14 +26,14 @@ import (
 )
 
 func newComposePushCommand() *cobra.Command {
-	var composePushCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "push [flags] [SERVICE...]",
 		Short:         "Push service images",
 		RunE:          composePushAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	return composePushCommand
+	return cmd
 }
 
 func composePushAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_restart.go
+++ b/cmd/nerdctl/compose/compose_restart.go
@@ -26,15 +26,15 @@ import (
 )
 
 func newComposeRestartCommand() *cobra.Command {
-	var composeRestartCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "restart [flags] [SERVICE...]",
 		Short:         "Restart containers of given (or all) services",
 		RunE:          composeRestartAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeRestartCommand.Flags().UintP("timeout", "t", 10, "Seconds to wait before restarting them")
-	return composeRestartCommand
+	cmd.Flags().UintP("timeout", "t", 10, "Seconds to wait before restarting them")
+	return cmd
 }
 
 func composeRestartAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_rm.go
+++ b/cmd/nerdctl/compose/compose_rm.go
@@ -29,17 +29,17 @@ import (
 )
 
 func newComposeRemoveCommand() *cobra.Command {
-	var composeRemoveCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "rm [flags] [SERVICE...]",
 		Short:         "Remove stopped service containers",
 		RunE:          composeRemoveAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeRemoveCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	composeRemoveCommand.Flags().BoolP("stop", "s", false, "Stop containers before removing")
-	composeRemoveCommand.Flags().BoolP("volumes", "v", false, "Remove anonymous volumes associated with containers")
-	return composeRemoveCommand
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	cmd.Flags().BoolP("stop", "s", false, "Stop containers before removing")
+	cmd.Flags().BoolP("volumes", "v", false, "Remove anonymous volumes associated with containers")
+	return cmd
 }
 
 func composeRemoveAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_run.go
+++ b/cmd/nerdctl/compose/compose_run.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newComposeRunCommand() *cobra.Command {
-	var composeRunCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "run [flags] SERVICE [COMMAND] [ARGS...]",
 		Short:                 "Run a one-off command on a service",
 		Args:                  cobra.MinimumNArgs(1),
@@ -38,35 +38,35 @@ func newComposeRunCommand() *cobra.Command {
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 	}
-	composeRunCommand.Flags().SetInterspersed(false)
-	composeRunCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
-	composeRunCommand.Flags().Bool("no-build", false, "Don't build an image, even if it's missing.")
-	composeRunCommand.Flags().Bool("no-color", false, "Produce monochrome output")
-	composeRunCommand.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
-	composeRunCommand.Flags().Bool("build", false, "Build images before starting containers.")
-	composeRunCommand.Flags().Bool("quiet-pull", false, "Pull without printing progress information")
-	composeRunCommand.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+	cmd.Flags().SetInterspersed(false)
+	cmd.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background")
+	cmd.Flags().Bool("no-build", false, "Don't build an image, even if it's missing.")
+	cmd.Flags().Bool("no-color", false, "Produce monochrome output")
+	cmd.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
+	cmd.Flags().Bool("build", false, "Build images before starting containers.")
+	cmd.Flags().Bool("quiet-pull", false, "Pull without printing progress information")
+	cmd.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
 
-	composeRunCommand.Flags().String("name", "", "Assign a name to the container")
-	composeRunCommand.Flags().Bool("no-deps", false, "Don't start dependencies")
+	cmd.Flags().String("name", "", "Assign a name to the container")
+	cmd.Flags().Bool("no-deps", false, "Don't start dependencies")
 	// TODO: no-TTY flag
 	//       In docker-compose's documentation, no-TTY is automatically detected
 	//       But, it follows `-i` flag because currently `run` command needs `-it` simultaneously.
-	composeRunCommand.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached")
-	composeRunCommand.Flags().Bool("rm", false, "Automatically remove the container when it exits")
-	composeRunCommand.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
-	composeRunCommand.Flags().StringArrayP("volume", "v", nil, "Bind mount a volume")
-	composeRunCommand.Flags().StringArray("entrypoint", nil, "Overwrite the default ENTRYPOINT of the image")
-	composeRunCommand.Flags().StringArrayP("env", "e", nil, "Set environment variables")
-	composeRunCommand.Flags().StringArrayP("label", "l", nil, "Set metadata on container")
-	composeRunCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
+	cmd.Flags().BoolP("interactive", "i", true, "Keep STDIN open even if not attached")
+	cmd.Flags().Bool("rm", false, "Automatically remove the container when it exits")
+	cmd.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	cmd.Flags().StringArrayP("volume", "v", nil, "Bind mount a volume")
+	cmd.Flags().StringArray("entrypoint", nil, "Overwrite the default ENTRYPOINT of the image")
+	cmd.Flags().StringArrayP("env", "e", nil, "Set environment variables")
+	cmd.Flags().StringArrayP("label", "l", nil, "Set metadata on container")
+	cmd.Flags().StringP("workdir", "w", "", "Working directory inside the container")
 	// FIXME: `-p` conflicts with the `--project-name` in PersistentFlags of parent command `compose`
 	//        For docker compatibility, it should be fixed.
-	composeRunCommand.Flags().StringSlice("publish", nil, "Publish a container's port(s) to the host")
-	composeRunCommand.Flags().Bool("service-ports", false, "Run command with the service's ports enabled and mapped to the host")
+	cmd.Flags().StringSlice("publish", nil, "Publish a container's port(s) to the host")
+	cmd.Flags().Bool("service-ports", false, "Run command with the service's ports enabled and mapped to the host")
 	// TODO: use-aliases
 
-	return composeRunCommand
+	return cmd
 }
 
 func composeRunAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_start.go
+++ b/cmd/nerdctl/compose/compose_start.go
@@ -35,7 +35,7 @@ import (
 )
 
 func newComposeStartCommand() *cobra.Command {
-	var composeRestartCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "start [SERVICE...]",
 		Short:                 "Start existing containers for service(s)",
 		RunE:                  composeStartAction,
@@ -43,7 +43,7 @@ func newComposeStartCommand() *cobra.Command {
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 	}
-	return composeRestartCommand
+	return cmd
 }
 
 func composeStartAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_stop.go
+++ b/cmd/nerdctl/compose/compose_stop.go
@@ -26,15 +26,15 @@ import (
 )
 
 func newComposeStopCommand() *cobra.Command {
-	var composeStopCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "stop [flags] [SERVICE...]",
 		Short:         "Stop running containers without removing them.",
 		RunE:          composeStopAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeStopCommand.Flags().UintP("timeout", "t", 10, "Seconds to wait for stop before killing them")
-	return composeStopCommand
+	cmd.Flags().UintP("timeout", "t", 10, "Seconds to wait for stop before killing them")
+	return cmd
 }
 
 func composeStopAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_top.go
+++ b/cmd/nerdctl/compose/compose_top.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newComposeTopCommand() *cobra.Command {
-	var composeTopCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "top [SERVICE...]",
 		Short:                 "Display the running processes of service containers",
 		RunE:                  composeTopAction,
@@ -41,7 +41,7 @@ func newComposeTopCommand() *cobra.Command {
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
 	}
-	return composeTopCommand
+	return cmd
 }
 
 func composeTopAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/compose/compose_up.go
+++ b/cmd/nerdctl/compose/compose_up.go
@@ -31,27 +31,27 @@ import (
 )
 
 func newComposeUpCommand() *cobra.Command {
-	var composeUpCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "up [flags] [SERVICE...]",
 		Short:         "Create and start containers",
 		RunE:          composeUpAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeUpCommand.Flags().Bool("abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d.")
-	composeUpCommand.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background. Incompatible with --abort-on-container-exit.")
-	composeUpCommand.Flags().Bool("no-build", false, "Don't build an image, even if it's missing.")
-	composeUpCommand.Flags().Bool("no-color", false, "Produce monochrome output")
-	composeUpCommand.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
-	composeUpCommand.Flags().Bool("build", false, "Build images before starting containers.")
-	composeUpCommand.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
-	composeUpCommand.Flags().Bool("quiet-pull", false, "Pull without printing progress information")
-	composeUpCommand.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
-	composeUpCommand.Flags().Bool("force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
-	composeUpCommand.Flags().Bool("no-recreate", false, "Don't recreate containers if they exist, conflict with --force-recreate.")
-	composeUpCommand.Flags().StringArray("scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
-	composeUpCommand.Flags().String("pull", "", "Pull image before running (\"always\"|\"missing\"|\"never\")")
-	return composeUpCommand
+	cmd.Flags().Bool("abort-on-container-exit", false, "Stops all containers if any container was stopped. Incompatible with -d.")
+	cmd.Flags().BoolP("detach", "d", false, "Detached mode: Run containers in the background. Incompatible with --abort-on-container-exit.")
+	cmd.Flags().Bool("no-build", false, "Don't build an image, even if it's missing.")
+	cmd.Flags().Bool("no-color", false, "Produce monochrome output")
+	cmd.Flags().Bool("no-log-prefix", false, "Don't print prefix in logs")
+	cmd.Flags().Bool("build", false, "Build images before starting containers.")
+	cmd.Flags().Bool("ipfs", false, "Allow pulling base images from IPFS during build")
+	cmd.Flags().Bool("quiet-pull", false, "Pull without printing progress information")
+	cmd.Flags().Bool("remove-orphans", false, "Remove containers for services not defined in the Compose file.")
+	cmd.Flags().Bool("force-recreate", false, "Recreate containers even if their configuration and image haven't changed.")
+	cmd.Flags().Bool("no-recreate", false, "Don't recreate containers if they exist, conflict with --force-recreate.")
+	cmd.Flags().StringArray("scale", []string{}, "Scale SERVICE to NUM instances. Overrides the `scale` setting in the Compose file if present.")
+	cmd.Flags().String("pull", "", "Pull image before running (\"always\"|\"missing\"|\"never\")")
+	return cmd
 }
 
 func composeUpAction(cmd *cobra.Command, services []string) error {

--- a/cmd/nerdctl/compose/compose_version.go
+++ b/cmd/nerdctl/compose/compose_version.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newComposeVersionCommand() *cobra.Command {
-	var composeVersionCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "version",
 		Short:         "Show the Compose version information",
 		Args:          cobra.NoArgs,
@@ -34,12 +34,12 @@ func newComposeVersionCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	composeVersionCommand.Flags().StringP("format", "f", "pretty", "Format the output. Values: [pretty | json]")
-	composeVersionCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "pretty", "Format the output. Values: [pretty | json]")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "pretty"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	composeVersionCommand.Flags().Bool("short", false, "Shows only Compose's version number")
-	return composeVersionCommand
+	cmd.Flags().Bool("short", false, "Shows only Compose's version number")
+	return cmd
 }
 
 func composeVersionAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container.go
+++ b/cmd/nerdctl/container/container.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewContainerCommand() *cobra.Command {
-	containerCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "container",
 		Short:         "Manage containers",
@@ -31,7 +31,7 @@ func NewContainerCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	containerCommand.AddCommand(
+	cmd.AddCommand(
 		NewCreateCommand(),
 		NewRunCommand(),
 		NewUpdateCommand(),
@@ -55,8 +55,8 @@ func NewContainerCommand() *cobra.Command {
 		NewStatsCommand(),
 		NewAttachCommand(),
 	)
-	AddCpCommand(containerCommand)
-	return containerCommand
+	AddCpCommand(cmd)
+	return cmd
 }
 
 func containerLsCommand() *cobra.Command {

--- a/cmd/nerdctl/container/container_attach.go
+++ b/cmd/nerdctl/container/container_attach.go
@@ -45,7 +45,7 @@ Caveats:
 - Until dual logging (issue #1946) is implemented,
   a container that is spun up by either 'nerdctl run -d' or 'nerdctl start' (without '--attach') cannot be attached to.`
 
-	var attachCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "attach [flags] CONTAINER",
 		Args:              cobra.ExactArgs(1),
 		Short:             shortHelp,
@@ -55,8 +55,8 @@ Caveats:
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	attachCommand.Flags().String("detach-keys", consoleutil.DefaultDetachKeys, "Override the default detach keys")
-	return attachCommand
+	cmd.Flags().String("detach-keys", consoleutil.DefaultDetachKeys, "Override the default detach keys")
+	return cmd
 }
 
 func processContainerAttachOptions(cmd *cobra.Command) (types.ContainerAttachOptions, error) {

--- a/cmd/nerdctl/container/container_commit.go
+++ b/cmd/nerdctl/container/container_commit.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewCommitCommand() *cobra.Command {
-	var commitCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "commit [flags] CONTAINER REPOSITORY[:TAG]",
 		Short:             "Create a new image from a container's changes",
 		Args:              helpers.IsExactArgs(2),
@@ -36,11 +36,11 @@ func NewCommitCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	commitCommand.Flags().StringP("author", "a", "", `Author (e.g., "nerdctl contributor <nerdctl-dev@example.com>")`)
-	commitCommand.Flags().StringP("message", "m", "", "Commit message")
-	commitCommand.Flags().StringArrayP("change", "c", nil, "Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])")
-	commitCommand.Flags().BoolP("pause", "p", true, "Pause container during commit")
-	return commitCommand
+	cmd.Flags().StringP("author", "a", "", `Author (e.g., "nerdctl contributor <nerdctl-dev@example.com>")`)
+	cmd.Flags().StringP("message", "m", "", "Commit message")
+	cmd.Flags().StringArrayP("change", "c", nil, "Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])")
+	cmd.Flags().BoolP("pause", "p", true, "Pause container during commit")
+	return cmd
 }
 
 func processCommitCommandOptions(cmd *cobra.Command) (types.ContainerCommitOptions, error) {

--- a/cmd/nerdctl/container/container_cp_linux.go
+++ b/cmd/nerdctl/container/container_cp_linux.go
@@ -45,7 +45,7 @@ Using 'nerdctl cp' with untrusted or malicious containers is unsupported and may
 
 	usage := `cp [flags] CONTAINER:SRC_PATH DEST_PATH|-
   nerdctl cp [flags] SRC_PATH|- CONTAINER:DEST_PATH`
-	var cpCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               usage,
 		Args:              helpers.IsExactArgs(2),
 		Short:             shortHelp,
@@ -56,9 +56,9 @@ Using 'nerdctl cp' with untrusted or malicious containers is unsupported and may
 		SilenceErrors:     true,
 	}
 
-	cpCommand.Flags().BoolP("follow-link", "L", false, "Always follow symbolic link in SRC_PATH.")
+	cmd.Flags().BoolP("follow-link", "L", false, "Always follow symbolic link in SRC_PATH.")
 
-	return cpCommand
+	return cmd
 }
 
 func cpAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -40,7 +40,7 @@ func NewCreateCommand() *cobra.Command {
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl create` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
 	}
-	var createCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "create [flags] IMAGE [COMMAND] [ARG...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             shortHelp,
@@ -50,9 +50,9 @@ func NewCreateCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	createCommand.Flags().SetInterspersed(false)
-	setCreateFlags(createCommand)
-	return createCommand
+	cmd.Flags().SetInterspersed(false)
+	setCreateFlags(cmd)
+	return cmd
 }
 
 func processContainerCreateOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {

--- a/cmd/nerdctl/container/container_diff.go
+++ b/cmd/nerdctl/container/container_diff.go
@@ -44,7 +44,7 @@ import (
 )
 
 func NewDiffCommand() *cobra.Command {
-	var diffCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "diff [CONTAINER]",
 		Short:             "Inspect changes to files or directories on a container's filesystem",
 		Args:              cobra.MinimumNArgs(1),
@@ -53,7 +53,7 @@ func NewDiffCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return diffCommand
+	return cmd
 }
 
 func processContainerDiffOptions(cmd *cobra.Command) (types.ContainerDiffOptions, error) {

--- a/cmd/nerdctl/container/container_exec.go
+++ b/cmd/nerdctl/container/container_exec.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewExecCommand() *cobra.Command {
-	var execCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "exec [flags] CONTAINER COMMAND [ARG...]",
 		Args:              cobra.MinimumNArgs(2),
 		Short:             "Run a command in a running container",
@@ -40,19 +40,19 @@ func NewExecCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	execCommand.Flags().SetInterspersed(false)
+	cmd.Flags().SetInterspersed(false)
 
-	execCommand.Flags().BoolP("tty", "t", false, "Allocate a pseudo-TTY")
-	execCommand.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
-	execCommand.Flags().BoolP("detach", "d", false, "Detached mode: run command in the background")
-	execCommand.Flags().StringP("workdir", "w", "", "Working directory inside the container")
+	cmd.Flags().BoolP("tty", "t", false, "Allocate a pseudo-TTY")
+	cmd.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
+	cmd.Flags().BoolP("detach", "d", false, "Detached mode: run command in the background")
+	cmd.Flags().StringP("workdir", "w", "", "Working directory inside the container")
 	// env needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}
-	execCommand.Flags().StringArrayP("env", "e", nil, "Set environment variables")
+	cmd.Flags().StringArrayP("env", "e", nil, "Set environment variables")
 	// env-file is defined as StringSlice, not StringArray, to allow specifying "--env-file=FILE1,FILE2" (compatible with Podman)
-	execCommand.Flags().StringSlice("env-file", nil, "Set environment variables from file")
-	execCommand.Flags().Bool("privileged", false, "Give extended privileges to the command")
-	execCommand.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
-	return execCommand
+	cmd.Flags().StringSlice("env-file", nil, "Set environment variables from file")
+	cmd.Flags().Bool("privileged", false, "Give extended privileges to the command")
+	cmd.Flags().StringP("user", "u", "", "Username or UID (format: <name|uid>[:<group|gid>])")
+	return cmd
 }
 
 func processExecCommandOptions(cmd *cobra.Command) (types.ContainerExecOptions, error) {

--- a/cmd/nerdctl/container/container_inspect.go
+++ b/cmd/nerdctl/container/container_inspect.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newContainerInspectCommand() *cobra.Command {
-	var containerInspectCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "inspect [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Display detailed information on one or more containers.",
 		Long:              "Hint: set `--mode=native` for showing the full output",
@@ -39,17 +39,17 @@ func newContainerInspectCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	containerInspectCommand.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
-	containerInspectCommand.Flags().BoolP("size", "s", false, "Display total file sizes")
+	cmd.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
+	cmd.Flags().BoolP("size", "s", false, "Display total file sizes")
 
-	containerInspectCommand.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"dockercompat", "native"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	containerInspectCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	containerInspectCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return containerInspectCommand
+	return cmd
 }
 
 var validModeType = map[string]bool{

--- a/cmd/nerdctl/container/container_kill.go
+++ b/cmd/nerdctl/container/container_kill.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewKillCommand() *cobra.Command {
-	var killCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "kill [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Kill one or more running containers",
 		Args:              cobra.MinimumNArgs(1),
@@ -38,8 +38,8 @@ func NewKillCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	killCommand.Flags().StringP("signal", "s", "KILL", "Signal to send to the container")
-	return killCommand
+	cmd.Flags().StringP("signal", "s", "KILL", "Signal to send to the container")
+	return cmd
 }
 
 func killAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container_list.go
+++ b/cmd/nerdctl/container/container_list.go
@@ -34,7 +34,7 @@ import (
 )
 
 func NewPsCommand() *cobra.Command {
-	var psCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "ps",
 		Args:          cobra.NoArgs,
 		Short:         "List containers",
@@ -42,20 +42,20 @@ func NewPsCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	psCommand.Flags().BoolP("all", "a", false, "Show all containers (default shows just running)")
-	psCommand.Flags().IntP("last", "n", -1, "Show n last created containers (includes all states)")
-	psCommand.Flags().BoolP("latest", "l", false, "Show the latest created container (includes all states)")
-	psCommand.Flags().Bool("no-trunc", false, "Don't truncate output")
-	psCommand.Flags().BoolP("quiet", "q", false, "Only display container IDs")
-	psCommand.Flags().BoolP("size", "s", false, "Display total file sizes")
+	cmd.Flags().BoolP("all", "a", false, "Show all containers (default shows just running)")
+	cmd.Flags().IntP("last", "n", -1, "Show n last created containers (includes all states)")
+	cmd.Flags().BoolP("latest", "l", false, "Show the latest created container (includes all states)")
+	cmd.Flags().Bool("no-trunc", false, "Don't truncate output")
+	cmd.Flags().BoolP("quiet", "q", false, "Only display container IDs")
+	cmd.Flags().BoolP("size", "s", false, "Display total file sizes")
 
 	// Alias "-f" is reserved for "--filter"
-	psCommand.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}', 'wide'")
-	psCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}', 'wide'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "table", "wide"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	psCommand.Flags().StringSliceP("filter", "f", nil, "Filter matches containers based on given conditions. When specifying the condition 'status', it filters all containers")
-	return psCommand
+	cmd.Flags().StringSliceP("filter", "f", nil, "Filter matches containers based on given conditions. When specifying the condition 'status', it filters all containers")
+	return cmd
 }
 
 func processOptions(cmd *cobra.Command) (types.ContainerListOptions, FormattingAndPrintingOptions, error) {

--- a/cmd/nerdctl/container/container_logs.go
+++ b/cmd/nerdctl/container/container_logs.go
@@ -38,7 +38,7 @@ The following containers are supported:
 - Containers created with 'nerdctl compose'.
 - Containers created with Kubernetes (EXPERIMENTAL).
 `
-	var logsCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "logs [flags] CONTAINER",
 		Args:              helpers.IsExactArgs(1),
 		Short:             shortUsage,
@@ -48,12 +48,12 @@ The following containers are supported:
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	logsCommand.Flags().BoolP("follow", "f", false, "Follow log output")
-	logsCommand.Flags().BoolP("timestamps", "t", false, "Show timestamps")
-	logsCommand.Flags().StringP("tail", "n", "all", "Number of lines to show from the end of the logs")
-	logsCommand.Flags().String("since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
-	logsCommand.Flags().String("until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
-	return logsCommand
+	cmd.Flags().BoolP("follow", "f", false, "Follow log output")
+	cmd.Flags().BoolP("timestamps", "t", false, "Show timestamps")
+	cmd.Flags().StringP("tail", "n", "all", "Number of lines to show from the end of the logs")
+	cmd.Flags().String("since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	cmd.Flags().String("until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	return cmd
 }
 
 func processContainerLogsOptions(cmd *cobra.Command) (types.ContainerLogsOptions, error) {

--- a/cmd/nerdctl/container/container_pause.go
+++ b/cmd/nerdctl/container/container_pause.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewPauseCommand() *cobra.Command {
-	var pauseCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "pause [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Pause all processes within one or more containers",
@@ -38,7 +38,7 @@ func NewPauseCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return pauseCommand
+	return cmd
 }
 
 func processContainerPauseOptions(cmd *cobra.Command) (types.ContainerPauseOptions, error) {

--- a/cmd/nerdctl/container/container_port.go
+++ b/cmd/nerdctl/container/container_port.go
@@ -32,7 +32,7 @@ import (
 )
 
 func NewPortCommand() *cobra.Command {
-	var portCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "port [flags] CONTAINER [PRIVATE_PORT[/PROTO]]",
 		Args:              cobra.RangeArgs(1, 2),
 		Short:             "List port mappings or a specific mapping for the container",
@@ -41,7 +41,7 @@ func NewPortCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return portCommand
+	return cmd
 }
 
 func portAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container_prune.go
+++ b/cmd/nerdctl/container/container_prune.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newContainerPruneCommand() *cobra.Command {
-	containerPruneCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all stopped containers",
 		Args:          cobra.NoArgs,
@@ -34,8 +34,8 @@ func newContainerPruneCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	containerPruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	return containerPruneCommand
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	return cmd
 }
 
 func processContainerPruneOptions(cmd *cobra.Command) (types.ContainerPruneOptions, error) {

--- a/cmd/nerdctl/container/container_remove.go
+++ b/cmd/nerdctl/container/container_remove.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewRmCommand() *cobra.Command {
-	var rmCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "rm [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Remove one or more containers",
@@ -36,10 +36,10 @@ func NewRmCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	rmCommand.Aliases = []string{"remove"}
-	rmCommand.Flags().BoolP("force", "f", false, "Force the removal of a running|paused|unknown container (uses SIGKILL)")
-	rmCommand.Flags().BoolP("volumes", "v", false, "Remove volumes associated with the container")
-	return rmCommand
+	cmd.Aliases = []string{"remove"}
+	cmd.Flags().BoolP("force", "f", false, "Force the removal of a running|paused|unknown container (uses SIGKILL)")
+	cmd.Flags().BoolP("volumes", "v", false, "Remove volumes associated with the container")
+	return cmd
 }
 
 func rmAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container_rename.go
+++ b/cmd/nerdctl/container/container_rename.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewRenameCommand() *cobra.Command {
-	var renameCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "rename [flags] CONTAINER NEW_NAME",
 		Args:              helpers.IsExactArgs(2),
 		Short:             "rename a container",
@@ -36,7 +36,7 @@ func NewRenameCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return renameCommand
+	return cmd
 }
 
 func processContainerRenameOptions(cmd *cobra.Command) (types.ContainerRenameOptions, error) {

--- a/cmd/nerdctl/container/container_restart.go
+++ b/cmd/nerdctl/container/container_restart.go
@@ -28,7 +28,7 @@ import (
 )
 
 func NewRestartCommand() *cobra.Command {
-	var restartCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "restart [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Restart one or more running containers",
@@ -37,9 +37,9 @@ func NewRestartCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	restartCommand.Flags().UintP("time", "t", 10, "Seconds to wait for stop before killing it")
-	restartCommand.Flags().StringP("signal", "s", "", "Signal to send to stop the container, before killing it")
-	return restartCommand
+	cmd.Flags().UintP("time", "t", 10, "Seconds to wait for stop before killing it")
+	cmd.Flags().StringP("signal", "s", "", "Signal to send to stop the container, before killing it")
+	return cmd
 }
 
 func processContainerRestartOptions(cmd *cobra.Command) (types.ContainerRestartOptions, error) {

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -58,7 +58,7 @@ func NewRunCommand() *cobra.Command {
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl run` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
 	}
-	var runCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "run [flags] IMAGE [COMMAND] [ARG...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             shortHelp,
@@ -69,13 +69,13 @@ func NewRunCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 
-	runCommand.Flags().SetInterspersed(false)
-	setCreateFlags(runCommand)
+	cmd.Flags().SetInterspersed(false)
+	setCreateFlags(cmd)
 
-	runCommand.Flags().BoolP("detach", "d", false, "Run container in background and print container ID")
-	runCommand.Flags().StringSliceP("attach", "a", []string{}, "Attach STDIN, STDOUT, or STDERR")
+	cmd.Flags().BoolP("detach", "d", false, "Run container in background and print container ID")
+	cmd.Flags().StringSliceP("attach", "a", []string{}, "Attach STDIN, STDOUT, or STDERR")
 
-	return runCommand
+	return cmd
 }
 
 func setCreateFlags(cmd *cobra.Command) {

--- a/cmd/nerdctl/container/container_start.go
+++ b/cmd/nerdctl/container/container_start.go
@@ -30,7 +30,7 @@ import (
 )
 
 func NewStartCommand() *cobra.Command {
-	var startCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "start [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Start one or more running containers",
@@ -40,11 +40,11 @@ func NewStartCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 
-	startCommand.Flags().SetInterspersed(false)
-	startCommand.Flags().BoolP("attach", "a", false, "Attach STDOUT/STDERR and forward signals")
-	startCommand.Flags().String("detach-keys", consoleutil.DefaultDetachKeys, "Override the default detach keys")
+	cmd.Flags().SetInterspersed(false)
+	cmd.Flags().BoolP("attach", "a", false, "Attach STDOUT/STDERR and forward signals")
+	cmd.Flags().String("detach-keys", consoleutil.DefaultDetachKeys, "Override the default detach keys")
 
-	return startCommand
+	return cmd
 }
 
 func processContainerStartOptions(cmd *cobra.Command) (types.ContainerStartOptions, error) {

--- a/cmd/nerdctl/container/container_stats.go
+++ b/cmd/nerdctl/container/container_stats.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewStatsCommand() *cobra.Command {
-	var statsCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "stats",
 		Short:             "Display a live stream of container(s) resource usage statistics.",
 		RunE:              statsAction,
@@ -38,9 +38,9 @@ func NewStatsCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 
-	addStatsFlags(statsCommand)
+	addStatsFlags(cmd)
 
-	return statsCommand
+	return cmd
 }
 
 func addStatsFlags(cmd *cobra.Command) {

--- a/cmd/nerdctl/container/container_stop.go
+++ b/cmd/nerdctl/container/container_stop.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewStopCommand() *cobra.Command {
-	var stopCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "stop [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Stop one or more running containers",
@@ -40,9 +40,9 @@ func NewStopCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	stopCommand.Flags().IntP("time", "t", 10, "Seconds to wait before sending a SIGKILL")
-	stopCommand.Flags().StringP("signal", "s", "SIGTERM", "Signal to send to the container")
-	return stopCommand
+	cmd.Flags().IntP("time", "t", 10, "Seconds to wait before sending a SIGKILL")
+	cmd.Flags().StringP("signal", "s", "SIGTERM", "Signal to send to the container")
+	return cmd
 }
 
 func processContainerStopOptions(cmd *cobra.Command) (types.ContainerStopOptions, error) {

--- a/cmd/nerdctl/container/container_top.go
+++ b/cmd/nerdctl/container/container_top.go
@@ -34,7 +34,7 @@ import (
 )
 
 func NewTopCommand() *cobra.Command {
-	var topCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "top CONTAINER [ps OPTIONS]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Display the running processes of a container",
@@ -43,8 +43,8 @@ func NewTopCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	topCommand.Flags().SetInterspersed(false)
-	return topCommand
+	cmd.Flags().SetInterspersed(false)
+	return cmd
 }
 
 func topAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/container/container_unpause.go
+++ b/cmd/nerdctl/container/container_unpause.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewUnpauseCommand() *cobra.Command {
-	var unpauseCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "unpause [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Unpause all processes within one or more containers",
@@ -38,7 +38,7 @@ func NewUnpauseCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return unpauseCommand
+	return cmd
 }
 
 func processContainerUnpauseOptions(cmd *cobra.Command) (types.ContainerUnpauseOptions, error) {

--- a/cmd/nerdctl/container/container_update.go
+++ b/cmd/nerdctl/container/container_update.go
@@ -58,7 +58,7 @@ type updateResourceOptions struct {
 }
 
 func NewUpdateCommand() *cobra.Command {
-	var updateCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "update [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Update one or more running containers",
@@ -67,9 +67,9 @@ func NewUpdateCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	updateCommand.Flags().SetInterspersed(false)
-	setUpdateFlags(updateCommand)
-	return updateCommand
+	cmd.Flags().SetInterspersed(false)
+	setUpdateFlags(cmd)
+	return cmd
 }
 
 func setUpdateFlags(cmd *cobra.Command) {

--- a/cmd/nerdctl/container/container_wait.go
+++ b/cmd/nerdctl/container/container_wait.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewWaitCommand() *cobra.Command {
-	var waitCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "wait [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Block until one or more containers stop, then print their exit codes.",
@@ -38,7 +38,7 @@ func NewWaitCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return waitCommand
+	return cmd
 }
 
 func processContainerWaitOptions(cmd *cobra.Command) (types.ContainerWaitOptions, error) {

--- a/cmd/nerdctl/image/image_convert.go
+++ b/cmd/nerdctl/image/image_convert.go
@@ -40,7 +40,7 @@ For encryption and decryption, use 'nerdctl image (encrypt|decrypt)' command.
 
 // imageConvertCommand is from https://github.com/containerd/stargz-snapshotter/blob/d58f43a8235e46da73fb94a1a35280cb4d607b2c/cmd/ctr-remote/commands/convert.go
 func newImageConvertCommand() *cobra.Command {
-	imageConvertCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "convert [flags] <source_ref> <target_ref>...",
 		Short:             "convert an image",
 		Long:              imageConvertHelp,
@@ -51,57 +51,57 @@ func newImageConvertCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 
-	imageConvertCommand.Flags().String("format", "", "Format the output using the given Go template, e.g, 'json'")
+	cmd.Flags().String("format", "", "Format the output using the given Go template, e.g, 'json'")
 
 	// #region estargz flags
-	imageConvertCommand.Flags().Bool("estargz", false, "Convert legacy tar(.gz) layers to eStargz for lazy pulling. Should be used in conjunction with '--oci'")
-	imageConvertCommand.Flags().String("estargz-record-in", "", "Read 'ctr-remote optimize --record-out=<FILE>' record file (EXPERIMENTAL)")
-	imageConvertCommand.Flags().Int("estargz-compression-level", gzip.BestCompression, "eStargz compression level")
-	imageConvertCommand.Flags().Int("estargz-chunk-size", 0, "eStargz chunk size")
-	imageConvertCommand.Flags().Int("estargz-min-chunk-size", 0, "The minimal number of bytes of data must be written in one gzip stream. (requires stargz-snapshotter >= v0.13.0)")
-	imageConvertCommand.Flags().Bool("estargz-external-toc", false, "Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. (requires stargz-snapshotter >= v0.13.0) (EXPERIMENTAL)")
-	imageConvertCommand.Flags().Bool("estargz-keep-diff-id", false, "Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')")
+	cmd.Flags().Bool("estargz", false, "Convert legacy tar(.gz) layers to eStargz for lazy pulling. Should be used in conjunction with '--oci'")
+	cmd.Flags().String("estargz-record-in", "", "Read 'ctr-remote optimize --record-out=<FILE>' record file (EXPERIMENTAL)")
+	cmd.Flags().Int("estargz-compression-level", gzip.BestCompression, "eStargz compression level")
+	cmd.Flags().Int("estargz-chunk-size", 0, "eStargz chunk size")
+	cmd.Flags().Int("estargz-min-chunk-size", 0, "The minimal number of bytes of data must be written in one gzip stream. (requires stargz-snapshotter >= v0.13.0)")
+	cmd.Flags().Bool("estargz-external-toc", false, "Separate TOC JSON into another image (called \"TOC image\"). The name of TOC image is the original + \"-esgztoc\" suffix. Both eStargz and the TOC image should be pushed to the same registry. (requires stargz-snapshotter >= v0.13.0) (EXPERIMENTAL)")
+	cmd.Flags().Bool("estargz-keep-diff-id", false, "Convert to esgz without changing diffID (cannot be used in conjunction with '--estargz-record-in'. must be specified with '--estargz-external-toc')")
 	// #endregion
 
 	// #region zstd flags
-	imageConvertCommand.Flags().Bool("zstd", false, "Convert legacy tar(.gz) layers to zstd. Should be used in conjunction with '--oci'")
-	imageConvertCommand.Flags().Int("zstd-compression-level", 3, "zstd compression level")
+	cmd.Flags().Bool("zstd", false, "Convert legacy tar(.gz) layers to zstd. Should be used in conjunction with '--oci'")
+	cmd.Flags().Int("zstd-compression-level", 3, "zstd compression level")
 	// #endregion
 
 	// #region zstd:chunked flags
-	imageConvertCommand.Flags().Bool("zstdchunked", false, "Convert legacy tar(.gz) layers to zstd:chunked for lazy pulling. Should be used in conjunction with '--oci'")
-	imageConvertCommand.Flags().String("zstdchunked-record-in", "", "Read 'ctr-remote optimize --record-out=<FILE>' record file (EXPERIMENTAL)")
-	imageConvertCommand.Flags().Int("zstdchunked-compression-level", 3, "zstd:chunked compression level") // SpeedDefault; see also https://pkg.go.dev/github.com/klauspost/compress/zstd#EncoderLevel
-	imageConvertCommand.Flags().Int("zstdchunked-chunk-size", 0, "zstd:chunked chunk size")
+	cmd.Flags().Bool("zstdchunked", false, "Convert legacy tar(.gz) layers to zstd:chunked for lazy pulling. Should be used in conjunction with '--oci'")
+	cmd.Flags().String("zstdchunked-record-in", "", "Read 'ctr-remote optimize --record-out=<FILE>' record file (EXPERIMENTAL)")
+	cmd.Flags().Int("zstdchunked-compression-level", 3, "zstd:chunked compression level") // SpeedDefault; see also https://pkg.go.dev/github.com/klauspost/compress/zstd#EncoderLevel
+	cmd.Flags().Int("zstdchunked-chunk-size", 0, "zstd:chunked chunk size")
 	// #endregion
 
 	// #region nydus flags
-	imageConvertCommand.Flags().Bool("nydus", false, "Convert an OCI image to Nydus image. Should be used in conjunction with '--oci'")
-	imageConvertCommand.Flags().String("nydus-builder-path", "nydus-image", "The nydus-image binary path, if unset, search in PATH environment")
-	imageConvertCommand.Flags().String("nydus-work-dir", "", "Work directory path for image conversion, default is the nerdctl data root directory")
-	imageConvertCommand.Flags().String("nydus-prefetch-patterns", "", "The file path pattern list want to prefetch")
-	imageConvertCommand.Flags().String("nydus-compressor", "lz4_block", "Nydus blob compression algorithm, possible values: `none`, `lz4_block`, `zstd`, default is `lz4_block`")
+	cmd.Flags().Bool("nydus", false, "Convert an OCI image to Nydus image. Should be used in conjunction with '--oci'")
+	cmd.Flags().String("nydus-builder-path", "nydus-image", "The nydus-image binary path, if unset, search in PATH environment")
+	cmd.Flags().String("nydus-work-dir", "", "Work directory path for image conversion, default is the nerdctl data root directory")
+	cmd.Flags().String("nydus-prefetch-patterns", "", "The file path pattern list want to prefetch")
+	cmd.Flags().String("nydus-compressor", "lz4_block", "Nydus blob compression algorithm, possible values: `none`, `lz4_block`, `zstd`, default is `lz4_block`")
 	// #endregion
 
 	// #region overlaybd flags
-	imageConvertCommand.Flags().Bool("overlaybd", false, "Convert tar.gz layers to overlaybd layers")
-	imageConvertCommand.Flags().String("overlaybd-fs-type", "ext4", "Filesystem type for overlaybd")
-	imageConvertCommand.Flags().String("overlaybd-dbstr", "", "Database config string for overlaybd")
+	cmd.Flags().Bool("overlaybd", false, "Convert tar.gz layers to overlaybd layers")
+	cmd.Flags().String("overlaybd-fs-type", "ext4", "Filesystem type for overlaybd")
+	cmd.Flags().String("overlaybd-dbstr", "", "Database config string for overlaybd")
 	// #endregion
 
 	// #region generic flags
-	imageConvertCommand.Flags().Bool("uncompress", false, "Convert tar.gz layers to uncompressed tar layers")
-	imageConvertCommand.Flags().Bool("oci", false, "Convert Docker media types to OCI media types")
+	cmd.Flags().Bool("uncompress", false, "Convert tar.gz layers to uncompressed tar layers")
+	cmd.Flags().Bool("oci", false, "Convert Docker media types to OCI media types")
 	// #endregion
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	imageConvertCommand.Flags().StringSlice("platform", []string{}, "Convert content for a specific platform")
-	imageConvertCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	imageConvertCommand.Flags().Bool("all-platforms", false, "Convert content for all platforms")
+	cmd.Flags().StringSlice("platform", []string{}, "Convert content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().Bool("all-platforms", false, "Convert content for all platforms")
 	// #endregion
 
-	return imageConvertCommand
+	return cmd
 }
 
 func processImageConvertOptions(cmd *cobra.Command) (types.ImageConvertOptions, error) {

--- a/cmd/nerdctl/image/image_history.go
+++ b/cmd/nerdctl/image/image_history.go
@@ -44,7 +44,7 @@ import (
 )
 
 func NewHistoryCommand() *cobra.Command {
-	var historyCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "history [flags] IMAGE",
 		Short:             "Show the history of an image",
 		Args:              helpers.IsExactArgs(1),
@@ -53,8 +53,8 @@ func NewHistoryCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	addHistoryFlags(historyCommand)
-	return historyCommand
+	addHistoryFlags(cmd)
+	return cmd
 }
 
 func addHistoryFlags(cmd *cobra.Command) {

--- a/cmd/nerdctl/image/image_inspect.go
+++ b/cmd/nerdctl/image/image_inspect.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newImageInspectCommand() *cobra.Command {
-	imageInspectCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "inspect [flags] IMAGE [IMAGE...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Display detailed information on one or more images.",
@@ -39,21 +39,21 @@ func newImageInspectCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	imageInspectCommand.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
-	imageInspectCommand.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
+	cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"dockercompat", "native"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	imageInspectCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	imageInspectCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	// #region platform flags
-	imageInspectCommand.Flags().String("platform", "", "Inspect a specific platform") // not a slice, and there is no --all-platforms
-	imageInspectCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().String("platform", "", "Inspect a specific platform") // not a slice, and there is no --all-platforms
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
 	// #endregion
 
-	return imageInspectCommand
+	return cmd
 }
 
 func ProcessImageInspectOptions(cmd *cobra.Command, platform *string) (types.ImageInspectOptions, error) {

--- a/cmd/nerdctl/image/image_list.go
+++ b/cmd/nerdctl/image/image_list.go
@@ -43,7 +43,7 @@ Properties:
 - SIZE:       Size of the unpacked snapshots
 - BLOB SIZE:  Size of the blobs (such as layer tarballs) in the content store
 `
-	var imagesCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:                   "images [flags] [REPOSITORY[:TAG]]",
 		Short:                 shortHelp,
 		Long:                  longHelp,
@@ -55,19 +55,19 @@ Properties:
 		DisableFlagsInUseLine: true,
 	}
 
-	imagesCommand.Flags().BoolP("quiet", "q", false, "Only show numeric IDs")
-	imagesCommand.Flags().Bool("no-trunc", false, "Don't truncate output")
+	cmd.Flags().BoolP("quiet", "q", false, "Only show numeric IDs")
+	cmd.Flags().Bool("no-trunc", false, "Don't truncate output")
 	// Alias "-f" is reserved for "--filter"
-	imagesCommand.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}', 'wide'")
-	imagesCommand.Flags().StringSliceP("filter", "f", []string{}, "Filter output based on conditions provided")
-	imagesCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}', 'wide'")
+	cmd.Flags().StringSliceP("filter", "f", []string{}, "Filter output based on conditions provided")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "table", "wide"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	imagesCommand.Flags().Bool("digests", false, "Show digests (compatible with Docker, unlike ID)")
-	imagesCommand.Flags().Bool("names", false, "Show image names")
-	imagesCommand.Flags().BoolP("all", "a", true, "(unimplemented yet, always true)")
+	cmd.Flags().Bool("digests", false, "Show digests (compatible with Docker, unlike ID)")
+	cmd.Flags().Bool("names", false, "Show image names")
+	cmd.Flags().BoolP("all", "a", true, "(unimplemented yet, always true)")
 
-	return imagesCommand
+	return cmd
 }
 
 func processImageListOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, error) {

--- a/cmd/nerdctl/image/image_load.go
+++ b/cmd/nerdctl/image/image_load.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewLoadCommand() *cobra.Command {
-	var loadCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "load",
 		Args:          cobra.NoArgs,
 		Short:         "Load an image from a tar archive or STDIN",
@@ -37,17 +37,17 @@ func NewLoadCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	loadCommand.Flags().StringP("input", "i", "", "Read from tar archive file, instead of STDIN")
-	loadCommand.Flags().BoolP("quiet", "q", false, "Suppress the load output")
+	cmd.Flags().StringP("input", "i", "", "Read from tar archive file, instead of STDIN")
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress the load output")
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	loadCommand.Flags().StringSlice("platform", []string{}, "Import content for a specific platform")
-	loadCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	loadCommand.Flags().Bool("all-platforms", false, "Import content for all platforms")
+	cmd.Flags().StringSlice("platform", []string{}, "Import content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().Bool("all-platforms", false, "Import content for all platforms")
 	// #endregion
 
-	return loadCommand
+	return cmd
 }
 
 func processLoadCommandFlags(cmd *cobra.Command) (types.ImageLoadOptions, error) {

--- a/cmd/nerdctl/image/image_prune.go
+++ b/cmd/nerdctl/image/image_prune.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newImagePruneCommand() *cobra.Command {
-	imagePruneCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove unused images",
 		Args:          cobra.NoArgs,
@@ -37,10 +37,10 @@ func newImagePruneCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	imagePruneCommand.Flags().BoolP("all", "a", false, "Remove all unused images, not just dangling ones")
-	imagePruneCommand.Flags().StringSlice("filter", []string{}, "Filter output based on conditions provided")
-	imagePruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	return imagePruneCommand
+	cmd.Flags().BoolP("all", "a", false, "Remove all unused images, not just dangling ones")
+	cmd.Flags().StringSlice("filter", []string{}, "Filter output based on conditions provided")
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	return cmd
 }
 
 func processImagePruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, error) {

--- a/cmd/nerdctl/image/image_pull.go
+++ b/cmd/nerdctl/image/image_pull.go
@@ -29,7 +29,7 @@ import (
 )
 
 func NewPullCommand() *cobra.Command {
-	var pullCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "pull [flags] NAME[:TAG]",
 		Short:         "Pull an image from a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS.",
 		Args:          helpers.IsExactArgs(1),
@@ -37,39 +37,39 @@ func NewPullCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	pullCommand.Flags().String("unpack", "auto", "Unpack the image for the current single platform (auto/true/false)")
-	pullCommand.RegisterFlagCompletionFunc("unpack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("unpack", "auto", "Unpack the image for the current single platform (auto/true/false)")
+	cmd.RegisterFlagCompletionFunc("unpack", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"auto", "true", "false"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	pullCommand.Flags().StringSlice("platform", nil, "Pull content for a specific platform")
-	pullCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	pullCommand.Flags().Bool("all-platforms", false, "Pull content for all platforms")
+	cmd.Flags().StringSlice("platform", nil, "Pull content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().Bool("all-platforms", false, "Pull content for all platforms")
 	// #endregion
 
 	// #region verify flags
-	pullCommand.Flags().String("verify", "none", "Verify the image (none|cosign|notation)")
-	pullCommand.RegisterFlagCompletionFunc("verify", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("verify", "none", "Verify the image (none|cosign|notation)")
+	cmd.RegisterFlagCompletionFunc("verify", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "cosign", "notation"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	pullCommand.Flags().String("cosign-key", "", "Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign")
-	pullCommand.Flags().String("cosign-certificate-identity", "", "The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
-	pullCommand.Flags().String("cosign-certificate-identity-regexp", "", "A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
-	pullCommand.Flags().String("cosign-certificate-oidc-issuer", "", "The OIDC issuer expected in a valid Fulcio certificate for --verify=cosign,, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows")
-	pullCommand.Flags().String("cosign-certificate-oidc-issuer-regexp", "", "A regular expression alternative to --certificate-oidc-issuer for --verify=cosign,. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows")
+	cmd.Flags().String("cosign-key", "", "Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign")
+	cmd.Flags().String("cosign-certificate-identity", "", "The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
+	cmd.Flags().String("cosign-certificate-identity-regexp", "", "A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
+	cmd.Flags().String("cosign-certificate-oidc-issuer", "", "The OIDC issuer expected in a valid Fulcio certificate for --verify=cosign,, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows")
+	cmd.Flags().String("cosign-certificate-oidc-issuer-regexp", "", "A regular expression alternative to --certificate-oidc-issuer for --verify=cosign,. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-oidc-issuer or --cosign-certificate-oidc-issuer-regexp must be set for keyless flows")
 	// #endregion
 
 	// #region socipull flags
-	pullCommand.Flags().String("soci-index-digest", "", "Specify a particular index digest for SOCI. If left empty, SOCI will automatically use the index determined by the selection policy.")
+	cmd.Flags().String("soci-index-digest", "", "Specify a particular index digest for SOCI. If left empty, SOCI will automatically use the index determined by the selection policy.")
 	// #endregion
 
-	pullCommand.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
 
-	pullCommand.Flags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
+	cmd.Flags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
 
-	return pullCommand
+	return cmd
 }
 
 func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error) {

--- a/cmd/nerdctl/image/image_push.go
+++ b/cmd/nerdctl/image/image_push.go
@@ -31,7 +31,7 @@ const (
 )
 
 func NewPushCommand() *cobra.Command {
-	var pushCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "push [flags] NAME[:TAG]",
 		Short:             "Push an image or a repository to a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to push image to IPFS.",
 		Args:              helpers.IsExactArgs(1),
@@ -42,34 +42,34 @@ func NewPushCommand() *cobra.Command {
 	}
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	pushCommand.Flags().StringSlice("platform", []string{}, "Push content for a specific platform")
-	pushCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	pushCommand.Flags().Bool("all-platforms", false, "Push content for all platforms")
+	cmd.Flags().StringSlice("platform", []string{}, "Push content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().Bool("all-platforms", false, "Push content for all platforms")
 	// #endregion
 
-	pushCommand.Flags().Bool("estargz", false, "Convert the image into eStargz")
-	pushCommand.Flags().Bool("ipfs-ensure-image", true, "Ensure the entire contents of the image is locally available before push")
-	pushCommand.Flags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
+	cmd.Flags().Bool("estargz", false, "Convert the image into eStargz")
+	cmd.Flags().Bool("ipfs-ensure-image", true, "Ensure the entire contents of the image is locally available before push")
+	cmd.Flags().String("ipfs-address", "", "multiaddr of IPFS API (default uses $IPFS_PATH env variable if defined or local directory ~/.ipfs)")
 
 	// #region sign flags
-	pushCommand.Flags().String("sign", "none", "Sign the image (none|cosign|notation")
-	pushCommand.RegisterFlagCompletionFunc("sign", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("sign", "none", "Sign the image (none|cosign|notation")
+	cmd.RegisterFlagCompletionFunc("sign", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "cosign", "notation"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	pushCommand.Flags().String("cosign-key", "", "Path to the private key file, KMS URI or Kubernetes Secret for --sign=cosign")
-	pushCommand.Flags().String("notation-key-name", "", "Signing key name for a key previously added to notation's key list for --sign=notation")
+	cmd.Flags().String("cosign-key", "", "Path to the private key file, KMS URI or Kubernetes Secret for --sign=cosign")
+	cmd.Flags().String("notation-key-name", "", "Signing key name for a key previously added to notation's key list for --sign=notation")
 	// #endregion
 
 	// #region soci flags
-	pushCommand.Flags().Int64("soci-span-size", -1, "Span size that soci index uses to segment layer data. Default is 4 MiB.")
-	pushCommand.Flags().Int64("soci-min-layer-size", -1, "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.")
+	cmd.Flags().Int64("soci-span-size", -1, "Span size that soci index uses to segment layer data. Default is 4 MiB.")
+	cmd.Flags().Int64("soci-min-layer-size", -1, "Minimum layer size to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.")
 	// #endregion
 
-	pushCommand.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress verbose output")
 
-	pushCommand.Flags().Bool(allowNonDistFlag, false, "Allow pushing images with non-distributable blobs")
+	cmd.Flags().Bool(allowNonDistFlag, false, "Allow pushing images with non-distributable blobs")
 
-	return pushCommand
+	return cmd
 }
 
 func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error) {

--- a/cmd/nerdctl/image/image_remove.go
+++ b/cmd/nerdctl/image/image_remove.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewRmiCommand() *cobra.Command {
-	var rmiCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "rmi [flags] IMAGE [IMAGE, ...]",
 		Short:             "Remove one or more images",
 		Args:              cobra.MinimumNArgs(1),
@@ -36,10 +36,10 @@ func NewRmiCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	rmiCommand.Flags().BoolP("force", "f", false, "Force removal of the image")
+	cmd.Flags().BoolP("force", "f", false, "Force removal of the image")
 	// Alias `-a` is reserved for `--all`. Should be compatible with `podman rmi --all`.
-	rmiCommand.Flags().Bool("async", false, "Asynchronous mode")
-	return rmiCommand
+	cmd.Flags().Bool("async", false, "Asynchronous mode")
+	return cmd
 }
 
 func processImageRemoveOptions(cmd *cobra.Command) (types.ImageRemoveOptions, error) {

--- a/cmd/nerdctl/image/image_save.go
+++ b/cmd/nerdctl/image/image_save.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewSaveCommand() *cobra.Command {
-	var saveCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "save",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Save one or more images to a tar archive (streamed to STDOUT by default)",
@@ -41,16 +41,16 @@ func NewSaveCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	saveCommand.Flags().StringP("output", "o", "", "Write to a file, instead of STDOUT")
+	cmd.Flags().StringP("output", "o", "", "Write to a file, instead of STDOUT")
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
-	saveCommand.Flags().StringSlice("platform", []string{}, "Export content for a specific platform")
-	saveCommand.RegisterFlagCompletionFunc("platform", completion.Platforms)
-	saveCommand.Flags().Bool("all-platforms", false, "Export content for all platforms")
+	cmd.Flags().StringSlice("platform", []string{}, "Export content for a specific platform")
+	cmd.RegisterFlagCompletionFunc("platform", completion.Platforms)
+	cmd.Flags().Bool("all-platforms", false, "Export content for all platforms")
 	// #endregion
 
-	return saveCommand
+	return cmd
 }
 
 func processImageSaveOptions(cmd *cobra.Command) (types.ImageSaveOptions, error) {

--- a/cmd/nerdctl/image/image_tag.go
+++ b/cmd/nerdctl/image/image_tag.go
@@ -27,7 +27,7 @@ import (
 )
 
 func NewTagCommand() *cobra.Command {
-	var tagCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
 		Short:             "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",
 		Args:              helpers.IsExactArgs(2),
@@ -36,7 +36,7 @@ func NewTagCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return tagCommand
+	return cmd
 }
 
 func tagAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/inspect/inspect.go
+++ b/cmd/nerdctl/inspect/inspect.go
@@ -35,7 +35,7 @@ import (
 )
 
 func NewInspectCommand() *cobra.Command {
-	var inspectCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:               "inspect",
 		Short:             "Return low-level information on objects.",
 		Args:              cobra.MinimumNArgs(1),
@@ -45,9 +45,9 @@ func NewInspectCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 
-	addInspectFlags(inspectCommand)
+	addInspectFlags(cmd)
 
-	return inspectCommand
+	return cmd
 }
 
 var validInspectType = map[string]bool{

--- a/cmd/nerdctl/internal/internal.go
+++ b/cmd/nerdctl/internal/internal.go
@@ -21,7 +21,7 @@ import (
 )
 
 func NewInternalCommand() *cobra.Command {
-	var internalCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "internal",
 		Short:         "DO NOT EXECUTE MANUALLY",
 		Hidden:        true,
@@ -29,9 +29,9 @@ func NewInternalCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	internalCommand.AddCommand(
+	cmd.AddCommand(
 		newInternalOCIHookCommandCommand(),
 	)
 
-	return internalCommand
+	return cmd
 }

--- a/cmd/nerdctl/internal/internal_oci_hook.go
+++ b/cmd/nerdctl/internal/internal_oci_hook.go
@@ -28,14 +28,14 @@ import (
 )
 
 func newInternalOCIHookCommandCommand() *cobra.Command {
-	var internalOCIHookCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "oci-hook",
 		Short:         "OCI hook",
 		RunE:          internalOCIHookAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	return internalOCIHookCommand
+	return cmd
 }
 
 func internalOCIHookAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/ipfs/ipfs_registry_serve.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_serve.go
@@ -31,7 +31,7 @@ const (
 )
 
 func newIPFSRegistryServeCommand() *cobra.Command {
-	var ipfsRegistryServeCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "serve",
 		Short:         "serve read-only registry backed by IPFS on localhost.",
 		RunE:          ipfsRegistryServeAction,
@@ -39,12 +39,12 @@ func newIPFSRegistryServeCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	helpers.AddStringFlag(ipfsRegistryServeCommand, "listen-registry", nil, defaultIPFSRegistry, "IPFS_REGISTRY_SERVE_LISTEN_REGISTRY", "address to listen")
-	helpers.AddStringFlag(ipfsRegistryServeCommand, "ipfs-address", nil, "", "IPFS_REGISTRY_SERVE_IPFS_ADDRESS", "multiaddr of IPFS API (default is pulled from $IPFS_PATH/api file. If $IPFS_PATH env var is not present, it defaults to ~/.ipfs)")
-	helpers.AddIntFlag(ipfsRegistryServeCommand, "read-retry-num", nil, defaultIPFSReadRetryNum, "IPFS_REGISTRY_SERVE_READ_RETRY_NUM", "times to retry query on IPFS. Zero or lower means no retry.")
-	helpers.AddDurationFlag(ipfsRegistryServeCommand, "read-timeout", nil, defaultIPFSReadTimeoutDuration, "IPFS_REGISTRY_SERVE_READ_TIMEOUT", "timeout duration of a read request to IPFS. Zero means no timeout.")
+	helpers.AddStringFlag(cmd, "listen-registry", nil, defaultIPFSRegistry, "IPFS_REGISTRY_SERVE_LISTEN_REGISTRY", "address to listen")
+	helpers.AddStringFlag(cmd, "ipfs-address", nil, "", "IPFS_REGISTRY_SERVE_IPFS_ADDRESS", "multiaddr of IPFS API (default is pulled from $IPFS_PATH/api file. If $IPFS_PATH env var is not present, it defaults to ~/.ipfs)")
+	helpers.AddIntFlag(cmd, "read-retry-num", nil, defaultIPFSReadRetryNum, "IPFS_REGISTRY_SERVE_READ_RETRY_NUM", "times to retry query on IPFS. Zero or lower means no retry.")
+	helpers.AddDurationFlag(cmd, "read-timeout", nil, defaultIPFSReadTimeoutDuration, "IPFS_REGISTRY_SERVE_READ_TIMEOUT", "timeout duration of a read request to IPFS. Zero means no timeout.")
 
-	return ipfsRegistryServeCommand
+	return cmd
 }
 
 func processIPFSRegistryServeOptions(cmd *cobra.Command) (opts types.IPFSRegistryServeOptions, err error) {

--- a/cmd/nerdctl/login/login.go
+++ b/cmd/nerdctl/login/login.go
@@ -31,7 +31,7 @@ import (
 )
 
 func NewLoginCommand() *cobra.Command {
-	var loginCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "login [flags] [SERVER]",
 		Args:          cobra.MaximumNArgs(1),
 		Short:         "Log in to a container registry",
@@ -39,10 +39,10 @@ func NewLoginCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	loginCommand.Flags().StringP("username", "u", "", "Username")
-	loginCommand.Flags().StringP("password", "p", "", "Password")
-	loginCommand.Flags().Bool("password-stdin", false, "Take the password from stdin")
-	return loginCommand
+	cmd.Flags().StringP("username", "u", "", "Username")
+	cmd.Flags().StringP("password", "p", "", "Password")
+	cmd.Flags().Bool("password-stdin", false, "Take the password from stdin")
+	return cmd
 }
 
 func processLoginOptions(cmd *cobra.Command) (types.LoginCommandOptions, error) {

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -35,28 +35,28 @@ func TestMain(m *testing.M) {
 func TestUnknownCommand(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	var unknownSubCommand = errors.New("unknown subcommand")
+	var cmd = errors.New("unknown subcommand")
 
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "non-existent-command",
 			Command:     test.Command("non-existent-command"),
-			Expected:    test.Expects(1, []error{unknownSubCommand}, nil),
+			Expected:    test.Expects(1, []error{cmd}, nil),
 		},
 		{
 			Description: "non-existent-command info",
 			Command:     test.Command("non-existent-command", "info"),
-			Expected:    test.Expects(1, []error{unknownSubCommand}, nil),
+			Expected:    test.Expects(1, []error{cmd}, nil),
 		},
 		{
 			Description: "system non-existent-command",
 			Command:     test.Command("system", "non-existent-command"),
-			Expected:    test.Expects(1, []error{unknownSubCommand}, nil),
+			Expected:    test.Expects(1, []error{cmd}, nil),
 		},
 		{
 			Description: "system non-existent-command info",
 			Command:     test.Command("system", "non-existent-command", "info"),
-			Expected:    test.Expects(1, []error{unknownSubCommand}, nil),
+			Expected:    test.Expects(1, []error{cmd}, nil),
 		},
 		{
 			Description: "system",

--- a/cmd/nerdctl/namespace/namespace.go
+++ b/cmd/nerdctl/namespace/namespace.go
@@ -33,7 +33,7 @@ import (
 )
 
 func NewNamespaceCommand() *cobra.Command {
-	namespaceCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "namespace",
 		Aliases:       []string{"ns"},
@@ -43,16 +43,16 @@ func NewNamespaceCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	namespaceCommand.AddCommand(newNamespaceLsCommand())
-	namespaceCommand.AddCommand(newNamespaceRmCommand())
-	namespaceCommand.AddCommand(newNamespaceCreateCommand())
-	namespaceCommand.AddCommand(newNamespacelabelUpdateCommand())
-	namespaceCommand.AddCommand(newNamespaceInspectCommand())
-	return namespaceCommand
+	cmd.AddCommand(newNamespaceLsCommand())
+	cmd.AddCommand(newNamespaceRmCommand())
+	cmd.AddCommand(newNamespaceCreateCommand())
+	cmd.AddCommand(newNamespacelabelUpdateCommand())
+	cmd.AddCommand(newNamespaceInspectCommand())
+	return cmd
 }
 
 func newNamespaceLsCommand() *cobra.Command {
-	namespaceLsCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List containerd namespaces",
@@ -60,8 +60,8 @@ func newNamespaceLsCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	namespaceLsCommand.Flags().BoolP("quiet", "q", false, "Only display names")
-	return namespaceLsCommand
+	cmd.Flags().BoolP("quiet", "q", false, "Only display names")
+	return cmd
 }
 
 func namespaceLsAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/namespace/namespace_create.go
+++ b/cmd/nerdctl/namespace/namespace_create.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newNamespaceCreateCommand() *cobra.Command {
-	namespaceCreateCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "create NAMESPACE",
 		Short:         "Create a new namespace",
 		Args:          cobra.MinimumNArgs(1),
@@ -35,8 +35,8 @@ func newNamespaceCreateCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	namespaceCreateCommand.Flags().StringArrayP("label", "l", nil, "Set labels for a namespace")
-	return namespaceCreateCommand
+	cmd.Flags().StringArrayP("label", "l", nil, "Set labels for a namespace")
+	return cmd
 }
 
 func processNamespaceCreateCommandOption(cmd *cobra.Command) (types.NamespaceCreateOptions, error) {

--- a/cmd/nerdctl/namespace/namespace_inspect.go
+++ b/cmd/nerdctl/namespace/namespace_inspect.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newNamespaceInspectCommand() *cobra.Command {
-	namespaceInspectCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "inspect NAMESPACE",
 		Short:         "Display detailed information on one or more namespaces.",
 		RunE:          labelInspectAction,
@@ -34,11 +34,11 @@ func newNamespaceInspectCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	namespaceInspectCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	namespaceInspectCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return namespaceInspectCommand
+	return cmd
 }
 
 func processNamespaceInspectOptions(cmd *cobra.Command) (types.NamespaceInspectOptions, error) {

--- a/cmd/nerdctl/namespace/namespace_remove.go
+++ b/cmd/nerdctl/namespace/namespace_remove.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newNamespaceRmCommand() *cobra.Command {
-	namespaceRmCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "remove [flags] NAMESPACE [NAMESPACE...]",
 		Aliases:       []string{"rm"},
 		Args:          cobra.MinimumNArgs(1),
@@ -35,8 +35,8 @@ func newNamespaceRmCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	namespaceRmCommand.Flags().BoolP("cgroup", "c", false, "delete the namespace's cgroup")
-	return namespaceRmCommand
+	cmd.Flags().BoolP("cgroup", "c", false, "delete the namespace's cgroup")
+	return cmd
 }
 
 func processNamespaceRemoveOptions(cmd *cobra.Command) (types.NamespaceRemoveOptions, error) {

--- a/cmd/nerdctl/namespace/namespace_update.go
+++ b/cmd/nerdctl/namespace/namespace_update.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newNamespacelabelUpdateCommand() *cobra.Command {
-	namespaceLableCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "update [flags] NAMESPACE",
 		Short:         "Update labels for a namespace",
 		RunE:          labelUpdateAction,
@@ -34,8 +34,8 @@ func newNamespacelabelUpdateCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	namespaceLableCommand.Flags().StringArrayP("label", "l", nil, "Set labels for a namespace")
-	return namespaceLableCommand
+	cmd.Flags().StringArrayP("label", "l", nil, "Set labels for a namespace")
+	return cmd
 }
 
 func processNamespaceUpdateCommandOption(cmd *cobra.Command) (types.NamespaceUpdateOptions, error) {

--- a/cmd/nerdctl/network/network.go
+++ b/cmd/nerdctl/network/network.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewNetworkCommand() *cobra.Command {
-	networkCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "network",
 		Short:         "Manage networks",
@@ -31,12 +31,12 @@ func NewNetworkCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	networkCommand.AddCommand(
+	cmd.AddCommand(
 		newNetworkLsCommand(),
 		newNetworkInspectCommand(),
 		newNetworkCreateCommand(),
 		newNetworkRmCommand(),
 		newNetworkPruneCommand(),
 	)
-	return networkCommand
+	return cmd
 }

--- a/cmd/nerdctl/network/network_create.go
+++ b/cmd/nerdctl/network/network_create.go
@@ -30,7 +30,7 @@ import (
 )
 
 func newNetworkCreateCommand() *cobra.Command {
-	var networkCreateCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "create [flags] NETWORK",
 		Short:         "Create a network",
 		Long:          `NOTE: To isolate CNI bridge, CNI plugin "firewall" (>= v1.1.0) is needed.`,
@@ -39,18 +39,18 @@ func newNetworkCreateCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	networkCreateCommand.Flags().StringP("driver", "d", DefaultNetworkDriver, "Driver to manage the Network")
-	networkCreateCommand.RegisterFlagCompletionFunc("driver", completion.NetworkDrivers)
-	networkCreateCommand.Flags().StringArrayP("opt", "o", nil, "Set driver specific options")
-	networkCreateCommand.Flags().String("ipam-driver", "default", "IP Address helpers.Management Driver")
-	networkCreateCommand.RegisterFlagCompletionFunc("ipam-driver", completion.IPAMDrivers)
-	networkCreateCommand.Flags().StringArray("ipam-opt", nil, "Set IPAM driver specific options")
-	networkCreateCommand.Flags().StringArray("subnet", nil, `Subnet in CIDR format that represents a network segment, e.g. "10.5.0.0/16"`)
-	networkCreateCommand.Flags().String("gateway", "", `Gateway for the master subnet`)
-	networkCreateCommand.Flags().String("ip-range", "", `Allocate container ip from a sub-range`)
-	networkCreateCommand.Flags().StringArray("label", nil, "Set metadata for a network")
-	networkCreateCommand.Flags().Bool("ipv6", false, "Enable IPv6 networking")
-	return networkCreateCommand
+	cmd.Flags().StringP("driver", "d", DefaultNetworkDriver, "Driver to manage the Network")
+	cmd.RegisterFlagCompletionFunc("driver", completion.NetworkDrivers)
+	cmd.Flags().StringArrayP("opt", "o", nil, "Set driver specific options")
+	cmd.Flags().String("ipam-driver", "default", "IP Address helpers.Management Driver")
+	cmd.RegisterFlagCompletionFunc("ipam-driver", completion.IPAMDrivers)
+	cmd.Flags().StringArray("ipam-opt", nil, "Set IPAM driver specific options")
+	cmd.Flags().StringArray("subnet", nil, `Subnet in CIDR format that represents a network segment, e.g. "10.5.0.0/16"`)
+	cmd.Flags().String("gateway", "", `Gateway for the master subnet`)
+	cmd.Flags().String("ip-range", "", `Allocate container ip from a sub-range`)
+	cmd.Flags().StringArray("label", nil, "Set metadata for a network")
+	cmd.Flags().Bool("ipv6", false, "Enable IPv6 networking")
+	return cmd
 }
 
 func networkCreateAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/network/network_inspect.go
+++ b/cmd/nerdctl/network/network_inspect.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newNetworkInspectCommand() *cobra.Command {
-	networkInspectCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "inspect [flags] NETWORK [NETWORK, ...]",
 		Short:             "Display detailed information on one or more networks",
 		Args:              cobra.MinimumNArgs(1),
@@ -35,15 +35,15 @@ func newNetworkInspectCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	networkInspectCommand.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
-	networkInspectCommand.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("mode", "dockercompat", `Inspect mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
+	cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"dockercompat", "native"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	networkInspectCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	networkInspectCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return networkInspectCommand
+	return cmd
 }
 
 func networkInspectAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/network/network_prune.go
+++ b/cmd/nerdctl/network/network_prune.go
@@ -31,7 +31,7 @@ import (
 var NetworkDriversToKeep = []string{"host", "none", DefaultNetworkDriver}
 
 func newNetworkPruneCommand() *cobra.Command {
-	networkPruneCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all unused networks",
 		Args:          cobra.NoArgs,
@@ -39,8 +39,8 @@ func newNetworkPruneCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	networkPruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	return networkPruneCommand
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	return cmd
 }
 
 func networkPruneAction(cmd *cobra.Command, _ []string) error {

--- a/cmd/nerdctl/network/network_remove.go
+++ b/cmd/nerdctl/network/network_remove.go
@@ -28,7 +28,7 @@ import (
 )
 
 func newNetworkRmCommand() *cobra.Command {
-	networkRmCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "rm [flags] NETWORK [NETWORK, ...]",
 		Aliases:           []string{"remove"},
 		Short:             "Remove one or more networks",
@@ -39,7 +39,7 @@ func newNetworkRmCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	return networkRmCommand
+	return cmd
 }
 
 func networkRmAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/system/system.go
+++ b/cmd/nerdctl/system/system.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewSystemCommand() *cobra.Command {
-	var systemCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "system",
 		Short:         "Manage containerd",
@@ -32,10 +32,10 @@ func NewSystemCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	// versionCommand is not here
-	systemCommand.AddCommand(
+	cmd.AddCommand(
 		NewEventsCommand(),
 		NewInfoCommand(),
 		newSystemPruneCommand(),
 	)
-	return systemCommand
+	return cmd
 }

--- a/cmd/nerdctl/system/system_events.go
+++ b/cmd/nerdctl/system/system_events.go
@@ -28,7 +28,7 @@ import (
 func NewEventsCommand() *cobra.Command {
 	shortHelp := `Get real time events from the server`
 	longHelp := shortHelp + "\nNOTE: The output format is not compatible with Docker."
-	var eventsCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "events",
 		Args:          cobra.NoArgs,
 		Short:         shortHelp,
@@ -37,12 +37,12 @@ func NewEventsCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	eventsCommand.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	eventsCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("format", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	eventsCommand.Flags().StringSliceP("filter", "f", []string{}, "Filter matches containers based on given conditions")
-	return eventsCommand
+	cmd.Flags().StringSliceP("filter", "f", []string{}, "Filter matches containers based on given conditions")
+	return cmd
 }
 
 func processSystemEventsOptions(cmd *cobra.Command) (types.SystemEventsOptions, error) {

--- a/cmd/nerdctl/system/system_info.go
+++ b/cmd/nerdctl/system/system_info.go
@@ -26,7 +26,7 @@ import (
 )
 
 func NewInfoCommand() *cobra.Command {
-	var infoCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "info",
 		Args:          cobra.NoArgs,
 		Short:         "Display system-wide information",
@@ -34,15 +34,15 @@ func NewInfoCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	infoCommand.Flags().String("mode", "dockercompat", `Information mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
-	infoCommand.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("mode", "dockercompat", `Information mode, "dockercompat" for Docker-compatible output, "native" for containerd-native output`)
+	cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"dockercompat", "native"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	infoCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	infoCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return infoCommand
+	return cmd
 }
 
 func processInfoOptions(cmd *cobra.Command) (types.SystemInfoOptions, error) {

--- a/cmd/nerdctl/system/system_prune.go
+++ b/cmd/nerdctl/system/system_prune.go
@@ -33,7 +33,7 @@ import (
 )
 
 func newSystemPruneCommand() *cobra.Command {
-	systemPruneCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove unused data",
 		Args:          cobra.NoArgs,
@@ -41,10 +41,10 @@ func newSystemPruneCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	systemPruneCommand.Flags().BoolP("all", "a", false, "Remove all unused images, not just dangling ones")
-	systemPruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	systemPruneCommand.Flags().Bool("volumes", false, "Prune volumes")
-	return systemPruneCommand
+	cmd.Flags().BoolP("all", "a", false, "Remove all unused images, not just dangling ones")
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	cmd.Flags().Bool("volumes", false, "Prune volumes")
+	return cmd
 }
 
 func processSystemPruneOptions(cmd *cobra.Command) (types.SystemPruneOptions, error) {

--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -36,7 +36,7 @@ import (
 )
 
 func newVersionCommand() *cobra.Command {
-	var versionCommand = &cobra.Command{
+	var cmd = &cobra.Command{
 		Use:           "version",
 		Args:          cobra.NoArgs,
 		Short:         "Show the nerdctl version information",
@@ -44,11 +44,11 @@ func newVersionCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	versionCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	versionCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return versionCommand
+	return cmd
 }
 
 func versionAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/volume/volume.go
+++ b/cmd/nerdctl/volume/volume.go
@@ -23,7 +23,7 @@ import (
 )
 
 func NewVolumeCommand() *cobra.Command {
-	volumeCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "volume",
 		Short:         "Manage volumes",
@@ -31,12 +31,12 @@ func NewVolumeCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	volumeCommand.AddCommand(
+	cmd.AddCommand(
 		newVolumeLsCommand(),
 		newVolumeInspectCommand(),
 		newVolumeCreateCommand(),
 		newVolumeRmCommand(),
 		newVolumePruneCommand(),
 	)
-	return volumeCommand
+	return cmd
 }

--- a/cmd/nerdctl/volume/volume_create.go
+++ b/cmd/nerdctl/volume/volume_create.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newVolumeCreateCommand() *cobra.Command {
-	volumeCreateCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "create [flags] [VOLUME]",
 		Short:         "Create a volume",
 		Args:          cobra.MaximumNArgs(1),
@@ -37,8 +37,8 @@ func newVolumeCreateCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	volumeCreateCommand.Flags().StringArray("label", nil, "Set a label on the volume")
-	return volumeCreateCommand
+	cmd.Flags().StringArray("label", nil, "Set a label on the volume")
+	return cmd
 }
 
 func processVolumeCreateOptions(cmd *cobra.Command) (types.VolumeCreateOptions, error) {

--- a/cmd/nerdctl/volume/volume_inspect.go
+++ b/cmd/nerdctl/volume/volume_inspect.go
@@ -26,7 +26,7 @@ import (
 )
 
 func newVolumeInspectCommand() *cobra.Command {
-	volumeInspectCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "inspect [flags] VOLUME [VOLUME...]",
 		Short:             "Display detailed information on one or more volumes",
 		Args:              cobra.MinimumNArgs(1),
@@ -35,12 +35,12 @@ func newVolumeInspectCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	volumeInspectCommand.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
-	volumeInspectCommand.Flags().BoolP("size", "s", false, "Display the disk usage of the volume")
-	volumeInspectCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
+	cmd.Flags().BoolP("size", "s", false, "Display the disk usage of the volume")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	return volumeInspectCommand
+	return cmd
 }
 
 func processVolumeInspectOptions(cmd *cobra.Command) (types.VolumeInspectOptions, error) {

--- a/cmd/nerdctl/volume/volume_list.go
+++ b/cmd/nerdctl/volume/volume_list.go
@@ -25,7 +25,7 @@ import (
 )
 
 func newVolumeLsCommand() *cobra.Command {
-	volumeLsCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List volumes",
@@ -34,15 +34,15 @@ func newVolumeLsCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	volumeLsCommand.Flags().BoolP("quiet", "q", false, "Only display volume names")
+	cmd.Flags().BoolP("quiet", "q", false, "Only display volume names")
 	// Alias "-f" is reserved for "--filter"
-	volumeLsCommand.Flags().String("format", "", "Format the output using the given go template")
-	volumeLsCommand.Flags().BoolP("size", "s", false, "Display the disk usage of volumes. Can be slow with volumes having loads of directories.")
-	volumeLsCommand.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	cmd.Flags().String("format", "", "Format the output using the given go template")
+	cmd.Flags().BoolP("size", "s", false, "Display the disk usage of volumes. Can be slow with volumes having loads of directories.")
+	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "table", "wide"}, cobra.ShellCompDirectiveNoFileComp
 	})
-	volumeLsCommand.Flags().StringSliceP("filter", "f", []string{}, "Filter matches volumes based on given conditions")
-	return volumeLsCommand
+	cmd.Flags().StringSliceP("filter", "f", []string{}, "Filter matches volumes based on given conditions")
+	return cmd
 }
 
 func processVolumeLsOptions(cmd *cobra.Command) (types.VolumeListOptions, error) {

--- a/cmd/nerdctl/volume/volume_prune.go
+++ b/cmd/nerdctl/volume/volume_prune.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newVolumePruneCommand() *cobra.Command {
-	volumePruneCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all unused local volumes",
 		Args:          cobra.NoArgs,
@@ -37,9 +37,9 @@ func newVolumePruneCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	volumePruneCommand.Flags().BoolP("all", "a", false, "Remove all unused volumes, not just anonymous ones")
-	volumePruneCommand.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
-	return volumePruneCommand
+	cmd.Flags().BoolP("all", "a", false, "Remove all unused volumes, not just anonymous ones")
+	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
+	return cmd
 }
 
 func processVolumePruneOptions(cmd *cobra.Command) (types.VolumePruneOptions, error) {

--- a/cmd/nerdctl/volume/volume_remove.go
+++ b/cmd/nerdctl/volume/volume_remove.go
@@ -27,7 +27,7 @@ import (
 )
 
 func newVolumeRmCommand() *cobra.Command {
-	volumeRmCommand := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "rm [flags] VOLUME [VOLUME...]",
 		Aliases:           []string{"remove"},
 		Short:             "Remove one or more volumes",
@@ -38,8 +38,8 @@ func newVolumeRmCommand() *cobra.Command {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
-	volumeRmCommand.Flags().BoolP("force", "f", false, "(unimplemented yet)")
-	return volumeRmCommand
+	cmd.Flags().BoolP("force", "f", false, "(unimplemented yet)")
+	return cmd
 }
 
 func processVolumeRmOptions(cmd *cobra.Command) (types.VolumeRemoveOptions, error) {


### PR DESCRIPTION
This is a very simple, purely cosmetic PR, harmonizing all command variables to `var cmd` (under the cmd folder).

The proposed cleanup enhances code readability and removes what is currently just noise.

If this is something we think is good, more PRs will follow that focus on the same topic overall: cleanups / reorgs fostering simplicity and code readability.

Let me know your thoughts.