### PR TITLE
Increase wait for ensurecontainerstarted

### DIFF
--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -97,7 +97,7 @@ func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
 }
 
 const (
-	maxRetry = 10
+	maxRetry = 20
 	sleep    = time.Second
 )
 


### PR DESCRIPTION
On EL8, TestStop is supposedly failing to bring up containers in time.

https://github.com/containerd/nerdctl/actions/runs/13648882661/job/38152811978?pr=3976#step:11:2044

This increases the timeout.