### PR TITLE
fix: inspect should return one array rather than a stream of array

### DIFF
--- a/cmd/nerdctl/image/image_inspect.go
+++ b/cmd/nerdctl/image/image_inspect.go
@@ -21,11 +21,14 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
+	"github.com/containerd/nerdctl/v2/pkg/formatter"
 )
 
 func inspectCommand() *cobra.Command {
@@ -102,7 +105,18 @@ func imageInspectAction(cmd *cobra.Command, args []string) error {
 	}
 	defer cancel()
 
-	return image.Inspect(ctx, client, args, options)
+	entries, err := image.Inspect(ctx, client, args, options)
+	if err != nil {
+		return err
+	}
+
+	// Display
+	if len(entries) > 0 {
+		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, entries); formatErr != nil {
+			log.G(ctx).Error(formatErr)
+		}
+	}
+	return err
 }
 
 func imageInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/inspect/inspect.go
+++ b/cmd/nerdctl/inspect/inspect.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	containercmd "github.com/containerd/nerdctl/v2/cmd/nerdctl/container"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
@@ -30,12 +32,13 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/image"
+	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/imagewalker"
 )
 
 func Command() *cobra.Command {
-	var cmd = &cobra.Command{
+	cmd := &cobra.Command{
 		Use:               "inspect",
 		Short:             "Return low-level information on objects.",
 		Args:              cobra.MinimumNArgs(1),
@@ -79,6 +82,10 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 	}
 	namespace := globalOptions.Namespace
 	address := globalOptions.Address
+	format, err := cmd.Flags().GetString("format")
+	if err != nil {
+		return err
+	}
 	inspectType, err := cmd.Flags().GetString("type")
 	if err != nil {
 		return err
@@ -130,6 +137,7 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 	}
 
 	var errs []error
+	var entries []interface{}
 	for _, req := range args {
 		var ni int
 		var nc int
@@ -150,18 +158,26 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 		if ni == 0 && nc == 0 {
 			errs = append(errs, fmt.Errorf("no such object %s", req))
 		} else if ni > 0 {
-			if err := image.Inspect(ctx, client, []string{req}, imageInspectOptions); err != nil {
+			if imageEntries, err := image.Inspect(ctx, client, []string{req}, imageInspectOptions); err != nil {
 				errs = append(errs, err)
+			} else {
+				entries = append(entries, imageEntries...)
 			}
 		} else if nc > 0 {
-			if err := container.Inspect(ctx, client, []string{req}, containerInspectOptions); err != nil {
+			if containerEntries, err := container.Inspect(ctx, client, []string{req}, containerInspectOptions); err != nil {
 				errs = append(errs, err)
+			} else {
+				entries = append(entries, containerEntries...)
 			}
 		}
 	}
 
 	if len(errs) > 0 {
 		return fmt.Errorf("%d errors: %v", len(errs), errs)
+	}
+
+	if formatErr := formatter.FormatSlice(format, cmd.OutOrStdout(), entries); formatErr != nil {
+		log.G(ctx).Error(formatErr)
 	}
 
 	return nil

--- a/cmd/nerdctl/inspect/inspect_test.go
+++ b/cmd/nerdctl/inspect/inspect_test.go
@@ -17,11 +17,60 @@
 package inspect
 
 import (
+	"encoding/json"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
+	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestMain(m *testing.M) {
 	testutil.M(m)
+}
+
+func TestInspectSimpleCase(t *testing.T) {
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Description: "inspect container and image return one single json array",
+		Setup: func(data test.Data, helpers test.Helpers) {
+			identifier := data.Identifier()
+			helpers.Ensure("run", "-d", "--quiet", "--name", identifier, testutil.CommonImage, "sleep", nerdtest.Infinity)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			identifier := data.Identifier()
+			helpers.Anyhow("rm", "-f", identifier)
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("inspect", testutil.CommonImage, data.Identifier())
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				Output: func(stdout string, info string, t *testing.T) {
+					var inspectResult []json.RawMessage
+					err := json.Unmarshal([]byte(stdout), &inspectResult)
+					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					assert.Equal(t, len(inspectResult), 2, "Unexpectedly got multiple results\n"+info)
+
+					var dci dockercompat.Image
+					err = json.Unmarshal(inspectResult[0], &dci)
+					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					inspecti := nerdtest.InspectImage(helpers, testutil.CommonImage)
+					assert.Equal(t, dci.ID, inspecti.ID, info)
+
+					var dcc dockercompat.Container
+					err = json.Unmarshal(inspectResult[1], &dcc)
+					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					inspectc := nerdtest.InspectContainer(helpers, data.Identifier())
+					assert.Assert(t, dcc.ID == inspectc.ID, info)
+				},
+			}
+		},
+	}
+
+	testCase.Run(t)
 }

--- a/pkg/cmd/container/inspect.go
+++ b/pkg/cmd/container/inspect.go
@@ -23,19 +23,17 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/snapshots"
-	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerinspector"
-	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 )
 
 // Inspect prints detailed information for each container in `containers`.
-func Inspect(ctx context.Context, client *containerd.Client, containers []string, options types.ContainerInspectOptions) error {
+func Inspect(ctx context.Context, client *containerd.Client, containers []string, options types.ContainerInspectOptions) ([]any, error) {
 	f := &containerInspector{
 		mode:        options.Mode,
 		size:        options.Size,
@@ -48,13 +46,11 @@ func Inspect(ctx context.Context, client *containerd.Client, containers []string
 	}
 
 	err := walker.WalkAll(ctx, containers, true)
-	if len(f.entries) > 0 {
-		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, f.entries); formatErr != nil {
-			log.L.Error(formatErr)
-		}
+	if err != nil {
+		return []any{}, err
 	}
 
-	return err
+	return f.entries, nil
 }
 
 type containerInspector struct {

--- a/pkg/cmd/image/inspect.go
+++ b/pkg/cmd/image/inspect.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
-	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imageinspector"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
@@ -87,7 +86,7 @@ func inspectIdentifier(ctx context.Context, client *containerd.Client, identifie
 }
 
 // Inspect prints detailed information of each image in `images`.
-func Inspect(ctx context.Context, client *containerd.Client, identifiers []string, options types.ImageInspectOptions) error {
+func Inspect(ctx context.Context, client *containerd.Client, identifiers []string, options types.ImageInspectOptions) ([]any, error) {
 	// Set a timeout
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
@@ -189,16 +188,9 @@ func Inspect(ctx context.Context, client *containerd.Client, identifiers []strin
 		}
 	}
 
-	// Display
-	if len(entries) > 0 {
-		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, entries); formatErr != nil {
-			log.G(ctx).Error(formatErr)
-		}
-	}
-
 	if len(errs) > 0 {
-		return fmt.Errorf("%d errors:\n%w", len(errs), errors.Join(errs...))
+		return []any{}, fmt.Errorf("%d errors:\n%w", len(errs), errors.Join(errs...))
 	}
 
-	return nil
+	return entries, nil
 }


### PR DESCRIPTION
# Description
This PR fixes an issue where `nerdctl inspect <container1> <image1>` return a stream of array rather than one array.

# Steps to reproduce the issue
## current
```bash
> nerdctl inspect container1 image1
[
    {
       <container1-info>
    }
]
[
    {
       <image1-info>
    }
]
```

## fixed
```bash
> nerdctl inspect container1 image1
[
    {
       <container1-info>
    },
    {
       <image1-info>
    }
]
```


Fix: https://github.com/containerd/nerdctl/issues/3006