### PR TITLE
[Tigron]: expect.JSON comparator and updated volume test

### DIFF
--- a/cmd/nerdctl/volume/volume_inspect_test.go
+++ b/cmd/nerdctl/volume/volume_inspect_test.go
@@ -18,7 +18,6 @@ package volume
 
 import (
 	"crypto/rand"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -31,6 +30,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -99,15 +99,11 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Get("vol1")),
-						func(stdout string, info string, t *testing.T) {
-							var dc []native.Volume
-							if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
-								t.Fatal(err)
-							}
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc))+info)
 							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name)+info)
 							assert.Assert(t, dc[0].Labels == nil, fmt.Sprintf("expected labels to be nil and were %v", dc[0].Labels)+info)
-						},
+						}),
 					),
 				}
 			},
@@ -121,16 +117,12 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Get("vol2")),
-						func(stdout string, info string, t *testing.T) {
-							var dc []native.Volume
-							if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
-								t.Fatal(err)
-							}
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							labels := *dc[0].Labels
 							assert.Assert(t, len(labels) == 2, fmt.Sprintf("two results, not %d", len(labels)))
 							assert.Assert(t, labels["foo"] == "fooval", fmt.Sprintf("label foo should be fooval, not %s", labels["foo"]))
 							assert.Assert(t, labels["bar"] == "barval", fmt.Sprintf("label bar should be barval, not %s", labels["bar"]))
-						},
+						}),
 					),
 				}
 			},
@@ -145,13 +137,9 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Get("vol1")),
-						func(stdout string, info string, t *testing.T) {
-							var dc []native.Volume
-							if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
-								t.Fatal(err)
-							}
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, dc[0].Size == size, fmt.Sprintf("expected size to be %d (was %d)", size, dc[0].Size))
-						},
+						}),
 					),
 				}
 			},
@@ -166,15 +154,11 @@ func TestVolumeInspect(t *testing.T) {
 					Output: expect.All(
 						expect.Contains(data.Get("vol1")),
 						expect.Contains(data.Get("vol2")),
-						func(stdout string, info string, t *testing.T) {
-							var dc []native.Volume
-							if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
-								t.Fatal(err)
-							}
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 2, fmt.Sprintf("two results, not %d", len(dc)))
 							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name))
 							assert.Assert(t, dc[1].Name == data.Get("vol2"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol2"), dc[1].Name))
-						},
+						}),
 					),
 				}
 			},
@@ -190,14 +174,10 @@ func TestVolumeInspect(t *testing.T) {
 					Errors:   []error{errdefs.ErrNotFound, errdefs.ErrInvalidArgument},
 					Output: expect.All(
 						expect.Contains(data.Get("vol1")),
-						func(stdout string, info string, t *testing.T) {
-							var dc []native.Volume
-							if err := json.Unmarshal([]byte(stdout), &dc); err != nil {
-								t.Fatal(err)
-							}
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
 							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name))
-						},
+						}),
 					),
 				}
 			},

--- a/mod/tigron/expect/comparators_test.go
+++ b/mod/tigron/expect/comparators_test.go
@@ -20,24 +20,45 @@ package expect_test
 // TODO: add a lot more tests including failure conditions with mimicry
 
 import (
+	"encoding/json"
 	"regexp"
 	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 func TestExpect(t *testing.T) {
 	t.Parallel()
 
-	expect.Contains("b")("a b c", "info", t)
-	expect.DoesNotContain("d")("a b c", "info", t)
-	expect.Equals("a b c")("a b c", "info", t)
-	expect.Match(regexp.MustCompile("[a-z ]+"))("a b c", "info", t)
+	expect.Contains("b")("a b c", "contains works", t)
+	expect.DoesNotContain("d")("a b c", "does not contain works", t)
+	expect.Equals("a b c")("a b c", "equals work", t)
+	expect.Match(regexp.MustCompile("[a-z ]+"))("a b c", "match works", t)
 
 	expect.All(
 		expect.Contains("b"),
 		expect.DoesNotContain("d"),
 		expect.Equals("a b c"),
 		expect.Match(regexp.MustCompile("[a-z ]+")),
-	)("a b c", "info", t)
+	)("a b c", "all", t)
+
+	type foo struct {
+		Foo map[string]string `json:"foo"`
+	}
+
+	data, err := json.Marshal(&foo{
+		Foo: map[string]string{
+			"foo": "bar",
+		},
+	})
+
+	assertive.ErrorIsNil(t, err)
+
+	expect.JSON(&foo{}, nil)(string(data), "json, no verifier", t)
+
+	expect.JSON(&foo{}, func(obj *foo, info string, t tig.T) {
+		assertive.IsEqual(t, obj.Foo["foo"], "bar", info)
+	})(string(data), "json, with verifier", t)
 }

