### PR TITLE
[CI] Update golangci to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -75,6 +75,3 @@ jobs:
         run: make lint-yaml
       - name: shell
         run: make lint-shell
-      - name: go imports ordering
-        run: |
-          make lint-imports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,167 +1,233 @@
----
+version: "2"
+
 run:
-  concurrency: 6
-  timeout: 5m
+  modules-download-mode: readonly
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
 linters:
-  disable-all: true
+  default: none
   enable:
     - depguard
-    - gofmt
-    - goimports
     - govet
     - ineffassign
     - misspell
     - nakedret
     - prealloc
-    - typecheck
-    # - asciicheck
-    # - bodyclose
-    # - dogsled
-    # - dupl
-    # - errcheck
-    # - errorlint
-    # - exhaustive
-    # - exhaustivestruct
-    # - exportloopref
-    # - funlen
-    # - gci
-    # - gochecknoglobals
-    # - gochecknoinits
-    # - gocognit
-    # - goconst
-    # - gocritic
-    # - gocyclo
-    # - godot
-    # - godox
-    # - goerr113
-    # - gofumpt
-    # - goheader
-    # - golint
-    # - gomnd
-    # - gomodguard
-    # - goprintffuncname
-    # - gosec (gas)
-    - gosimple  # (megacheck)
-    # - interfacer
-    # - lll
-    # - maligned
-    # - nestif
-    # - nlreturn
-    # - noctx
-    # - nolintlint
     - revive
-    # - rowserrcheck
-    # - scopelint
-    # - sqlclosecheck
     - staticcheck
-    - stylecheck
-    # - testpackage
-    # - tparallel
     - unconvert
-    # - unparam
     - unused
-    # - whitespace
-    # - wrapcheck
-    # - wsl
-linters-settings:
-  gocritic:
-    enabled-checks:
-      # Diagnostic
-      - appendAssign
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
-      - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
-      - nilValReturn
-      - offBy1
-      - sloppyReassign
-      - weakCond
-      - octalLiteral
+  settings:
+    staticcheck:
+      checks:
+        # Below is the default set
+        - "all"
+        - "-ST1000"
+        - "-ST1003"
+        - "-ST1016"
+        - "-ST1020"
+        - "-ST1021"
+        - "-ST1022"
+        # FIXME: this below this point is disabled for now, but we should investigate
+        - "-QF1008"  # Omit embedded fields from selector expression https://staticcheck.dev/docs/checks#QF1008
+        - "-QF1003"  # Convert if/else-if chain to tagged switch https://staticcheck.dev/docs/checks#QF1003
+        - "-QF1009"  # Use time.Time.Equal instead of == operator https://staticcheck.dev/docs/checks#QF1009
+        - "-QF1001"  # Apply De Morgan’s law https://staticcheck.dev/docs/checks#QF1001
+        - "-QF1012"  # Use fmt.Fprintf(x, ...) instead of x.Write(fmt.Sprintf(...)) https://staticcheck.dev/docs/checks#QF1012
+        - "-ST1005"  # Expand call to math.Pow https://staticcheck.dev/docs/checks#QF1005
+        - "-QF1004"  # Use strings.ReplaceAll instead of strings.Replace with n == -1 https://staticcheck.dev/docs/checks#QF1004
+    revive:
+      enable-all-rules: true
+      rules:
+        # See https://revive.run/r
+        # Below are unsorted, and we might want to review them to decide which one we want to enable
+        - name: exported
+          disabled: true
+        - name: add-constant
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: package-comments
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: deep-exit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: flag-parameter
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: max-control-nesting
+          disabled: true
+        - name: confusing-results
+          disabled: true
+        - name: nested-structs
+          disabled: true
+        - name: import-alias-naming
+          disabled: true
+        - name: filename-format
+          disabled: true
+        - name: use-any
+          disabled: true
+        # FIXME: we should enable these below
+        - name: struct-tag
+          disabled: true
+        - name: redundant-import-alias
+          disabled: true
+        - name: empty-lines
+          disabled: true
+        - name: unhandled-error
+          disabled: true
+        - name: confusing-naming
+          disabled: true
+        - name: unused-parameter
+          disabled: true
+        - name: unused-receiver
+          disabled: true
+        - name: import-shadowing
+          disabled: true
+        - name: use-errors-new
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: time-equal
+          disabled: true
+        - name: defer
+          disabled: true
+        - name: early-return
+          disabled: true
+        - name: comment-spacings
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: unexported-naming
+          disabled: true
+        - name: unnecessary-stmt
+          disabled: true
+        - name: if-return
+          disabled: true
+        - name: unchecked-type-assertion
+          disabled: true
+        - name: bare-return
+          disabled: true
+        # Below have been reviewed and disabled
+        - name: line-length-limit
+          # Better dealt with by formatter golines
+          disabled: true
 
