### PR TITLE
fix: none log driver creating log uri

### DIFF
--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -330,3 +330,18 @@ func TestTailFollowRotateLogs(t *testing.T) {
 	}
 	assert.Equal(t, true, len(tailLogs) > linesPerFile, logRun.Stderr())
 }
+func TestNoneLoggerHasNoLogURI(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "--name", data.Identifier(), "--log-driver", "none", testutil.CommonImage, "sh", "-euxc", "echo foo")
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("logs", data.Identifier())
+	}
+	testCase.Expected = test.Expects(1, nil, nil)
+	testCase.Run(t)
+}

--- a/pkg/cioutil/container_io.go
+++ b/pkg/cioutil/container_io.go
@@ -148,7 +148,7 @@ func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, 
 			stderrWriters = append(stderrWriters, stderr)
 		}
 
-		if runtime.GOOS != "windows" {
+		if runtime.GOOS != "windows" && logURI != "" && logURI != "none" {
 			// starting logging binary logic is from https://github.com/containerd/containerd/blob/194a1fdd2cde35bc019ef138f30485e27fe0913e/cmd/containerd-shim-runc-v2/process/io.go#L247
 			stdoutr, stdoutw, err := os.Pipe()
 			if err != nil {

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -885,7 +885,7 @@ func writeCIDFile(path, id string) error {
 // generateLogConfig creates a LogConfig for the current container store
 func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
-	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
+	if u, err = url.Parse(logDriver); err == nil && (u.Scheme != "" || logDriver == "none") {
 		logConfig.LogURI = logDriver
 	} else {
 		logConfig.Driver = logDriver

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -121,7 +121,7 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			}
 		}
 		ioCreator = cioutil.NewContainerIO(namespace, logURI, true, in, os.Stdout, os.Stderr)
-	} else if flagD && logURI != "" {
+	} else if flagD && logURI != "" && logURI != "none" {
 		u, err := url.Parse(logURI)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fix for Issue: https://github.com/containerd/nerdctl/issues/3895

Description:
The log driver none was creating a logURI. In this case we handle it via setting the log driver to none and escaping starting the logging binary for cases where we have set the driver as none.

Another option was to set logURI to "" in case of none but there are hard coded checks to default the log driver to json in that case avoided refactoring that. 