### PR TITLE
feat: add --details flag to logs command

### DIFF
--- a/cmd/nerdctl/container/container_logs.go
+++ b/cmd/nerdctl/container/container_logs.go
@@ -53,6 +53,7 @@ The following containers are supported:
 	cmd.Flags().StringP("tail", "n", "all", "Number of lines to show from the end of the logs")
 	cmd.Flags().String("since", "", "Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
 	cmd.Flags().String("until", "", "Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)")
+	cmd.Flags().Bool("details", false, "Show extra details provided to logs")
 	return cmd
 }
 
@@ -88,6 +89,10 @@ func logsOptions(cmd *cobra.Command) (types.ContainerLogsOptions, error) {
 	if err != nil {
 		return types.ContainerLogsOptions{}, err
 	}
+	details, err := cmd.Flags().GetBool("details")
+	if err != nil {
+		return types.ContainerLogsOptions{}, err
+	}
 	return types.ContainerLogsOptions{
 		Stdout:     cmd.OutOrStdout(),
 		Stderr:     cmd.OutOrStderr(),
@@ -97,6 +102,7 @@ func logsOptions(cmd *cobra.Command) (types.ContainerLogsOptions, error) {
 		Tail:       tail,
 		Since:      since,
 		Until:      until,
+		Details:    details,
 	}, nil
 }
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -328,8 +328,12 @@ Logging flags:
       - :nerd_face: `--log-opt=log-path=<LOG-PATH>`: The log path where the logs are written. The path will be created if it does not exist. If the log file exists, the old file will be renamed to `<LOG-PATH>.1`.
         - Default: `<data-root>/<containerd-socket-hash>/<namespace>/<container-id>/<container-id>-json.log`
         - Example: `/var/lib/nerdctl/1935db59/containers/default/<container-id>/<container-id>-json.log`
+      - :whale: `--log-opt labels=production_status,geo`: A comma-separated list of logging-related labels this daemon accepts.
+      - :whale: `--log-opt env=os,customer`: A comma-separated list of logging-related environment variables this daemon accepts.
   - :whale: `--log-driver=journald`: Writes log messages to `journald`. The `journald` daemon must be running on the host machine.
     - :whale: `--log-opt=tag=<TEMPLATE>`: Specify template to set `SYSLOG_IDENTIFIER` value in journald logs.
+    - :whale: `--log-opt labels=production_status,geo`: A comma-separated list of logging-related labels this daemon accepts.
+    - :whale: `--log-opt env=os,customer`: A comma-separated list of logging-related environment variables this daemon accepts.
   - :whale: `--log-driver=fluentd`: Writes log messages to `fluentd`. The `fluentd` daemon must be running on the host machine.
     - The `fluentd` logging driver supports the following logging options:
       - :whale: `--log-opt=fluentd-address=<ADDRESS>`: The address of the `fluentd` daemon, tcp(default) and unix sockets are supported..
@@ -542,13 +546,12 @@ Usage: `nerdctl logs [OPTIONS] CONTAINER`
 
 Flags:
 
+- :whale: `--details`: Show extra details provided to logs
 - :whale: `-f, --follow`: Follow log output
 - :whale: `--since`: Show logs since timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
 - :whale: `--until`: Show logs before a timestamp (e.g. 2013-01-02T13:23:37Z) or relative (e.g. 42m for 42 minutes)
 - :whale: `-t, --timestamps`: Show timestamps
 - :whale: `-n, --tail`: Number of lines to show from the end of the logs (default "all")
-
-Unimplemented `docker logs` flags: `--details`
 
 ### :whale: nerdctl port
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -404,6 +404,8 @@ type ContainerLogsOptions struct {
 	Since string
 	// Show logs before a timestamp (e.g., 2013-01-02T13:23:37Z) or relative (e.g., 42m for 42 minutes).
 	Until string
+	// Details specifies whether to show extra details provided to logs
+	Details bool
 }
 
 // ContainerWaitOptions specifies options for `nerdctl (container) wait`.

--- a/pkg/logging/detail_writer.go
+++ b/pkg/logging/detail_writer.go
@@ -1,0 +1,42 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import "io"
+
+type DetailWriter struct {
+	w      io.Writer
+	prefix string
+}
+
+func NewDetailWriter(w io.Writer, prefix string) io.Writer {
+	return &DetailWriter{
+		w:      w,
+		prefix: prefix,
+	}
+}
+
+func (dw *DetailWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 {
+		if _, err = dw.w.Write([]byte(dw.prefix)); err != nil {
+			return 0, err
+		}
+
+		return dw.w.Write(p)
+	}
+	return 0, nil
+}

--- a/pkg/logging/journald_logger.go
+++ b/pkg/logging/journald_logger.go
@@ -43,6 +43,8 @@ import (
 
 var JournalDriverLogOpts = []string{
 	Tag,
+	Env,
+	Labels,
 }
 
 func JournalLogOptsValidate(logOptMap map[string]string) error {

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -42,6 +42,8 @@ var JSONDriverLogOpts = []string{
 	LogPath,
 	MaxSize,
 	MaxFile,
+	Env,
+	Labels,
 }
 
 type JSONLogger struct {

--- a/pkg/logging/log_viewer.go
+++ b/pkg/logging/log_viewer.go
@@ -82,6 +82,12 @@ type LogViewOptions struct {
 	// Start/end timestampts to filter logs by.
 	Since string
 	Until string
+
+	// Details enables showing extra details(env and label) in logs.
+	Details bool
+
+	// DetailPrefix is the prefix added when Details is enabled.
+	DetailPrefix *string
 }
 
 func (lvo *LogViewOptions) Validate() error {
@@ -150,6 +156,14 @@ func InitContainerLogViewer(containerLabels map[string]string, lvopts LogViewOpt
 
 // Prints all logs for this LogViewer's containers to the provided io.Writers.
 func (lv *ContainerLogViewer) PrintLogsTo(stdout, stderr io.Writer) error {
+	if lv.logViewingOptions.Details {
+		if lv.logViewingOptions.DetailPrefix != nil {
+			prefix := *lv.logViewingOptions.DetailPrefix + " "
+			stdout = NewDetailWriter(stdout, prefix)
+			stderr = NewDetailWriter(stderr, prefix)
+		}
+
+	}
 	viewerFunc, err := getLogViewer(lv.loggingConfig.Driver)
 	if err != nil {
 		return err

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -48,6 +48,8 @@ const (
 	MaxSize    = "max-size"
 	MaxFile    = "max-file"
 	Tag        = "tag"
+	Env        = "env"
+	Labels     = "labels"
 )
 
 type Driver interface {


### PR DESCRIPTION
## Description
Implements the `--details` flag for `nerdctl logs` to display log options(`env` and `labels`) as a prefix to each log line. 

## Test

**json-file**
```
nerdctl run -d \
  --name json-file-details \
  --log-driver json-file \
  --log-opt env=foo \
  --log-opt env=os,customer \
  --log-opt labels=production_status,geo \
  --log-opt labels=bar \
  --label geo=GEO \
  --env customer=CUSTOMER \
  --env os=OS \
  --label bar=BAR \
  --env foo=FOO \
  busybox sh -c "echo 'This is a test message'"

nerdctl logs --details json-file-details
bar=BAR,customer=CUSTOMER,os=OS This is a test message
```

**journald**
```
nerdctl run -d \
  --name journald-details \
  --log-driver json-file \
  --log-opt env=foo \
  --log-opt env=os,customer \
  --log-opt labels=production_status,geo \
  --log-opt labels=bar \
  --label geo=GEO \
  --env customer=CUSTOMER \
  --env os=OS \
  --label bar=BAR \
  --env foo=FOO \
  busybox sh -c "echo 'This is a test message'"

nerdctl logs --details journald-details
bar=BAR,customer=CUSTOMER,os=OS This is a test message
```