### PR TITLE
Remove WORKAROUND_ISSUE_622 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,6 @@ jobs:
             containerd: v1.6.36
             arch: amd64
           - runner: ubuntu-24.04
-            containerd: v1.7.25
-            arch: amd64
-          - runner: ubuntu-24.04
             containerd: v2.0.3
             arch: amd64
           - runner: ubuntu-24.04-arm
@@ -106,7 +103,7 @@ jobs:
       matrix:
         include:
           - ubuntu: 22.04
-            containerd: v1.7.25
+            containerd: v1.6.36
             runner: "ubuntu-22.04"
             arch: amd64
           - ubuntu: 24.04
@@ -115,7 +112,7 @@ jobs:
             arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.3
-            runner: ubuntu-24.04-arm
+            runner: "ubuntu-24.04-arm"
             arch: arm64
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
@@ -219,26 +216,35 @@ jobs:
     needs: build-dependencies
     timeout-minutes: 40
     name: "${{ matrix.target }} | ${{ matrix.containerd }} | ${{ matrix.rootlesskit }} | ${{ matrix.ubuntu }}"
-    runs-on: "ubuntu-${{ matrix.ubuntu }}"
+    runs-on: "${{ matrix.runner }}"
     strategy:
       fail-fast: false
       matrix:
         include:
           - ubuntu: 22.04
-            containerd: v1.7.25
+            containerd: v1.6.36
             rootlesskit: v1.1.1  # Deprecated
             target: rootless
+            runner: "ubuntu-22.04"
             arch: amd64
           - ubuntu: 24.04
             containerd: v2.0.3
             rootlesskit: v2.3.2
             target: rootless
             arch: amd64
+            runner: "ubuntu-24.04"
           - ubuntu: 24.04
-            containerd: v1.7.25
+            containerd: v2.0.3
+            rootlesskit: v2.3.2
+            target: rootless
+            arch: arm64
+            runner: "ubuntu-24.04-arm"
+          - ubuntu: 24.04
+            containerd: v2.0.3
             rootlesskit: v2.3.2
             target: rootless-port-slirp4netns
             arch: amd64
+            runner: "ubuntu-24.04"
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
       ARCH: "${{ matrix.arch }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,18 +288,10 @@ jobs:
             --output=type=docker \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
-      - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
-        run: |
-          # https://github.com/containerd/nerdctl/issues/622
-          WORKAROUND_ISSUE_622=
-          if echo "${ROOTLESSKIT_VERSION}" | grep -q v1; then
-            WORKAROUND_ISSUE_622=1
-          fi
-          echo "WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622}" >> "$GITHUB_ENV"
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false
+        run: docker run -t --rm --privileged ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false
       - name: "Test (network driver=slirp4netns, port driver=builtin) (flaky)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true
+        run: docker run -t --rm --privileged ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true
 
   build:
     timeout-minutes: 5

--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -25,11 +25,6 @@ if [[ "$(id -u)" = "0" ]]; then
 		nerdctl apparmor load
 	fi
 
-	: "${WORKAROUND_ISSUE_622:=}"
-	if [[ "$WORKAROUND_ISSUE_622" = "1" ]]; then
-		touch /workaround-issue-622
-	fi
-
 	# Switch to the rootless user via SSH
 	systemctl start ssh
 	exec ssh -o StrictHostKeyChecking=no rootless@localhost "$0" "$@"
@@ -39,11 +34,7 @@ else
 		containerd-rootless-setuptool.sh nsenter -- sh -euc 'echo "options use-vc" >>/etc/resolv.conf'
 	fi
 
-	if [[ -e /workaround-issue-622 ]]; then
-		echo "WORKAROUND_ISSUE_622: Not enabling BuildKit (https://github.com/containerd/nerdctl/issues/622)" >&2
-	else
-		CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-setuptool.sh install-buildkit-containerd
-	fi
+	CONTAINERD_NAMESPACE="nerdctl-test" containerd-rootless-setuptool.sh install-buildkit-containerd
 	containerd-rootless-setuptool.sh install-stargz
 	if [ ! -f "/home/rootless/.config/containerd/config.toml" ] ; then
 		echo "version = 2" > /home/rootless/.config/containerd/config.toml


### PR DESCRIPTION
On top of #3973 

We no longer test rootlesskit v1 + slirp4netns (actually, we haven't for a while), so this hack is presumably no longer necessary.