-      # Performance
-      - appendCombine
-      - equalFold
-      - hugeParam
-      - indexAlloc
-      - rangeExprCopy
-      - rangeValCopy
+    depguard:
+      rules:
+        no-patent:
+          # do not link in golang-lru anywhere (problematic patent)
+          deny:
+            - pkg: github.com/hashicorp/golang-lru/arc/v2
+              desc: patented (https://github.com/hashicorp/golang-lru/blob/arc/v2.0.7/arc/arc.go#L18)
+        pkg:
+          # pkg files must not depend on cobra nor anything in cmd
+          files:
+            - '**/pkg/**/*.go'
+          deny:
+            - pkg: github.com/spf13/cobra
+              desc: pkg must not depend on cobra
+            - pkg: github.com/spf13/pflag
+              desc: pkg must not depend on pflag
+            - pkg: github.com/spf13/viper
+              desc: pkg must not depend on viper
+            - pkg: github.com/containerd/nerdctl/v2/cmd
+              desc: pkg must not depend on any cmd files
+    gocritic:
+      enabled-checks:
+        - appendAssign
+        - argOrder
+        - badCond
+        - caseOrder
+        - codegenComment
+        - commentedOutCode
+        - deprecatedComment
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - dupSubExpr
+        - exitAfterDefer
+        - flagDeref
+        - flagName
+        - nilValReturn
+        - offBy1
+        - sloppyReassign
+        - weakCond
+        - octalLiteral
+        - appendCombine
+        - equalFold
+        - hugeParam
+        - indexAlloc
+        - rangeExprCopy
+        - rangeValCopy
+        - assignOp
+        - boolExprSimplify
+        - captLocal
+        - commentFormatting
+        - commentedOutImport
+        - defaultCaseOrder
+        - docStub
+        - elseif
+        - emptyFallthrough
+        - emptyStringTest
+        - hexLiteral
+        - ifElseChain
+        - methodExprCall
+        - regexpMust
+        - singleCaseSwitch
+        - sloppyLen
+        - stringXbytes
+        - switchTrue
+        - typeAssertChain
+        - typeSwitchVar
+        - underef
+        - unlabelStmt
+        - unlambda
+        - unslice
+        - valSwap
+        - wrapperFunc
+        - yodaStyleExpr
+        - builtinShadow
+        - importShadow
+        - initClause
+        - nestingReduce
+        - paramTypeCombine
+        - ptrToRefParam
+        - typeUnparen
+        - unnamedResult
+        - unnecessaryBlock
+  exclusions:
+    generated: disable
 
-      # Style
-      - assignOp
-      - boolExprSimplify
-      - captLocal
-      - commentFormatting
-      - commentedOutImport
-      - defaultCaseOrder
-      - docStub
-      - elseif
-      - emptyFallthrough
-      - emptyStringTest
-      - hexLiteral
-      - ifElseChain
-      - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
-      - stringXbytes
-      - switchTrue
-      - typeAssertChain
-      - typeSwitchVar
-      - underef
-      - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
-      - yodaStyleExpr
-
-      # Opinionated
-      - builtinShadow
-      - importShadow
-      - initClause
-      - nestingReduce
-      - paramTypeCombine
-      - ptrToRefParam
-      - typeUnparen
-      - unnamedResult
-      - unnecessaryBlock
-
-  depguard:
-    rules:
-      # pkg files must not depend on cobra nor anything in cmd
-      pkg:
-        files:
-          - "**/pkg/**/*.go"
-        deny:
-          - pkg: "github.com/spf13/cobra"
-            desc: "pkg must not depend on cobra"
-          - pkg: "github.com/spf13/pflag"
-            desc: "pkg must not depend on pflag"
-          - pkg: "github.com/spf13/viper"
-            desc: "pkg must not depend on viper"
-          - pkg: "github.com/containerd/nerdctl/v2/cmd"
-            desc: "pkg must not depend on any cmd files"
-      no-patent:
-        deny:
-          - pkg: "github.com/hashicorp/golang-lru/arc/v2"
-            desc: "patented (https://github.com/hashicorp/golang-lru/blob/arc/v2.0.7/arc/arc.go#L18)"
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  exclude-rules:
-    - linters:
-        - revive
-      text: "unused-parameter"
-
-output:
-  sort-results: true
+formatters:
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/containerd)
+        - localmodule
+      no-inline-comments: true
+      no-prefix-comments: true
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+    golines:
+      max-len: 100
+      tab-len: 4
+      shorten-comments: true
+  enable:
+    - gci
+    - gofmt
+    # We might consider enabling the following:
+    #    - gofumpt
+    #    - golines
+  exclusions:
+    generated: disable

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@
 # Configuration
 ##########################
 PACKAGE := "github.com/containerd/nerdctl/v2"
-ORG_PREFIXES := "github.com/containerd"
 
 DOCKER ?= docker
 GO ?= go
@@ -80,9 +79,9 @@ endef
 ##########################
 all: binaries
 
-lint: lint-go-all lint-imports lint-yaml lint-shell lint-commits lint-mod lint-licenses-all
+lint: lint-go-all lint-yaml lint-shell lint-commits lint-mod lint-licenses-all
 
