### PR TITLE
fix: Return empty network settings for non started containers

### DIFF
--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -458,6 +458,14 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		}
 		c.NetworkSettings = nSettings
 		c.HostConfig.PortBindings = *nSettings.Ports
+	} else {
+		// n.process is not set if the container is not started, making the networkSetting null
+		// we should send an empty object even in this case inorder for it to be compatible with docker inspect response
+		nSettings, err := networkSettingsFromNative(nil, n.Spec.(*specs.Spec))
+		if err != nil {
+			return nil, err
+		}
+		c.NetworkSettings = nSettings
 	}
 
 	cpuSetting, err := cpuSettingsFromNative(n.Spec.(*specs.Spec))


### PR DESCRIPTION
current docker inspect response of non started containers

```
... 
"NetworkSettings": {
            "Bridge": "",
            "SandboxID": "",
            "SandboxKey": "",
            "Ports": {},
            "HairpinMode": false,
            "LinkLocalIPv6Address": "",
            "LinkLocalIPv6PrefixLen": 0,
            "SecondaryIPAddresses": null,
            "SecondaryIPv6Addresses": null,
            "EndpointID": "",
            "Gateway": "",
            "GlobalIPv6Address": "",
            "GlobalIPv6PrefixLen": 0,
            "IPAddress": "",
            "IPPrefixLen": 0,
            "IPv6Gateway": "",
            "MacAddress": "",
            "Networks": {
                "bridge": {
                    "IPAMConfig": null,
                    "Links": null,
                    "Aliases": null,
                    "MacAddress": "",
                    "NetworkID": "",
                    "EndpointID": "",
                    "Gateway": "",
                    "IPAddress": "",
                    "IPPrefixLen": 0,
                    "IPv6Gateway": "",
                    "GlobalIPv6Address": "",
                    "GlobalIPv6PrefixLen": 0,
                    "DriverOpts": null,
                    "DNSNames": null
                }
            }
        }
...
```

nerdctl sends 
```
"NetworkSettings": null
```

Updated the inspect response