### PR TITLE
Fix: restrict EnsureContent to the requested platform

### DIFF
--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -76,7 +76,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 	convertOpts = append(convertOpts, converter.WithPlatform(platMC))
 
 	// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
-	err = EnsureAllContent(ctx, client, srcRef, options.GOptions)
+	err = EnsureAllContent(ctx, client, srcRef, platMC, options.GOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -67,7 +67,12 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 
 		// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3489
 		// XXX what if the image is a CID, or only otherwise available on ipfs?
-		err = EnsureAllContent(ctx, client, parsedReference.String(), options.GOptions)
+		platMC, err := platformutil.NewMatchComparer(options.AllPlatforms, options.Platforms)
+		if err != nil {
+			return err
+		}
+
+		err = EnsureAllContent(ctx, client, parsedReference.String(), platMC, options.GOptions)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -50,7 +50,7 @@ func Save(ctx context.Context, client *containerd.Client, images []string, optio
 			}
 
 			// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
-			err = EnsureAllContent(ctx, client, found.Image.Name, options.GOptions)
+			err = EnsureAllContent(ctx, client, found.Image.Name, platMC, options.GOptions)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/image/tag.go
+++ b/pkg/cmd/image/tag.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
+	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 
@@ -61,7 +62,12 @@ func Tag(ctx context.Context, client *containerd.Client, options types.ImageTagO
 	defer done(ctx)
 
 	// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
-	err = EnsureAllContent(ctx, client, srcName, options.GOptions)
+	platMC, err := platformutil.NewMatchComparer(true, nil)
+	if err != nil {
+		return err
+	}
+
+	err = EnsureAllContent(ctx, client, srcName, platMC, options.GOptions)
 	if err != nil {
 		log.G(ctx).Warn("Unable to fetch missing layers before committing. " +
 			"If you try to save or push this image, it might fail. See https://github.com/containerd/nerdctl/issues/3439.")

--- a/pkg/imgutil/commit/commit.go
+++ b/pkg/imgutil/commit/commit.go
@@ -128,7 +128,7 @@ func Commit(ctx context.Context, client *containerd.Client, container containerd
 	}
 
 	// Ensure all the layers are here: https://github.com/containerd/nerdctl/issues/3425
-	err = image.EnsureAllContent(ctx, client, baseImg.Name(), globalOptions)
+	err = image.EnsureAllContent(ctx, client, baseImg.Name(), platformMC, globalOptions)
 	if err != nil {
 		log.G(ctx).Warn("Unable to fetch missing layers before committing. " +
 			"If you try to save or push this image, it might fail. See https://github.com/containerd/nerdctl/issues/3439.")


### PR DESCRIPTION
Hopefully fix #3866 (to be confirmed).

This is 5-minutes-slapstick patching, so, this one needs scrutiny.