### PR TITLE
--quiet image pulls in tests

### DIFF
--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -43,7 +43,7 @@ type psTestContainer struct {
 func preparePsTestContainer(t *testing.T, identity string, keepAlive bool) (*testutil.Base, psTestContainer) {
 	base := testutil.NewBase(t)
 
-	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	base.Cmd("pull", "--quiet", testutil.CommonImage).AssertOK()
 
 	testContainerName := testutil.Identifier(t) + identity
 	rwVolName := testContainerName + "-rw"

--- a/cmd/nerdctl/container/container_list_windows_test.go
+++ b/cmd/nerdctl/container/container_list_windows_test.go
@@ -38,7 +38,7 @@ type psTestContainer struct {
 func preparePsTestContainer(t *testing.T, identity string, restart bool, hyperv bool) (*testutil.Base, psTestContainer) {
 	base := testutil.NewBase(t)
 
-	base.Cmd("pull", testutil.NginxAlpineImage).AssertOK()
+	base.Cmd("pull", "--quiet", testutil.NginxAlpineImage).AssertOK()
 
 	testContainerName := testutil.Identifier(t) + identity
 	t.Cleanup(func() {

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -66,7 +66,7 @@ func TestRunCustomRootfs(t *testing.T) {
 }
 
 func prepareCustomRootfs(base *testutil.Base, imageName string) string {
-	base.Cmd("pull", imageName).AssertOK()
+	base.Cmd("pull", "--quiet", imageName).AssertOK()
 	tmpDir, err := os.MkdirTemp(base.T.TempDir(), "test-save")
 	assert.NilError(base.T, err)
 	defer os.RemoveAll(tmpDir)

--- a/cmd/nerdctl/container/container_run_log_driver_syslog_test.go
+++ b/cmd/nerdctl/container/container_run_log_driver_syslog_test.go
@@ -39,7 +39,7 @@ func runSyslogTest(t *testing.T, networks []string, syslogFacilities map[string]
 	}
 
 	base := testutil.NewBase(t)
-	base.Cmd("pull", testutil.CommonImage).AssertOK()
+	base.Cmd("pull", "--quiet", testutil.CommonImage).AssertOK()
 	hostname, err := os.Hostname()
 	if err != nil {
 		t.Fatalf("Error retrieving hostname")

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -534,7 +534,7 @@ func TestRunAddHostRemainsWhenAnotherContainerCreated(t *testing.T) {
 // https://github.com/containerd/nerdctl/issues/2726
 func TestRunRmTime(t *testing.T) {
 	base := testutil.NewBase(t)
-	base.Cmd("pull", testutil.CommonImage)
+	base.Cmd("pull", "--quiet", testutil.CommonImage)
 	t0 := time.Now()
 	base.Cmd("run", "--rm", testutil.CommonImage, "true").AssertOK()
 	t1 := time.Now()

--- a/cmd/nerdctl/container/container_run_user_linux_test.go
+++ b/cmd/nerdctl/container/container_run_user_linux_test.go
@@ -168,7 +168,7 @@ func TestRunAddGroup_CVE_2023_25173(t *testing.T) {
 		},
 	}
 
-	base.Cmd("pull", testutil.BusyboxImage).AssertOK()
+	base.Cmd("pull", "--quiet", testutil.BusyboxImage).AssertOK()
 	for _, testCase := range testCases {
 		cmd := []string{"run", "--rm"}
 		if testCase.user != "" {

--- a/cmd/nerdctl/container/multi_platform_linux_test.go
+++ b/cmd/nerdctl/container/multi_platform_linux_test.go
@@ -113,7 +113,7 @@ func TestMultiPlatformPullPushAllPlatforms(t *testing.T) {
 	pushImageName := fmt.Sprintf("localhost:%d/%s:latest", reg.Port, tID)
 	defer base.Cmd("rmi", pushImageName).Run()
 
-	base.Cmd("pull", "--all-platforms", testutil.AlpineImage).AssertOK()
+	base.Cmd("pull", "--quiet", "--all-platforms", testutil.AlpineImage).AssertOK()
 	base.Cmd("tag", testutil.AlpineImage, pushImageName).AssertOK()
 	base.Cmd("push", "--all-platforms", pushImageName).AssertOK()
 	testMultiPlatformRun(base, pushImageName)

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -39,7 +39,7 @@ func TestImageInspectSimpleCases(t *testing.T) {
 
 	testCase := &test.Case{
 		Setup: func(data test.Data, helpers test.Helpers) {
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 		},
 		SubTests: []*test.Case{
 			{

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -92,7 +92,7 @@ func TestLoadQuiet(t *testing.T) {
 		Description: "TestLoadQuiet",
 		Setup: func(data test.Data, helpers test.Helpers) {
 			identifier := data.Identifier()
-			helpers.Ensure("pull", testutil.CommonImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, identifier)
 			helpers.Ensure("save", identifier, "-o", filepath.Join(data.TempDir(), "common.tar"))
 			helpers.Ensure("rmi", "-f", identifier)

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -86,7 +86,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 			{
 				Description: "Pull with the correct key",
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("pull", "--verify=cosign", "--cosign-key="+keyPair.PublicKey, data.Get("imageref")+":one")
+					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+keyPair.PublicKey, data.Get("imageref")+":one")
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -97,7 +97,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					newKeyPair := testhelpers.NewCosignKeyPair(t, "cosign-key-pair-test", "2")
-					return helpers.Command("pull", "--verify=cosign", "--cosign-key="+newKeyPair.PublicKey, data.Get("imageref")+":two")
+					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+newKeyPair.PublicKey, data.Get("imageref")+":two")
 				},
 				Expected: test.Expects(12, nil, nil),
 			},

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -53,7 +53,7 @@ func TestRemove(t *testing.T) {
 				require.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -75,7 +75,7 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with stopped container - with -f",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -98,7 +98,7 @@ func TestRemove(t *testing.T) {
 				require.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -123,7 +123,7 @@ func TestRemove(t *testing.T) {
 				require.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 
 				img := nerdtest.InspectImage(helpers, testutil.CommonImage)
 				repoName, _ := imgutil.ParseRepoTag(testutil.CommonImage)
@@ -152,7 +152,7 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with created container - without -f",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("create", "--quiet", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
@@ -175,7 +175,7 @@ func TestRemove(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
-				helpers.Ensure("create", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("create", "--quiet", "--pull", "always", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("rmi", testutil.NginxAlpineImage)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -204,7 +204,7 @@ func TestRemove(t *testing.T) {
 				nerdtest.CGroup,
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("pause", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -231,7 +231,7 @@ func TestRemove(t *testing.T) {
 				require.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("pause", data.Identifier())
 
 				img := nerdtest.InspectImage(helpers, testutil.CommonImage)
@@ -264,7 +264,7 @@ func TestRemove(t *testing.T) {
 				require.Not(nerdtest.Docker),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("kill", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -287,7 +287,7 @@ func TestRemove(t *testing.T) {
 			Description: "Remove image with killed container - with -f",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("run", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("run", "--quiet", "--pull", "always", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
 				helpers.Ensure("kill", data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -321,8 +321,8 @@ func TestIssue3016(t *testing.T) {
 		{
 			Description: "Issue #3016 - Tags created using the short digest ids of container images cannot be deleted using the nerdctl rmi command.",
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.CommonImage)
-				helpers.Ensure("pull", testutil.NginxAlpineImage)
+				helpers.Ensure("pull", "--quiet", testutil.CommonImage)
+				helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
 
 				img := nerdtest.InspectImage(helpers, testutil.NginxAlpineImage)
 				repoName, _ := imgutil.ParseRepoTag(testutil.NginxAlpineImage)
@@ -374,7 +374,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			Description: "After removing the tag without kube-hide-dupe, repodigest is shown as <none>",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.BusyboxImage)
+				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)
 			},
 			Command: test.Command("rmi", "-f", testutil.BusyboxImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -405,7 +405,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 				helpers.Anyhow("--kube-hide-dupe", "rmi", data.Identifier())
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.BusyboxImage)
+				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)
 				helpers.Ensure("tag", testutil.BusyboxImage, data.Identifier())
 			},
 			Command: test.Command("--kube-hide-dupe", "rmi", testutil.BusyboxImage),
@@ -434,7 +434,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			Description: "After deleting all repo:tag entries, all repodigests will be cleaned up",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.BusyboxImage)
+				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)
 				helpers.Ensure("tag", testutil.BusyboxImage, data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
@@ -464,7 +464,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			Description: "Test multiple IDs found with provided prefix and force with shortID",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.BusyboxImage)
+				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)
 				helpers.Ensure("tag", testutil.BusyboxImage, data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
@@ -494,7 +494,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			Description: "Test remove image with digestID",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("pull", testutil.BusyboxImage)
+				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)
 				helpers.Ensure("tag", testutil.BusyboxImage, data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {

--- a/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
@@ -66,7 +66,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)))
-				helpers.Ensure("pull", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
+				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
 				data.Set(mainImageCIDKey, ipfsCID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -89,7 +89,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)), "--estargz")
-				helpers.Ensure("pull", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
+				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
 				data.Set(mainImageCIDKey, ipfsCID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -54,7 +54,7 @@ func TestIPFSSimple(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				if data.Get(mainImageCIDKey) != "" {
@@ -75,7 +75,7 @@ func TestIPFSSimple(t *testing.T) {
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
-				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				if data.Get(mainImageCIDKey) != "" {
@@ -92,7 +92,7 @@ func TestIPFSSimple(t *testing.T) {
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
 				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
@@ -104,7 +104,7 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("rmi", data.Identifier("commit-image"))
 
 				// Pull back the committed image
-				helpers.Ensure("pull", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier("commit-container"))
@@ -130,7 +130,7 @@ func TestIPFSSimple(t *testing.T) {
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
-				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
 				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
@@ -142,7 +142,7 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("rmi", data.Identifier("commit-image"))
 
 				// Pull back the image
-				helpers.Ensure("pull", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier("commit-container"))
@@ -165,7 +165,7 @@ func TestIPFSSimple(t *testing.T) {
 			Require:     require.Binary("openssl"),
 			Setup: func(data test.Data, helpers test.Helpers) {
 				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "ipfs://"+data.Get(mainImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
 
 				// Prep a key pair
 				keyPair := testhelpers.NewJWEKeyPair(t)
@@ -193,7 +193,7 @@ func TestIPFSSimple(t *testing.T) {
 				helpers.Ensure("rmi", "-f", data.Get(transformedImageCIDKey))
 
 				// Pull back without unpacking
-				helpers.Ensure("pull", "--unpack=false", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "--unpack=false", "ipfs://"+data.Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				if data.Get(mainImageCIDKey) != "" {

--- a/cmd/nerdctl/issues/issues_linux_test.go
+++ b/cmd/nerdctl/issues/issues_linux_test.go
@@ -52,10 +52,10 @@ func TestIssue3425(t *testing.T) {
 				Require:     nerdtest.Private,
 				Setup: func(data test.Data, helpers test.Helpers) {
 					identifier := data.Identifier()
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage)
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("tag", testutil.CommonImage, fmt.Sprintf("localhost:%d/%s", reg.Port, identifier))
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -73,10 +73,10 @@ func TestIssue3425(t *testing.T) {
 				Require:     nerdtest.Private,
 				Setup: func(data test.Data, helpers test.Helpers) {
 					identifier := data.Identifier()
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("run", "-d", "--name", identifier, testutil.CommonImage, "touch", "/something")
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("commit", identifier, fmt.Sprintf("localhost:%d/%s", reg.Port, identifier))
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -92,10 +92,10 @@ func TestIssue3425(t *testing.T) {
 				Description: "with save",
 				Require:     nerdtest.Private,
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rm", "-f", data.Identifier())
@@ -113,10 +113,10 @@ func TestIssue3425(t *testing.T) {
 					require.Not(nerdtest.Docker),
 				),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rm", "-f", data.Identifier())
@@ -136,10 +136,10 @@ func TestIssue3425(t *testing.T) {
 					require.Not(nerdtest.Docker),
 				),
 				Setup: func(data test.Data, helpers test.Helpers) {
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 					helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage)
 					helpers.Ensure("image", "rm", "-f", testutil.CommonImage)
-					helpers.Ensure("image", "pull", testutil.CommonImage)
+					helpers.Ensure("image", "pull", "--quiet", testutil.CommonImage)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rm", "-f", data.Identifier())


### PR DESCRIPTION
pull output is very loud and makes debugging much harder.

This PR does mute pull output in most tests.