### PR TITLE
[Tigron]: Testing logs user experience

### DIFF
--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -37,6 +37,7 @@ linters:
     - cyclop            # provided by revive
     - exhaustruct       # does not serve much of a purpose
     - errcheck          # provided by revive
+    - errchkjson        # forces handling of json err (eg: prevents _), which is too much
     - forcetypeassert   # provided by revive
     - funlen            # provided by revive
     - gocognit          # provided by revive
@@ -65,7 +66,7 @@ linters:
           arguments: [60]
         - name: function-length
           # Default is 50, 75
-          arguments: [80, 180]
+          arguments: [80, 200]
         - name: cyclomatic
           # Default is 10
           arguments: [30]
@@ -93,11 +94,17 @@ linters:
           files:
             - $all
           allow:
+            # Allowing go standard library and tigron itself
             - $gostd
             - github.com/containerd/nerdctl/mod/tigron
+            # We use creack as our base for pty
             - github.com/creack/pty
+            # Used for display width computation in internal/formatter
+            - golang.org/x/text/width
+            # errgroups and term (make raw) are used by internal/pipes
             - golang.org/x/sync
             - golang.org/x/term
+            # EXPERIMENTAL: for go routines leakage detection
             - go.uber.org/goleak
     staticcheck:
       checks:

--- a/mod/tigron/expect/comparators.go
+++ b/mod/tigron/expect/comparators.go
@@ -30,11 +30,11 @@ import (
 
 // All can be used as a parameter for expected.Output to group a set of comparators.
 func All(comparators ...test.Comparator) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
 
 		for _, comparator := range comparators {
-			comparator(stdout, info, t)
+			comparator(stdout, "", t)
 		}
 	}
 }
@@ -42,47 +42,47 @@ func All(comparators ...test.Comparator) test.Comparator {
 // Contains can be used as a parameter for expected.Output and ensures a comparison string is found contained in the
 // output.
 func Contains(compare string) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
-		assertive.Contains(assertive.WithFailLater(t), stdout, compare, info)
+		assertive.Contains(assertive.WithFailLater(t), stdout, compare, "Inspecting output (contains)")
 	}
 }
 
 // DoesNotContain is to be used for expected.Output to ensure a comparison string is NOT found in the output.
 func DoesNotContain(compare string) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
-		assertive.DoesNotContain(assertive.WithFailLater(t), stdout, compare, info)
+		assertive.DoesNotContain(assertive.WithFailLater(t), stdout, compare, "Inspecting output (does not contain)")
 	}
 }
 
 // Equals is to be used for expected.Output to ensure it is exactly the output.
 func Equals(compare string) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
-		assertive.IsEqual(assertive.WithFailLater(t), stdout, compare, info)
+		assertive.IsEqual(assertive.WithFailLater(t), stdout, compare, "Inspecting output (equals)")
 	}
 }
 
 // Match is to be used for expected.Output to ensure we match a regexp.
 func Match(reg *regexp.Regexp) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
-		assertive.Match(assertive.WithFailLater(t), stdout, reg, info)
+		assertive.Match(assertive.WithFailLater(t), stdout, reg, "Inspecting output (match)")
 	}
 }
 
 // JSON allows to verify that the output can be marshalled into T, and optionally can be further verified by a provided
 // method.
 func JSON[T any](obj T, verifier func(T, string, tig.T)) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout, _ string, t *testing.T) {
 		t.Helper()
 
 		err := json.Unmarshal([]byte(stdout), &obj)
-		assertive.ErrorIsNil(assertive.WithFailLater(t), err, "failed to unmarshal JSON from stdout")
+		assertive.ErrorIsNil(assertive.WithSilentSuccess(t), err, "Unmarshalling JSON from stdout must succeed")
 
 		if verifier != nil && err == nil {
-			verifier(obj, info, t)
+			verifier(obj, "Inspecting output (JSON)", t)
 		}
 	}
 }

--- a/mod/tigron/go.mod
+++ b/mod/tigron/go.mod
@@ -5,8 +5,9 @@ go 1.23.0
 require (
 	github.com/creack/pty v1.1.24
 	go.uber.org/goleak v1.3.0
-	golang.org/x/sync v0.12.0
+	golang.org/x/sync v0.13.0
 	golang.org/x/term v0.30.0
+	golang.org/x/text v0.24.0
 )
 
 require golang.org/x/sys v0.31.0 // indirect