--- a/mod/tigron/expect/doc.md
+++ b/mod/tigron/expect/doc.md
@@ -1,0 +1,221 @@
+# Expectations
+
+Attaching expectations to a test case is how the developer can express conditions on exit code, stdout, or stderr,
+to be verified for the test to pass.
+
+The simplest way to do that is to use the helper `test.Expects(exitCode int, errors []error, outputCompare test.Comparator)`.
+
+```go
+package main
+
+import (
+    "testing"
+
+    "github.com/containerd/nerdctl/mod/tigron/test"
+)
+
+func TestMyThing(t *testing.T) {
+    // Declare your test
+    myTest := &test.Case{}
+
+    // Attach a command to run
+    myTest.Command = test.Custom("ls")
+
+    // Set your expectations
+    myTest.Expected = test.Expects(expect.ExitCodeSuccess, nil, nil)
+
+    // Run it
+    myTest.Run(t)
+}
+```
+
+### Exit status expectations
+
+The first parameter, `exitCode` should be set to one of the provided `expect.ExitCodeXXX` constants:
+- `expect.ExitCodeSuccess`: validates that the command ran and exited successfully
+- `expect.ExitCodeTimeout`: validates that the command did time out
+- `expect.ExitCodeSignaled`: validates that the command received a signal
+- `expect.ExitCodeGenericFail`: validates that the command failed (failed to start, or returned a non-zero exit code)
+- `expect.ExitCodeNoCheck`: does not enforce any verification at all on the command
+
+... you may also pass explicit exit codes directly (> 0) if you want to precisely match them.
+
+### Stderr expectations with []error
+
+To validate that stderr contain specific information, you can pass a slice of `error` as `test.Expects`
+second parameter.
+
+The command output on stderr is then verified to contain all stringified errors.
+
+### Stdout expectations with Comparators
+
+The last parameter of `test.Expects` accepts a `test.Comparator`, which allows testing the content of the command
+output on `stdout`.
+
+The following ready-made `test.Comparator` generators are provided:
+- `expect.Contains(string)`: verifies that stdout contains the string parameter
+- `expect.DoesNotContain(string)`: negation of above
+- `expect.Equals(string)`: strict equality
+- `expect.Match(*regexp.Regexp)`: regexp matching
+- `expect.All(comparators ...Comparator)`: allows to bundle together a bunch of other comparators
+- `expect.JSON[T any](obj T, verifier func(T, string, tig.T))`: allows to verify the output is valid JSON and optionally
+pass `verifier(T, string, tig.T)` extra validation
+
+### A complete example
+
+```go
+package main
+
+import (
+    "testing"
+    "errors"
+
+    "github.com/containerd/nerdctl/mod/tigron/tig"
+    "github.com/containerd/nerdctl/mod/tigron/test"
+    "github.com/containerd/nerdctl/mod/tigron/expect"
+)
+
+type Thing struct {
+    Name string
+}
+
+func TestMyThing(t *testing.T) {
+    // Declare your test
+    myTest := &test.Case{}
+
+    // Attach a command to run
+    myTest.Command = test.Custom("bash", "-c", "--", ">&2 echo thing; echo '{\"Name\": \"out\"}'; exit 42;")
+
+    // Set your expectations
+    myTest.Expected = test.Expects(
+        expect.ExitCodeGenericFail,
+        []error{errors.New("thing")},
+        expect.All(
+            expect.Contains("out"),
+            expect.DoesNotContain("something"),
+            expect.JSON(&Thing{}, func(obj *Thing, info string, t tig.T) {
+                assert.Equal(t, obj.Name, "something", info)
+            }),
+        ),
+    )
+
+    // Run it
+    myTest.Run(t)
+}
+```
+
+### Custom stdout comparators
+
+If you need to implement more advanced verifications on stdout that the ready-made comparators can't do,
+you can implement your own custom `test.Comparator`.
+
+For example:
+
+```go
+package whatever
+
+import (
+    "testing"
+
+    "gotest.tools/v3/assert"
+
+    "github.com/containerd/nerdctl/mod/tigron/tig"
+    "github.com/containerd/nerdctl/mod/tigron/test"
+)
+
+func TestMyThing(t *testing.T) {
+    // Declare your test
+    myTest := &test.Case{}
+
+    // Attach a command to run
+    myTest.Command = test.Custom("ls")
+
+    // Set your expectations
+    myTest.Expected = test.Expects(0, nil, func(stdout, info string, t tig.T){
+        t.Helper()
+        // Bla bla, do whatever advanced stuff and some asserts
+    })
+
+    // Run it
+    myTest.Run(t)
+}
+
+// You can of course generalize your comparator into a generator if it is going to be useful repeatedly
+
+func MyComparatorGenerator(param1, param2 any) test.Comparator {
+    return func(stdout, info string, t tig.T) {
+        t.Helper()
+        // Do your thing...
+        // ...
+    }
+}
+
+```
+
+You can now pass along `MyComparator(comparisonString)` as the third parameter of `test.Expects`, or compose it with
+other comparators using `expect.All(MyComparator(comparisonString), OtherComparator(somethingElse))`
+
+Note that you have access to an opaque `info` string, that provides a brief formatted header message that assert
+will use in case of failure to provide context on the error.
+You may of course ignore it and write your own message.
+
+### Advanced expectations
+
+You may want to have expectations that contain a certain piece of data that is being used in the command or at
+other stages of your test (like `Setup` for example).
+
+To achieve that, you should write your own `test.Manager` instead of using the helper `test.Expects`.
+
+A manager is a simple function which only role is to return a `test.Expected` struct.
+The `test.Manager` signature makes available `test.Data` and `test.Helpers` to you.
+
+Here is an example, where we are using `data.Get("sometestdata")`.
+
+```go
+package main
+
+import (
+    "errors"
+    "testing"
+
+    "gotest.tools/v3/assert"
+
+    "github.com/containerd/nerdctl/mod/tigron/test"
+)
+
+func TestMyThing(t *testing.T) {
+    // Declare your test
+    myTest := &test.Case{}
+
+    myTest.Setup = func(data test.Data, helpers test.Helpers){
+        // Do things...
+        // ...
+        // Save this for later
+        data.Set("something", "lalala")
+    }
+
+    // Attach a command to run
+    myTest.Command = test.Custom("somecommand")
+
+    // Set your fully custom expectations
+    myTest.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+        // With a custom Manager you have access to both the test.Data and test.Helpers to perform more
+        // refined verifications.
+        return &test.Expected{
+            ExitCode: 1,
+            Errors: []error{
+                errors.New("foobla"),
+            },
+            Output: func(stdout, info string, t tig.T) {
+                t.Helper()
+
+                // Retrieve the data that was set during the Setup phase.
+                assert.Assert(t, stdout == data.Get("sometestdata"), info)
+            },
+        }
+    }
+
+    // Run it
+    myTest.Run(t)
+}
+```

