### PR TITLE
fix nerdctl ps show nothing when timeout

### DIFF
--- a/cmd/nerdctl/compose/compose_ps.go
+++ b/cmd/nerdctl/compose/compose_ps.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -345,10 +344,6 @@ func formatPublishers(labelMap map[string]string) []PortPublisher {
 
 // statusForFilter returns the status value to be matched with the 'status' filter
 func statusForFilter(ctx context.Context, c containerd.Container) string {
-	// Just in case, there is something wrong in server.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	task, err := c.Task(ctx, nil)
 	if err != nil {
 		// NOTE: NotFound doesn't mean that container hasn't started.

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -86,10 +86,6 @@ func PrintHostPort(ctx context.Context, writer io.Writer, container containerd.C
 
 // ContainerStatus returns the container's status from its task.
 func ContainerStatus(ctx context.Context, c containerd.Container) (containerd.Status, error) {
-	// Just in case, there is something wrong in server.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
 	task, err := c.Task(ctx, nil)
 	if err != nil {
 		return containerd.Status{}, err

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -39,11 +39,7 @@ import (
 )
 
 func ContainerStatus(ctx context.Context, c containerd.Container) string {
-	// Just in case, there is something wrong in server.
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 	titleCaser := cases.Title(language.English)
-
 	task, err := c.Task(ctx, nil)
 	if err != nil {
 		// NOTE: NotFound doesn't mean that container hasn't started.


### PR DESCRIPTION
```
[root@RISC-v-test-minion-0-1 nmx]# nerdctl  -n k8s.io ps
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES
```
containerd many log
```
Mar 17 15:40:42 RISC-v-test-minion-0-1 containerd[2922522]: time="2025-03-17T15:40:41.993695418+08:00" level=error msg="get state for 6366492fc9778f66e90c228faee9154484d8cd6c0440eb1770bd91c93a60eeb1" error="context canceled: unknown


```