--- a/mod/tigron/go.sum
+++ b/mod/tigron/go.sum
@@ -8,11 +8,13 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
-golang.org/x/sync v0.12.0 h1:MHc5BpPuC30uJk597Ri8TV3CNZcTLu6B6z4lJy+g6Jw=
-golang.org/x/sync v0.12.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.30.0 h1:PQ39fJZ+mfadBm0y5WlL4vlM7Sx1Hgf13sMIY2+QS9Y=
 golang.org/x/term v0.30.0/go.mod h1:NYYFdzHoI5wRh/h5tDMdMqCqPJZEuNqVR5xJLd/n67g=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mod/tigron/internal/mimicry/print.go
+++ b/mod/tigron/internal/mimicry/print.go
@@ -40,7 +40,7 @@ func PrintCall(call *Call) string {
 	}
 
 	output := []string{
-		formatter.Table(debug),
+		formatter.Table(debug, "-"),
 		sectionSeparator,
 	}
 

--- a/mod/tigron/test/case.go
+++ b/mod/tigron/test/case.go
@@ -17,10 +17,13 @@
 package test
 
 import (
+	"encoding/json"
+	"fmt"
 	"slices"
 	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
+	"github.com/containerd/nerdctl/mod/tigron/internal/formatter"
 )
 
 // Case describes an entire test-case, including data, setup and cleanup routines, command and
@@ -62,9 +65,15 @@ type Case struct {
 	parent  *Case
 }
 
+const (
+	startDecorator  = "🚀"
+	cleanDecorator  = "🧽"
+	setupDecorator  = "🏗"
+	subinDecorator  = "⤵️"
+	suboutDecorator = "↩️"
+)
+
 // Run prepares and executes the test, and any possible subtests.
