### PR TITLE
go.mod: experimental integration of gomodjail (library sandbox)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 # artifacts
 /nerdctl
 _output
+*.gomodjail
 
 # golangci-lint
 /build

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -197,7 +197,7 @@ jobs:
   test-integration-rootless:
     needs: build-dependencies
     timeout-minutes: 40
-    name: "${{ matrix.target }} | ${{ matrix.containerd }} | ${{ matrix.rootlesskit }} | ${{ matrix.ubuntu }}"
+    name: "${{ matrix.target }} | ${{ matrix.containerd }} | ${{ matrix.rootlesskit }} | ${{ matrix.ubuntu }} || ${{ matrix.nerdctl }}"
     runs-on: "${{ matrix.runner }}"
     strategy:
       fail-fast: false
@@ -209,30 +209,47 @@ jobs:
             target: rootless
             runner: "ubuntu-22.04"
             arch: amd64
+            nerdctl: ""
+            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless
             arch: amd64
             runner: "ubuntu-24.04"
+            nerdctl: ""
+            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless
             arch: arm64
             runner: "ubuntu-24.04-arm"
+            nerdctl: ""
+            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless-port-slirp4netns
             arch: amd64
             runner: "ubuntu-24.04"
+            nerdctl: ""
+            comment: ""
+          - ubuntu: 24.04
+            containerd: v2.0.5
+            rootlesskit: v2.3.4
+            target: rootless
+            arch: amd64
+            runner: "ubuntu-24.04"
+            nerdctl: "nerdctl.gomodjail"
+            comment: "Flaky, not a blocker for merging PRs"
     env:
       CONTAINERD_VERSION: "${{ matrix.containerd }}"
       ARCH: "${{ matrix.arch }}"
       UBUNTU_VERSION: "${{ matrix.ubuntu }}"
       ROOTLESSKIT_VERSION: "${{ matrix.rootlesskit }}"
       TEST_TARGET: "test-integration-${{ matrix.target }}"
+      NERDCTL: "${{ matrix.nerdctl }}"
     steps:
       - name: "Set up AppArmor"
         if: matrix.ubuntu == '24.04'
@@ -279,9 +296,10 @@ jobs:
           fi
           echo "WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622}" >> "$GITHUB_ENV"
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false
+        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} -e NERDCTL=${NERDCTL} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false
       - name: "Test (network driver=slirp4netns, port driver=builtin) (flaky)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true
+        if: matrix.nerdctl != 'nerdctl.gomodjail'
+        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} -e NERDCTL=${NERDCTL} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true
 
   test-integration-docker-compatibility:
     timeout-minutes: 40

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # artifacts
 /nerdctl
 _output
+*.gomodjail
 
 # golangci-lint
 /build

--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -15,6 +15,7 @@
 #   limitations under the License.
 
 set -eux -o pipefail
+: "${NERDCTL:=}"
 if [[ "$(id -u)" = "0" ]]; then
   # Ensure securityfs is mounted for apparmor to work
   if ! mountpoint -q /sys/kernel/security; then
@@ -32,7 +33,7 @@ if [[ "$(id -u)" = "0" ]]; then
 
 	# Switch to the rootless user via SSH
 	systemctl start ssh
-	exec ssh -o StrictHostKeyChecking=no rootless@localhost "$0" "$@"
+	exec ssh -o StrictHostKeyChecking=no rootless@localhost NERDCTL="$NERDCTL" "$0" "$@"
 else
 	containerd-rootless-setuptool.sh install
 	if grep -q "options use-vc" /etc/resolv.conf; then
@@ -63,5 +64,5 @@ EOF
 	# Once ssh-ed, we lost the Dockerfile working dir, so, get back in the nerdctl checkout
 	cd /go/src/github.com/containerd/nerdctl
 	# We also lose the PATH (and SendEnv=PATH would require sshd config changes)
-	exec env PATH="/usr/local/go/bin:$PATH" "$@"
+	exec env PATH="/usr/local/go/bin:$PATH" NERDCTL="$NERDCTL" "$@"
 fi

