### PR TITLE
[CI] Tigron breakout 2: remove gotest.tools assert dependency internally

### DIFF
--- a/mod/tigron/expect/comparators.go
+++ b/mod/tigron/expect/comparators.go
@@ -22,8 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"gotest.tools/v3/assert"
-
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 )
 
@@ -45,7 +44,7 @@ func Contains(compare string) test.Comparator {
 	//nolint:thelper
 	return func(stdout, info string, t *testing.T) {
 		t.Helper()
-		assert.Check(t, strings.Contains(stdout, compare),
+		assertive.Check(t, strings.Contains(stdout, compare),
 			fmt.Sprintf("Output does not contain: %q", compare)+info)
 	}
 }
@@ -56,8 +55,8 @@ func DoesNotContain(compare string) test.Comparator {
 	//nolint:thelper
 	return func(stdout, info string, t *testing.T) {
 		t.Helper()
-		assert.Check(t, !strings.Contains(stdout, compare),
-			fmt.Sprintf("Output does contain: %q", compare)+info)
+		assertive.Check(t, !strings.Contains(stdout, compare),
+			fmt.Sprintf("Output should not contain: %q", compare)+info)
 	}
 }
 
@@ -66,7 +65,11 @@ func Equals(compare string) test.Comparator {
 	//nolint:thelper
 	return func(stdout, info string, t *testing.T) {
 		t.Helper()
-		assert.Equal(t, compare, stdout, info)
+		assertive.Check(
+			t,
+			compare == stdout,
+			fmt.Sprintf("Output is not equal to: %q", compare)+info,
+		)
 	}
 }
 
@@ -76,6 +79,11 @@ func Match(reg *regexp.Regexp) test.Comparator {
 	//nolint:thelper
 	return func(stdout, info string, t *testing.T) {
 		t.Helper()
-		assert.Check(t, reg.MatchString(stdout), "Output does not match: "+reg.String(), info)
+		assertive.Check(
+			t,
+			reg.MatchString(stdout),
+			fmt.Sprintf("Output does not match: %q", reg.String()),
+			info,
+		)
 	}
 }

--- a/mod/tigron/internal/assertive/assertive.go
+++ b/mod/tigron/internal/assertive/assertive.go
@@ -1,0 +1,169 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package assertive
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type testingT interface {
+	Helper()
+	FailNow()
+	Fail()
+	Log(args ...interface{})
+}
+
+// ErrorIsNil immediately fails a test if err is not nil.
+func ErrorIsNil(t testingT, err error, msg ...string) {
+	t.Helper()
+
+	if err != nil {
+		t.Log("expecting nil error, but got:", err)
+		failNow(t, msg...)
+	}
+}
+
+// ErrorIs immediately fails a test if err is not the comparison error.
+func ErrorIs(t testingT, err, compErr error, msg ...string) {
+	t.Helper()
+
+	if !errors.Is(err, compErr) {
+		t.Log("expected error to be:", compErr, "- instead it is:", err)
+		failNow(t, msg...)
+	}
+}
+
+// IsEqual immediately fails a test if the two interfaces are not equal.
+func IsEqual(t testingT, actual, expected interface{}, msg ...string) {
+	t.Helper()
+
+	if !isEqual(t, actual, expected) {
+		t.Log("expected:", actual, " - to be equal to:", expected)
+		failNow(t, msg...)
+	}
+}
+
+// IsNotEqual immediately fails a test if the two interfaces are equal.
+func IsNotEqual(t testingT, actual, expected interface{}, msg ...string) {
+	t.Helper()
+
+	if isEqual(t, actual, expected) {
+		t.Log("expected:", actual, " - to be equal to:", expected)
+		failNow(t, msg...)
+	}
+}
+
+// StringContains immediately fails a test if the actual string does not contain the other string.
+func StringContains(t testingT, actual, contains string, msg ...string) {
+	t.Helper()
+
+	if !strings.Contains(actual, contains) {
+		t.Log("expected:", actual, " - to contain:", contains)
+		failNow(t, msg...)
+	}
+}
+
+// StringDoesNotContain immediately fails a test if the actual string contains the other string.
+func StringDoesNotContain(t testingT, actual, contains string, msg ...string) {
+	t.Helper()
+
+	if strings.Contains(actual, contains) {
+		t.Log("expected:", actual, " - to NOT contain:", contains)
+		failNow(t, msg...)
+	}
+}
+
+// StringHasSuffix immediately fails a test if the string does not end with suffix.
+func StringHasSuffix(t testingT, actual, suffix string, msg ...string) {
+	t.Helper()
+
+	if !strings.HasSuffix(actual, suffix) {
+		t.Log("expected:", actual, " - to end with:", suffix)
+		failNow(t, msg...)
+	}
+}
+
+// StringHasPrefix immediately fails a test if the string does not start with prefix.
+func StringHasPrefix(t testingT, actual, prefix string, msg ...string) {
+	t.Helper()
+
+	if !strings.HasPrefix(actual, prefix) {
+		t.Log("expected:", actual, " - to start with:", prefix)
+		failNow(t, msg...)
+	}
+}
+
+// DurationIsLessThan immediately fails a test if the duration is more than the reference.
+func DurationIsLessThan(t testingT, actual, expected time.Duration, msg ...string) {
+	t.Helper()
+
+	if actual >= expected {
+		t.Log("expected:", actual, " - to be less than:", expected)
+		failNow(t, msg...)
+	}
+}
+
+// True immediately fails a test if the boolean is not true...
+func True(t testingT, comp bool, msg ...string) bool {
+	t.Helper()
+
+	if !comp {
+		failNow(t, msg...)
+	}
+
+	return comp
+}
+
+// Check marks a test as failed if the boolean is not true (safe in go routines)
+//
+//nolint:varnamelen
+func Check(t testingT, comp bool, msg ...string) bool {
+	t.Helper()
+
+	if !comp {
+		for _, m := range msg {
+			t.Log(m)
+		}
+
+		t.Fail()
+	}
+
+	return comp
+}
+
+//nolint:varnamelen
+func failNow(t testingT, msg ...string) {
+	t.Helper()
+
+	if len(msg) > 0 {
+		for _, m := range msg {
+			t.Log(m)
+		}
+	}
+
+	t.FailNow()
+}
+
+func isEqual(t testingT, actual, expected interface{}) bool {
+	t.Helper()
+
+	// FIXME: this is risky and limited. Right now this is fine internally, but do better if this
+	// becomes public.
+	return actual == expected
+}

--- a/mod/tigron/internal/assertive/assertive_test.go
+++ b/mod/tigron/internal/assertive/assertive_test.go
@@ -1,0 +1,48 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package assertive_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
+)
+
+func TestY(t *testing.T) {
+	t.Parallel()
+
+	var err error
+
+	assertive.ErrorIsNil(t, err)
+
+	//nolint:err113
+	someErr := errors.New("test error")
+
+	err = fmt.Errorf("wrap: %w", someErr)
+	assertive.ErrorIs(t, err, someErr)
+
+	foo := "foo"
+	assertive.IsEqual(t, foo, "foo")
+
+	bar := 10
+	assertive.IsEqual(t, bar, 10)
+
+	baz := true
+	assertive.IsEqual(t, baz, true)
+}