-//
-//nolint:gocognit
 func (test *Case) Run(t *testing.T) {
 	t.Helper()
 	// Run the test
@@ -72,17 +81,17 @@ func (test *Case) Run(t *testing.T) {
 	testRun := func(subT *testing.T) {
 		subT.Helper()
 
-		assertive.True(subT, test.t == nil, "You cannot run a test multiple times")
+		silentT := assertive.WithSilentSuccess(subT)
+
+		assertive.True(silentT, test.t == nil, "You cannot run a test multiple times")
+		assertive.True(silentT, test.Description != "" || test.parent == nil,
+			"A subtest description cannot be empty")
+		assertive.True(silentT, test.Command == nil || test.Expected != nil,
+			"Expectations for a test command cannot be nil. You may want to use `Setup` instead"+
+				"of `Command`.")
 
 		// Attach testing.T
 		test.t = subT
-		assertive.True(
-			test.t,
-			test.Description != "" || test.parent == nil,
-			"A test description cannot be empty",
-		)
-		assertive.True(test.t, test.Command == nil || test.Expected != nil,
-			"Expectations for a test command cannot be nil. You may want to use Setup instead.")
 
 		// Ensure we have env
 		if test.Env == nil {
@@ -168,49 +177,83 @@ func (test *Case) Run(t *testing.T) {
 		}
 
 		// Execute cleanups now
-		test.t.Log("")
-		test.t.Log("======================== Pre-test cleanup ========================")
-
-		for _, cleanup := range cleanups {
-			cleanup(test.Data, test.helpers)
-		}
-
-		// Register the cleanups, in reverse
-		test.t.Cleanup(func() {
-			test.t.Log("")
-			test.t.Log("======================== Post-test cleanup ========================")
-
-			slices.Reverse(cleanups)
+		if len(cleanups) > 0 {
+			test.t.Log(
+				"\n\n" + formatter.Table(
+					[][]any{{cleanDecorator, fmt.Sprintf("%q: initial cleanup", test.t.Name())}},
+					"=",
+				) + "\n",
+			)
 
 			for _, cleanup := range cleanups {
 				cleanup(test.Data, test.helpers)
 			}
-		})
+
+			// Register the cleanups, in reverse
+			test.t.Cleanup(func() {
+				test.t.Helper()
+				test.t.Log(
+					"\n\n" + formatter.Table(
+						[][]any{{cleanDecorator, fmt.Sprintf("%q: post-cleanup", test.t.Name())}},
+						"=",
+					) + "\n",
+				)
+
+				slices.Reverse(cleanups)
+
+				for _, cleanup := range cleanups {
+					cleanup(test.Data, test.helpers)
+				}
+			})
+		}
 
 		// Run the setups
-		test.t.Log("")
-		test.t.Log("======================== Test setup ========================")
+		if len(setups) > 0 {
+			test.t.Log(
+				"\n\n" + formatter.Table(
+					[][]any{{setupDecorator, fmt.Sprintf("%q: setup", test.t.Name())}},
+					"=",
+				) + "\n",
+			)
 
-		for _, setup := range setups {
-			setup(test.Data, test.helpers)
+			for _, setup := range setups {
+				setup(test.Data, test.helpers)
+			}
 		}
 
 		// Run the command if any, with expectations
 		// Note: if we have a command, we already know we DO have Expected
-		test.t.Log("")
-		test.t.Log("======================== Test Run ========================")
-
 		if test.Command != nil {
-			test.Command(test.Data, test.helpers).Run(test.Expected(test.Data, test.helpers))
+			cmd := test.Command(test.Data, test.helpers)
+
+			debugConfig, _ := json.MarshalIndent(test.Config.(*config).config, "", "  ")
+			debugData, _ := json.MarshalIndent(test.Data.(*data).labels, "", "  ")
+
+			test.t.Log(
+				"\n\n" + formatter.Table(
+					[][]any{
+						{startDecorator, fmt.Sprintf("%q: starting test!", test.t.Name())},
+						{"cwd", test.Data.TempDir()},
+						{"config", string(debugConfig)},
+						{"data", string(debugData)},
+					},
+					"=",
+				) + "\n",
+			)
+
+			cmd.Run(test.Expected(test.Data, test.helpers))
 		}
 
-		// Now go for the subtests
-		test.t.Log("")
-		test.t.Log("======================== Processing subtests ========================")
+		if len(test.SubTests) > 0 {
+			// Now go for the subtests
+			test.t.Logf("\n%s️ %q: into subtests prep", subinDecorator, test.t.Name())
 
-		for _, subTest := range test.SubTests {
-			subTest.parent = test
-			subTest.Run(test.t)
+			for _, subTest := range test.SubTests {
+				subTest.parent = test
+				subTest.Run(test.t)
+			}
+
+			test.t.Logf("\n%s️ %q: done with subtests prep", suboutDecorator, test.t.Name())
 		}
 	}
 

--- a/mod/tigron/test/helpers.go
+++ b/mod/tigron/test/helpers.go
@@ -32,6 +32,7 @@ type helpersInternal struct {
 
 // Ensure will run a command and make sure it is successful.
 func (help *helpersInternal) Ensure(args ...string) {
+	help.t.Helper()
 	help.Command(args...).Run(&Expected{
 		ExitCode: internal.ExitCodeSuccess,
 	})
@@ -39,6 +40,7 @@ func (help *helpersInternal) Ensure(args ...string) {
 
 // Anyhow will run a command regardless of outcome (may or may not fail).
 func (help *helpersInternal) Anyhow(args ...string) {
+	help.t.Helper()
 	help.Command(args...).Run(&Expected{
 		ExitCode: internal.ExitCodeNoCheck,
 	})
@@ -46,6 +48,7 @@ func (help *helpersInternal) Anyhow(args ...string) {
 
 // Fail will run a command and make sure it does fail.
 func (help *helpersInternal) Fail(args ...string) {
+	help.t.Helper()
 	help.Command(args...).Run(&Expected{
 		ExitCode: internal.ExitCodeGenericFail,
 	})
@@ -55,6 +58,7 @@ func (help *helpersInternal) Fail(args ...string) {
 func (help *helpersInternal) Capture(args ...string) string {
 	var ret string
 
+	help.t.Helper()
 	help.Command(args...).Run(&Expected{
 		//nolint:thelper
 		Output: func(stdout, _ string, _ *testing.T) {
@@ -67,6 +71,7 @@ func (help *helpersInternal) Capture(args ...string) string {
 
 // Err will run a command with no expectation and return Stderr.
 func (help *helpersInternal) Err(args ...string) string {
+	help.t.Helper()
 	cmd := help.Command(args...)
 	cmd.Run(nil)
 

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -105,6 +105,7 @@ type nerdCommand struct {
 }
 
 func (nc *nerdCommand) Run(expect *test.Expected) {
+	nc.T().Helper()
 	nc.prep()
 	if getTarget() == targetDocker {
 		// We are not in the business of testing docker *error* output, so, spay expectation here

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -45,6 +45,7 @@ func IsDocker() bool {
 
 // InspectContainer is a helper that can be used inside custom commands or Setup
 func InspectContainer(helpers test.Helpers, name string) dockercompat.Container {
+	helpers.T().Helper()
 	var dc []dockercompat.Container
 	cmd := helpers.Command("container", "inspect", name)
 	cmd.Run(&test.Expected{
@@ -58,6 +59,7 @@ func InspectContainer(helpers test.Helpers, name string) dockercompat.Container 
 }
 
 func InspectVolume(helpers test.Helpers, name string) native.Volume {
+	helpers.T().Helper()
 	var dc []native.Volume
 	cmd := helpers.Command("volume", "inspect", name)
 	cmd.Run(&test.Expected{
@@ -71,6 +73,7 @@ func InspectVolume(helpers test.Helpers, name string) native.Volume {
 }
 
 func InspectNetwork(helpers test.Helpers, name string) dockercompat.Network {
+	helpers.T().Helper()
 	var dc []dockercompat.Network
 	cmd := helpers.Command("network", "inspect", name)
 	cmd.Run(&test.Expected{
@@ -84,6 +87,7 @@ func InspectNetwork(helpers test.Helpers, name string) dockercompat.Network {
 }
 
 func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
+	helpers.T().Helper()
 	var dc []dockercompat.Image
 	cmd := helpers.Command("image", "inspect", name)
 	cmd.Run(&test.Expected{
@@ -102,6 +106,7 @@ const (
 )
 
 func EnsureContainerStarted(helpers test.Helpers, con string) {
+	helpers.T().Helper()
 	started := false
 	for i := 0; i < maxRetry && !started; i++ {
 		helpers.Command("container", "inspect", con).


### PR DESCRIPTION
<!> Blocked by <!>:
- [x] #4079

----------------------------------

This PR focuses specifically on enhancing the human experience of looking at  this:


![Untitled](https://github.com/user-attachments/assets/14d96d65-ba8b-47d5-bac0-8ebff87b527e)

I do spend a lot of time debugging on the CI, or locally, and here are my issues with this:

It is all packed, and very hard to distinguish one line from the other - everything visually stands at the same level - headers, context information, failure, file and line numbers.

This here is actually a simple failure - for more complex ones, it literally takes minutes of squinting to figure out where is the command that was run, and more time to figure out what is the "failure".

More often than not, the failure is really cryptic, as in `false is not true`.
Yeah, no shit Sherlock.
So, you do have to context switch to an IDE, find the file, go to that line number, try to understand the test, read the tea leaves, etc.
Also, since the filename is shown as basename only, I regularly open the wrong (identically named) one.

Context is hard to figure out too.

There are empty sections ("Setup") - did anything run in there? or not? if nothing ran, why show the section?
If something ran, what was it so that I can reproduce the context before trying to debug the command.

`Env` is a can of worms on its own - useful, but also very loud.

This PR would like to propose we address all these issues:
- separate things so that they are easier to visually spot
- hide what is not necessary, show what is
- show full lifecycle context to ease manual reproduction
- use indentation, tables, colors, borders, arrows, emoji, kitchen sink if necessary, in order to make this thing easier to visually grok and navigate _fast_
- hyperlinks where feasible to quickly open the right file in your IDE instead of searching around
- clear failure information, what was `actual`, what was `expected`, what did it all mean?
- clear sections emphasizing lifecycle

I do appreciate that everyone has their own tastes and preferences when it comes to visual things, so, I do not expect that we are going to agree on every detail, and we will have to settle on something.

The important part here is to come up with something that objectively addresses these issues - then we can bikeshed all we want on pink vs. green :-) (or I will make the output configurable so that different projects can pick their poison).

**I truly believe very few people engage with the CI failures not because they are lazy, but _because it looks like a train accident_.**


~~PLEASE NOTE THAT THIS PR **CODE** IS NOT READY FOR REVIEW.~~
~~What is ready for review and discussion right now is the visual end-result (see next comment).~~