### PR TITLE
Fix test TestNoneNetworkHostName

### DIFF
--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/netns"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
@@ -924,23 +925,19 @@ func TestNoneNetworkHostName(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier())
+			output := helpers.Capture("run", "-d", "--name", data.Identifier(), "--network", "none", testutil.NginxAlpineImage)
+			assert.Assert(helpers.T(), len(output) > 12, output)
+			data.Set("hostname", output[:12])
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rm", "-f", data.Identifier())
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			return helpers.Command("run", "-d", "--name", data.Identifier(), "--network", "none", testutil.NginxAlpineImage)
+			return helpers.Command("exec", data.Identifier(), "cat", "/etc/hostname")
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, info string, t *testing.T) {
-					hostname := stdout
-					if len(hostname) > 12 {
-						hostname = hostname[:12]
-					}
-					assert.Assert(t, strings.Compare(strings.TrimSpace(helpers.Capture("exec", data.Identifier(), "cat", "/etc/hostname")), hostname) == 0, info)
-				},
+				Output: expect.Equals(data.Get("hostname") + "\n"),
 			}
 		},
 	}


### PR DESCRIPTION
TestNoneNetworkHostName failed on an unrelated build:
https://github.com/containerd/nerdctl/actions/runs/13622696958/job/38074815721#step:8:2329

However, the way the test is currently written prevents useful information from being shown.

This PR rewrite part of it to make it simpler / more sensical and actually show information if it fails. 