--- a/cmd/nerdctl/builder/builder_builder_test.go
+++ b/cmd/nerdctl/builder/builder_builder_test.go
@@ -133,7 +133,8 @@ CMD ["echo", "nerdctl-test-builder-prune"]`, testutil.CommonImage)
 			{
 				Description: "Debug",
 				// `nerdctl builder debug` is currently incompatible with `docker buildx debug`.
-				Require:    require.All(require.Not(nerdtest.Docker)),
+				// FIXME: fails with gomodjail: "timed out to access cache storage. other debug session is running?"
+				Require:    require.All(require.Not(nerdtest.Docker), require.Not(nerdtest.Gomodjail)),
 				NoParallel: true,
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					dockerfile := fmt.Sprintf(`FROM %s

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -128,6 +129,8 @@ func TestRestartWithTime(t *testing.T) {
 
 func TestRestartWithSignal(t *testing.T) {
 	testCase := nerdtest.Setup()
+
+	testCase.Require = require.Not(nerdtest.Gomodjail) // FIXME
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("rm", "-f", data.Identifier())

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -34,6 +34,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
@@ -381,6 +382,7 @@ func TestRunTTY(t *testing.T) {
 
 func TestRunSigProxy(t *testing.T) {
 	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Gomodjail) // FIXME
 
 	testCase.SubTests = []*test.Case{
 		{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+//gomodjail:confined
 module github.com/containerd/nerdctl/v2
 
 go 1.23.0
@@ -6,65 +7,65 @@ require (
 	github.com/Masterminds/semver/v3 v3.3.1
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/Microsoft/hcsshim v0.12.9
-	github.com/compose-spec/compose-go/v2 v2.6.1
+	github.com/compose-spec/compose-go/v2 v2.6.1 //gomodjail:unconfined
 	github.com/containerd/accelerated-container-image v1.3.0
-	github.com/containerd/cgroups/v3 v3.0.5
-	github.com/containerd/console v1.0.4
+	github.com/containerd/cgroups/v3 v3.0.5 //gomodjail:unconfined
+	github.com/containerd/console v1.0.4 //gomodjail:unconfined
 	github.com/containerd/containerd/api v1.8.0
-	github.com/containerd/containerd/v2 v2.0.5
-	github.com/containerd/continuity v0.4.5
+	github.com/containerd/containerd/v2 v2.0.5 //gomodjail:unconfined
+	github.com/containerd/continuity v0.4.5 //gomodjail:unconfined
 	github.com/containerd/errdefs v1.0.0
-	github.com/containerd/fifo v1.1.0
-	github.com/containerd/go-cni v1.1.12
-	github.com/containerd/imgcrypt/v2 v2.0.1
+	github.com/containerd/fifo v1.1.0 //gomodjail:unconfined
+	github.com/containerd/go-cni v1.1.12 //gomodjail:unconfined
+	github.com/containerd/imgcrypt/v2 v2.0.1 //gomodjail:unconfined
 	github.com/containerd/log v0.1.0
 	github.com/containerd/nerdctl/mod/tigron v0.0.0
-	github.com/containerd/nydus-snapshotter v0.15.1
-	github.com/containerd/platforms v1.0.0-rc.1
-	github.com/containerd/stargz-snapshotter v0.16.3
-	github.com/containerd/stargz-snapshotter/estargz v0.16.3
-	github.com/containerd/stargz-snapshotter/ipfs v0.16.3
+	github.com/containerd/nydus-snapshotter v0.15.1 //gomodjail:unconfined
+	github.com/containerd/platforms v1.0.0-rc.1 //gomodjail:unconfined
+	github.com/containerd/stargz-snapshotter v0.16.3 //gomodjail:unconfined
+	github.com/containerd/stargz-snapshotter/estargz v0.16.3 //gomodjail:unconfined
+	github.com/containerd/stargz-snapshotter/ipfs v0.16.3 //gomodjail:unconfined
 	github.com/containerd/typeurl/v2 v2.2.3
-	github.com/containernetworking/cni v1.3.0
-	github.com/containernetworking/plugins v1.7.1
+	github.com/containernetworking/cni v1.3.0 //gomodjail:unconfined
+	github.com/containernetworking/plugins v1.7.1 //gomodjail:unconfined
 	github.com/coreos/go-iptables v0.8.0
 	github.com/coreos/go-systemd/v22 v22.5.0
-	github.com/cyphar/filepath-securejoin v0.4.1
+	github.com/cyphar/filepath-securejoin v0.4.1 //gomodjail:unconfined
 	github.com/distribution/reference v0.6.0
-	github.com/docker/cli v28.1.1+incompatible
-	github.com/docker/docker v28.1.1+incompatible
+	github.com/docker/cli v28.1.1+incompatible //gomodjail:unconfined
+	github.com/docker/docker v28.1.1+incompatible //gomodjail:unconfined
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
-	github.com/fahedouch/go-logrotate v0.3.0
-	github.com/fatih/color v1.18.0
+	github.com/fahedouch/go-logrotate v0.3.0 //gomodjail:unconfined
+	github.com/fatih/color v1.18.0 //gomodjail:unconfined
 	github.com/fluent/fluent-logger-golang v1.9.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/ipfs/go-cid v0.5.0
 	github.com/klauspost/compress v1.18.0
-	github.com/mattn/go-isatty v0.0.20
+	github.com/mattn/go-isatty v0.0.20 //gomodjail:unconfined
 	github.com/moby/sys/mount v0.3.4
 	github.com/moby/sys/signal v0.7.1
-	github.com/moby/sys/userns v0.1.0
-	github.com/moby/term v0.5.2
-	github.com/muesli/cancelreader v0.2.2
+	github.com/moby/sys/userns v0.1.0 //gomodjail:unconfined
+	github.com/moby/term v0.5.2 //gomodjail:unconfined
+	github.com/muesli/cancelreader v0.2.2 //gomodjail:unconfined
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runtime-spec v1.2.1
 	github.com/pelletier/go-toml/v2 v2.2.4
-	github.com/rootless-containers/bypass4netns v0.4.2
-	github.com/rootless-containers/rootlesskit/v2 v2.3.4
-	github.com/spf13/cobra v1.9.1
-	github.com/spf13/pflag v1.0.6
-	github.com/vishvananda/netlink v1.3.1-0.20250303224720-0e7078ed04c8
-	github.com/vishvananda/netns v0.0.5
+	github.com/rootless-containers/bypass4netns v0.4.2 //gomodjail:unconfined
+	github.com/rootless-containers/rootlesskit/v2 v2.3.4 //gomodjail:unconfined
+	github.com/spf13/cobra v1.9.1 //gomodjail:unconfined
+	github.com/spf13/pflag v1.0.6 //gomodjail:unconfined
+	github.com/vishvananda/netlink v1.3.1-0.20250303224720-0e7078ed04c8 //gomodjail:unconfined
+	github.com/vishvananda/netns v0.0.5 //gomodjail:unconfined
 	github.com/yuchanns/srslog v1.1.0
 	go.uber.org/mock v0.5.2
 	golang.org/x/crypto v0.37.0
 	golang.org/x/net v0.39.0
-	golang.org/x/sync v0.13.0
-	golang.org/x/sys v0.32.0
-	golang.org/x/term v0.31.0
+	golang.org/x/sync v0.13.0 //gomodjail:unconfined
+	golang.org/x/sys v0.32.0 //gomodjail:unconfined
+	golang.org/x/term v0.31.0 //gomodjail:unconfined
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
@@ -105,6 +106,7 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/symlink v0.3.0 // indirect
+	//gomodjail:unconfined
 	github.com/moby/sys/user v0.3.0 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.1.0 // indirect
@@ -118,6 +120,7 @@ require (
 	github.com/philhofer/fwd v1.1.3-0.20240612014219-fbbf4953d986 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sasha-s/go-deadlock v0.3.5 // indirect
+	//gomodjail:unconfined
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
@@ -135,7 +138,9 @@ require (
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	golang.org/x/exp v0.0.0-20241108190413-2d47ceb2692f // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250106144421-5f5ef82da422 // indirect
+	//gomodjail:unconfined
 	google.golang.org/grpc v1.69.4 // indirect
+	//gomodjail:unconfined
 	google.golang.org/protobuf v1.36.5 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 )

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -110,6 +110,10 @@ type GenericCommand struct {
 	rawStdErr string
 }
 
+func (gc *GenericCommand) Binary() string {
+	return gc.cmd.Binary
+}
+
 func (gc *GenericCommand) WithBinary(binary string) {
 	gc.cmd.Binary = binary
 }

--- a/mod/tigron/test/interfaces.go
+++ b/mod/tigron/test/interfaces.go
@@ -101,6 +101,8 @@ type Helpers interface {
 // a Setup or Cleanup routine, and as the basis of any type of helper.
 // For more powerful use-cases outside of test cases, see below CustomizableCommand.
 type TestableCommand interface {
+	// Binary returns what binary to execute.
+	Binary() string
 	// WithBinary specifies what binary to execute.
 	WithBinary(binary string)
 	// WithArgs specifies the args to pass to the binary. Note that WithArgs can be used multiple

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -56,20 +56,28 @@ func newNerdCommand(conf test.Config, t *testing.T) *nerdCommand {
 	trgt := getTarget()
 	switch trgt {
 	case targetNerdctl:
-		binary, err = exec.LookPath(trgt)
+		nerdctl := trgt
+		if env := os.Getenv("NERDCTL"); env != "" {
+			nerdctl = env
+		}
+		binary, err = exec.LookPath(nerdctl)
 		if err != nil {
-			t.Fatalf("unable to find binary %q: %v", trgt, err)
+			t.Fatalf("unable to find binary %q: %v", nerdctl, err)
 		}
 		// Set the default namespace if we do not have something already
 		if conf.Read(Namespace) == "" {
 			conf.Write(Namespace, defaultNamespace)
 		}
 	case targetDocker:
-		binary, err = exec.LookPath(trgt)
-		if err != nil {
-			t.Fatalf("unable to find binary %q: %v", trgt, err)
+		docker := trgt
+		if env := os.Getenv("DOCKER"); env != "" {
+			docker = env
 		}
-		if err = exec.Command("docker", "compose", "version").Run(); err != nil {
+		binary, err = exec.LookPath(docker)
+		if err != nil {
+			t.Fatalf("unable to find binary %q: %v", docker, err)
+		}
+		if err = exec.Command(binary, "compose", "version").Run(); err != nil {
 			t.Fatalf("docker does not support compose: %v", err)
 		}
 	default:

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -360,3 +360,19 @@ var Private = &test.Requirement{
 		}
 	},
 }
+
+// Gomodjail returns whether the binary is packed with gomodjail.
+// https://github.com/AkihiroSuda/gomodjail
+var Gomodjail = &test.Requirement{
+	Check: func(_ test.Data, helpers test.Helpers) (ret bool, mess string) {
+		binary := helpers.Command().Binary()
+		// FIXME: do not rely on the filename
+		ret = strings.HasSuffix(binary, ".gomodjail")
+		if ret {
+			mess = "current target is packed with gomodjail"
+		} else {
+			mess = "current target is not packed with gomodjail"
+		}
+		return ret, mess
+	},
+}

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -721,13 +721,21 @@ func newBase(t *testing.T, ns string, ipv6Compatible bool, kubernetesCompatible 
 	var err error
 	switch base.Target {
 	case Nerdctl:
-		base.Binary, err = exec.LookPath("nerdctl")
+		nerdctl := "nerdctl"
+		if env := os.Getenv("NERDCTL"); env != "" {
+			nerdctl = env
+		}
+		base.Binary, err = exec.LookPath(nerdctl)
 		if err != nil {
 			t.Fatal(err)
 		}
 		base.Args = []string{"--namespace=" + ns}
 	case Docker:
-		base.Binary, err = exec.LookPath("docker")
+		docker := "docker"
+		if env := os.Getenv("DOCKER"); env != "" {
+			docker = env
+		}
+		base.Binary, err = exec.LookPath(docker)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
https://github.com/AkihiroSuda/gomodjail

gomodjail imposes syscall restrictions on a specific set of Go modules (excepts ones that use unsafe pointers, reflections, etc.), so as to mitigate their potential vulnerabilities and supply chain attack vectors.

Usage:
```
gomodjail run --go-mod=./go.mod -- nerdctl run hello-world
```

or

```
gomodjail pack --go-mod=./go.mod /usr/local/bin/nerdctl
./nerdctl.gomodjail run hello-world
```

Hint: use `git diff --word-diff` for reviewing the changes in this commit