-fix: fix-mod fix-imports fix-go-all
+fix: fix-mod fix-go-all
 
 # TODO: fix race task and add it
 test: test-unit # test-unit-race test-unit-bench
@@ -137,12 +136,6 @@ lint-go-all:
 		&& GOOS=linux make lint-go \
 		&& GOOS=windows make lint-go \
 		&& GOOS=freebsd make lint-go
-	$(call footer, $@)
-
-lint-imports:
-	$(call title, $@)
-	@cd $(MAKEFILE_DIR) \
-		&& goimports-reviser -recursive -list-diff -set-exit-status -output stdout -company-prefixes "$(ORG_PREFIXES)"  ./...
 	$(call footer, $@)
 
 lint-yaml:
@@ -206,12 +199,6 @@ fix-go-all:
 		&& GOOS=windows make fix-go
 	$(call footer, $@)
 
-fix-imports:
-	$(call title, $@)
-	@cd $(MAKEFILE_DIR) \
-		&& goimports-reviser -company-prefixes $(ORG_PREFIXES) ./...
-	$(call footer, $@)
-
 fix-mod:
 	$(call title, $@)
 	@cd $(MAKEFILE_DIR) \
@@ -223,19 +210,17 @@ fix-mod:
 ##########################
 install-dev-tools:
 	$(call title, $@)
-	# golangci: v1.64.5
-	# git-validation: main from 2023/11
-	# ltag: v0.2.5
-	# go-licenses: v2.0.0-alpha.1
-	# goimports-reviser: v3.8.2
+	# golangci: v2.0.2 (2024-03-26)
+	# git-validation: main (2025-02-25)
+	# ltag: main (2025-03-04)
+	# go-licenses: v2.0.0-alpha.1 (2024-06-27)
 	@cd $(MAKEFILE_DIR) \
-		&& go install github.com/golangci/golangci-lint/cmd/golangci-lint@0a603e49e5e9870f5f9f2035bcbe42cd9620a9d5 \
-		&& go install github.com/vbatts/git-validation@679e5cad8c50f1605ab3d8a0a947aaf72fb24c07 \
-		&& go install github.com/kunalkushwaha/ltag@b0cfa33e4cc9383095dc584d3990b62c95096de0 \
+		&& go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@2b224c2cf4c9f261c22a16af7f8ca6408467f338 \
+		&& go install github.com/vbatts/git-validation@7b60e35b055dd2eab5844202ffffad51d9c93922 \
+		&& go install github.com/containerd/ltag@66e6a514664ee2d11a470735519fa22b1a9eaabd \
 		&& go install github.com/google/go-licenses/v2@d01822334fba5896920a060f762ea7ecdbd086e8 \
-		&& go install github.com/incu6us/goimports-reviser/v3@f034195cc8a7ffc7cc70d60aa3a25500874eaf04 \
 		&& go install gotest.tools/gotestsum@ac6dad9c7d87b969004f7749d1942938526c9716
-	@echo "Remember to add GOROOT/bin to your path"
+	@echo "Remember to add \$$HOME/go/bin to your path"
 	$(call footer, $@)
 
 ##########################
@@ -312,8 +297,8 @@ artifacts: clean
 	binaries \
 	install \
 	clean \
-	lint-go lint-go-all lint-imports lint-yaml lint-shell lint-commits lint-mod lint-licenses lint-licenses-all \
-	fix-go fix-go-all fix-imports fix-mod \
+	lint-go lint-go-all lint-yaml lint-shell lint-commits lint-mod lint-licenses lint-licenses-all \
+	fix-go fix-go-all fix-mod \
 	install-dev-tools \
 	test-unit test-unit-race test-unit-bench \
 	artifacts

--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/labels"

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -126,7 +126,7 @@ func parseMountFlags(volStore volumestore.VolumeStore, options types.ContainerCr
 // Other mounts such as procfs mount are not handled here.
 func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredImage *imgutil.EnsuredImage,
 	volStore volumestore.VolumeStore, options types.ContainerCreateOptions) ([]oci.SpecOpts, []string, []*mountutil.Processed, error) {
-	//nolint:golint,prealloc
+	//nolint:prealloc
 	var (
 		opts        []oci.SpecOpts
 		anonVolumes []string

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -30,13 +30,14 @@ import (
 	"sync"
 	"time"
 
-	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/fsnotify/fsnotify"
 	"github.com/muesli/cancelreader"
 
+	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+
 	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 )
 


### PR DESCRIPTION
This updates golangci to their newly released v2.

1. convert the configuration file to the new format
2. update the makefile install task (also bump version for other tools we use)
3. remove go-imports-reviser - we can now use `gci` (bundled with golangci) with 99% compatibility (save a handful of changes required in code)
4. remove fix-imports, lint-imports (see ^)

I opted to configure the new .golangci.yml for the minimal set of changes to the source code.
However, that meant disabling a bunch of checks from `staticcheck` and a couple of formatters, that we may want to investigate / enable. 