### PR TITLE
Remove golanci-lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,8 +35,6 @@ jobs:
             goos: linux
             # This allows the canary script to select any upcoming golang alpha/beta/RC
             canary: go-canary
-    env:
-      GOOS: "${{ matrix.goos }}"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -52,12 +50,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
+      - name: install required linters and dev-tools
+        run: |
+          make install-dev-tools
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837  # v6.5.0
-        with:
-          args: --verbose
-          # See https://github.com/containerd/nerdctl/issues/3914
-          verify: false
+        run: |
+          NO_COLOR=true GOOS="${{ matrix.goos }}" make lint-go
   other:
     timeout-minutes: 5
     name: yaml | shell | imports order


### PR DESCRIPTION
Fix #3761 

Depending on the action means depending on a precompiled version of golangci-lint that is incompatible with updated golang versions. Alternatively, the action offers to build it from source, but unfortunately, the specified GOOS has to apply for both the compilation and verification stages, which does not work here as we want to be able to lint for non-native GOOS.

The action also performs additional steps (--verify) that are unnecessary to us and have been a source of issues in the past.

Finally, golangci-lint version has to be maintained in two distinct places:
- local developer environment (canonically defined in the Makefile)
- github CI side (updated by dependabot)

Removing the action in favor of calling `make install-dev-tools` will fix these issues and make local/CI more consistent for developers.

I do appreciate that in the past we have been unwilling to remove dependencies on third-party (actions) and own setup instead, so, let me know your thoughts here, especially if you folks think this is worth it or not.