--- a/mod/tigron/internal/assertive/doc.go
+++ b/mod/tigron/internal/assertive/doc.go
@@ -1,0 +1,22 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package assertive is an experimental, zero-dependencies assert library.
+// Right now, it is not public and meant to be used only inside tigron.
+// Consumers of tigron are free to use whatever assert library they want.
+// In the future, this may become public for peeps who want `assert` to be
+// bundled in.
+package assertive

--- a/mod/tigron/test/case.go
+++ b/mod/tigron/test/case.go
@@ -20,7 +20,7 @@ import (
 	"slices"
 	"testing"
 
-	"gotest.tools/v3/assert"
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 )
 
 // Case describes an entire test-case, including data, setup and cleanup routines, command and
@@ -72,16 +72,16 @@ func (test *Case) Run(t *testing.T) {
 	testRun := func(subT *testing.T) {
 		subT.Helper()
 
-		assert.Assert(subT, test.t == nil, "You cannot run a test multiple times")
+		assertive.True(subT, test.t == nil, "You cannot run a test multiple times")
 
 		// Attach testing.T
 		test.t = subT
-		assert.Assert(
+		assertive.True(
 			test.t,
 			test.Description != "" || test.parent == nil,
 			"A test description cannot be empty",
 		)
-		assert.Assert(test.t, test.Command == nil || test.Expected != nil,
+		assertive.True(test.t, test.Command == nil || test.Expected != nil,
 			"Expectations for a test command cannot be nil. You may want to use Setup instead.")
 
 		// Ensure we have env

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -28,9 +28,9 @@ import (
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/term"
-	"gotest.tools/v3/assert"
 	"gotest.tools/v3/icmd"
 
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 	"github.com/containerd/nerdctl/mod/tigron/test/internal"
 	"github.com/containerd/nerdctl/mod/tigron/test/internal/pty"
 )
@@ -215,19 +215,19 @@ func (gc *GenericCommand) Run(expect *Expected) {
 			// success, or a timeout.
 		case internal.ExitCodeGenericFail:
 			// ExitCodeGenericFail means we expect an error (excluding timeout).
-			assert.Assert(gc.t, result.ExitCode != 0,
+			assertive.True(gc.t, result.ExitCode != 0,
 				"Expected exit code to be different than 0\n"+debug)
 		case internal.ExitCodeTimeout:
-			assert.Assert(gc.t, expect.ExitCode == internal.ExitCodeTimeout,
+			assertive.True(gc.t, expect.ExitCode == internal.ExitCodeTimeout,
 				"Command unexpectedly timed-out\n"+debug)
 		default:
-			assert.Assert(gc.t, expect.ExitCode == result.ExitCode,
+			assertive.True(gc.t, expect.ExitCode == result.ExitCode,
 				fmt.Sprintf("Expected exit code: %d\n", expect.ExitCode)+debug)
 		}
 
 		// Range through the expected errors and confirm they are seen on stderr
 		for _, expectErr := range expect.Errors {
-			assert.Assert(gc.t, strings.Contains(gc.rawStdErr, expectErr.Error()),
+			assertive.True(gc.t, strings.Contains(gc.rawStdErr, expectErr.Error()),
 				fmt.Sprintf("Expected error: %q to be found in stderr\n", expectErr.Error())+debug)
 		}
 


### PR DESCRIPTION
This is on top of #4041.

This PR removes our dependency on `gotest.tools/v3/assert` and replaces it with a much simpler, no-dependency `internal/assertive`.

People can still use whatever assert library they want while writing their tests (gotest, stretchr/testify, or else) - but there is no reason for Tigron internally to use any.