### PR TITLE
feat: add cpu-rt-period and cpu-rt-runtime options in nerdctl create/run

### DIFF
--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -159,6 +159,14 @@ func createOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
 	if err != nil {
 		return opt, err
 	}
+	opt.CPURealtimePeriod, err = cmd.Flags().GetUint64("cpu-rt-period")
+	if err != nil {
+		return opt, err
+	}
+	opt.CPURealtimeRuntime, err = cmd.Flags().GetUint64("cpu-rt-runtime")
+	if err != nil {
+		return opt, err
+	}
 	opt.Memory, err = cmd.Flags().GetString("memory")
 	if err != nil {
 		return opt, err

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -166,6 +166,8 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64("cpu-shares", 0, "CPU shares (relative weight)")
 	cmd.Flags().Int64("cpu-quota", -1, "Limit CPU CFS (Completely Fair Scheduler) quota")
 	cmd.Flags().Uint64("cpu-period", 0, "Limit CPU CFS (Completely Fair Scheduler) period")
+	cmd.Flags().Uint64("cpu-rt-period", 0, "Limit CPU real-time period in microseconds")
+	cmd.Flags().Uint64("cpu-rt-runtime", 0, "Limit CPU real-time runtime in microseconds")
 	// device is defined as StringSlice, not StringArray, to allow specifying "--device=DEV1,DEV2" (compatible with Podman)
 	cmd.Flags().StringSlice("device", nil, "Add a host device to the container")
 	// ulimit is defined as StringSlice, not StringArray, to allow specifying "--ulimit=ULIMIT1,ULIMIT2" (compatible with Podman)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -203,6 +203,8 @@ Resource flags:
 - :whale: `--cpu-shares`: CPU shares (relative weight)
 - :whale: `--cpuset-cpus`: CPUs in which to allow execution (0-3, 0,1)
 - :whale: `--cpuset-mems`: Memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems
+- :whale: `--cpu-rt-period`: Limit CPU real-time period in microseconds. Only supported with cgroup v1.
+- :whale: `--cpu-rt-runtime`: Limit CPU real-time runtime in microseconds. Only supported with cgroup v1.
 - :whale: `--memory`: Memory limit
 - :whale: `--memory-reservation`: Memory soft limit
 - :whale: `--memory-swap`: Swap limit equal to memory plus swap: '-1' to enable unlimited swap
@@ -419,10 +421,8 @@ IPFS flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker run` flags:
-    `--cpu-rt-*`, `--device-cgroup-rule`,
-    `--disable-content-trust`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
-    `--link*`, `--publish-all`, `--storage-opt`,
-    `--userns`, `--volume-driver`
+    `--device-cgroup-rule`, `--disable-content-trust`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
+    `--link*`, `--publish-all`, `--storage-opt`, `--userns`, `--volume-driver`
 
 ### :whale: :blue_square: nerdctl exec
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -114,6 +114,10 @@ type ContainerCreateOptions struct {
 	CPUSetCPUs string
 	// CPUSetMems specifies the memory nodes (MEMs) in which to allow execution (0-3, 0,1). Only effective on NUMA systems.
 	CPUSetMems string
+	// Limit CPU real-time period in microseconds
+	CPURealtimePeriod uint64
+	// Limit CPU real-time runtime in microseconds
+	CPURealtimeRuntime uint64
 	// Memory specifies the memory limit
 	Memory string
 	// MemoryReservationChanged specifies whether the memory soft limit has been changed

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -284,3 +284,8 @@ func BlockIOReadIOpsDevice(cgroupManager string) bool {
 func BlockIOWriteIOpsDevice(cgroupManager string) bool {
 	return getMobySysInfo(cgroupManager).BlkioWriteIOpsDevice
 }
+
+// CPURealtime returns whether CPU realtime period is supported or not
+func CPURealtime(cgroupManager string) bool {
+	return getMobySysInfo(cgroupManager).CPURealtime
+}

--- a/pkg/inspecttypes/dockercompat/info.go
+++ b/pkg/inspecttypes/dockercompat/info.go
@@ -37,6 +37,7 @@ type Info struct {
 	CPUCfsQuota       bool `json:"CpuCfsQuota"`
 	CPUShares         bool
 	CPUSet            bool
+	CPURealtime       bool
 	PidsLimit         bool
 	IPv4Forwarding    bool
 	BridgeNfIptables  bool


### PR DESCRIPTION
Adds `cpu-rt-runtime` and `cpu-rt-period` options with nerdctl run and create.

Tested locally on a system with cgroup v1. 

One issue with the current implementation is that the realtime cgroup settings rely on the parent cgroup. So, for a container to set this value, the parent cgroup `/sys/fs/cgroup/cpu,cpuacct/default/cpu.rt_runtime_us` should also be set. Podman also appears to have the similar issue [containers/podman#12444]. Also, it is not a issue in docker since you can set these values at the daemon level [moby/moby#31411]

