### PR TITLE
Cleanup/refactor proposal

### DIFF
--- a/cmd/nerdctl/apparmor/apparmor_inspect_linux.go
+++ b/cmd/nerdctl/apparmor/apparmor_inspect_linux.go
@@ -26,19 +26,19 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )
 
-func newApparmorInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "inspect",
 		Short:         fmt.Sprintf("Display the default AppArmor profile %q. Other profiles cannot be displayed with this command.", defaults.AppArmorProfileName),
 		Args:          cobra.NoArgs,
-		RunE:          apparmorInspectAction,
+		RunE:          inspectAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd
 }
 
-func apparmorInspectAction(cmd *cobra.Command, args []string) error {
+func inspectAction(cmd *cobra.Command, args []string) error {
 	return apparmor.Inspect(types.ApparmorInspectOptions{
 		Stdout: cmd.OutOrStdout(),
 	})

--- a/cmd/nerdctl/apparmor/apparmor_linux.go
+++ b/cmd/nerdctl/apparmor/apparmor_linux.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewApparmorCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "apparmor",
@@ -32,10 +32,10 @@ func NewApparmorCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		newApparmorLsCommand(),
-		newApparmorInspectCommand(),
-		newApparmorLoadCommand(),
-		newApparmorUnloadCommand(),
+		listCommand(),
+		inspectCommand(),
+		loadCommand(),
+		unloadCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/apparmor/apparmor_list_linux.go
+++ b/cmd/nerdctl/apparmor/apparmor_list_linux.go
@@ -23,13 +23,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/apparmor"
 )
 
-func newApparmorLsCommand() *cobra.Command {
+func listCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List the loaded AppArmor profiles",
 		Args:          cobra.NoArgs,
-		RunE:          apparmorLsAction,
+		RunE:          listAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -42,7 +42,7 @@ func newApparmorLsCommand() *cobra.Command {
 	return cmd
 }
 
-func processApparmorListOptions(cmd *cobra.Command) (types.ApparmorListOptions, error) {
+func listOptions(cmd *cobra.Command) (types.ApparmorListOptions, error) {
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
 		return types.ApparmorListOptions{}, err
@@ -58,8 +58,8 @@ func processApparmorListOptions(cmd *cobra.Command) (types.ApparmorListOptions, 
 	}, nil
 }
 
-func apparmorLsAction(cmd *cobra.Command, args []string) error {
-	options, err := processApparmorListOptions(cmd)
+func listAction(cmd *cobra.Command, args []string) error {
+	options, err := listOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/apparmor/apparmor_load_linux.go
+++ b/cmd/nerdctl/apparmor/apparmor_load_linux.go
@@ -25,18 +25,18 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )
 
-func newApparmorLoadCommand() *cobra.Command {
+func loadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "load",
 		Short:         fmt.Sprintf("Load the default AppArmor profile %q. Requires root.", defaults.AppArmorProfileName),
 		Args:          cobra.NoArgs,
-		RunE:          apparmorLoadAction,
+		RunE:          loadAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd
 }
 
-func apparmorLoadAction(cmd *cobra.Command, args []string) error {
+func loadAction(cmd *cobra.Command, args []string) error {
 	return apparmor.Load()
 }

--- a/cmd/nerdctl/apparmor/apparmor_unload_linux.go
+++ b/cmd/nerdctl/apparmor/apparmor_unload_linux.go
@@ -26,20 +26,20 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/defaults"
 )
 
-func newApparmorUnloadCommand() *cobra.Command {
+func unloadCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "unload [PROFILE]",
 		Short:             fmt.Sprintf("Unload an AppArmor profile. The target profile name defaults to %q. Requires root.", defaults.AppArmorProfileName),
 		Args:              cobra.MaximumNArgs(1),
-		RunE:              apparmorUnloadAction,
-		ValidArgsFunction: apparmorUnloadShellComplete,
+		RunE:              unloadAction,
+		ValidArgsFunction: unloadShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
 	return cmd
 }
 
-func apparmorUnloadAction(cmd *cobra.Command, args []string) error {
+func unloadAction(cmd *cobra.Command, args []string) error {
 	target := defaults.AppArmorProfileName
 	if len(args) > 0 {
 		target = args[0]
@@ -47,6 +47,6 @@ func apparmorUnloadAction(cmd *cobra.Command, args []string) error {
 	return apparmor.Unload(target)
 }
 
-func apparmorUnloadShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func unloadShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return completion.ApparmorProfiles(cmd)
 }

--- a/cmd/nerdctl/builder/builder.go
+++ b/cmd/nerdctl/builder/builder.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/builder"
 )
 
-func NewBuilderCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "builder",
@@ -40,20 +40,20 @@ func NewBuilderCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		NewBuildCommand(),
-		newBuilderPruneCommand(),
-		newBuilderDebugCommand(),
+		BuildCommand(),
+		pruneCommand(),
+		debugCommand(),
 	)
 	return cmd
 }
 
-func newBuilderPruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	shortHelp := `Clean up BuildKit build cache`
 	var cmd = &cobra.Command{
 		Use:           "prune",
 		Args:          cobra.NoArgs,
 		Short:         shortHelp,
-		RunE:          builderPruneAction,
+		RunE:          pruneAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -65,8 +65,8 @@ func newBuilderPruneCommand() *cobra.Command {
 	return cmd
 }
 
-func builderPruneAction(cmd *cobra.Command, _ []string) error {
-	options, err := processBuilderPruneOptions(cmd)
+func pruneAction(cmd *cobra.Command, _ []string) error {
+	options, err := pruneOptions(cmd)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func builderPruneAction(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
-func processBuilderPruneOptions(cmd *cobra.Command) (types.BuilderPruneOptions, error) {
+func pruneOptions(cmd *cobra.Command) (types.BuilderPruneOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.BuilderPruneOptions{}, err
@@ -131,13 +131,13 @@ func processBuilderPruneOptions(cmd *cobra.Command) (types.BuilderPruneOptions, 
 	}, nil
 }
 
-func newBuilderDebugCommand() *cobra.Command {
+func debugCommand() *cobra.Command {
 	shortHelp := `Debug Dockerfile`
 	var cmd = &cobra.Command{
 		Use:           "debug",
 		Short:         shortHelp,
 		PreRunE:       helpers.CheckExperimental("`nerdctl builder debug`"),
-		RunE:          builderDebugAction,
+		RunE:          debugAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -150,7 +150,7 @@ func newBuilderDebugCommand() *cobra.Command {
 	return cmd
 }
 
-func builderDebugAction(cmd *cobra.Command, args []string) error {
+func debugAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/builder/builder_build.go
+++ b/cmd/nerdctl/builder/builder_build.go
@@ -34,7 +34,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
-func NewBuildCommand() *cobra.Command {
+func BuildCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "build [flags] PATH",
 		Short: "Build an image from a Dockerfile. Needs buildkitd to be running.",

--- a/cmd/nerdctl/compose/compose.go
+++ b/cmd/nerdctl/compose/compose.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func NewComposeCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:              "compose [flags] COMMAND",
 		Short:            "Compose",
@@ -41,29 +41,29 @@ func NewComposeCommand() *cobra.Command {
 	cmd.PersistentFlags().StringArray("profile", []string{}, "Specify a profile to enable")
 
 	cmd.AddCommand(
-		newComposeUpCommand(),
-		newComposeLogsCommand(),
-		newComposeConfigCommand(),
-		newComposeCopyCommand(),
-		newComposeBuildCommand(),
-		newComposeExecCommand(),
-		newComposeImagesCommand(),
-		newComposePortCommand(),
-		newComposePushCommand(),
-		newComposePullCommand(),
-		newComposeDownCommand(),
-		newComposePsCommand(),
-		newComposeKillCommand(),
-		newComposeRestartCommand(),
-		newComposeRemoveCommand(),
-		newComposeRunCommand(),
-		newComposeVersionCommand(),
-		newComposeStartCommand(),
-		newComposeStopCommand(),
-		newComposePauseCommand(),
-		newComposeUnpauseCommand(),
-		newComposeTopCommand(),
-		newComposeCreateCommand(),
+		upCommand(),
+		logsCommand(),
+		configCommand(),
+		copyCommand(),
+		buildCommand(),
+		execCommand(),
+		imagesCommand(),
+		portCommand(),
+		pushCommand(),
+		pullCommand(),
+		downCommand(),
+		psCommand(),
+		killCommand(),
+		restartCommand(),
+		removeCommand(),
+		runCommand(),
+		versionCommand(),
+		startCommand(),
+		stopCommand(),
+		pauseCommand(),
+		unpauseCommand(),
+		topCommand(),
+		createCommand(),
 	)
 
 	return cmd

--- a/cmd/nerdctl/compose/compose_build.go
+++ b/cmd/nerdctl/compose/compose_build.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeBuildCommand() *cobra.Command {
+func buildCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "build [flags] [SERVICE...]",
 		Short:         "Build or rebuild services",
-		RunE:          composeBuildAction,
+		RunE:          buildAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -40,7 +40,7 @@ func newComposeBuildCommand() *cobra.Command {
 	return cmd
 }
 
-func composeBuildAction(cmd *cobra.Command, args []string) error {
+func buildAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_config.go
+++ b/cmd/nerdctl/compose/compose_config.go
@@ -27,11 +27,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeConfigCommand() *cobra.Command {
+func configCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "config",
 		Short:         "Validate and view the Compose file",
-		RunE:          composeConfigAction,
+		RunE:          configAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -45,7 +45,7 @@ func newComposeConfigCommand() *cobra.Command {
 	return cmd
 }
 
-func composeConfigAction(cmd *cobra.Command, args []string) error {
+func configAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_cp.go
+++ b/cmd/nerdctl/compose/compose_cp.go
@@ -28,14 +28,14 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func newComposeCopyCommand() *cobra.Command {
+func copyCommand() *cobra.Command {
 	usage := `cp [OPTIONS] SERVICE:SRC_PATH DEST_PATH|-
        nerdctl compose cp [OPTIONS] SRC_PATH|- SERVICE:DEST_PATH`
 	var cmd = &cobra.Command{
 		Use:           usage,
 		Short:         "Copy files/folders between a service container and the local filesystem",
 		Args:          cobra.ExactArgs(2),
-		RunE:          composeCopyAction,
+		RunE:          copyAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -45,7 +45,7 @@ func newComposeCopyCommand() *cobra.Command {
 	return cmd
 }
 
-func composeCopyAction(cmd *cobra.Command, args []string) error {
+func copyAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_create.go
+++ b/cmd/nerdctl/compose/compose_create.go
@@ -27,11 +27,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeCreateCommand() *cobra.Command {
+func createCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "create [flags] [SERVICE...]",
 		Short:         "Creates containers for one or more services",
-		RunE:          composeCreateAction,
+		RunE:          createAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -43,7 +43,7 @@ func newComposeCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func composeCreateAction(cmd *cobra.Command, args []string) error {
+func createAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_down.go
+++ b/cmd/nerdctl/compose/compose_down.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeDownCommand() *cobra.Command {
+func downCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "down",
 		Short:         "Remove containers and associated resources",
 		Args:          cobra.NoArgs,
-		RunE:          composeDownAction,
+		RunE:          downAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -39,7 +39,7 @@ func newComposeDownCommand() *cobra.Command {
 	return cmd
 }
 
-func composeDownAction(cmd *cobra.Command, args []string) error {
+func downAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_exec.go
+++ b/cmd/nerdctl/compose/compose_exec.go
@@ -29,12 +29,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeExecCommand() *cobra.Command {
+func execCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "exec [flags] SERVICE COMMAND [ARGS...]",
 		Short:         "Execute a command in a running container of the service",
 		Args:          cobra.MinimumNArgs(2),
-		RunE:          composeExecAction,
+		RunE:          execAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -61,7 +61,7 @@ func newComposeExecCommand() *cobra.Command {
 	return cmd
 }
 
-func composeExecAction(cmd *cobra.Command, args []string) error {
+func execAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_images.go
+++ b/cmd/nerdctl/compose/compose_images.go
@@ -38,11 +38,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
-func newComposeImagesCommand() *cobra.Command {
+func imagesCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "images [flags] [SERVICE...]",
 		Short:         "List images used by created containers in services",
-		RunE:          composeImagesAction,
+		RunE:          imagesAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -51,7 +51,7 @@ func newComposeImagesCommand() *cobra.Command {
 	return cmd
 }
 
-func composeImagesAction(cmd *cobra.Command, args []string) error {
+func imagesAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_kill.go
+++ b/cmd/nerdctl/compose/compose_kill.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeKillCommand() *cobra.Command {
+func killCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "kill [flags] [SERVICE...]",
 		Short:         "Force stop service containers",
-		RunE:          composeKillAction,
+		RunE:          killAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -37,7 +37,7 @@ func newComposeKillCommand() *cobra.Command {
 	return cmd
 }
 
-func composeKillAction(cmd *cobra.Command, args []string) error {
+func killAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_logs.go
+++ b/cmd/nerdctl/compose/compose_logs.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeLogsCommand() *cobra.Command {
+func logsCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "logs [flags] [SERVICE...]",
 		Short:         "Show logs of running containers",
-		RunE:          composeLogsAction,
+		RunE:          logsAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -41,7 +41,7 @@ func newComposeLogsCommand() *cobra.Command {
 	return cmd
 }
 
-func composeLogsAction(cmd *cobra.Command, args []string) error {
+func logsAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_pause.go
+++ b/cmd/nerdctl/compose/compose_pause.go
@@ -24,11 +24,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
 )
 
-func newComposePauseCommand() *cobra.Command {
+func pauseCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:                   "pause [SERVICE...]",
 		Short:                 "Pause all processes within containers of service(s). They can be unpaused with nerdctl compose unpause",
-		RunE:                  composePauseAction,
+		RunE:                  pauseAction,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
@@ -36,7 +36,7 @@ func newComposePauseCommand() *cobra.Command {
 	return cmd
 }
 
-func composePauseAction(cmd *cobra.Command, args []string) error {
+func pauseAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err
@@ -59,11 +59,11 @@ func composePauseAction(cmd *cobra.Command, args []string) error {
 	return c.Pause(ctx, args, cmd.OutOrStdout())
 }
 
-func newComposeUnpauseCommand() *cobra.Command {
+func unpauseCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:                   "unpause [SERVICE...]",
 		Short:                 "Unpause all processes within containers of service(s).",
-		RunE:                  composeUnpauseAction,
+		RunE:                  unpauseAction,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
@@ -71,7 +71,7 @@ func newComposeUnpauseCommand() *cobra.Command {
 	return cmd
 }
 
-func composeUnpauseAction(cmd *cobra.Command, args []string) error {
+func unpauseAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_port.go
+++ b/cmd/nerdctl/compose/compose_port.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposePortCommand() *cobra.Command {
+func portCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "port [flags] SERVICE PRIVATE_PORT",
 		Short:         "Print the public port for a port binding",
 		Args:          cobra.ExactArgs(2),
-		RunE:          composePortAction,
+		RunE:          portAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -43,7 +43,7 @@ func newComposePortCommand() *cobra.Command {
 	return cmd
 }
 
-func composePortAction(cmd *cobra.Command, args []string) error {
+func portAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_ps.go
+++ b/cmd/nerdctl/compose/compose_ps.go
@@ -41,11 +41,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
 )
 
-func newComposePsCommand() *cobra.Command {
+func psCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "ps [flags] [SERVICE...]",
 		Short:         "List containers of services",
-		RunE:          composePsAction,
+		RunE:          psAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -74,7 +74,7 @@ type composeContainerPrintable struct {
 	Ports      string `json:"-"`
 }
 
-func composePsAction(cmd *cobra.Command, args []string) error {
+func psAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_pull.go
+++ b/cmd/nerdctl/compose/compose_pull.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposePullCommand() *cobra.Command {
+func pullCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "pull [flags] [SERVICE...]",
 		Short:         "Pull service images",
-		RunE:          composePullAction,
+		RunE:          pullAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -37,7 +37,7 @@ func newComposePullCommand() *cobra.Command {
 	return cmd
 }
 
-func composePullAction(cmd *cobra.Command, args []string) error {
+func pullAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_push.go
+++ b/cmd/nerdctl/compose/compose_push.go
@@ -25,18 +25,18 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposePushCommand() *cobra.Command {
+func pushCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "push [flags] [SERVICE...]",
 		Short:         "Push service images",
-		RunE:          composePushAction,
+		RunE:          pushAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
 	return cmd
 }
 
-func composePushAction(cmd *cobra.Command, args []string) error {
+func pushAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_restart.go
+++ b/cmd/nerdctl/compose/compose_restart.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeRestartCommand() *cobra.Command {
+func restartCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "restart [flags] [SERVICE...]",
 		Short:         "Restart containers of given (or all) services",
-		RunE:          composeRestartAction,
+		RunE:          restartAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -37,7 +37,7 @@ func newComposeRestartCommand() *cobra.Command {
 	return cmd
 }
 
-func composeRestartAction(cmd *cobra.Command, args []string) error {
+func restartAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_rm.go
+++ b/cmd/nerdctl/compose/compose_rm.go
@@ -28,11 +28,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeRemoveCommand() *cobra.Command {
+func removeCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "rm [flags] [SERVICE...]",
 		Short:         "Remove stopped service containers",
-		RunE:          composeRemoveAction,
+		RunE:          removeAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -42,7 +42,7 @@ func newComposeRemoveCommand() *cobra.Command {
 	return cmd
 }
 
-func composeRemoveAction(cmd *cobra.Command, args []string) error {
+func removeAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_run.go
+++ b/cmd/nerdctl/compose/compose_run.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeRunCommand() *cobra.Command {
+func runCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:                   "run [flags] SERVICE [COMMAND] [ARGS...]",
 		Short:                 "Run a one-off command on a service",
 		Args:                  cobra.MinimumNArgs(1),
-		RunE:                  composeRunAction,
+		RunE:                  runAction,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
@@ -69,7 +69,7 @@ func newComposeRunCommand() *cobra.Command {
 	return cmd
 }
 
-func composeRunAction(cmd *cobra.Command, args []string) error {
+func runAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_start.go
+++ b/cmd/nerdctl/compose/compose_start.go
@@ -34,11 +34,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
-func newComposeStartCommand() *cobra.Command {
+func startCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:                   "start [SERVICE...]",
 		Short:                 "Start existing containers for service(s)",
-		RunE:                  composeStartAction,
+		RunE:                  startAction,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
@@ -46,7 +46,7 @@ func newComposeStartCommand() *cobra.Command {
 	return cmd
 }
 
-func composeStartAction(cmd *cobra.Command, args []string) error {
+func startAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_stop.go
+++ b/cmd/nerdctl/compose/compose_stop.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeStopCommand() *cobra.Command {
+func stopCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "stop [flags] [SERVICE...]",
 		Short:         "Stop running containers without removing them.",
-		RunE:          composeStopAction,
+		RunE:          stopAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -37,7 +37,7 @@ func newComposeStopCommand() *cobra.Command {
 	return cmd
 }
 
-func composeStopAction(cmd *cobra.Command, args []string) error {
+func stopAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_top.go
+++ b/cmd/nerdctl/compose/compose_top.go
@@ -32,11 +32,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
-func newComposeTopCommand() *cobra.Command {
+func topCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:                   "top [SERVICE...]",
 		Short:                 "Display the running processes of service containers",
-		RunE:                  composeTopAction,
+		RunE:                  topAction,
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		DisableFlagsInUseLine: true,
@@ -44,7 +44,7 @@ func newComposeTopCommand() *cobra.Command {
 	return cmd
 }
 
-func composeTopAction(cmd *cobra.Command, args []string) error {
+func topAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_up.go
+++ b/cmd/nerdctl/compose/compose_up.go
@@ -30,11 +30,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 )
 
-func newComposeUpCommand() *cobra.Command {
+func upCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "up [flags] [SERVICE...]",
 		Short:         "Create and start containers",
-		RunE:          composeUpAction,
+		RunE:          upAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -54,7 +54,7 @@ func newComposeUpCommand() *cobra.Command {
 	return cmd
 }
 
-func composeUpAction(cmd *cobra.Command, services []string) error {
+func upAction(cmd *cobra.Command, services []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/compose/compose_version.go
+++ b/cmd/nerdctl/compose/compose_version.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/version"
 )
 
-func newComposeVersionCommand() *cobra.Command {
+func versionCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "version",
 		Short:         "Show the Compose version information",
 		Args:          cobra.NoArgs,
-		RunE:          composeVersionAction,
+		RunE:          versionAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -42,7 +42,7 @@ func newComposeVersionCommand() *cobra.Command {
 	return cmd
 }
 
-func composeVersionAction(cmd *cobra.Command, args []string) error {
+func versionAction(cmd *cobra.Command, args []string) error {
 	short, err := cmd.Flags().GetBool("short")
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container/container.go
+++ b/cmd/nerdctl/container/container.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewContainerCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "container",
@@ -32,35 +32,35 @@ func NewContainerCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		NewCreateCommand(),
-		NewRunCommand(),
-		NewUpdateCommand(),
-		NewExecCommand(),
-		containerLsCommand(),
-		newContainerInspectCommand(),
-		NewLogsCommand(),
-		NewPortCommand(),
-		NewRmCommand(),
-		NewStopCommand(),
-		NewStartCommand(),
-		NewRestartCommand(),
-		NewKillCommand(),
-		NewPauseCommand(),
-		NewDiffCommand(),
-		NewWaitCommand(),
-		NewUnpauseCommand(),
-		NewCommitCommand(),
-		NewRenameCommand(),
-		newContainerPruneCommand(),
-		NewStatsCommand(),
-		NewAttachCommand(),
+		CreateCommand(),
+		RunCommand(),
+		UpdateCommand(),
+		ExecCommand(),
+		listCommand(),
+		inspectCommand(),
+		LogsCommand(),
+		PortCommand(),
+		RemoveCommand(),
+		StopCommand(),
+		StartCommand(),
+		RestartCommand(),
+		KillCommand(),
+		PauseCommand(),
+		DiffCommand(),
+		WaitCommand(),
+		UnpauseCommand(),
+		CommitCommand(),
+		RenameCommand(),
+		pruneCommand(),
+		StatsCommand(),
+		AttachCommand(),
 	)
 	AddCpCommand(cmd)
 	return cmd
 }
 
-func containerLsCommand() *cobra.Command {
-	x := NewPsCommand()
+func listCommand() *cobra.Command {
+	x := PsCommand()
 	x.Use = "ls"
 	x.Aliases = []string{"list"}
 	return x

--- a/cmd/nerdctl/container/container_attach.go
+++ b/cmd/nerdctl/container/container_attach.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 )
 
-func NewAttachCommand() *cobra.Command {
+func AttachCommand() *cobra.Command {
 	const shortHelp = "Attach stdin, stdout, and stderr to a running container."
 	const longHelp = `Attach stdin, stdout, and stderr to a running container. For example:
 
@@ -50,7 +50,7 @@ Caveats:
 		Args:              cobra.ExactArgs(1),
 		Short:             shortHelp,
 		Long:              longHelp,
-		RunE:              containerAttachAction,
+		RunE:              attachAction,
 		ValidArgsFunction: attachShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -59,7 +59,7 @@ Caveats:
 	return cmd
 }
 
-func processContainerAttachOptions(cmd *cobra.Command) (types.ContainerAttachOptions, error) {
+func attachOptions(cmd *cobra.Command) (types.ContainerAttachOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerAttachOptions{}, err
@@ -77,8 +77,8 @@ func processContainerAttachOptions(cmd *cobra.Command) (types.ContainerAttachOpt
 	}, nil
 }
 
-func containerAttachAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerAttachOptions(cmd)
+func attachAction(cmd *cobra.Command, args []string) error {
+	options, err := attachOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_commit.go
+++ b/cmd/nerdctl/container/container_commit.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewCommitCommand() *cobra.Command {
+func CommitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "commit [flags] CONTAINER REPOSITORY[:TAG]",
 		Short:             "Create a new image from a container's changes",
@@ -43,7 +43,7 @@ func NewCommitCommand() *cobra.Command {
 	return cmd
 }
 
-func processCommitCommandOptions(cmd *cobra.Command) (types.ContainerCommitOptions, error) {
+func commitOptions(cmd *cobra.Command) (types.ContainerCommitOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerCommitOptions{}, err
@@ -78,7 +78,7 @@ func processCommitCommandOptions(cmd *cobra.Command) (types.ContainerCommitOptio
 }
 
 func commitAction(cmd *cobra.Command, args []string) error {
-	options, err := processCommitCommandOptions(cmd)
+	options, err := commitOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_cp_linux.go
+++ b/cmd/nerdctl/container/container_cp_linux.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func newCpCommand() *cobra.Command {
+func copyCommand() *cobra.Command {
 	shortHelp := "Copy files/folders between a running container and the local filesystem."
 
 	longHelp := shortHelp + `
@@ -50,8 +50,8 @@ Using 'nerdctl cp' with untrusted or malicious containers is unsupported and may
 		Args:              helpers.IsExactArgs(2),
 		Short:             shortHelp,
 		Long:              longHelp,
-		RunE:              cpAction,
-		ValidArgsFunction: cpShellComplete,
+		RunE:              copyAction,
+		ValidArgsFunction: copyShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
@@ -61,8 +61,8 @@ Using 'nerdctl cp' with untrusted or malicious containers is unsupported and may
 	return cmd
 }
 
-func cpAction(cmd *cobra.Command, args []string) error {
-	options, err := processCpOptions(cmd, args)
+func copyAction(cmd *cobra.Command, args []string) error {
+	options, err := copyOptions(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func cpAction(cmd *cobra.Command, args []string) error {
 	return container.Cp(ctx, client, options)
 }
 
-func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptions, error) {
+func copyOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerCpOptions{}, err
@@ -132,12 +132,12 @@ func processCpOptions(cmd *cobra.Command, args []string) (types.ContainerCpOptio
 }
 
 func AddCpCommand(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(newCpCommand())
+	rootCmd.AddCommand(copyCommand())
 }
 
 var errFileSpecDoesntMatchFormat = errors.New("filespec must match the canonical format: [container:]file/path")
 
-func parseCpFileSpec(arg string) (*cpFileSpec, error) {
+func parseCpFileSpec(arg string) (*copyFileSpec, error) {
 	i := strings.Index(arg, ":")
 
 	// filespec starting with a semicolon is invalid
@@ -147,7 +147,7 @@ func parseCpFileSpec(arg string) (*cpFileSpec, error) {
 
 	if filepath.IsAbs(arg) {
 		// Explicit local absolute path, e.g., `C:\foo` or `/foo`.
-		return &cpFileSpec{
+		return &copyFileSpec{
 			Container: nil,
 			Path:      arg,
 		}, nil
@@ -158,22 +158,22 @@ func parseCpFileSpec(arg string) (*cpFileSpec, error) {
 	if len(parts) == 1 || strings.HasPrefix(parts[0], ".") {
 		// Either there's no `:` in the arg
 		// OR it's an explicit local relative path like `./file:name.txt`.
-		return &cpFileSpec{
+		return &copyFileSpec{
 			Path: arg,
 		}, nil
 	}
 
-	return &cpFileSpec{
+	return &copyFileSpec{
 		Container: &parts[0],
 		Path:      parts[1],
 	}, nil
 }
 
-type cpFileSpec struct {
+type copyFileSpec struct {
 	Container *string
 	Path      string
 }
 
-func cpShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func copyShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	return nil, cobra.ShellCompDirectiveFilterFileExt
 }

--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 )
 
-func NewCreateCommand() *cobra.Command {
+func CreateCommand() *cobra.Command {
 	shortHelp := "Create a new container. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS."
 	longHelp := shortHelp
 	switch runtime.GOOS {
@@ -55,7 +55,7 @@ func NewCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerCreateOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
+func createOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
 	var err error
 	opt := types.ContainerCreateOptions{
 		Stdout: cmd.OutOrStdout(),
@@ -405,7 +405,7 @@ func processContainerCreateOptions(cmd *cobra.Command) (types.ContainerCreateOpt
 	// #endregion
 
 	// #region for image pull and verify options
-	imageVerifyOpt, err := helpers.ProcessImageVerifyOptions(cmd)
+	imageVerifyOpt, err := helpers.VerifyOptions(cmd)
 	if err != nil {
 		return opt, err
 	}
@@ -427,7 +427,7 @@ func processContainerCreateOptions(cmd *cobra.Command) (types.ContainerCreateOpt
 }
 
 func createAction(cmd *cobra.Command, args []string) error {
-	createOpt, err := processContainerCreateOptions(cmd)
+	createOpt, err := createOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_diff.go
+++ b/cmd/nerdctl/container/container_diff.go
@@ -43,7 +43,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
-func NewDiffCommand() *cobra.Command {
+func DiffCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "diff [CONTAINER]",
 		Short:             "Inspect changes to files or directories on a container's filesystem",
@@ -56,7 +56,7 @@ func NewDiffCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerDiffOptions(cmd *cobra.Command) (types.ContainerDiffOptions, error) {
+func diffOptions(cmd *cobra.Command) (types.ContainerDiffOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerDiffOptions{}, err
@@ -69,7 +69,7 @@ func processContainerDiffOptions(cmd *cobra.Command) (types.ContainerDiffOptions
 }
 
 func diffAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerDiffOptions(cmd)
+	options, err := diffOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_exec.go
+++ b/cmd/nerdctl/container/container_exec.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewExecCommand() *cobra.Command {
+func ExecCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "exec [flags] CONTAINER COMMAND [ARG...]",
 		Args:              cobra.MinimumNArgs(2),
@@ -55,7 +55,7 @@ func NewExecCommand() *cobra.Command {
 	return cmd
 }
 
-func processExecCommandOptions(cmd *cobra.Command) (types.ContainerExecOptions, error) {
+func execOptions(cmd *cobra.Command) (types.ContainerExecOptions, error) {
 	// We do not check if we have a terminal here, as container.Exec calling console.Current will ensure that
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
@@ -123,7 +123,7 @@ func processExecCommandOptions(cmd *cobra.Command) (types.ContainerExecOptions, 
 }
 
 func execAction(cmd *cobra.Command, args []string) error {
-	options, err := processExecCommandOptions(cmd)
+	options, err := execOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_inspect.go
+++ b/cmd/nerdctl/container/container_inspect.go
@@ -28,13 +28,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func newContainerInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "inspect [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Display detailed information on one or more containers.",
 		Long:              "Hint: set `--mode=native` for showing the full output",
 		Args:              cobra.MinimumNArgs(1),
-		RunE:              containerInspectAction,
+		RunE:              inspectAction,
 		ValidArgsFunction: containerInspectShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -57,7 +57,7 @@ var validModeType = map[string]bool{
 	"dockercompat": true,
 }
 
-func ProcessContainerInspectOptions(cmd *cobra.Command) (opt types.ContainerInspectOptions, err error) {
+func InspectOptions(cmd *cobra.Command) (opt types.ContainerInspectOptions, err error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return
@@ -89,8 +89,8 @@ func ProcessContainerInspectOptions(cmd *cobra.Command) (opt types.ContainerInsp
 	}, nil
 }
 
-func containerInspectAction(cmd *cobra.Command, args []string) error {
-	opt, err := ProcessContainerInspectOptions(cmd)
+func inspectAction(cmd *cobra.Command, args []string) error {
+	opt, err := InspectOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_kill.go
+++ b/cmd/nerdctl/container/container_kill.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewKillCommand() *cobra.Command {
+func KillCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "kill [flags] CONTAINER [CONTAINER, ...]",
 		Short:             "Kill one or more running containers",

--- a/cmd/nerdctl/container/container_list.go
+++ b/cmd/nerdctl/container/container_list.go
@@ -33,7 +33,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 )
 
-func NewPsCommand() *cobra.Command {
+func PsCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "ps",
 		Args:          cobra.NoArgs,

--- a/cmd/nerdctl/container/container_logs.go
+++ b/cmd/nerdctl/container/container_logs.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewLogsCommand() *cobra.Command {
+func LogsCommand() *cobra.Command {
 	const shortUsage = "Fetch the logs of a container. Expected to be used with 'nerdctl run -d'."
 	const longUsage = `Fetch the logs of a container.
 
@@ -56,7 +56,7 @@ The following containers are supported:
 	return cmd
 }
 
-func processContainerLogsOptions(cmd *cobra.Command) (types.ContainerLogsOptions, error) {
+func logsOptions(cmd *cobra.Command) (types.ContainerLogsOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerLogsOptions{}, err
@@ -101,7 +101,7 @@ func processContainerLogsOptions(cmd *cobra.Command) (types.ContainerLogsOptions
 }
 
 func logsAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerLogsOptions(cmd)
+	options, err := logsOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_pause.go
+++ b/cmd/nerdctl/container/container_pause.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewPauseCommand() *cobra.Command {
+func PauseCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "pause [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -41,7 +41,7 @@ func NewPauseCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerPauseOptions(cmd *cobra.Command) (types.ContainerPauseOptions, error) {
+func pauseOptions(cmd *cobra.Command) (types.ContainerPauseOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerPauseOptions{}, err
@@ -53,7 +53,7 @@ func processContainerPauseOptions(cmd *cobra.Command) (types.ContainerPauseOptio
 }
 
 func pauseAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerPauseOptions(cmd)
+	options, err := pauseOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_port.go
+++ b/cmd/nerdctl/container/container_port.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )
 
-func NewPortCommand() *cobra.Command {
+func PortCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "port [flags] CONTAINER [PRIVATE_PORT[/PROTO]]",
 		Args:              cobra.RangeArgs(1, 2),

--- a/cmd/nerdctl/container/container_prune.go
+++ b/cmd/nerdctl/container/container_prune.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func newContainerPruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all stopped containers",
 		Args:          cobra.NoArgs,
-		RunE:          containerPruneAction,
+		RunE:          pruneAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -38,7 +38,7 @@ func newContainerPruneCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerPruneOptions(cmd *cobra.Command) (types.ContainerPruneOptions, error) {
+func pruneOptions(cmd *cobra.Command) (types.ContainerPruneOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerPruneOptions{}, err
@@ -62,8 +62,8 @@ func grantPrunePermission(cmd *cobra.Command) (bool, error) {
 	return true, nil
 }
 
-func containerPruneAction(cmd *cobra.Command, _ []string) error {
-	options, err := processContainerPruneOptions(cmd)
+func pruneAction(cmd *cobra.Command, _ []string) error {
+	options, err := pruneOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_remove.go
+++ b/cmd/nerdctl/container/container_remove.go
@@ -26,12 +26,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewRmCommand() *cobra.Command {
+func RemoveCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "rm [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Remove one or more containers",
-		RunE:              rmAction,
+		RunE:              removeAction,
 		ValidArgsFunction: rmShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -42,7 +42,7 @@ func NewRmCommand() *cobra.Command {
 	return cmd
 }
 
-func rmAction(cmd *cobra.Command, args []string) error {
+func removeAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container/container_rename.go
+++ b/cmd/nerdctl/container/container_rename.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewRenameCommand() *cobra.Command {
+func RenameCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "rename [flags] CONTAINER NEW_NAME",
 		Args:              helpers.IsExactArgs(2),
@@ -39,7 +39,7 @@ func NewRenameCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerRenameOptions(cmd *cobra.Command) (types.ContainerRenameOptions, error) {
+func renameOptions(cmd *cobra.Command) (types.ContainerRenameOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerRenameOptions{}, err
@@ -51,7 +51,7 @@ func processContainerRenameOptions(cmd *cobra.Command) (types.ContainerRenameOpt
 }
 
 func renameAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerRenameOptions(cmd)
+	options, err := renameOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_restart.go
+++ b/cmd/nerdctl/container/container_restart.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewRestartCommand() *cobra.Command {
+func RestartCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "restart [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -42,7 +42,7 @@ func NewRestartCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerRestartOptions(cmd *cobra.Command) (types.ContainerRestartOptions, error) {
+func restartOptions(cmd *cobra.Command) (types.ContainerRestartOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerRestartOptions{}, err
@@ -78,7 +78,7 @@ func processContainerRestartOptions(cmd *cobra.Command) (types.ContainerRestartO
 }
 
 func restartAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerRestartOptions(cmd)
+	options, err := restartOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -47,7 +47,7 @@ const (
 	tiniInitBinary = "tini"
 )
 
-func NewRunCommand() *cobra.Command {
+func RunCommand() *cobra.Command {
 	shortHelp := "Run a command in a new container. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS."
 	longHelp := shortHelp
 	switch runtime.GOOS {
@@ -289,7 +289,7 @@ func setCreateFlags(cmd *cobra.Command) {
 }
 
 func processCreateCommandFlagsInRun(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
-	opt, err := processContainerCreateOptions(cmd)
+	opt, err := createOptions(cmd)
 	if err != nil {
 		return opt, err
 	}

--- a/cmd/nerdctl/container/container_start.go
+++ b/cmd/nerdctl/container/container_start.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 )
 
-func NewStartCommand() *cobra.Command {
+func StartCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "start [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -47,7 +47,7 @@ func NewStartCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerStartOptions(cmd *cobra.Command) (types.ContainerStartOptions, error) {
+func startOptions(cmd *cobra.Command) (types.ContainerStartOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerStartOptions{}, err
@@ -69,7 +69,7 @@ func processContainerStartOptions(cmd *cobra.Command) (types.ContainerStartOptio
 }
 
 func startAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerStartOptions(cmd)
+	options, err := startOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_stats.go
+++ b/cmd/nerdctl/container/container_stats.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewStatsCommand() *cobra.Command {
+func StatsCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "stats",
 		Short:             "Display a live stream of container(s) resource usage statistics.",

--- a/cmd/nerdctl/container/container_stop.go
+++ b/cmd/nerdctl/container/container_stop.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewStopCommand() *cobra.Command {
+func StopCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "stop [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -45,7 +45,7 @@ func NewStopCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerStopOptions(cmd *cobra.Command) (types.ContainerStopOptions, error) {
+func stopOptions(cmd *cobra.Command) (types.ContainerStopOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerStopOptions{}, err
@@ -77,7 +77,7 @@ func processContainerStopOptions(cmd *cobra.Command) (types.ContainerStopOptions
 }
 
 func stopAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerStopOptions(cmd)
+	options, err := stopOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_top.go
+++ b/cmd/nerdctl/container/container_top.go
@@ -33,7 +33,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func NewTopCommand() *cobra.Command {
+func TopCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "top CONTAINER [ps OPTIONS]",
 		Args:              cobra.MinimumNArgs(1),

--- a/cmd/nerdctl/container/container_unpause.go
+++ b/cmd/nerdctl/container/container_unpause.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewUnpauseCommand() *cobra.Command {
+func UnpauseCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "unpause [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -41,7 +41,7 @@ func NewUnpauseCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerUnpauseOptions(cmd *cobra.Command) (types.ContainerUnpauseOptions, error) {
+func unpauseOptions(cmd *cobra.Command) (types.ContainerUnpauseOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerUnpauseOptions{}, err
@@ -53,7 +53,7 @@ func processContainerUnpauseOptions(cmd *cobra.Command) (types.ContainerUnpauseO
 }
 
 func unpauseAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerUnpauseOptions(cmd)
+	options, err := unpauseOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/container/container_update.go
+++ b/cmd/nerdctl/container/container_update.go
@@ -57,7 +57,7 @@ type updateResourceOptions struct {
 	BlkioWeight        uint16
 }
 
-func NewUpdateCommand() *cobra.Command {
+func UpdateCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "update [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),

--- a/cmd/nerdctl/container/container_wait.go
+++ b/cmd/nerdctl/container/container_wait.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 )
 
-func NewWaitCommand() *cobra.Command {
+func WaitCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "wait [flags] CONTAINER [CONTAINER, ...]",
 		Args:              cobra.MinimumNArgs(1),
 		Short:             "Block until one or more containers stop, then print their exit codes.",
-		RunE:              containerWaitAction,
+		RunE:              waitAction,
 		ValidArgsFunction: waitShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -41,7 +41,7 @@ func NewWaitCommand() *cobra.Command {
 	return cmd
 }
 
-func processContainerWaitOptions(cmd *cobra.Command) (types.ContainerWaitOptions, error) {
+func waitOptions(cmd *cobra.Command) (types.ContainerWaitOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ContainerWaitOptions{}, err
@@ -52,8 +52,8 @@ func processContainerWaitOptions(cmd *cobra.Command) (types.ContainerWaitOptions
 	}, nil
 }
 
-func containerWaitAction(cmd *cobra.Command, args []string) error {
-	options, err := processContainerWaitOptions(cmd)
+func waitAction(cmd *cobra.Command, args []string) error {
+	options, err := waitOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 
-func ProcessImageVerifyOptions(cmd *cobra.Command) (opt types.ImageVerifyOptions, err error) {
+func VerifyOptions(cmd *cobra.Command) (opt types.ImageVerifyOptions, err error) {
 	if opt.Provider, err = cmd.Flags().GetString("verify"); err != nil {
 		return
 	}

--- a/cmd/nerdctl/image/image.go
+++ b/cmd/nerdctl/image/image.go
@@ -23,7 +23,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewImageCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "image",
@@ -33,34 +33,34 @@ func NewImageCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		builder.NewBuildCommand(),
+		builder.BuildCommand(),
 		// commitCommand is in "container", not in "image"
 		imageLsCommand(),
-		NewHistoryCommand(),
-		NewPullCommand(),
-		NewPushCommand(),
-		NewLoadCommand(),
-		NewSaveCommand(),
-		NewTagCommand(),
-		imageRmCommand(),
-		newImageConvertCommand(),
-		newImageInspectCommand(),
-		newImageEncryptCommand(),
-		newImageDecryptCommand(),
-		newImagePruneCommand(),
+		HistoryCommand(),
+		PullCommand(),
+		PushCommand(),
+		LoadCommand(),
+		SaveCommand(),
+		TagCommand(),
+		imageRemoveCommand(),
+		convertCommand(),
+		inspectCommand(),
+		encryptCommand(),
+		decryptCommand(),
+		pruneCommand(),
 	)
 	return cmd
 }
 
 func imageLsCommand() *cobra.Command {
-	x := NewImagesCommand()
+	x := ImagesCommand()
 	x.Use = "ls"
 	x.Aliases = []string{"list"}
 	return x
 }
 
-func imageRmCommand() *cobra.Command {
-	x := NewRmiCommand()
+func imageRemoveCommand() *cobra.Command {
+	x := RmiCommand()
 	x.Use = "rm"
 	x.Aliases = []string{"remove"}
 	return x

--- a/cmd/nerdctl/image/image_convert.go
+++ b/cmd/nerdctl/image/image_convert.go
@@ -39,7 +39,7 @@ For encryption and decryption, use 'nerdctl image (encrypt|decrypt)' command.
 `
 
 // imageConvertCommand is from https://github.com/containerd/stargz-snapshotter/blob/d58f43a8235e46da73fb94a1a35280cb4d607b2c/cmd/ctr-remote/commands/convert.go
-func newImageConvertCommand() *cobra.Command {
+func convertCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "convert [flags] <source_ref> <target_ref>...",
 		Short:             "convert an image",
@@ -104,7 +104,7 @@ func newImageConvertCommand() *cobra.Command {
 	return cmd
 }
 
-func processImageConvertOptions(cmd *cobra.Command) (types.ImageConvertOptions, error) {
+func convertOptions(cmd *cobra.Command) (types.ImageConvertOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageConvertOptions{}, err
@@ -281,7 +281,7 @@ func processImageConvertOptions(cmd *cobra.Command) (types.ImageConvertOptions, 
 }
 
 func imageConvertAction(cmd *cobra.Command, args []string) error {
-	options, err := processImageConvertOptions(cmd)
+	options, err := convertOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_cryptutil.go
+++ b/cmd/nerdctl/image/image_cryptutil.go
@@ -55,7 +55,7 @@ func registerImgcryptFlags(cmd *cobra.Command, encrypt bool) {
 	}
 }
 
-func processImgCryptOptions(cmd *cobra.Command, args []string, encrypt bool) (types.ImageCryptOptions, error) {
+func cryptOptions(cmd *cobra.Command, args []string, encrypt bool) (types.ImageCryptOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageCryptOptions{}, err
@@ -106,7 +106,7 @@ func processImgCryptOptions(cmd *cobra.Command, args []string, encrypt bool) (ty
 
 func getImgcryptAction(encrypt bool) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		options, err := processImgCryptOptions(cmd, args, encrypt)
+		options, err := cryptOptions(cmd, args, encrypt)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/image/image_decrypt.go
+++ b/cmd/nerdctl/image/image_decrypt.go
@@ -45,7 +45,7 @@ Example (decrypt):
   nerdctl image decrypt --key=mykey.pem example.com/foo:encrypted foo:decrypted
 `
 
-func newImageDecryptCommand() *cobra.Command {
+func decryptCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "decrypt [flags] <source_ref> <target_ref>...",
 		Short:             "decrypt an image",

--- a/cmd/nerdctl/image/image_encrypt.go
+++ b/cmd/nerdctl/image/image_encrypt.go
@@ -45,7 +45,7 @@ CAUTION: This command only encrypts image layers, but does NOT encrypt container
 To see non-encrypted information, run 'nerdctl image inspect --mode=native --platform=PLATFORM example.com/foo:encrypted' .
 `
 
-func newImageEncryptCommand() *cobra.Command {
+func encryptCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "encrypt [flags] <source_ref> <target_ref>...",
 		Short:             "encrypt image layers",

--- a/cmd/nerdctl/image/image_history.go
+++ b/cmd/nerdctl/image/image_history.go
@@ -43,7 +43,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 )
 
-func NewHistoryCommand() *cobra.Command {
+func HistoryCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "history [flags] IMAGE",
 		Short:             "Show the history of an image",

--- a/cmd/nerdctl/image/image_inspect.go
+++ b/cmd/nerdctl/image/image_inspect.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 )
 
-func newImageInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect [flags] IMAGE [IMAGE...]",
 		Args:              cobra.MinimumNArgs(1),
@@ -56,7 +56,7 @@ func newImageInspectCommand() *cobra.Command {
 	return cmd
 }
 
-func ProcessImageInspectOptions(cmd *cobra.Command, platform *string) (types.ImageInspectOptions, error) {
+func InspectOptions(cmd *cobra.Command, platform *string) (types.ImageInspectOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageInspectOptions{}, err
@@ -86,7 +86,7 @@ func ProcessImageInspectOptions(cmd *cobra.Command, platform *string) (types.Ima
 }
 
 func imageInspectAction(cmd *cobra.Command, args []string) error {
-	options, err := ProcessImageInspectOptions(cmd, nil)
+	options, err := InspectOptions(cmd, nil)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_list.go
+++ b/cmd/nerdctl/image/image_list.go
@@ -29,7 +29,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 
-func NewImagesCommand() *cobra.Command {
+func ImagesCommand() *cobra.Command {
 	shortHelp := "List images"
 	longHelp := shortHelp + `
 
@@ -70,7 +70,7 @@ Properties:
 	return cmd
 }
 
-func processImageListOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, error) {
+func listOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return nil, err
@@ -126,7 +126,7 @@ func processImageListOptions(cmd *cobra.Command, args []string) (*types.ImageLis
 }
 
 func imagesAction(cmd *cobra.Command, args []string) error {
-	options, err := processImageListOptions(cmd, args)
+	options, err := listOptions(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_load.go
+++ b/cmd/nerdctl/image/image_load.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/load"
 )
 
-func NewLoadCommand() *cobra.Command {
+func LoadCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "load",
 		Args:          cobra.NoArgs,

--- a/cmd/nerdctl/image/image_prune.go
+++ b/cmd/nerdctl/image/image_prune.go
@@ -27,7 +27,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 )
 
-func newImagePruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove unused images",
@@ -43,7 +43,7 @@ func newImagePruneCommand() *cobra.Command {
 	return cmd
 }
 
-func processImagePruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, error) {
+func pruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImagePruneOptions{}, err
@@ -76,7 +76,7 @@ func processImagePruneOptions(cmd *cobra.Command) (types.ImagePruneOptions, erro
 }
 
 func imagePruneAction(cmd *cobra.Command, _ []string) error {
-	options, err := processImagePruneOptions(cmd)
+	options, err := pruneOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_pull.go
+++ b/cmd/nerdctl/image/image_pull.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
-func NewPullCommand() *cobra.Command {
+func PullCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "pull [flags] NAME[:TAG]",
 		Short:         "Pull an image from a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to pull image from IPFS.",
@@ -114,7 +114,7 @@ func processPullCommandFlags(cmd *cobra.Command) (types.ImagePullOptions, error)
 		return types.ImagePullOptions{}, err
 	}
 
-	verifyOptions, err := helpers.ProcessImageVerifyOptions(cmd)
+	verifyOptions, err := helpers.VerifyOptions(cmd)
 	if err != nil {
 		return types.ImagePullOptions{}, err
 	}

--- a/cmd/nerdctl/image/image_push.go
+++ b/cmd/nerdctl/image/image_push.go
@@ -30,7 +30,7 @@ const (
 	allowNonDistFlag = "allow-nondistributable-artifacts"
 )
 
-func NewPushCommand() *cobra.Command {
+func PushCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "push [flags] NAME[:TAG]",
 		Short:             "Push an image or a repository to a registry. Optionally specify \"ipfs://\" or \"ipns://\" scheme to push image to IPFS.",
@@ -72,7 +72,7 @@ func NewPushCommand() *cobra.Command {
 	return cmd
 }
 
-func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error) {
+func pushOptions(cmd *cobra.Command) (types.ImagePushOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImagePushOptions{}, err
@@ -105,11 +105,11 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
-	signOptions, err := processImageSignOptions(cmd)
+	signOptions, err := signOptions(cmd)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
-	sociOptions, err := processSociOptions(cmd)
+	sociOptions, err := sociOptions(cmd)
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
@@ -129,7 +129,7 @@ func processImagePushOptions(cmd *cobra.Command) (types.ImagePushOptions, error)
 }
 
 func pushAction(cmd *cobra.Command, args []string) error {
-	options, err := processImagePushOptions(cmd)
+	options, err := pushOptions(cmd)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func pushShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]
 	return completion.ImageNames(cmd)
 }
 
-func processImageSignOptions(cmd *cobra.Command) (opt types.ImageSignOptions, err error) {
+func signOptions(cmd *cobra.Command) (opt types.ImageSignOptions, err error) {
 	if opt.Provider, err = cmd.Flags().GetString("sign"); err != nil {
 		return
 	}
@@ -162,7 +162,7 @@ func processImageSignOptions(cmd *cobra.Command) (opt types.ImageSignOptions, er
 	return
 }
 
-func processSociOptions(cmd *cobra.Command) (opt types.SociOptions, err error) {
+func sociOptions(cmd *cobra.Command) (opt types.SociOptions, err error) {
 	if opt.SpanSize, err = cmd.Flags().GetInt64("soci-span-size"); err != nil {
 		return
 	}

--- a/cmd/nerdctl/image/image_remove.go
+++ b/cmd/nerdctl/image/image_remove.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 )
 
-func NewRmiCommand() *cobra.Command {
+func RmiCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "rmi [flags] IMAGE [IMAGE, ...]",
 		Short:             "Remove one or more images",
@@ -42,7 +42,7 @@ func NewRmiCommand() *cobra.Command {
 	return cmd
 }
 
-func processImageRemoveOptions(cmd *cobra.Command) (types.ImageRemoveOptions, error) {
+func removeOptions(cmd *cobra.Command) (types.ImageRemoveOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageRemoveOptions{}, err
@@ -66,7 +66,7 @@ func processImageRemoveOptions(cmd *cobra.Command) (types.ImageRemoveOptions, er
 }
 
 func rmiAction(cmd *cobra.Command, args []string) error {
-	options, err := processImageRemoveOptions(cmd)
+	options, err := removeOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_save.go
+++ b/cmd/nerdctl/image/image_save.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 )
 
-func NewSaveCommand() *cobra.Command {
+func SaveCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "save",
 		Args:              cobra.MinimumNArgs(1),
@@ -53,7 +53,7 @@ func NewSaveCommand() *cobra.Command {
 	return cmd
 }
 
-func processImageSaveOptions(cmd *cobra.Command) (types.ImageSaveOptions, error) {
+func saveOptions(cmd *cobra.Command) (types.ImageSaveOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.ImageSaveOptions{}, err
@@ -76,7 +76,7 @@ func processImageSaveOptions(cmd *cobra.Command) (types.ImageSaveOptions, error)
 }
 
 func saveAction(cmd *cobra.Command, args []string) error {
-	options, err := processImageSaveOptions(cmd)
+	options, err := saveOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/image/image_tag.go
+++ b/cmd/nerdctl/image/image_tag.go
@@ -26,7 +26,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
 )
 
-func NewTagCommand() *cobra.Command {
+func TagCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "tag [flags] SOURCE_IMAGE[:TAG] TARGET_IMAGE[:TAG]",
 		Short:             "Create a tag TARGET_IMAGE that refers to SOURCE_IMAGE",

--- a/cmd/nerdctl/inspect/inspect.go
+++ b/cmd/nerdctl/inspect/inspect.go
@@ -34,7 +34,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 )
 
-func NewInspectCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:               "inspect",
 		Short:             "Return low-level information on objects.",
@@ -117,13 +117,13 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 	var containerInspectOptions types.ContainerInspectOptions
 	if inspectImage {
 		platform := ""
-		imageInspectOptions, err = imageCmd.ProcessImageInspectOptions(cmd, &platform)
+		imageInspectOptions, err = imageCmd.InspectOptions(cmd, &platform)
 		if err != nil {
 			return err
 		}
 	}
 	if inspectContainer {
-		containerInspectOptions, err = containerCmd.ProcessContainerInspectOptions(cmd)
+		containerInspectOptions, err = containerCmd.InspectOptions(cmd)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/internal/internal.go
+++ b/cmd/nerdctl/internal/internal.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewInternalCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "internal",
 		Short:         "DO NOT EXECUTE MANUALLY",

--- a/cmd/nerdctl/login/login.go
+++ b/cmd/nerdctl/login/login.go
@@ -30,7 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/login"
 )
 
-func NewLoginCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "login [flags] [SERVER]",
 		Args:          cobra.MaximumNArgs(1),
@@ -45,7 +45,7 @@ func NewLoginCommand() *cobra.Command {
 	return cmd
 }
 
-func processLoginOptions(cmd *cobra.Command) (types.LoginCommandOptions, error) {
+func loginOptions(cmd *cobra.Command) (types.LoginCommandOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.LoginCommandOptions{}, err
@@ -96,7 +96,7 @@ func processLoginOptions(cmd *cobra.Command) (types.LoginCommandOptions, error) 
 }
 
 func loginAction(cmd *cobra.Command, args []string) error {
-	options, err := processLoginOptions(cmd)
+	options, err := loginOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/login/logout.go
+++ b/cmd/nerdctl/login/logout.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/logout"
 )
 
-func NewLogoutCommand() *cobra.Command {
+func LogoutCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:               "logout [flags] [SERVER]",
 		Args:              cobra.MaximumNArgs(1),

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -259,79 +259,79 @@ Config file ($NERDCTL_TOML): %s
 	}
 	rootCmd.RunE = helpers.UnknownSubcommandAction
 	rootCmd.AddCommand(
-		container.NewCreateCommand(),
+		container.CreateCommand(),
 		// #region Run & Exec
-		container.NewRunCommand(),
-		container.NewUpdateCommand(),
-		container.NewExecCommand(),
+		container.RunCommand(),
+		container.UpdateCommand(),
+		container.ExecCommand(),
 		// #endregion
 
 		// #region Container management
-		container.NewPsCommand(),
-		container.NewLogsCommand(),
-		container.NewPortCommand(),
-		container.NewStopCommand(),
-		container.NewStartCommand(),
-		container.NewDiffCommand(),
-		container.NewRestartCommand(),
-		container.NewKillCommand(),
-		container.NewRmCommand(),
-		container.NewPauseCommand(),
-		container.NewUnpauseCommand(),
-		container.NewCommitCommand(),
-		container.NewWaitCommand(),
-		container.NewRenameCommand(),
-		container.NewAttachCommand(),
+		container.PsCommand(),
+		container.LogsCommand(),
+		container.PortCommand(),
+		container.StopCommand(),
+		container.StartCommand(),
+		container.DiffCommand(),
+		container.RestartCommand(),
+		container.KillCommand(),
+		container.RemoveCommand(),
+		container.PauseCommand(),
+		container.UnpauseCommand(),
+		container.CommitCommand(),
+		container.WaitCommand(),
+		container.RenameCommand(),
+		container.AttachCommand(),
 		// #endregion
 
 		// Build
-		builder.NewBuildCommand(),
+		builder.BuildCommand(),
 
 		// #region Image management
-		image.NewImagesCommand(),
-		image.NewPullCommand(),
-		image.NewPushCommand(),
-		image.NewLoadCommand(),
-		image.NewSaveCommand(),
-		image.NewTagCommand(),
-		image.NewRmiCommand(),
-		image.NewHistoryCommand(),
+		image.ImagesCommand(),
+		image.PullCommand(),
+		image.PushCommand(),
+		image.LoadCommand(),
+		image.SaveCommand(),
+		image.TagCommand(),
+		image.RmiCommand(),
+		image.HistoryCommand(),
 		// #endregion
 
 		// #region System
-		system.NewEventsCommand(),
-		system.NewInfoCommand(),
-		newVersionCommand(),
+		system.EventsCommand(),
+		system.InfoCommand(),
+		versionCommand(),
 		// #endregion
 
 		// Inspect
-		inspect.NewInspectCommand(),
+		inspect.Command(),
 
 		// stats
-		container.NewTopCommand(),
-		container.NewStatsCommand(),
+		container.TopCommand(),
+		container.StatsCommand(),
 
 		// #region helpers.Management
-		container.NewContainerCommand(),
-		image.NewImageCommand(),
-		network.NewNetworkCommand(),
-		volume.NewVolumeCommand(),
-		system.NewSystemCommand(),
-		namespace.NewNamespaceCommand(),
-		builder.NewBuilderCommand(),
+		container.Command(),
+		image.Command(),
+		network.Command(),
+		volume.Command(),
+		system.Command(),
+		namespace.Command(),
+		builder.Command(),
 		// #endregion
 
 		// Internal
-		internal.NewInternalCommand(),
+		internal.Command(),
 
 		// login
-		login.NewLoginCommand(),
+		login.Command(),
 
 		// Logout
-		login.NewLogoutCommand(),
+		login.LogoutCommand(),
 
 		// Compose
-		compose.NewComposeCommand(),
+		compose.Command(),
 
 		// IPFS
 		ipfs.NewIPFSCommand(),

--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -64,5 +64,5 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 }
 
 func addApparmorCommand(rootCmd *cobra.Command) {
-	rootCmd.AddCommand(apparmor.NewApparmorCommand())
+	rootCmd.AddCommand(apparmor.Command())
 }

--- a/cmd/nerdctl/namespace/namespace.go
+++ b/cmd/nerdctl/namespace/namespace.go
@@ -32,7 +32,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 )
 
-func NewNamespaceCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "namespace",
@@ -43,20 +43,20 @@ func NewNamespaceCommand() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
-	cmd.AddCommand(newNamespaceLsCommand())
-	cmd.AddCommand(newNamespaceRmCommand())
-	cmd.AddCommand(newNamespaceCreateCommand())
-	cmd.AddCommand(newNamespacelabelUpdateCommand())
-	cmd.AddCommand(newNamespaceInspectCommand())
+	cmd.AddCommand(listCommand())
+	cmd.AddCommand(removeCommand())
+	cmd.AddCommand(createCommand())
+	cmd.AddCommand(updateCommand())
+	cmd.AddCommand(inspectCommand())
 	return cmd
 }
 
-func newNamespaceLsCommand() *cobra.Command {
+func listCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List containerd namespaces",
-		RunE:          namespaceLsAction,
+		RunE:          listAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -64,7 +64,7 @@ func newNamespaceLsCommand() *cobra.Command {
 	return cmd
 }
 
-func namespaceLsAction(cmd *cobra.Command, args []string) error {
+func listAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/namespace/namespace_create.go
+++ b/cmd/nerdctl/namespace/namespace_create.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/namespace"
 )
 
-func newNamespaceCreateCommand() *cobra.Command {
+func createCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "create NAMESPACE",
 		Short:         "Create a new namespace",
 		Args:          cobra.MinimumNArgs(1),
-		RunE:          namespaceCreateAction,
+		RunE:          createAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -54,7 +54,7 @@ func processNamespaceCreateCommandOption(cmd *cobra.Command) (types.NamespaceCre
 	}, nil
 }
 
-func namespaceCreateAction(cmd *cobra.Command, args []string) error {
+func createAction(cmd *cobra.Command, args []string) error {
 	options, err := processNamespaceCreateCommandOption(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/namespace/namespace_inspect.go
+++ b/cmd/nerdctl/namespace/namespace_inspect.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/namespace"
 )
 
-func newNamespaceInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "inspect NAMESPACE",
 		Short:         "Display detailed information on one or more namespaces.",
-		RunE:          labelInspectAction,
+		RunE:          inspectAction,
 		Args:          cobra.MinimumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -41,7 +41,7 @@ func newNamespaceInspectCommand() *cobra.Command {
 	return cmd
 }
 
-func processNamespaceInspectOptions(cmd *cobra.Command) (types.NamespaceInspectOptions, error) {
+func inspectOptions(cmd *cobra.Command) (types.NamespaceInspectOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.NamespaceInspectOptions{}, err
@@ -57,8 +57,8 @@ func processNamespaceInspectOptions(cmd *cobra.Command) (types.NamespaceInspectO
 	}, nil
 }
 
-func labelInspectAction(cmd *cobra.Command, args []string) error {
-	options, err := processNamespaceInspectOptions(cmd)
+func inspectAction(cmd *cobra.Command, args []string) error {
+	options, err := inspectOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace/namespace_remove.go
+++ b/cmd/nerdctl/namespace/namespace_remove.go
@@ -25,13 +25,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/namespace"
 )
 
-func newNamespaceRmCommand() *cobra.Command {
+func removeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "remove [flags] NAMESPACE [NAMESPACE...]",
 		Aliases:       []string{"rm"},
 		Args:          cobra.MinimumNArgs(1),
 		Short:         "Remove one or more namespaces",
-		RunE:          namespaceRmAction,
+		RunE:          removeAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -39,7 +39,7 @@ func newNamespaceRmCommand() *cobra.Command {
 	return cmd
 }
 
-func processNamespaceRemoveOptions(cmd *cobra.Command) (types.NamespaceRemoveOptions, error) {
+func removeOptions(cmd *cobra.Command) (types.NamespaceRemoveOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.NamespaceRemoveOptions{}, err
@@ -55,8 +55,8 @@ func processNamespaceRemoveOptions(cmd *cobra.Command) (types.NamespaceRemoveOpt
 	}, nil
 }
 
-func namespaceRmAction(cmd *cobra.Command, args []string) error {
-	options, err := processNamespaceRemoveOptions(cmd)
+func removeAction(cmd *cobra.Command, args []string) error {
+	options, err := removeOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/namespace/namespace_update.go
+++ b/cmd/nerdctl/namespace/namespace_update.go
@@ -25,11 +25,11 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/namespace"
 )
 
-func newNamespacelabelUpdateCommand() *cobra.Command {
+func updateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "update [flags] NAMESPACE",
 		Short:         "Update labels for a namespace",
-		RunE:          labelUpdateAction,
+		RunE:          updateAction,
 		Args:          cobra.MinimumNArgs(1),
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -53,7 +53,7 @@ func processNamespaceUpdateCommandOption(cmd *cobra.Command) (types.NamespaceUpd
 	}, nil
 }
 
-func labelUpdateAction(cmd *cobra.Command, args []string) error {
+func updateAction(cmd *cobra.Command, args []string) error {
 	options, err := processNamespaceUpdateCommandOption(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network/network.go
+++ b/cmd/nerdctl/network/network.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewNetworkCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "network",
@@ -32,11 +32,11 @@ func NewNetworkCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		newNetworkLsCommand(),
-		newNetworkInspectCommand(),
-		newNetworkCreateCommand(),
-		newNetworkRmCommand(),
-		newNetworkPruneCommand(),
+		listCommand(),
+		inspectCommand(),
+		createCommand(),
+		removeCommand(),
+		pruneCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/network/network_create.go
+++ b/cmd/nerdctl/network/network_create.go
@@ -29,13 +29,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 )
 
-func newNetworkCreateCommand() *cobra.Command {
+func createCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "create [flags] NETWORK",
 		Short:         "Create a network",
 		Long:          `NOTE: To isolate CNI bridge, CNI plugin "firewall" (>= v1.1.0) is needed.`,
 		Args:          helpers.IsExactArgs(1),
-		RunE:          networkCreateAction,
+		RunE:          createAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -53,7 +53,7 @@ func newNetworkCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func networkCreateAction(cmd *cobra.Command, args []string) error {
+func createAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network/network_inspect.go
+++ b/cmd/nerdctl/network/network_inspect.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/network"
 )
 
-func newNetworkInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect [flags] NETWORK [NETWORK, ...]",
 		Short:             "Display detailed information on one or more networks",
 		Args:              cobra.MinimumNArgs(1),
-		RunE:              networkInspectAction,
+		RunE:              inspectAction,
 		ValidArgsFunction: networkInspectShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -46,7 +46,7 @@ func newNetworkInspectCommand() *cobra.Command {
 	return cmd
 }
 
-func networkInspectAction(cmd *cobra.Command, args []string) error {
+func inspectAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network/network_list.go
+++ b/cmd/nerdctl/network/network_list.go
@@ -24,13 +24,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/network"
 )
 
-func newNetworkLsCommand() *cobra.Command {
+func listCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List networks",
 		Args:          cobra.NoArgs,
-		RunE:          networkLsAction,
+		RunE:          listAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -43,7 +43,7 @@ func newNetworkLsCommand() *cobra.Command {
 	return cmd
 }
 
-func networkLsAction(cmd *cobra.Command, args []string) error {
+func listAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network/network_prune.go
+++ b/cmd/nerdctl/network/network_prune.go
@@ -30,12 +30,12 @@ import (
 
 var NetworkDriversToKeep = []string{"host", "none", DefaultNetworkDriver}
 
-func newNetworkPruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all unused networks",
 		Args:          cobra.NoArgs,
-		RunE:          networkPruneAction,
+		RunE:          pruneAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -43,7 +43,7 @@ func newNetworkPruneCommand() *cobra.Command {
 	return cmd
 }
 
-func networkPruneAction(cmd *cobra.Command, _ []string) error {
+func pruneAction(cmd *cobra.Command, _ []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/network/network_remove.go
+++ b/cmd/nerdctl/network/network_remove.go
@@ -27,14 +27,14 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 )
 
-func newNetworkRmCommand() *cobra.Command {
+func removeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "rm [flags] NETWORK [NETWORK, ...]",
 		Aliases:           []string{"remove"},
 		Short:             "Remove one or more networks",
 		Long:              "NOTE: network in use is deleted without caution",
 		Args:              cobra.MinimumNArgs(1),
-		RunE:              networkRmAction,
+		RunE:              removeAction,
 		ValidArgsFunction: networkRmShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -42,7 +42,7 @@ func newNetworkRmCommand() *cobra.Command {
 	return cmd
 }
 
-func networkRmAction(cmd *cobra.Command, args []string) error {
+func removeAction(cmd *cobra.Command, args []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err

--- a/cmd/nerdctl/system/system.go
+++ b/cmd/nerdctl/system/system.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewSystemCommand() *cobra.Command {
+func Command() *cobra.Command {
 	var cmd = &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "system",
@@ -33,9 +33,9 @@ func NewSystemCommand() *cobra.Command {
 	}
 	// versionCommand is not here
 	cmd.AddCommand(
-		NewEventsCommand(),
-		NewInfoCommand(),
-		newSystemPruneCommand(),
+		EventsCommand(),
+		InfoCommand(),
+		pruneCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/system/system_events.go
+++ b/cmd/nerdctl/system/system_events.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/system"
 )
 
-func NewEventsCommand() *cobra.Command {
+func EventsCommand() *cobra.Command {
 	shortHelp := `Get real time events from the server`
 	longHelp := shortHelp + "\nNOTE: The output format is not compatible with Docker."
 	var cmd = &cobra.Command{
@@ -45,7 +45,7 @@ func NewEventsCommand() *cobra.Command {
 	return cmd
 }
 
-func processSystemEventsOptions(cmd *cobra.Command) (types.SystemEventsOptions, error) {
+func eventsOptions(cmd *cobra.Command) (types.SystemEventsOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.SystemEventsOptions{}, err
@@ -67,7 +67,7 @@ func processSystemEventsOptions(cmd *cobra.Command) (types.SystemEventsOptions, 
 }
 
 func eventsAction(cmd *cobra.Command, args []string) error {
-	options, err := processSystemEventsOptions(cmd)
+	options, err := eventsOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/system/system_info.go
+++ b/cmd/nerdctl/system/system_info.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/system"
 )
 
-func NewInfoCommand() *cobra.Command {
+func InfoCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "info",
 		Args:          cobra.NoArgs,
@@ -45,7 +45,7 @@ func NewInfoCommand() *cobra.Command {
 	return cmd
 }
 
-func processInfoOptions(cmd *cobra.Command) (types.SystemInfoOptions, error) {
+func infoOptions(cmd *cobra.Command) (types.SystemInfoOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.SystemInfoOptions{}, err
@@ -69,7 +69,7 @@ func processInfoOptions(cmd *cobra.Command) (types.SystemInfoOptions, error) {
 }
 
 func infoAction(cmd *cobra.Command, args []string) error {
-	options, err := processInfoOptions(cmd)
+	options, err := infoOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/system/system_prune.go
+++ b/cmd/nerdctl/system/system_prune.go
@@ -32,12 +32,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/system"
 )
 
-func newSystemPruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove unused data",
 		Args:          cobra.NoArgs,
-		RunE:          systemPruneAction,
+		RunE:          pruneAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -47,7 +47,7 @@ func newSystemPruneCommand() *cobra.Command {
 	return cmd
 }
 
-func processSystemPruneOptions(cmd *cobra.Command) (types.SystemPruneOptions, error) {
+func pruneOptions(cmd *cobra.Command) (types.SystemPruneOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.SystemPruneOptions{}, err
@@ -117,8 +117,8 @@ func grantSystemPrunePermission(cmd *cobra.Command, options types.SystemPruneOpt
 	return true, nil
 }
 
-func systemPruneAction(cmd *cobra.Command, _ []string) error {
-	options, err := processSystemPruneOptions(cmd)
+func pruneAction(cmd *cobra.Command, _ []string) error {
+	options, err := pruneOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/version.go
+++ b/cmd/nerdctl/version.go
@@ -35,7 +35,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
-func newVersionCommand() *cobra.Command {
+func versionCommand() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:           "version",
 		Args:          cobra.NoArgs,

--- a/cmd/nerdctl/volume/volume.go
+++ b/cmd/nerdctl/volume/volume.go
@@ -22,7 +22,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 )
 
-func NewVolumeCommand() *cobra.Command {
+func Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Annotations:   map[string]string{helpers.Category: helpers.Management},
 		Use:           "volume",
@@ -32,11 +32,11 @@ func NewVolumeCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 	cmd.AddCommand(
-		newVolumeLsCommand(),
-		newVolumeInspectCommand(),
-		newVolumeCreateCommand(),
-		newVolumeRmCommand(),
-		newVolumePruneCommand(),
+		listCommand(),
+		inspectCommand(),
+		createCommand(),
+		removeCommand(),
+		pruneCommand(),
 	)
 	return cmd
 }

--- a/cmd/nerdctl/volume/volume_create.go
+++ b/cmd/nerdctl/volume/volume_create.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )
 
-func newVolumeCreateCommand() *cobra.Command {
+func createCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "create [flags] [VOLUME]",
 		Short:         "Create a volume",
 		Args:          cobra.MaximumNArgs(1),
-		RunE:          volumeCreateAction,
+		RunE:          createAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -41,7 +41,7 @@ func newVolumeCreateCommand() *cobra.Command {
 	return cmd
 }
 
-func processVolumeCreateOptions(cmd *cobra.Command) (types.VolumeCreateOptions, error) {
+func createOptions(cmd *cobra.Command) (types.VolumeCreateOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.VolumeCreateOptions{}, err
@@ -63,8 +63,8 @@ func processVolumeCreateOptions(cmd *cobra.Command) (types.VolumeCreateOptions, 
 	}, nil
 }
 
-func volumeCreateAction(cmd *cobra.Command, args []string) error {
-	options, err := processVolumeCreateOptions(cmd)
+func createAction(cmd *cobra.Command, args []string) error {
+	options, err := createOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume/volume_inspect.go
+++ b/cmd/nerdctl/volume/volume_inspect.go
@@ -25,12 +25,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )
 
-func newVolumeInspectCommand() *cobra.Command {
+func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "inspect [flags] VOLUME [VOLUME...]",
 		Short:             "Display detailed information on one or more volumes",
 		Args:              cobra.MinimumNArgs(1),
-		RunE:              volumeInspectAction,
+		RunE:              inspectAction,
 		ValidArgsFunction: volumeInspectShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
@@ -43,7 +43,7 @@ func newVolumeInspectCommand() *cobra.Command {
 	return cmd
 }
 
-func processVolumeInspectOptions(cmd *cobra.Command) (types.VolumeInspectOptions, error) {
+func inspectOptions(cmd *cobra.Command) (types.VolumeInspectOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.VolumeInspectOptions{}, err
@@ -64,8 +64,8 @@ func processVolumeInspectOptions(cmd *cobra.Command) (types.VolumeInspectOptions
 	}, nil
 }
 
-func volumeInspectAction(cmd *cobra.Command, args []string) error {
-	options, err := processVolumeInspectOptions(cmd)
+func inspectAction(cmd *cobra.Command, args []string) error {
+	options, err := inspectOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume/volume_list.go
+++ b/cmd/nerdctl/volume/volume_list.go
@@ -24,12 +24,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )
 
-func newVolumeLsCommand() *cobra.Command {
+func listCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "ls",
 		Aliases:       []string{"list"},
 		Short:         "List volumes",
-		RunE:          volumeLsAction,
+		RunE:          listAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -45,7 +45,7 @@ func newVolumeLsCommand() *cobra.Command {
 	return cmd
 }
 
-func processVolumeLsOptions(cmd *cobra.Command) (types.VolumeListOptions, error) {
+func listOptions(cmd *cobra.Command) (types.VolumeListOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.VolumeListOptions{}, err
@@ -76,8 +76,8 @@ func processVolumeLsOptions(cmd *cobra.Command) (types.VolumeListOptions, error)
 	}, nil
 }
 
-func volumeLsAction(cmd *cobra.Command, args []string) error {
-	options, err := processVolumeLsOptions(cmd)
+func listAction(cmd *cobra.Command, args []string) error {
+	options, err := listOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume/volume_prune.go
+++ b/cmd/nerdctl/volume/volume_prune.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )
 
-func newVolumePruneCommand() *cobra.Command {
+func pruneCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:           "prune [flags]",
 		Short:         "Remove all unused local volumes",
 		Args:          cobra.NoArgs,
-		RunE:          volumePruneAction,
+		RunE:          pruneAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -42,7 +42,7 @@ func newVolumePruneCommand() *cobra.Command {
 	return cmd
 }
 
-func processVolumePruneOptions(cmd *cobra.Command) (types.VolumePruneOptions, error) {
+func pruneOptions(cmd *cobra.Command) (types.VolumePruneOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.VolumePruneOptions{}, err
@@ -67,8 +67,8 @@ func processVolumePruneOptions(cmd *cobra.Command) (types.VolumePruneOptions, er
 	return options, nil
 }
 
-func volumePruneAction(cmd *cobra.Command, _ []string) error {
-	options, err := processVolumePruneOptions(cmd)
+func pruneAction(cmd *cobra.Command, _ []string) error {
+	options, err := pruneOptions(cmd)
 	if err != nil {
 		return err
 	}

--- a/cmd/nerdctl/volume/volume_remove.go
+++ b/cmd/nerdctl/volume/volume_remove.go
@@ -26,15 +26,15 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 )
 
-func newVolumeRmCommand() *cobra.Command {
+func removeCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "rm [flags] VOLUME [VOLUME...]",
 		Aliases:           []string{"remove"},
 		Short:             "Remove one or more volumes",
 		Long:              "NOTE: You cannot remove a volume that is in use by a container.",
 		Args:              cobra.MinimumNArgs(1),
-		RunE:              volumeRmAction,
-		ValidArgsFunction: volumeRmShellComplete,
+		RunE:              removeAction,
+		ValidArgsFunction: removeShellComplete,
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 	}
@@ -42,7 +42,7 @@ func newVolumeRmCommand() *cobra.Command {
 	return cmd
 }
 
-func processVolumeRmOptions(cmd *cobra.Command) (types.VolumeRemoveOptions, error) {
+func removeOptions(cmd *cobra.Command) (types.VolumeRemoveOptions, error) {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return types.VolumeRemoveOptions{}, err
@@ -58,8 +58,8 @@ func processVolumeRmOptions(cmd *cobra.Command) (types.VolumeRemoveOptions, erro
 	}, nil
 }
 
-func volumeRmAction(cmd *cobra.Command, args []string) error {
-	options, err := processVolumeRmOptions(cmd)
+func removeAction(cmd *cobra.Command, args []string) error {
+	options, err := removeOptions(cmd)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func volumeRmAction(cmd *cobra.Command, args []string) error {
 	return volume.Remove(ctx, client, args, options)
 }
 
-func volumeRmShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func removeShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// show volume names
 	return completion.VolumeNames(cmd)
 }


### PR DESCRIPTION
This is a suggestion following on #3913

These changes are purely cosmetic, and their purpose is to increase code readability, by removing stuttering information from variables and functions name (following the refactor of cmd this last summer), and overall simplifying names.

This applies solely to `cmd/`

~~For now, these changes are solely on `apparmor`, so that we can talk about them.~~

~~If this is the right thing to do and we agree on the changes, I will apply them to the entirety of `cmd` and submit a complete / working PR.~~

The proposed changes are:
- rename all `newThingPackageCommand` function names to `thingCommand`:
- rename all `packageThingAction` function names to `thingAction`
- rename all `processPackageThingOptions` function names to `thingOptions`
- rename top-level `NewPackageCommand` unique functions to `Command`
- expand `Ls`, `Rm`,  to `List`, `Remove` where applicable

Reasoning is that:
- `Package` always stutter now that they are split under `cmd`
- `new`, or `process` does not add much value if any and is just noisy
- acronyms are bad

Thanks.

Tagging @AkihiroSuda for opinion.