### PR TITLE
[Feat] Add commit compression type support

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -765,6 +765,7 @@ Flags:
 - :whale: `-m, --message`: Commit message
 - :whale: `-c, --change`: Apply Dockerfile instruction to the created image (supported directives: [CMD, ENTRYPOINT])
 - :whale: `-p, --pause`: Pause container during commit (default: true)
+- :nerd_face: `--compression`: Commit compression algorithm (supported values: zstd or gzip) (default: gzip) (zstd is generally better for compression ratio but might not be as widely supported)
 
 ## Image management
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -385,7 +385,16 @@ type ContainerCommitOptions struct {
 	Change []string
 	// Pause container during commit
 	Pause bool
+	// Compression is set commit compression algorithm
+	Compression CompressionType
 }
+
+type CompressionType string
+
+const (
+	Zstd CompressionType = "zstd"
+	Gzip CompressionType = "gzip"
+)
 
 // ContainerDiffOptions specifies options for `nerdctl (container) diff`.
 type ContainerDiffOptions struct {

--- a/pkg/cmd/container/commit.go
+++ b/pkg/cmd/container/commit.go
@@ -44,11 +44,12 @@ func Commit(ctx context.Context, client *containerd.Client, rawRef string, req s
 	}
 
 	opts := &commit.Opts{
-		Author:  options.Author,
-		Message: options.Message,
-		Ref:     parsedReference.String(),
-		Pause:   options.Pause,
-		Changes: changes,
+		Author:      options.Author,
+		Message:     options.Message,
+		Ref:         parsedReference.String(),
+		Pause:       options.Pause,
+		Changes:     changes,
+		Compression: options.Compression,
 	}
 
 	walker := &containerwalker.ContainerWalker{


### PR DESCRIPTION
Fix https://github.com/containerd/nerdctl/issues/4060

Use zstd compression can shorten commit time. current containerd v2 having support `zstd` commit type, but containerd v1 version don't support.

Test case:
1. create nginx pod, write a 5G file.
```
#!/bin/sh
for ((i=1; i<=5; i++))
do
  dd if=/dev/urandom of=$i".txt" bs=500M count=2
done
```

2. use zstd compression to commit container only need 29s time.
```shell
$ nerdctl -n k8s.io commit ca45e0595384b14ee1fbef6f0a38efb2a2725471cb8fc143d9720a068d8b6cb1 easzlab.io.local:5000/demo/nginx:v2 --pause=true --compression=zstd
```
![image](https://github.com/user-attachments/assets/d8f7f6fe-914b-4a80-9c4d-29b62a6c4361)

to view blob type.
```
$ nerdctl -n k8s.io image inspect --mode=native easzlab.io.local:5000/demo/nginx:v2
```
![image](https://github.com/user-attachments/assets/19bc02e4-8d98-46b1-bbb9-ab5867d61f0a)


3. use gzip compression to commit container need 2m5s time.
```shell
$ nerdctl -n k8s.io commit ca45e0595384b14ee1fbef6f0a38efb2a2725471cb8fc143d9720a068d8b6cb1 easzlab.io.local:5000/demo/nginx:v3 --pause=true
```
![image](https://github.com/user-attachments/assets/870381fa-624e-4666-8261-d51b01dbb4f8)
