### PR TITLE
CI, build 1: disable buildx output for dependency stage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --output=type=docker \
             --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .


### PR DESCRIPTION
**For context, see #3940, #3924, and the start of this PR cycle at #3983.**

This is the first PR in a series to reduce build time and increase reliability.

**These PRs are broken down in digestible size from a large PR on my fork to ease review.**

-------

The dependencies stage purpose is solely to save cacheable stages into GHA.

There is no reason to load the image into docker store at this point.

The cost of this (useless) operation is about 40 seconds (out of 1 minute 20 seconds for that stage on a warm cache - or ~6 minutes on a cold cache).