### PR TITLE
Docker compatibility: Windows HostName should be allowed

### DIFF
--- a/pkg/containerutil/container_network_manager_windows.go
+++ b/pkg/containerutil/container_network_manager_windows.go
@@ -48,7 +48,7 @@ func (m *cniNetworkManager) VerifyNetworkOptions(_ context.Context) error {
 	}
 
 	nonZeroArgs := nonZeroMapValues(map[string]interface{}{
-		"--hostname":   m.netOpts.Hostname,
+		// "--hostname":   m.netOpts.Hostname,
 		"--domainname": m.netOpts.Domainname,
 		"--uts":        m.netOpts.UTSNamespace,
 		// NOTE: IP and MAC settings are currently ignored on Windows.


### PR DESCRIPTION
## PR Description

### Background

**Linked Issue:** [containerd/nerdctl#3808](https://github.com/containerd/nerdctl/issues/3808)

### How to test this change?

1.  Sample `docker-compose.yaml`

  ```Text
  # docker-compose.yaml
  services:
    github:
      image: mcr.microsoft.com/dotnet/runtime:8.0-windowsservercore-ltsc2022
      isolation: hyperv
      platform: windows/amd64
      restart: unless-stopped
      scale: 1
      # Hostname gets set and causes problem
  ```

2. CNI: [microsoft/windows-container-networking](https://github.com/microsoft/windows-container-networking)
3. Command:

  ```bash
  >  _output/nerdctl compose up
  
  time="2025-03-03T18:57:06+03:00" level=warning msg="Ignoring: service github: [Isolation]"
  time="2025-03-03T18:57:06+03:00" level=info msg="Ensuring image mcr.microsoft.com/dotnet/runtime:8.0-windowsservercore-ltsc2022"
  time="2025-03-03T18:57:06+03:00" level=info msg="Creating container tina-github-1"
  time="2025-03-03T18:57:06+03:00" level=info msg="Running [C:\\Users\\tina\\nerdctl\\_output\\nerdctl.exe run --cidfile=C:\\Users\\tina\\AppData\\Local\\Temp\\compose-2805706540\\cid -l=com.docker.compose.project=tina -l=com.docker.compose.service=github -d --name=tina-github-1 --pull=never --net=tina_default --hostname=github --platform=windows/amd64 --restart=unless-stopped mcr.microsoft.com/dotnet/runtime:8.0-windowsservercore-ltsc2022]"
  time="2025-03-03T18:57:08+03:00" level=info msg="Attaching to logs"
  github-1 |Microsoft Windows [Version 10.0.20348.3207]
  github-1 |(c) Microsoft Corporation. All rights reserved.
  github-1 |
  github-1 |C:\Windows\system32>
  time="2025-03-03T18:57:08+03:00" level=info msg="Container \"tina-github-1\" exited"
  time="2025-03-03T18:57:08+03:00" level=info msg="All the containers have exited"
  time="2025-03-03T18:57:08+03:00" level=info msg="Stopping containers (forcibly)"
  time="2025-03-03T18:57:08+03:00" level=info msg="Stopping container tina-github-1"
  ```