### PR TITLE
CI: arm64-8core-32gb -> ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           - runner: ubuntu-24.04
             containerd: v2.0.2
             arch: amd64
-          - runner: arm64-8core-32gb
+          - runner: ubuntu-24.04-arm
             containerd: v2.0.2
             arch: arm64
     env:
@@ -119,7 +119,7 @@ jobs:
             arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.2
-            runner: arm64-8core-32gb
+            runner: ubuntu-24.04-arm
             arch: arm64
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"


### PR DESCRIPTION
GHA now provides ARM runners for free

https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/