### PR TITLE
CI: rewrite signal tests

### DIFF
--- a/pkg/testutil/nerdtest/utilities_linux.go
+++ b/pkg/testutil/nerdtest/utilities_linux.go
@@ -1,0 +1,69 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nerdtest
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
+)
+
+const SignalCaught = "received"
+
+var SigQuit os.Signal = syscall.SIGQUIT
+var SigUsr1 os.Signal = syscall.SIGUSR1
+
+func RunSigProxyContainer(signal os.Signal, exitOnSignal bool, args []string, data test.Data, helpers test.Helpers) test.TestableCommand {
+	sig := strconv.Itoa(int(signal.(syscall.Signal)))
+	ready := "trap ready"
+	script := `#!/bin/sh
+	set -eu
+
+	sig_msg () {
+		printf "` + SignalCaught + `\n"
+		[ "` + strconv.FormatBool(exitOnSignal) + `" != true ] || exit 0
+	}
+
+	trap sig_msg ` + sig + `
+	printf "` + ready + `\n"
+	while true; do
+		sleep 0.1
+	done
+`
+
+	args = append(args, "--name", data.Identifier(), testutil.CommonImage, "sh", "-c", script)
+	args = append([]string{"run"}, args...)
+
+	cmd := helpers.Command(args...)
+	cmd.Background(10 * time.Second)
+	EnsureContainerStarted(helpers, data.Identifier())
+
+	for {
+		out := helpers.Capture("logs", data.Identifier())
+		if strings.Contains(out, ready) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return cmd
+}

--- a/pkg/testutil/test/command.go
+++ b/pkg/testutil/test/command.go
@@ -185,6 +185,10 @@ func (gc *GenericCommand) Background(timeout time.Duration) {
 	gc.result = icmd.StartCmd(i)
 }
 
+func (gc *GenericCommand) Signal(sig os.Signal) error {
+	return gc.result.Cmd.Process.Signal(sig)
+}
+
 func (gc *GenericCommand) withEnv(env map[string]string) {
 	if gc.Env == nil {
 		gc.Env = map[string]string{}

--- a/pkg/testutil/test/test.go
+++ b/pkg/testutil/test/test.go
@@ -114,6 +114,8 @@ type TestableCommand interface {
 	Run(expect *Expected)
 	// Background allows starting a command in the background
 	Background(timeout time.Duration)
+	// Signal sends a signal to a backgrounded command
+	Signal(sig os.Signal) error
 	// Stderr allows retrieving the raw stderr output of the command
 	Stderr() string
 }

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -54,25 +54,6 @@ var (
 	// It should be "connection refused" as per the TCP RFC.
 	// https://www.rfc-editor.org/rfc/rfc793
 	ExpectedConnectionRefusedError = "connection refused"
-
-	SigProxyTrueOut    = "received SIGINT"
-	SigProxyTimeoutMsg = "Timed Out; No signal received"
-	SigProxyTestScript = `#!/bin/sh
-	set -eu
-
-	sig_msg () {
-		printf "` + SigProxyTrueOut + `"
-		end
-	}
-
-	trap sig_msg INT
-	timeout=0
-	while [ $timeout -ne 10 ]; do
-		timeout=$((timeout+1))
-		sleep 1
-	done
-	printf "` + SigProxyTimeoutMsg + `"
-	end`
 )
 
 const (


### PR DESCRIPTION
Fix #3908 

Currently, tests involving signals have issues:
- bash sig proxy code is duplicated
- tests are flaky, as they may not wait for the container to start or the trap to be set - and/or use arbitrary sleep waits 
- a couple of these tests only test half of what they should (if the shell script exits when trapping the signal, we fail to test that the container should exit or restart on its own, and not through the script exiting its loop)

This PR does:
- expose the ability to send a signal to the tested command (in test tooling)
- rewrite the SigProxy helper with the new test framework and expanded abilities
- rewrite the tests themselves, fixing the aforementioned shortcomings

Hopefully these tests should stop flaking out (assuming `log` will be reliable in these cases).

Note that this PR likely conflicts with other in-flight PR impacting test tooling (specifically #3889).
Depending on merge order, I will rebase of course.