### PR TITLE
fix: Pass ps_args as option to container top

### DIFF
--- a/cmd/nerdctl/container/container_top.go
+++ b/cmd/nerdctl/container/container_top.go
@@ -19,6 +19,7 @@ package container
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -66,9 +67,18 @@ func topAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer cancel()
-	return container.Top(ctx, client, args, types.ContainerTopOptions{
+
+	containerID := args[0]
+	var psArgs string
+	if len(args) > 1 {
+		// Join all remaining arguments as ps args
+		psArgs = strings.Join(args[1:], " ")
+	}
+
+	return container.Top(ctx, client, []string{containerID}, types.ContainerTopOptions{
 		Stdout:   cmd.OutOrStdout(),
 		GOptions: globalOptions,
+		PsArgs:   psArgs,
 	})
 
 }

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -343,6 +343,9 @@ type ContainerTopOptions struct {
 	Stdout io.Writer
 	// GOptions is the global options
 	GOptions GlobalCommandOptions
+
+	// Arguments to pass through to the ps command
+	PsArgs string
 }
 
 // ContainerInspectOptions specifies options for `nerdctl container inspect`

--- a/pkg/cmd/container/top.go
+++ b/pkg/cmd/container/top.go
@@ -28,7 +28,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	containerd "github.com/containerd/containerd/v2/client"
 
@@ -60,7 +59,7 @@ func Top(ctx context.Context, client *containerd.Client, containers []string, op
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			return containerTop(ctx, opt.Stdout, client, found.Container.ID(), strings.Join(containers[1:], " "))
+			return containerTop(ctx, opt.Stdout, client, found.Container.ID(), opt.PsArgs)
 		},
 	}
 


### PR DESCRIPTION
Currently the arguments for the ps command is parsed out in the [top.go file](https://github.com/containerd/nerdctl/blob/00558aabc88e066658e4dc79cf5278c77833ddda/pkg/cmd/container/top.go#L63)
this PR moves the parsing logic to the parent function and passes the parsed values via a new field in the [ContainerTopOptions](https://github.com/containerd/nerdctl/blob/00558aabc88e066658e4dc79cf5278c77833ddda/pkg/api/types/container_types.go#L342)
This will enable nerdctl lib users to pass ps_args values. 

Tests are already present for these in [cmd/nerdctl/container/container_top_test.go](https://github.com/containerd/nerdctl/blob/main/cmd/nerdctl/container/container_top_test.go) 
I've just moved the parsing from child function to parent, no change in logical behavior