### PR TITLE
[P0] Fix #3513 (`[MAJOR] content digest not found`)

### DIFF
--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -127,7 +127,7 @@ func Build(ctx context.Context, client *containerd.Client, options types.Builder
 			if _, err := imageService.Create(ctx, image); err != nil {
 				// if already exists; skip.
 				if errors.Is(err, errdefs.ErrAlreadyExists) {
-					if err = imageService.Delete(ctx, targetRef); err != nil {
+					if err = imageService.Delete(ctx, targetRef, images.SynchronousDelete()); err != nil {
 						return err
 					}
 					if _, err = imageService.Create(ctx, image); err != nil {

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -190,7 +190,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 	}
 
 	// converter.Convert() gains the lease by itself
-	newImg, err := converter.Convert(ctx, client, targetRef, srcRef, convertOpts...)
+	newImg, err := converterutil.Convert(ctx, client, targetRef, srcRef, convertOpts...)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 			return err
 		}
 		is := client.ImageService()
-		_ = is.Delete(ctx, newI.Name)
+		_ = is.Delete(ctx, newI.Name, images.SynchronousDelete())
 		finimg, err := is.Create(ctx, *newI)
 		if err != nil {
 			return err

--- a/pkg/cmd/image/crypt.go
+++ b/pkg/cmd/image/crypt.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/imgcrypt/v2/images/encryption/parsehelpers"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	nerdconverter "github.com/containerd/nerdctl/v2/pkg/imgutil/converter"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
@@ -93,7 +94,7 @@ func Crypt(ctx context.Context, client *containerd.Client, srcRawRef, targetRawR
 	convertOpts = append(convertOpts, converter.WithIndexConvertFunc(convertFunc))
 
 	// converter.Convert() gains the lease by itself
-	newImg, err := converter.Convert(ctx, client, targetRef, srcRef, convertOpts...)
+	newImg, err := nerdconverter.Convert(ctx, client, targetRef, srcRef, convertOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -79,6 +79,8 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 
 			if cid, ok := runningImages[found.Image.Name]; ok {
 				if options.Force {
+					// FIXME: this is suspicious, but passing the opt seem to break some tests
+					// if err = is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
 					if err = is.Delete(ctx, found.Image.Name); err != nil {
 						return err
 					}
@@ -126,6 +128,8 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 
 			if cid, ok := runningImages[found.Image.Name]; ok {
 				if options.Force {
+					// FIXME: this is suspicious, but passing the opt seem to break some tests
+					// if err = is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
 					if err = is.Delete(ctx, found.Image.Name); err != nil {
 						return false, err
 					}

--- a/pkg/cmd/image/tag.go
+++ b/pkg/cmd/image/tag.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
@@ -81,7 +82,7 @@ func Tag(ctx context.Context, client *containerd.Client, options types.ImageTagO
 	img.Name = parsedReference.String()
 	if _, err = imageService.Create(ctx, img); err != nil {
 		if errdefs.IsAlreadyExists(err) {
-			if err = imageService.Delete(ctx, img.Name); err != nil {
+			if err = imageService.Delete(ctx, img.Name, images.SynchronousDelete()); err != nil {
 				return err
 			}
 			if _, err = imageService.Create(ctx, img); err != nil {

--- a/pkg/imgutil/converter/convert.go
+++ b/pkg/imgutil/converter/convert.go
@@ -1,0 +1,55 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package converter
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/converter"
+)
+
+// Something seems wrong in converter.Convert.
+// When dstRef != srcRef, convert will first forcefully delete dstRef,
+// *asynchronously*, then create the image.
+// This seems to cause a race conditions, and the deletion may kick in after the creation.
+// This here is to workaround the bug, by manually creating the image first,
+// then converting it in place (which avoid the problematic code-path).
+// See containerd upstream discussion https://github.com/containerd/containerd/pull/11628 and
+// nerdctl issues:
+// https://github.com/containerd/nerdctl/issues/3509#issuecomment-2398236766
+// https://github.com/containerd/nerdctl/issues/3513
+// Note this should be remove if/when containerd merges in a fix.
+
+func Convert(ctx context.Context, client converter.Client, dstRef, srcRef string, opts ...converter.Opt) (*images.Image, error) {
+	imageService := client.ImageService()
+
+	img, err := imageService.Get(ctx, srcRef)
+	if err != nil {
+		return nil, err
+	}
+
+	img.Name = dstRef
+
+	_ = imageService.Delete(ctx, img.Name, images.SynchronousDelete())
+
+	if _, err = imageService.Create(ctx, img); err != nil {
+		return nil, err
+	}
+
+	return converter.Convert(ctx, client, dstRef, dstRef, opts...)
+}


### PR DESCRIPTION
### Current status

Discussion and patch upstream: https://github.com/containerd/containerd/pull/11628

TL;DR here: this PR here on nerdctl _does seem to fix our issues_ (many runs of the CI with no issue), because it entirely bypasses `converter.Convert` `Delete` logic which _seems to trigger some underlying containerd issue related to lease and deletion_ (<- my opinion, unverified).

My patch upstream does ALSO fix our issue, with a clear reproducer, although it probably just avoids the underlying containerd problem.


-------------------------------------------------------------
### Original post below

It looks like containerd `imagestore.Delete` is asynchronous by default.

If you want a synchronous delete, you have to pass an additional opt.

Of course, this seems to be a problem when you:
- check if the image exist
- delete it (async) if it does
- create a new version of it

This seem to be the case (actually, it is worse) for https://github.com/containerd/containerd/blob/af013606262f9df1de4cc80688725a15a375fb3a/core/images/converter/converter.go#L120-L121
... where convert.Convert just forcefully delete, whether or not the image existed, async...


This of course is also something we are doing internally.

This PR addresses these issues:
- ensure we delete SYNCHRONOUSLY where it matters
- honor the async option when there is one
- wrap / workaround containerd (* maybe) faulty implementation of convert

At this point, this is still a hunch - but for the first time I feel confident that we may be reaching the bottom of it, as this explanation closely matches the soul-destroying symptoms we have witnessed in eg: https://github.com/containerd/nerdctl/issues/3509#issuecomment-2398236766 

and more generally, with anything touching containerd `Convert` (see #3513).

I will close an open this PR many times and confirm that the infamous #3513 is finally gone, but I would like the expert opinion of @lingdie on this - if you have time for a quick review.

Upstream PR: https://github.com/containerd/containerd/pull/11628

Note that this PR here does not try to do more than that - there MAY still be places where we would need to `EnsureContent`.

EDIT: looks like containerd maintainer disagree with this, so, maybe I am misreading this.
Anyhow, I will keep closing / opening and run the CI - we are currently at:
- four runs without failure
- fifth run failed on Github cache
- sixth run failure is #4046 