### PR TITLE
CI, build 2: Move GHA to zstd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-to type=gha,compression=zstd,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 


### PR DESCRIPTION
**For context, see #3940, #3924, and the start of this PR cycle at #3983.**

On top of #3983

--------

This moves caching to zstd.

Given the bottleneck with gha is IO and not compute, this is not likely to have an impact on speed - but it will on cache size.