### PR TITLE
CI: remove unbuffer from container tests

### DIFF
--- a/cmd/nerdctl/container/container_exec_linux_test.go
+++ b/cmd/nerdctl/container/container_exec_linux_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
 func TestExecWithUser(t *testing.T) {
@@ -52,19 +53,57 @@ func TestExecWithUser(t *testing.T) {
 }
 
 func TestExecTTY(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
-	testContainer := testutil.Identifier(t)
-	defer base.Cmd("rm", "-f", testContainer).Run()
-	base.Cmd("run", "-d", "--name", testContainer, testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
-
 	const sttyPartialOutput = "speed 38400 baud"
-	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
-	// unbuffer(1) can be installed with `apt-get install expect`.
-	unbuffer := []string{"unbuffer"}
-	base.CmdWithHelper(unbuffer, "exec", "-it", testContainer, "stty").AssertOutContains(sttyPartialOutput)
-	base.CmdWithHelper(unbuffer, "exec", "-t", testContainer, "stty").AssertOutContains(sttyPartialOutput)
-	base.Cmd("exec", "-i", testContainer, "stty").AssertFail()
-	base.Cmd("exec", testContainer, "stty").AssertFail()
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+		data.Set("container_name", data.Identifier())
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "stty with -it",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command("exec", "-it", data.Get("container_name"), "stty")
+				cmd.WithPseudoTTY()
+				return cmd
+			},
+			Expected: test.Expects(0, nil, test.Contains(sttyPartialOutput)),
+		},
+		{
+			Description: "stty with -t",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command("exec", "-t", data.Get("container_name"), "stty")
+				cmd.WithPseudoTTY()
+				return cmd
+			},
+			Expected: test.Expects(0, nil, test.Contains(sttyPartialOutput)),
+		},
+		{
+			Description: "stty with -i",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command("exec", "-i", data.Get("container_name"), "stty")
+				cmd.WithPseudoTTY()
+				return cmd
+			},
+			Expected: test.Expects(test.ExitCodeGenericFail, nil, nil),
+		},
+		{
+			Description: "stty without params",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command("exec", data.Get("container_name"), "stty")
+				cmd.WithPseudoTTY()
+				return cmd
+			},
+			Expected: test.Expects(test.ExitCodeGenericFail, nil, nil),
+		},
+	}
+
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -28,6 +28,8 @@ import (
 	"gotest.tools/v3/icmd"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/test"
 )
 
 func TestLogs(t *testing.T) {
@@ -160,64 +162,85 @@ func TestLogsWithFailingContainer(t *testing.T) {
 }
 
 func TestLogsWithForegroundContainers(t *testing.T) {
-	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("dual logging is not supported on Windows")
-	}
-	base := testutil.NewBase(t)
-	tid := testutil.Identifier(t)
+	testCase := nerdtest.Setup()
+	// dual logging is not supported on Windows
+	testCase.Require = test.Not(test.Windows)
 
-	// unbuffer(1) emulates tty, which is required by `nerdctl run -t`.
-	// unbuffer(1) can be installed with `apt-get install expect`.
-	unbuffer := []string{"unbuffer"}
+	testCase.Run(t)
 
-	testCases := []struct {
-		name  string
-		flags []string
-		tty   bool
-	}{
+	testCase.SubTests = []*test.Case{
 		{
-			name:  "foreground",
-			flags: nil,
-			tty:   false,
+			Description: "foreground",
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar")
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier())
+			},
+			Expected: test.Expects(0, nil, test.All(
+				test.Contains("foo"),
+				test.Contains("bar"),
+				test.DoesNotContain("baz"),
+			)),
 		},
 		{
-			name:  "interactive",
-			flags: []string{"-i"},
-			tty:   false,
+			Description: "interactive",
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-i", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar")
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier())
+			},
+			Expected: test.Expects(0, nil, test.All(
+				test.Contains("foo"),
+				test.Contains("bar"),
+				test.DoesNotContain("baz"),
+			)),
 		},
 		{
-			name:  "PTY",
-			flags: []string{"-t"},
-			tty:   true,
+			Description: "PTY",
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Setup: func(data test.Data, helpers test.Helpers) {
+				cmd := helpers.Command("run", "-t", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar")
+				cmd.WithPseudoTTY()
+				cmd.Run(&test.Expected{ExitCode: 0})
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier())
+			},
+			Expected: test.Expects(0, nil, test.All(
+				test.Contains("foo"),
+				test.Contains("bar"),
+				test.DoesNotContain("baz"),
+			)),
 		},
 		{
-			name:  "interactivePTY",
-			flags: []string{"-i", "-t"},
-			tty:   true,
+			Description: "interactivePTY",
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Setup: func(data test.Data, helpers test.Helpers) {
+				cmd := helpers.Command("run", "-i", "-t", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar")
+				cmd.WithPseudoTTY()
+				cmd.Run(&test.Expected{ExitCode: 0})
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier())
+			},
+			Expected: test.Expects(0, nil, test.All(
+				test.Contains("foo"),
+				test.Contains("bar"),
+				test.DoesNotContain("baz"),
+			)),
 		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		func(t *testing.T) {
-			containerName := tid + "-" + tc.name
-			var cmdArgs []string
-			defer base.Cmd("rm", "-f", containerName).Run()
-			cmdArgs = append(cmdArgs, "run", "--name", containerName)
-			cmdArgs = append(cmdArgs, tc.flags...)
-			cmdArgs = append(cmdArgs, testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar")
-
-			if tc.tty {
-				base.CmdWithHelper(unbuffer, cmdArgs...).AssertOK()
-			} else {
-				base.Cmd(cmdArgs...).AssertOK()
-			}
-
-			base.Cmd("logs", containerName).AssertOutContains("foo")
-			base.Cmd("logs", containerName).AssertOutContains("bar")
-			base.Cmd("logs", containerName).AssertOutNotContains("baz")
-		}(t)
 	}
 }
 


### PR DESCRIPTION
This PR rewrites a pair of container tests that were previously using unbuffer, using the new `WithPseudoTTY` test tooling facility.