### PR TITLE
add env and user to inspect in dockercompat

### DIFF
--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -561,6 +561,11 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		return nil, fmt.Errorf("failed to get blkio settings: %w", err)
 	}
 
+	if n.Spec != nil {
+		if spec, ok := n.Spec.(*specs.Spec); ok && spec.Process != nil {
+			c.Config.Env = spec.Process.Env
+		}
+	}
 	return c, nil
 }
 

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -566,6 +566,11 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 			c.Config.Env = spec.Process.Env
 		}
 	}
+
+	if n.Labels[labels.User] != "" {
+		c.Config.User = n.Labels[labels.User]
+	}
+
 	return c, nil
 }
 

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -57,7 +57,11 @@ func TestContainerFromNative(t *testing.T) {
 						"nerdctl/hostname":  "host1",
 					},
 				},
-				Spec: &specs.Spec{},
+				Spec: &specs.Spec{
+					Process: &specs.Process{
+						Env: []string{"/some/path"},
+					},
+				},
 				Process: &native.Process{
 					Pid: 10000,
 					Status: containerd.Status{
@@ -103,6 +107,7 @@ func TestContainerFromNative(t *testing.T) {
 						"nerdctl/hostname":  "host1",
 					},
 					Hostname: "host1",
+					Env:      []string{"/some/path"},
 				},
 				NetworkSettings: &NetworkSettings{
 					Ports:    &nat.PortMap{},

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -55,6 +55,7 @@ func TestContainerFromNative(t *testing.T) {
 						"nerdctl/mounts":    "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
 						"nerdctl/state-dir": tempStateDir,
 						"nerdctl/hostname":  "host1",
+						"nerdctl/user":      "test-user",
 					},
 				},
 				Spec: &specs.Spec{
@@ -105,9 +106,11 @@ func TestContainerFromNative(t *testing.T) {
 						"nerdctl/mounts":    "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
 						"nerdctl/state-dir": tempStateDir,
 						"nerdctl/hostname":  "host1",
+						"nerdctl/user":      "test-user",
 					},
 					Hostname: "host1",
 					Env:      []string{"/some/path"},
+					User:     "test-user",
 				},
 				NetworkSettings: &NetworkSettings{
 					Ports:    &nat.PortMap{},

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -115,4 +115,7 @@ const (
 
 	// DNSSettings sets the dockercompat DNS config values
 	DNSSetting = Prefix + "dns"
+
+	// User is the username of the container
+	User = Prefix + "user"
 )


### PR DESCRIPTION
Issue:
Docker Compat Inspect doesn't have Env and User parameter for the process

Description:
This PR adds Env and User for the docker compat inspect

Test:
1. Before adding the Env
```
   "Config": {
            "Hostname": "8ef7e6dbae24",
            "AttachStdin": false,
            "Labels": {
                "dev.containers.id": "base-alpine",
                "dev.containers.release": "v0.4.10",
}
```

2. After adding the Env:
```
    "Config": {
      "Hostname": "08826b4795c7",
      "AttachStdin": false,
      "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "HOSTNAME=08826b4795c7"
      ],
  "Labels": {
        "dev.containers.id": "base-alpine",
        "dev.containers.release": "v0.4.10",

}
```

---

1. Before adding the User
```
   "Config": {
            "Hostname": "8ef7e6dbae24",
            "AttachStdin": false,
            "Labels": {
                "dev.containers.id": "base-alpine",
                "dev.containers.release": "v0.4.10",
}
```

2. After adding the User
```
 "Config": {
            "Hostname": "5dceef466aa1",
            "User": "test",
            "AttachStdin": false,
            "Env": [
                "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "HOSTNAME=5dceef466aa1"
            ],
            "Labels": {
                "devcontainer.config_file": "/Users/shubhum/Documents/devcontainers/.devcontainer/devcontainer.json",
                "devcontainer.local_folder": "/Users/shubhum/Documents/devcontainers",
                }

```