### PR TITLE
fix: empty default snapshotter config for containerd namesapce default snapshotter label

### DIFF
--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
@@ -91,7 +90,7 @@ func TestNerdctlConfig(t *testing.T) {
 		{
 			Description: "Default",
 			Command:     test.Command("info", "-f", "{{.Driver}}"),
-			Expected:    test.Expects(0, nil, expect.Equals(defaults.DefaultSnapshotter+"\n")),
+			Expected:    test.Expects(0, nil, expect.Equals(""+"\n")),
 		},
 		{
 			Description: "TOML > Default",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,7 +51,7 @@ func New() *Config {
 		DebugFull:        false,
 		Address:          defaults.DefaultAddress,
 		Namespace:        namespaces.Default,
-		Snapshotter:      defaults.DefaultSnapshotter,
+		Snapshotter:      "",
 		CNIPath:          ncdefaults.CNIPath(),
 		CNINetConfPath:   ncdefaults.CNINetConfPath(),
 		DataRoot:         ncdefaults.DataRoot(),


### PR DESCRIPTION
fix #4033 