### PR TITLE
CI, build 4: Cleanup Dockerfile base images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-to type=gha,compression=zstd,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --output=type=docker \
             --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --cache-to type=gha,compression=zstd,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-to type=gha,compression=zstd,mode=max,scope=test-integration-dependencies-${ARCH} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 
   test-unit:
@@ -128,7 +128,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
@@ -186,7 +186,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
@@ -285,7 +285,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
         run: |


### PR DESCRIPTION
**For context, see #3940, #3924, and the start of this PR cycle at #3983.**

On top of #3985 

--------------

We currently depend on two distincts golang image (bookworm and alpine), and we also download a golang archive from go servers.

Depending at all on docker images is a significant source of issues:
- there is delay between availability of go version and availability of go images on the hub - this has regularly broken canary in the past (currently is broken (*))
- go images on the hub have their own versioning scheme that is different from golang's, requiring us to do some shell monkeying to convert one version to the other
- hitting the Hub often leads to the dreaded 429 (too many requests)
- the hub image adds no visible value on top of the archive that we are downloading anyways...

This PR does cleanup our base images.

It bases every build stage on a single image, a naked bookworm, and uses the golang version of go.

That will reduce our network traffic with Hub, improve cacheability, and make our life less miserable when new versions of go arrive.

Finally, this will drastically reduce network com with go servers, as currently the archive is never cached and always downloaded, for every target we build. There should be a speed boost out of that for the later build stages.

(*) this PR does fix the current canary bustage