--- a/mod/tigron/internal/com/command_test.go
+++ b/mod/tigron/internal/com/command_test.go
@@ -411,7 +411,6 @@ func TestStdoutStderr(t *testing.T) {
 func TestTimeoutPlain(t *testing.T) {
 	t.Parallel()
 
-	start := time.Now()
 	command := &com.Command{
 		Binary: "bash",
 		// XXX unclear if windows is really able to terminate sleep 5, so, split it up to give it a
@@ -421,11 +420,10 @@ func TestTimeoutPlain(t *testing.T) {
 	}
 
 	err := command.Run(context.WithValue(context.Background(), com.LoggerKey, t))
-
 	assertive.ErrorIsNil(t, err, "Err")
 
+	start := time.Now()
 	res, err := command.Wait()
-
 	end := time.Now()
 
 	assertive.ErrorIs(t, err, com.ErrTimeout, "Err")
@@ -438,7 +436,6 @@ func TestTimeoutPlain(t *testing.T) {
 func TestTimeoutDelayed(t *testing.T) {
 	t.Parallel()
 
-	start := time.Now()
 	command := &com.Command{
 		Binary: "bash",
 		// XXX unclear if windows is really able to terminate sleep 5, so, split it up to give it a
@@ -448,20 +445,20 @@ func TestTimeoutDelayed(t *testing.T) {
 	}
 
 	err := command.Run(context.WithValue(context.Background(), com.LoggerKey, t))
-
 	assertive.ErrorIsNil(t, err, "Err")
 
-	time.Sleep(1 * time.Second)
+	start := time.Now()
+
+	time.Sleep(2 * time.Second)
 
 	res, err := command.Wait()
-
 	end := time.Now()
 
 	assertive.ErrorIs(t, err, com.ErrTimeout, "Err")
 	assertive.IsEqual(t, res.ExitCode, -1, "ExitCode")
 	assertive.IsEqual(t, res.Stdout, "one", "Stdout")
 	assertive.IsEqual(t, res.Stderr, "", "Stderr")
-	assertive.IsLessThan(t, end.Sub(start), 2*time.Second, "Total execution time")
+	assertive.IsLessThan(t, end.Sub(start), 3*time.Second, "Total execution time")
 }
 
 func TestPTYStdout(t *testing.T) {


### PR DESCRIPTION
<!> Blocked by <!>:
- [x] #4077

----------------------------------

This is a new series of Tigron PRs.

Now that the big change with the new command implementation is in, upcoming work on Tigron will focus on:
- **P0**: internal testing, getting to the point we can absolutely trust Tigron to **never** faceplant
- **P0**: debugging output readability and other developers quality of life improvements
- **P1**: code cleanup and simplification

Ideally, none of these PRs will require ANY change in nerdctl, and are either changes to the way we test Tigron itself, or refactoring that does not change signatures and API.

Efforts are being made to break these PRs down into small, digestible changes to ease and fasten review, which explains the chain of PRs.

LMK at any point if a given PR needs to be further broken down.

----------------------------------

**This third PR is small as well** (most of it is documentation)

**Commit 1** adds support for `expect.JSON[T]`.

The point is to remove repeated json unmarshalling boilerplate from tests.
Parsing JSON of course is not complex, but it adds unnecessary noise to tests.
Also added a detailed doc.

**Second commit** does change a couple of tests in nerdctl to demonstrate usage on volume tests.
If we are happy with the direction this is going to, I will cleanup more helpers and tests in a follow-up PR.

**Third commit** is unrelated to `expect.JSON`, but does fix a condition that triggered a failure on this specific PR, and is a minor test adjustment.