### PR TITLE
CI, build 5: Extract cacheable part of runtime image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-to type=gha,compression=zstd,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,6 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --output=type=docker \
             --cache-to type=gha,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
             --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           docker buildx create --name with-gha --use
           docker buildx build \
-            --cache-to type=gha,compression=zstd,mode=max,scope=${ARCH}-${CONTAINERD_VERSION} \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-to type=gha,compression=zstd,mode=max,scope=test-integration-dependencies-${ARCH} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 
   test-unit:
@@ -128,7 +128,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
@@ -186,7 +186,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t test-integration --target test-integration --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
       - name: "Remove snap loopback devices (conflicts with our loopback devices in TestRunDevice)"
         run: |
@@ -285,7 +285,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=${ARCH}-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-${ARCH} \
             -t ${TEST_TARGET} --target ${TEST_TARGET} --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} --build-arg ROOTLESSKIT_VERSION=${ROOTLESSKIT_VERSION} .
       - name: "Disable BuildKit for RootlessKit v1 (workaround for issue #622)"
         run: |


### PR DESCRIPTION
For context, see #3924, and the start of this PR cycle at #3983.

On top of #3986

-------

Currently, we do not cache at all the runtime image.

So, for every supported target, at every run, we download ubuntu:24.04 from docker hub, then a bunch of packages from ubuntu servers.

This PR addresses that by extracting the cacheable part.

We should see a good speed-up on the later build stage, a significant decrease in our communications with Hub and Ubuntu repos, at the cost of a larger cache.

Note that these benefits will NOT be seen until a later PR, as getting this stage into the `dependencies` pipeline requires more modifications on other stages,