### PR TITLE
[Tigron]: revised Data interface

### DIFF
--- a/cmd/nerdctl/completion/completion_test.go
+++ b/cmd/nerdctl/completion/completion_test.go
@@ -41,7 +41,7 @@ func TestCompletion(t *testing.T) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("network", "create", identifier)
 			helpers.Ensure("volume", "create", identifier)
-			data.Set("identifier", identifier)
+			data.Labels().Set("identifier", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			identifier := data.Identifier()
@@ -93,7 +93,7 @@ func TestCompletion(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.Contains("host\n"),
-							expect.Contains(data.Get("identifier")+"\n"),
+							expect.Contains(data.Labels().Get("identifier")+"\n"),
 						),
 					}
 				},
@@ -105,7 +105,7 @@ func TestCompletion(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.Contains("host\n"),
-							expect.Contains(data.Get("identifier")+"\n"),
+							expect.Contains(data.Labels().Get("identifier")+"\n"),
 						),
 					}
 				},
@@ -117,7 +117,7 @@ func TestCompletion(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.Contains("host\n"),
-							expect.Contains(data.Get("identifier")+"\n"),
+							expect.Contains(data.Labels().Get("identifier")+"\n"),
 						),
 					}
 				},
@@ -134,7 +134,7 @@ func TestCompletion(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.DoesNotContain("host\n"),
-							expect.Contains(data.Get("identifier")+"\n"),
+							expect.Contains(data.Labels().Get("identifier")+"\n"),
 						),
 					}
 				},
@@ -153,7 +153,7 @@ func TestCompletion(t *testing.T) {
 				Command:     test.Command("__complete", "volume", "inspect", ""),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: expect.Contains(data.Get("identifier") + "\n"),
+						Output: expect.Contains(data.Labels().Get("identifier") + "\n"),
 					}
 				},
 			},
@@ -162,7 +162,7 @@ func TestCompletion(t *testing.T) {
 				Command:     test.Command("__complete", "volume", "rm", ""),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: expect.Contains(data.Get("identifier") + "\n"),
+						Output: expect.Contains(data.Labels().Get("identifier") + "\n"),
 					}
 				},
 			},

--- a/cmd/nerdctl/container/container_commit_linux_test.go
+++ b/cmd/nerdctl/container/container_commit_linux_test.go
@@ -45,7 +45,7 @@ func TestKubeCommitSave(t *testing.T) {
 				containerID = strings.TrimPrefix(stdout, "containerd://")
 			},
 		})
-		data.Set("containerID", containerID)
+		data.Labels().Set("containerID", containerID)
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -53,7 +53,7 @@ func TestKubeCommitSave(t *testing.T) {
 	}
 
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
-		helpers.Ensure("commit", data.Get("containerID"), "testcommitsave")
+		helpers.Ensure("commit", data.Labels().Get("containerID"), "testcommitsave")
 		return helpers.Command("save", "testcommitsave")
 	}
 

--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -199,7 +199,7 @@ func TestIssue2993(t *testing.T) {
 		{
 			Description: "Issue #2993 - nerdctl no longer leaks containers and etchosts directories and files when container creation fails.",
 			Setup: func(data test.Data, helpers test.Helpers) {
-				dataRoot := data.TempDir()
+				dataRoot := data.Temp().Path()
 
 				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 
@@ -218,25 +218,25 @@ func TestIssue2993(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Equal(t, len(etchostsDirs), 1)
 
-				data.Set(containersPathKey, containersPath)
-				data.Set(etchostsPathKey, etchostsPath)
+				data.Labels().Set(containersPathKey, containersPath)
+				data.Labels().Set(etchostsPathKey, etchostsPath)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "--data-root", data.TempDir(), "-f", data.Identifier())
+				helpers.Anyhow("rm", "--data-root", data.Temp().Path(), "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--data-root", data.TempDir(), "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
+				return helpers.Command("run", "--data-root", data.Temp().Path(), "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("is already used by ID")},
 					Output: func(stdout string, info string, t *testing.T) {
-						containersDirs, err := os.ReadDir(data.Get(containersPathKey))
+						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 1)
 
-						etchostsDirs, err := os.ReadDir(data.Get(etchostsPathKey))
+						etchostsDirs, err := os.ReadDir(data.Labels().Get(etchostsPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(etchostsDirs), 1)
 					},
@@ -246,7 +246,7 @@ func TestIssue2993(t *testing.T) {
 		{
 			Description: "Issue #2993 - nerdctl no longer leaks containers and etchosts directories and files when containers are removed.",
 			Setup: func(data test.Data, helpers test.Helpers) {
-				dataRoot := data.TempDir()
+				dataRoot := data.Temp().Path()
 
 				helpers.Ensure("run", "--data-root", dataRoot, "--name", data.Identifier(), "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity)
 
@@ -265,25 +265,25 @@ func TestIssue2993(t *testing.T) {
 				assert.NilError(t, err)
 				assert.Equal(t, len(etchostsDirs), 1)
 
-				data.Set(containersPathKey, containersPath)
-				data.Set(etchostsPathKey, etchostsPath)
+				data.Labels().Set(containersPathKey, containersPath)
+				data.Labels().Set(etchostsPathKey, etchostsPath)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("--data-root", data.TempDir(), "rm", "-f", data.Identifier())
+				helpers.Anyhow("--data-root", data.Temp().Path(), "rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("--data-root", data.TempDir(), "rm", "-f", data.Identifier())
+				return helpers.Command("--data-root", data.Temp().Path(), "rm", "-f", data.Identifier())
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
 					Output: func(stdout string, info string, t *testing.T) {
-						containersDirs, err := os.ReadDir(data.Get(containersPathKey))
+						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 0)
 
-						etchostsDirs, err := os.ReadDir(data.Get(etchostsPathKey))
+						etchostsDirs, err := os.ReadDir(data.Labels().Get(etchostsPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(etchostsDirs), 0)
 					},

--- a/cmd/nerdctl/container/container_create_test.go
+++ b/cmd/nerdctl/container/container_create_test.go
@@ -35,7 +35,7 @@ func TestCreate(t *testing.T) {
 	testCase := nerdtest.Setup()
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("create", "--name", data.Identifier("container"), testutil.CommonImage, "echo", "foo")
-		data.Set("cID", data.Identifier("container"))
+		data.Labels().Set("cID", data.Identifier("container"))
 	}
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("rm", "-f", data.Identifier("container"))
@@ -55,7 +55,7 @@ func TestCreate(t *testing.T) {
 			Description: "start",
 			NoParallel:  true,
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("start", data.Get("cID"))
+				return helpers.Command("start", data.Labels().Get("cID"))
 			},
 			Expected: test.Expects(0, nil, nil),
 		},
@@ -63,7 +63,7 @@ func TestCreate(t *testing.T) {
 			Description: "logs",
 			NoParallel:  true,
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", data.Get("cID"))
+				return helpers.Command("logs", data.Labels().Get("cID"))
 			},
 			Expected: test.Expects(0, nil, expect.Contains("foo")),
 		},
@@ -79,7 +79,7 @@ func TestCreateHyperVContainer(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("create", "--isolation", "hyperv", "--name", data.Identifier("container"), testutil.CommonImage, "echo", "foo")
-		data.Set("cID", data.Identifier("container"))
+		data.Labels().Set("cID", data.Identifier("container"))
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -98,10 +98,10 @@ func TestCreateHyperVContainer(t *testing.T) {
 			Description: "start",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				helpers.Ensure("start", data.Get("cID"))
+				helpers.Ensure("start", data.Labels().Get("cID"))
 				ran := false
 				for i := 0; i < 10 && !ran; i++ {
-					helpers.Command("container", "inspect", data.Get("cID")).
+					helpers.Command("container", "inspect", data.Labels().Get("cID")).
 						Run(&test.Expected{
 							ExitCode: expect.ExitCodeNoCheck,
 							Output: func(stdout string, info string, t *testing.T) {
@@ -119,7 +119,7 @@ func TestCreateHyperVContainer(t *testing.T) {
 				assert.Assert(t, ran, "container did not ran after 10 seconds")
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", data.Get("cID"))
+				return helpers.Command("logs", data.Labels().Get("cID"))
 			},
 			Expected: test.Expects(0, nil, expect.Contains("foo")),
 		},

--- a/cmd/nerdctl/container/container_exec_linux_test.go
+++ b/cmd/nerdctl/container/container_exec_linux_test.go
@@ -65,14 +65,14 @@ func TestExecTTY(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
-		data.Set("container_name", data.Identifier())
+		data.Labels().Set("container_name", data.Identifier())
 	}
 
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "stty with -it",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("exec", "-it", data.Get("container_name"), "stty")
+				cmd := helpers.Command("exec", "-it", data.Labels().Get("container_name"), "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -81,7 +81,7 @@ func TestExecTTY(t *testing.T) {
 		{
 			Description: "stty with -t",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("exec", "-t", data.Get("container_name"), "stty")
+				cmd := helpers.Command("exec", "-t", data.Labels().Get("container_name"), "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -90,7 +90,7 @@ func TestExecTTY(t *testing.T) {
 		{
 			Description: "stty with -i",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("exec", "-i", data.Get("container_name"), "stty")
+				cmd := helpers.Command("exec", "-i", data.Labels().Get("container_name"), "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -99,7 +99,7 @@ func TestExecTTY(t *testing.T) {
 		{
 			Description: "stty without params",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("exec", data.Get("container_name"), "stty")
+				cmd := helpers.Command("exec", data.Labels().Get("container_name"), "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},

--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -531,10 +531,10 @@ RUN groupadd -r test && useradd -r -g test test
 USER test
 `, testutil.UbuntuImage)
 
-			err := os.WriteFile(filepath.Join(data.TempDir(), "Dockerfile"), []byte(dockerfile), 0o600)
+			err := os.WriteFile(filepath.Join(data.Temp().Path(), "Dockerfile"), []byte(dockerfile), 0o600)
 			assert.NilError(helpers.T(), err)
 
-			helpers.Ensure("build", "-t", data.Identifier(), data.TempDir())
+			helpers.Ensure("build", "-t", data.Identifier(), data.Temp().Path())
 			helpers.Ensure("create", "--name", data.Identifier(), "--user", "test", data.Identifier())
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -136,7 +136,7 @@ func TestRestartWithSignal(t *testing.T) {
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
 		cmd := nerdtest.RunSigProxyContainer(nerdtest.SigUsr1, false, nil, data, helpers)
 		// Capture the current pid
-		data.Set("oldpid", strconv.Itoa(nerdtest.InspectContainer(helpers, data.Identifier()).State.Pid))
+		data.Labels().Set("oldpid", strconv.Itoa(nerdtest.InspectContainer(helpers, data.Identifier()).State.Pid))
 		// Send the signal
 		helpers.Ensure("restart", "--signal", "SIGUSR1", data.Identifier())
 		return cmd
@@ -154,7 +154,7 @@ func TestRestartWithSignal(t *testing.T) {
 					nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 					// Check the new pid is different
 					newpid := strconv.Itoa(nerdtest.InspectContainer(helpers, data.Identifier()).State.Pid)
-					assert.Assert(helpers.T(), newpid != data.Get("oldpid"), info)
+					assert.Assert(helpers.T(), newpid != data.Labels().Get("oldpid"), info)
 				},
 			),
 		}

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -242,7 +242,7 @@ func TestRunDevice(t *testing.T) {
 			t.Logf("lo[%d] = %+v", i, lo[i])
 			loContent := fmt.Sprintf("lo%d-content", i)
 			assert.NilError(t, os.WriteFile(lo[i].Device, []byte(loContent), 0o700))
-			data.Set("loContent"+strconv.Itoa(i), loContent)
+			data.Labels().Set("loContent"+strconv.Itoa(i), loContent)
 		}
 
 		// lo0 is readable but not writable.
@@ -254,7 +254,7 @@ func TestRunDevice(t *testing.T) {
 			"--device", lo[0].Device+":r",
 			"--device", lo[1].Device,
 			testutil.AlpineImage, "sleep", nerdtest.Infinity)
-		data.Set("id", data.Identifier())
+		data.Labels().Set("id", data.Identifier())
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -270,25 +270,25 @@ func TestRunDevice(t *testing.T) {
 		{
 			Description: "can read lo0",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("exec", data.Get("id"), "cat", lo[0].Device)
+				return helpers.Command("exec", data.Labels().Get("id"), "cat", lo[0].Device)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.Contains(data.Get("locontent0")),
+					Output: expect.Contains(data.Labels().Get("locontent0")),
 				}
 			},
 		},
 		{
 			Description: "cannot write lo0",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("exec", data.Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[0].Device)
+				return helpers.Command("exec", data.Labels().Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[0].Device)
 			},
 			Expected: test.Expects(expect.ExitCodeGenericFail, nil, nil),
 		},
 		{
 			Description: "cannot read lo2",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("exec", data.Get("id"), "cat", lo[2].Device)
+				return helpers.Command("exec", data.Labels().Get("id"), "cat", lo[2].Device)
 			},
 			Expected: test.Expects(expect.ExitCodeGenericFail, nil, nil),
 		},
@@ -296,11 +296,11 @@ func TestRunDevice(t *testing.T) {
 			Description: "can read lo1",
 			NoParallel:  true,
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("exec", data.Get("id"), "cat", lo[1].Device)
+				return helpers.Command("exec", data.Labels().Get("id"), "cat", lo[1].Device)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.Contains(data.Get("locontent1")),
+					Output: expect.Contains(data.Labels().Get("locontent1")),
 				}
 			},
 		},
@@ -308,7 +308,7 @@ func TestRunDevice(t *testing.T) {
 			Description: "can write lo1 and read back updated value",
 			NoParallel:  true,
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("exec", data.Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[1].Device)
+				return helpers.Command("exec", data.Labels().Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[1].Device)
 			},
 			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, info string, t *testing.T) {
 				lo1Read, err := os.ReadFile(lo[1].Device)

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -363,10 +363,10 @@ func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
 		{
 			Description: "Run a container with invalid ports, and then clean up.",
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("rm", "--data-root", data.TempDir(), "-f", data.Identifier())
+				helpers.Anyhow("rm", "--data-root", data.Temp().Path(), "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--data-root", data.TempDir(), "--rm", "--name", data.Identifier(), "-p", "22200-22299:22200-22299", testutil.CommonImage)
+				return helpers.Command("run", "--data-root", data.Temp().Path(), "--rm", "--name", data.Identifier(), "-p", "22200-22299:22200-22299", testutil.CommonImage)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -382,7 +382,7 @@ func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
 							return h
 						}
 
-						dataRoot := data.TempDir()
+						dataRoot := data.Temp().Path()
 						h := getAddrHash(defaults.DefaultAddress)
 						dataStore := filepath.Join(dataRoot, h)
 						namespace := string(helpers.Read(nerdtest.Namespace))
@@ -519,8 +519,8 @@ func TestSharedNetworkSetup(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier("-container1"))
-			containerName1 := data.Get("containerName1")
+			data.Labels().Set("containerName1", data.Identifier("-container1"))
+			containerName1 := data.Labels().Get("containerName1")
 			helpers.Ensure("run", "-d", "--name", containerName1,
 				testutil.NginxAlpineImage)
 		},
@@ -538,7 +538,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "-d", "--name", containerName2,
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.NginxAlpineImage)
 					return cmd
 				},
@@ -547,7 +547,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 						Output: func(stdout string, info string, t *testing.T) {
 							containerName2 := data.Identifier()
 							assert.Assert(t, strings.Contains(helpers.Capture("exec", containerName2, "wget", "-qO-", "http://127.0.0.1:80"), testutil.NginxAlpineIndexHTMLSnippet), info)
-							helpers.Ensure("restart", data.Get("containerName1"))
+							helpers.Ensure("restart", data.Labels().Get("containerName1"))
 							helpers.Ensure("stop", "--time=1", containerName2)
 							helpers.Ensure("start", containerName2)
 							assert.Assert(t, strings.Contains(helpers.Capture("exec", containerName2, "wget", "-qO-", "http://127.0.0.1:80"), testutil.NginxAlpineIndexHTMLSnippet), info)
@@ -564,7 +564,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "-d", "--name", containerName2, "--uts", "host",
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.AlpineImage)
 					return cmd
 				},
@@ -583,7 +583,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "-d", "--name", containerName2, "--dns", "0.1.2.3",
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.AlpineImage)
 					return cmd
 				},
@@ -608,7 +608,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "--name", containerName2, "--dns-option", "attempts:5",
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.AlpineImage, "cat", "/etc/resolv.conf")
 					return cmd
 				},
@@ -631,7 +631,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "-d", "--name", containerName2, "--publish", "80:8080",
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.AlpineImage)
 					return cmd
 				},
@@ -656,7 +656,7 @@ func TestSharedNetworkSetup(t *testing.T) {
 					containerName2 := data.Identifier()
 					cmd := helpers.Command()
 					cmd.WithArgs("run", "-d", "--name", containerName2, "--hostname", "test",
-						"--network=container:"+data.Get("containerName1"),
+						"--network=container:"+data.Labels().Get("containerName1"),
 						testutil.AlpineImage)
 					return cmd
 				},
@@ -682,19 +682,19 @@ func TestSharedNetworkWithNone(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier("-container1"))
-			containerName1 := data.Get("containerName1")
+			data.Labels().Set("containerName1", data.Identifier("-container1"))
+			containerName1 := data.Labels().Get("containerName1")
 			helpers.Ensure("run", "-d", "--name", containerName1, "--network", "none",
 				testutil.NginxAlpineImage)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
-			helpers.Anyhow("rm", "-f", data.Get("containerName1"))
+			helpers.Anyhow("rm", "-f", data.Labels().Get("containerName1"))
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 			containerName2 := data.Identifier()
 			cmd := helpers.Command()
 			cmd.WithArgs("run", "-d", "--name", containerName2,
-				"--network=container:"+data.Get("containerName1"),
+				"--network=container:"+data.Labels().Get("containerName1"),
 				testutil.NginxAlpineImage)
 			return cmd
 		},
@@ -927,7 +927,7 @@ func TestNoneNetworkHostName(t *testing.T) {
 		Setup: func(data test.Data, helpers test.Helpers) {
 			output := helpers.Capture("run", "-d", "--name", data.Identifier(), "--network", "none", testutil.NginxAlpineImage)
 			assert.Assert(helpers.T(), len(output) > 12, output)
-			data.Set("hostname", output[:12])
+			data.Labels().Set("hostname", output[:12])
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rm", "-f", data.Identifier())
@@ -937,7 +937,7 @@ func TestNoneNetworkHostName(t *testing.T) {
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: expect.Equals(data.Get("hostname") + "\n"),
+				Output: expect.Equals(data.Labels().Get("hostname") + "\n"),
 			}
 		},
 	}
@@ -949,7 +949,7 @@ func TestHostNetworkHostName(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier())
+			data.Labels().Set("containerName1", data.Identifier())
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rm", "-f", data.Identifier())
@@ -974,7 +974,7 @@ func TestNoneNetworkDnsConfigs(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier())
+			data.Labels().Set("containerName1", data.Identifier())
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rm", "-f", data.Identifier())
@@ -1003,7 +1003,7 @@ func TestHostNetworkDnsConfigs(t *testing.T) {
 	testCase := &test.Case{
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
-			data.Set("containerName1", data.Identifier())
+			data.Labels().Set("containerName1", data.Identifier())
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rm", "-f", data.Identifier())

--- a/cmd/nerdctl/container/container_stats_test.go
+++ b/cmd/nerdctl/container/container_stats_test.go
@@ -53,7 +53,7 @@ func TestStats(t *testing.T) {
 		helpers.Ensure("run", "-d", "--name", data.Identifier("container"), testutil.CommonImage, "sleep", nerdtest.Infinity)
 		helpers.Ensure("run", "-d", "--name", data.Identifier("memlimited"), "--memory", "1g", testutil.CommonImage, "sleep", nerdtest.Infinity)
 		helpers.Ensure("run", "--name", data.Identifier("exited"), testutil.CommonImage, "echo", "'exited'")
-		data.Set("id", data.Identifier("container"))
+		data.Labels().Set("id", data.Identifier("container"))
 	}
 
 	testCase.SubTests = []*test.Case{
@@ -62,7 +62,7 @@ func TestStats(t *testing.T) {
 			Command:     test.Command("stats", "--no-stream", "--no-trunc"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.Contains(data.Get("id")),
+					Output: expect.Contains(data.Labels().Get("id")),
 				}
 			},
 		},
@@ -71,21 +71,21 @@ func TestStats(t *testing.T) {
 			Command:     test.Command("container", "stats", "--no-stream", "--no-trunc"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.Contains(data.Get("id")),
+					Output: expect.Contains(data.Labels().Get("id")),
 				}
 			},
 		},
 		{
 			Description: "stats ID",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("stats", "--no-stream", data.Get("id"))
+				return helpers.Command("stats", "--no-stream", data.Labels().Get("id"))
 			},
 			Expected: test.Expects(0, nil, nil),
 		},
 		{
 			Description: "container stats ID",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("container", "stats", "--no-stream", data.Get("id"))
+				return helpers.Command("container", "stats", "--no-stream", data.Labels().Get("id"))
 			},
 			Expected: test.Expects(0, nil, nil),
 		},

--- a/cmd/nerdctl/container/container_top_test.go
+++ b/cmd/nerdctl/container/container_top_test.go
@@ -38,7 +38,7 @@ func TestTop(t *testing.T) {
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		// FIXME: busybox 1.36 on windows still appears to not support sleep inf. Unclear why.
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
-		data.Set("cID", data.Identifier())
+		data.Labels().Set("cID", data.Identifier())
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -51,7 +51,7 @@ func TestTop(t *testing.T) {
 			// Docker does not support top -o
 			Require: require.Not(nerdtest.Docker),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("top", data.Get("cID"), "-o", "pid,user,cmd")
+				return helpers.Command("top", data.Labels().Get("cID"), "-o", "pid,user,cmd")
 			},
 
 			Expected: test.Expects(0, nil, nil),
@@ -59,7 +59,7 @@ func TestTop(t *testing.T) {
 		{
 			Description: "simple",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("top", data.Get("cID"))
+				return helpers.Command("top", data.Labels().Get("cID"))
 			},
 
 			Expected: test.Expects(0, nil, nil),

--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -115,16 +115,16 @@ func TestImageConvertNydusVerify(t *testing.T) {
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			base := testutil.NewBase(t)
 			registry = testregistry.NewWithNoAuth(base, 0, false)
-			data.Set(remoteImageKey, fmt.Sprintf("%s:%d/nydusd-image:test", "localhost", registry.Port))
+			data.Labels().Set(remoteImageKey, fmt.Sprintf("%s:%d/nydusd-image:test", "localhost", registry.Port))
 			helpers.Ensure("image", "convert", "--nydus", "--oci", testutil.CommonImage, data.Identifier("converted-image"))
-			helpers.Ensure("tag", data.Identifier("converted-image"), data.Get(remoteImageKey))
-			helpers.Ensure("push", data.Get(remoteImageKey))
+			helpers.Ensure("tag", data.Identifier("converted-image"), data.Labels().Get(remoteImageKey))
+			helpers.Ensure("push", data.Labels().Get(remoteImageKey))
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rmi", "-f", data.Identifier("converted-image"))
 			if registry != nil {
 				registry.Cleanup(nil)
-				helpers.Anyhow("rmi", "-f", data.Get(remoteImageKey))
+				helpers.Anyhow("rmi", "-f", data.Labels().Get(remoteImageKey))
 			}
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
@@ -133,7 +133,7 @@ func TestImageConvertNydusVerify(t *testing.T) {
 				"--source",
 				testutil.CommonImage,
 				"--target",
-				data.Get(remoteImageKey),
+				data.Labels().Get(remoteImageKey),
 				"--source-insecure",
 				"--target-insecure",
 			)

--- a/cmd/nerdctl/image/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image/image_encrypt_linux_test.go
@@ -51,7 +51,7 @@ func TestImageEncryptJWE(t *testing.T) {
 			if registry != nil {
 				registry.Cleanup(nil)
 				keyPair.Cleanup()
-				helpers.Anyhow("rmi", "-f", data.Get(remoteImageKey))
+				helpers.Anyhow("rmi", "-f", data.Labels().Get(remoteImageKey))
 			}
 			helpers.Anyhow("rmi", "-f", data.Identifier("decrypted"))
 		},
@@ -69,13 +69,13 @@ func TestImageEncryptJWE(t *testing.T) {
 			helpers.Ensure("push", encryptImageRef)
 			helpers.Anyhow("rmi", "-f", encryptImageRef)
 			helpers.Anyhow("rmi", "-f", testutil.CommonImage)
-			data.Set(remoteImageKey, encryptImageRef)
+			data.Labels().Set(remoteImageKey, encryptImageRef)
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			helpers.Fail("pull", data.Get(remoteImageKey))
-			helpers.Ensure("pull", "--quiet", "--unpack=false", data.Get(remoteImageKey))
-			helpers.Fail("image", "decrypt", "--key="+keyPair.Pub, data.Get(remoteImageKey), data.Identifier("decrypted")) // decryption needs prv key, not pub key
-			return helpers.Command("image", "decrypt", "--key="+keyPair.Prv, data.Get(remoteImageKey), data.Identifier("decrypted"))
+			helpers.Fail("pull", data.Labels().Get(remoteImageKey))
+			helpers.Ensure("pull", "--quiet", "--unpack=false", data.Labels().Get(remoteImageKey))
+			helpers.Fail("image", "decrypt", "--key="+keyPair.Pub, data.Labels().Get(remoteImageKey), data.Identifier("decrypted")) // decryption needs prv key, not pub key
+			return helpers.Command("image", "decrypt", "--key="+keyPair.Prv, data.Labels().Get(remoteImageKey), data.Identifier("decrypted"))
 		},
 		Expected: test.Expects(0, nil, nil),
 	}

--- a/cmd/nerdctl/image/image_history_test.go
+++ b/cmd/nerdctl/image/image_history_test.go
@@ -83,7 +83,7 @@ func TestImageHistory(t *testing.T) {
 			// XXX: despite efforts to isolate this test, it keeps on having side effects linked to
 			// https://github.com/containerd/nerdctl/issues/3512
 			// Isolating it into a completely different root is the last ditched attempt at avoiding the issue
-			helpers.Write(nerdtest.DataRoot, test.ConfigValue(data.TempDir()))
+			helpers.Write(nerdtest.DataRoot, test.ConfigValue(data.Temp().Path()))
 			helpers.Ensure("pull", "--quiet", "--platform", "linux/arm64", testutil.CommonImage)
 		},
 		SubTests: []*test.Case{

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -43,7 +43,7 @@ func TestLoadStdinFromPipe(t *testing.T) {
 			identifier := data.Identifier()
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, identifier)
-			helpers.Ensure("save", identifier, "-o", filepath.Join(data.TempDir(), "common.tar"))
+			helpers.Ensure("save", identifier, "-o", filepath.Join(data.Temp().Path(), "common.tar"))
 			helpers.Ensure("rmi", "-f", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -51,7 +51,7 @@ func TestLoadStdinFromPipe(t *testing.T) {
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 			cmd := helpers.Command("load")
-			reader, err := os.Open(filepath.Join(data.TempDir(), "common.tar"))
+			reader, err := os.Open(filepath.Join(data.Temp().Path(), "common.tar"))
 			assert.NilError(t, err, "failed to open common.tar")
 			cmd.Feed(reader)
 			return cmd
@@ -94,14 +94,14 @@ func TestLoadQuiet(t *testing.T) {
 			identifier := data.Identifier()
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			helpers.Ensure("tag", testutil.CommonImage, identifier)
-			helpers.Ensure("save", identifier, "-o", filepath.Join(data.TempDir(), "common.tar"))
+			helpers.Ensure("save", identifier, "-o", filepath.Join(data.Temp().Path(), "common.tar"))
 			helpers.Ensure("rmi", "-f", identifier)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			helpers.Anyhow("rmi", "-f", data.Identifier())
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			return helpers.Command("load", "--quiet", "--input", filepath.Join(data.TempDir(), "common.tar"))
+			return helpers.Command("load", "--quiet", "--input", filepath.Join(data.Temp().Path(), "common.tar"))
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -71,7 +71,7 @@ func TestImagePrune(t *testing.T) {
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
 
-				buildCtx := data.TempDir()
+				buildCtx := data.Temp().Path()
 				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
 				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", buildCtx)
@@ -119,7 +119,7 @@ func TestImagePrune(t *testing.T) {
 				CMD ["echo", "nerdctl-test-image-prune"]
 					`, testutil.CommonImage)
 
-				buildCtx := data.TempDir()
+				buildCtx := data.Temp().Path()
 				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
 				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", buildCtx)
@@ -163,7 +163,7 @@ func TestImagePrune(t *testing.T) {
 CMD ["echo", "nerdctl-test-image-prune-filter-label"]
 LABEL foo=bar
 LABEL version=0.1`, testutil.CommonImage)
-				buildCtx := data.TempDir()
+				buildCtx := data.Temp().Path()
 				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
 				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
@@ -203,22 +203,22 @@ LABEL version=0.1`, testutil.CommonImage)
 				dockerfile := fmt.Sprintf(`FROM %s
 RUN echo "Anything, so that we create actual content for docker to set the current time for CreatedAt"
 CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
-				buildCtx := data.TempDir()
+				buildCtx := data.Temp().Path()
 				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
 				assert.NilError(helpers.T(), err)
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())
-				data.Set("imageID", data.Identifier())
+				data.Labels().Set("imageID", data.Identifier())
 			},
 			Command: test.Command("image", "prune", "--force", "--all", "--filter", "until=12h"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.DoesNotContain(data.Get("imageID")),
+						expect.DoesNotContain(data.Labels().Get("imageID")),
 						func(stdout string, info string, t *testing.T) {
 							imgList := helpers.Capture("images")
-							assert.Assert(t, strings.Contains(imgList, data.Get("imageID")), info)
+							assert.Assert(t, strings.Contains(imgList, data.Labels().Get("imageID")), info)
 						},
 					),
 				}
@@ -234,10 +234,10 @@ CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 					Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 						return &test.Expected{
 							Output: expect.All(
-								expect.Contains(data.Get("imageID")),
+								expect.Contains(data.Labels().Get("imageID")),
 								func(stdout string, info string, t *testing.T) {
 									imgList := helpers.Capture("images")
-									assert.Assert(t, !strings.Contains(imgList, data.Get("imageID")), imgList, info)
+									assert.Assert(t, !strings.Contains(imgList, data.Labels().Get("imageID")), imgList, info)
 								},
 							),
 						}

--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -67,16 +67,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", data.Get("testImageRef"))
+					return helpers.Command("push", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(1, []error{errors.New("server gave HTTP response to HTTPS client")}, nil),
 			},
@@ -87,16 +87,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--insecure-registry", data.Get("testImageRef"))
+					return helpers.Command("push", "--insecure-registry", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -106,11 +106,11 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						"127.0.0.1", registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", data.Get("testImageRef"))
+					return helpers.Command("push", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -121,16 +121,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s/%s:%s",
 						registryNoAuthHTTPDefault.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--insecure-registry", data.Get("testImageRef"))
+					return helpers.Command("push", "--insecure-registry", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -141,19 +141,19 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 					helpers.Ensure("--insecure-registry", "login", "-u", "admin", "-p", "badmin",
 						fmt.Sprintf("%s:%d", registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port))
 
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--insecure-registry", data.Get("testImageRef"))
+					return helpers.Command("push", "--insecure-registry", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -164,19 +164,19 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port, data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.CommonImage, testImageRef)
 					helpers.Ensure("--hosts-dir", registryTokenAuthHTTPSRandom.HostsDir, "login", "-u", "admin", "-p", "badmin",
 						fmt.Sprintf("%s:%d", registryTokenAuthHTTPSRandom.IP.String(), registryTokenAuthHTTPSRandom.Port))
 
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--hosts-dir", registryTokenAuthHTTPSRandom.HostsDir, data.Get("testImageRef"))
+					return helpers.Command("push", "--hosts-dir", registryTokenAuthHTTPSRandom.HostsDir, data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -187,16 +187,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.NonDistBlobImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.NonDistBlobImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.NonDistBlobImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--insecure-registry", data.Get("testImageRef"))
+					return helpers.Command("push", "--insecure-registry", data.Labels().Get("testImageRef"))
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
@@ -219,16 +219,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.NonDistBlobImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.NonDistBlobImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.NonDistBlobImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--insecure-registry", "--allow-nondistributable-artifacts", data.Get("testImageRef"))
+					return helpers.Command("push", "--insecure-registry", "--allow-nondistributable-artifacts", data.Labels().Get("testImageRef"))
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
@@ -254,16 +254,16 @@ func TestPush(t *testing.T) {
 					helpers.Ensure("pull", "--quiet", testutil.UbuntuImage)
 					testImageRef := fmt.Sprintf("%s:%d/%s:%s",
 						registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), strings.Split(testutil.UbuntuImage, ":")[1])
-					data.Set("testImageRef", testImageRef)
+					data.Labels().Set("testImageRef", testImageRef)
 					helpers.Ensure("tag", testutil.UbuntuImage, testImageRef)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
-					if data.Get("testImageRef") != "" {
-						helpers.Anyhow("rmi", "-f", data.Get("testImageRef"))
+					if data.Labels().Get("testImageRef") != "" {
+						helpers.Anyhow("rmi", "-f", data.Labels().Get("testImageRef"))
 					}
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("push", "--snapshotter=soci", "--insecure-registry", "--soci-span-size=2097152", "--soci-min-layer-size=20971520", data.Get("testImageRef"))
+					return helpers.Command("push", "--snapshotter=soci", "--insecure-registry", "--soci-span-size=2097152", "--soci-min-layer-size=20971520", data.Labels().Get("testImageRef"))
 				},
 				Expected: test.Expects(0, nil, nil),
 			},

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -129,11 +129,11 @@ func TestRemove(t *testing.T) {
 				repoName, _ := imgutil.ParseRepoTag(testutil.CommonImage)
 				imgShortID := strings.TrimPrefix(img.RepoDigests[0], repoName+"@sha256:")[0:8]
 
-				data.Set(imgShortIDKey, imgShortID)
+				data.Labels().Set(imgShortIDKey, imgShortID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("rmi", "-f", data.Get(imgShortIDKey))
+				helpers.Anyhow("rmi", "-f", data.Labels().Get(imgShortIDKey))
 			},
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -238,11 +238,11 @@ func TestRemove(t *testing.T) {
 				repoName, _ := imgutil.ParseRepoTag(testutil.CommonImage)
 				imgShortID := strings.TrimPrefix(img.RepoDigests[0], repoName+"@sha256:")[0:8]
 
-				data.Set(imgShortIDKey, imgShortID)
+				data.Labels().Set(imgShortIDKey, imgShortID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("rmi", "-f", data.Get(imgShortIDKey))
+				helpers.Anyhow("rmi", "-f", data.Labels().Get(imgShortIDKey))
 			},
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -330,17 +330,17 @@ func TestIssue3016(t *testing.T) {
 
 				helpers.Ensure("tag", testutil.CommonImage, tagID)
 
-				data.Set(tagIDKey, tagID)
+				data.Labels().Set(tagIDKey, tagID)
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("rmi", data.Get(tagIDKey))
+				return helpers.Command("rmi", data.Labels().Get(tagIDKey))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
 					Output: func(stdout string, info string, t *testing.T) {
-						helpers.Command("images", data.Get(tagIDKey)).Run(&test.Expected{
+						helpers.Command("images", data.Labels().Get(tagIDKey)).Run(&test.Expected{
 							ExitCode: 0,
 							Output: func(stdout string, info string, t *testing.T) {
 								assert.Equal(t, len(strings.Split(stdout, "\n")), 2)

--- a/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_kubo_linux_test.go
@@ -51,7 +51,7 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 		ipfsRegistry = registry.NewKuboRegistry(data, helpers, t, nil, 0, nil)
 		ipfsRegistry.Setup(data, helpers)
 		ipfsAddr := fmt.Sprintf("/ip4/%s/tcp/%d", ipfsRegistry.IP, ipfsRegistry.Port)
-		data.Set(ipfsAddrKey, ipfsAddr)
+		data.Labels().Set(ipfsAddrKey, ipfsAddr)
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -65,17 +65,17 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)))
-				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
-				data.Set(mainImageCIDKey, ipfsCID)
+				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Labels().Get(ipfsAddrKey)))
+				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Labels().Get(ipfsAddrKey), "ipfs://"+ipfsCID)
+				data.Labels().Set(mainImageCIDKey, ipfsCID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(mainImageCIDKey), "echo", "hello")
+				return helpers.Command("run", "--rm", data.Labels().Get(mainImageCIDKey), "echo", "hello")
 			},
 			Expected: test.Expects(0, nil, expect.Equals("hello\n")),
 		},
@@ -88,17 +88,17 @@ func TestIPFSAddrWithKubo(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Get(ipfsAddrKey)), "--estargz")
-				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Get(ipfsAddrKey), "ipfs://"+ipfsCID)
-				data.Set(mainImageCIDKey, ipfsCID)
+				ipfsCID := pushToIPFS(helpers, testutil.CommonImage, fmt.Sprintf("--ipfs-address=%s", data.Labels().Get(ipfsAddrKey)), "--estargz")
+				helpers.Ensure("pull", "--quiet", "--ipfs-address", data.Labels().Get(ipfsAddrKey), "ipfs://"+ipfsCID)
+				data.Labels().Set(mainImageCIDKey, ipfsCID)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(mainImageCIDKey), "ls", "/.stargz-snapshotter")
+				return helpers.Command("run", "--rm", data.Labels().Get(mainImageCIDKey), "ls", "/.stargz-snapshotter")
 			},
 			Expected: test.Expects(0, nil, expect.Match(regexp.MustCompile("sha256:.*[.]json[\n]"))),
 		},

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -89,16 +89,16 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
+				data.Labels().Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
+				helpers.Ensure("pull", "--quiet", data.Labels().Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(ipfsImageURLKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(ipfsImageURLKey))
+				if data.Labels().Get(ipfsImageURLKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(ipfsImageURLKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(ipfsImageURLKey), "echo", "hello")
+				return helpers.Command("run", "--rm", data.Labels().Get(ipfsImageURLKey), "echo", "hello")
 			},
 			Expected: test.Expects(0, nil, expect.Equals("hello\n")),
 		},
@@ -107,16 +107,16 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			NoParallel:  true,
 			Require:     nerdtest.Stargz,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
-				helpers.Ensure("pull", "--quiet", data.Get(ipfsImageURLKey))
+				data.Labels().Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
+				helpers.Ensure("pull", "--quiet", data.Labels().Get(ipfsImageURLKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(ipfsImageURLKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(ipfsImageURLKey))
+				if data.Labels().Get(ipfsImageURLKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(ipfsImageURLKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(ipfsImageURLKey), "ls", "/.stargz-snapshotter")
+				return helpers.Command("run", "--rm", data.Labels().Get(ipfsImageURLKey), "ls", "/.stargz-snapshotter")
 			},
 			Expected: test.Expects(0, nil, expect.Match(regexp.MustCompile("sha256:.*[.]json[\n]"))),
 		},
@@ -126,18 +126,18 @@ func TestIPFSNerdctlRegistry(t *testing.T) {
 			Require:     nerdtest.Build,
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rmi", "-f", data.Identifier("built-image"))
-				if data.Get(ipfsImageURLKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(ipfsImageURLKey))
+				if data.Labels().Get(ipfsImageURLKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(ipfsImageURLKey))
 				}
 			},
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
+				data.Labels().Set(ipfsImageURLKey, listenAddr+"/ipfs/"+pushToIPFS(helpers, testutil.CommonImage))
 
 				dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-test-string"]
-	`, data.Get(ipfsImageURLKey))
+	`, data.Labels().Get(ipfsImageURLKey))
 
-				buildCtx := data.TempDir()
+				buildCtx := data.Temp().Path()
 				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
 				assert.NilError(helpers.T(), err)
 

--- a/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_simple_linux_test.go
@@ -53,16 +53,16 @@ func TestIPFSSimple(t *testing.T) {
 			Description: "with default snapshotter",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
+				data.Labels().Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(mainImageCIDKey), "echo", "hello")
+				return helpers.Command("run", "--rm", data.Labels().Get(mainImageCIDKey), "echo", "hello")
 			},
 			Expected: test.Expects(0, nil, expect.Equals("hello\n")),
 		},
@@ -74,16 +74,16 @@ func TestIPFSSimple(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
+				data.Labels().Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(mainImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
 				}
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(mainImageCIDKey), "ls", "/.stargz-snapshotter")
+				return helpers.Command("run", "--rm", data.Labels().Get(mainImageCIDKey), "ls", "/.stargz-snapshotter")
 			},
 			Expected: test.Expects(0, nil, expect.Match(regexp.MustCompile("sha256:.*[.]json[\n]"))),
 		},
@@ -91,32 +91,32 @@ func TestIPFSSimple(t *testing.T) {
 			Description: "with commit and push",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
+				data.Labels().Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
-				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
+				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Labels().Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
 				helpers.Ensure("commit", data.Identifier("commit-container"), data.Identifier("commit-image"))
-				data.Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("commit-image")))
+				data.Labels().Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("commit-image")))
 
 				// Clean-up
 				helpers.Ensure("rm", data.Identifier("commit-container"))
 				helpers.Ensure("rmi", data.Identifier("commit-image"))
 
 				// Pull back the committed image
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier("commit-container"))
 				helpers.Anyhow("rmi", "-f", data.Identifier("commit-image"))
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
-					helpers.Anyhow("rmi", "-f", data.Get(transformedImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(transformedImageCIDKey))
 				}
 			},
 
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(transformedImageCIDKey), "cat", "/hello")
+				return helpers.Command("run", "--rm", data.Labels().Get(transformedImageCIDKey), "cat", "/hello")
 			},
 
 			Expected: test.Expects(0, nil, expect.Equals("hello\n")),
@@ -129,32 +129,32 @@ func TestIPFSSimple(t *testing.T) {
 				nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3475"),
 			),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
+				data.Labels().Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage, "--estargz"))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(mainImageCIDKey))
 
 				// Run a container that does modify something, then commit and push it
-				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
+				helpers.Ensure("run", "--name", data.Identifier("commit-container"), data.Labels().Get(mainImageCIDKey), "sh", "-c", "--", "echo hello > /hello")
 				helpers.Ensure("commit", data.Identifier("commit-container"), data.Identifier("commit-image"))
-				data.Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("commit-image")))
+				data.Labels().Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("commit-image")))
 
 				// Clean-up
 				helpers.Ensure("rm", data.Identifier("commit-container"))
 				helpers.Ensure("rmi", data.Identifier("commit-image"))
 
 				// Pull back the image
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier("commit-container"))
 				helpers.Anyhow("rmi", "-f", data.Identifier("commit-image"))
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
-					helpers.Anyhow("rmi", "-f", data.Get(transformedImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(transformedImageCIDKey))
 				}
 			},
 
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("run", "--rm", data.Get(transformedImageCIDKey), "sh", "-c", "--", "cat /hello && ls /.stargz-snapshotter")
+				return helpers.Command("run", "--rm", data.Labels().Get(transformedImageCIDKey), "sh", "-c", "--", "cat /hello && ls /.stargz-snapshotter")
 			},
 
 			Expected: test.Expects(0, nil, expect.Match(regexp.MustCompile("hello[\n]sha256:.*[.]json[\n]"))),
@@ -164,18 +164,18 @@ func TestIPFSSimple(t *testing.T) {
 			NoParallel:  true,
 			Require:     require.Binary("openssl"),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
-				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Get(mainImageCIDKey))
+				data.Labels().Set(mainImageCIDKey, pushToIPFS(helpers, testutil.CommonImage))
+				helpers.Ensure("pull", "--quiet", "ipfs://"+data.Labels().Get(mainImageCIDKey))
 
 				// Prep a key pair
 				keyPair := testhelpers.NewJWEKeyPair(t)
 				// FIXME: this will only cleanup when the group is done, not right, but it works
 				t.Cleanup(keyPair.Cleanup)
-				data.Set("pub", keyPair.Pub)
-				data.Set("prv", keyPair.Prv)
+				data.Labels().Set("pub", keyPair.Pub)
+				data.Labels().Set("prv", keyPair.Prv)
 
 				// Encrypt the image, and verify it is encrypted
-				helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, data.Get(mainImageCIDKey), data.Identifier("encrypted"))
+				helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, data.Labels().Get(mainImageCIDKey), data.Identifier("encrypted"))
 				cmd := helpers.Command("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", data.Identifier("encrypted"))
 				cmd.Run(&test.Expected{
 					Output: expect.Equals("1\n"),
@@ -186,19 +186,19 @@ func TestIPFSSimple(t *testing.T) {
 				})
 
 				// Push the encrypted image and save the CID
-				data.Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("encrypted")))
+				data.Labels().Set(transformedImageCIDKey, pushToIPFS(helpers, data.Identifier("encrypted")))
 
 				// Remove both images locally
-				helpers.Ensure("rmi", "-f", data.Get(mainImageCIDKey))
-				helpers.Ensure("rmi", "-f", data.Get(transformedImageCIDKey))
+				helpers.Ensure("rmi", "-f", data.Labels().Get(mainImageCIDKey))
+				helpers.Ensure("rmi", "-f", data.Labels().Get(transformedImageCIDKey))
 
 				// Pull back without unpacking
-				helpers.Ensure("pull", "--quiet", "--unpack=false", "ipfs://"+data.Get(transformedImageCIDKey))
+				helpers.Ensure("pull", "--quiet", "--unpack=false", "ipfs://"+data.Labels().Get(transformedImageCIDKey))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get(mainImageCIDKey) != "" {
-					helpers.Anyhow("rmi", "-f", data.Get(mainImageCIDKey))
-					helpers.Anyhow("rmi", "-f", data.Get(transformedImageCIDKey))
+				if data.Labels().Get(mainImageCIDKey) != "" {
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(mainImageCIDKey))
+					helpers.Anyhow("rmi", "-f", data.Labels().Get(transformedImageCIDKey))
 				}
 			},
 			SubTests: []*test.Case{
@@ -208,7 +208,7 @@ func TestIPFSSimple(t *testing.T) {
 						helpers.Anyhow("rm", "-f", data.Identifier("decrypted"))
 					},
 					Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-						return helpers.Command("image", "decrypt", "--key="+data.Get("pub"), data.Get(transformedImageCIDKey), data.Identifier("decrypted"))
+						return helpers.Command("image", "decrypt", "--key="+data.Labels().Get("pub"), data.Labels().Get(transformedImageCIDKey), data.Identifier("decrypted"))
 					},
 					Expected: test.Expects(1, nil, nil),
 				},
@@ -218,7 +218,7 @@ func TestIPFSSimple(t *testing.T) {
 						helpers.Anyhow("rm", "-f", data.Identifier("decrypted"))
 					},
 					Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-						return helpers.Command("image", "decrypt", "--key="+data.Get("prv"), data.Get(transformedImageCIDKey), data.Identifier("decrypted"))
+						return helpers.Command("image", "decrypt", "--key="+data.Labels().Get("prv"), data.Labels().Get(transformedImageCIDKey), data.Identifier("decrypted"))
 					},
 					Expected: test.Expects(0, nil, nil),
 				},

--- a/cmd/nerdctl/main_test_test.go
+++ b/cmd/nerdctl/main_test_test.go
@@ -72,29 +72,29 @@ func TestTest(t *testing.T) {
 		},
 		{
 			Description: "data propagation",
-			Data:        test.WithData("status", "uninitialized"),
+			Data:        test.WithLabels(map[string]string{"status": "uninitialized"}),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				data.Set("status", data.Get("status")+"-setup")
+				data.Labels().Set("status", data.Labels().Get("status")+"-setup")
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Custom("printf", data.Get("status"))
-				data.Set("status", data.Get("status")+"-command")
+				cmd := helpers.Custom("printf", data.Labels().Get("status"))
+				data.Labels().Set("status", data.Labels().Get("status")+"-command")
 				return cmd
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				if data.Get("status") == "uninitialized" {
+				if data.Labels().Get("status") == "uninitialized" {
 					return
 				}
-				if data.Get("status") != "uninitialized-setup-command" {
-					log.Fatalf("unexpected status label %q", data.Get("status"))
+				if data.Labels().Get("status") != "uninitialized-setup-command" {
+					log.Fatalf("unexpected status label %q", data.Labels().Get("status"))
 				}
-				data.Set("status", data.Get("status")+"-cleanup")
+				data.Labels().Set("status", data.Labels().Get("status")+"-cleanup")
 			},
 			SubTests: []*test.Case{
 				{
 					Description: "Subtest data propagation",
 					Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-						return helpers.Custom("printf", data.Get("status"))
+						return helpers.Custom("printf", data.Labels().Get("status"))
 					},
 					Expected: test.Expects(0, nil, expect.Equals("uninitialized-setup-command")),
 				},

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -42,7 +42,7 @@ func TestNetworkCreate(t *testing.T) {
 				helpers.Ensure("network", "create", identifier)
 				netw := nerdtest.InspectNetwork(helpers, identifier)
 				assert.Equal(t, len(netw.IPAM.Config), 1)
-				data.Set("subnet", netw.IPAM.Config[0].Subnet)
+				data.Labels().Set("subnet", netw.IPAM.Config[0].Subnet)
 
 				helpers.Ensure("network", "create", data.Identifier("1"))
 			},
@@ -51,7 +51,7 @@ func TestNetworkCreate(t *testing.T) {
 				helpers.Anyhow("network", "rm", data.Identifier("1"))
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				data.Set("container2", helpers.Capture("run", "--rm", "--net", data.Identifier("1"), testutil.CommonImage, "ip", "route"))
+				data.Labels().Set("container2", helpers.Capture("run", "--rm", "--net", data.Identifier("1"), testutil.CommonImage, "ip", "route"))
 				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.CommonImage, "ip", "route")
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -59,8 +59,8 @@ func TestNetworkCreate(t *testing.T) {
 					ExitCode: 0,
 					Errors:   nil,
 					Output: func(stdout string, info string, t *testing.T) {
-						assert.Assert(t, strings.Contains(stdout, data.Get("subnet")), info)
-						assert.Assert(t, !strings.Contains(data.Get("container2"), data.Get("subnet")), info)
+						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("subnet")), info)
+						assert.Assert(t, !strings.Contains(data.Labels().Get("container2"), data.Labels().Get("subnet")), info)
 					},
 				}
 			},
@@ -83,7 +83,7 @@ func TestNetworkCreate(t *testing.T) {
 			Require:     nerdtest.OnlyIPv6,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				subnetStr := "2001:db8:8::/64"
-				data.Set("subnetStr", subnetStr)
+				data.Labels().Set("subnetStr", subnetStr)
 				_, _, err := net.ParseCIDR(subnetStr)
 				assert.Assert(t, err == nil)
 
@@ -99,7 +99,7 @@ func TestNetworkCreate(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
-						_, subnet, _ := net.ParseCIDR(data.Get("subnetStr"))
+						_, subnet, _ := net.ParseCIDR(data.Labels().Get("subnetStr"))
 						ip := ipv6helper.FindIPv6(stdout)
 						assert.Assert(t, subnet.Contains(ip), info)
 					},

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -43,7 +43,7 @@ func TestNetworkInspect(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("network", "create", data.Identifier("basenet"))
-		data.Set("basenet", data.Identifier("basenet"))
+		data.Labels().Set("basenet", data.Identifier("basenet"))
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -132,7 +132,7 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "match exact id",
 			// See notes below
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Get("basenet"), "--format", "{{ .Id }}"))
+				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Labels().Get("basenet"), "--format", "{{ .Id }}"))
 				return helpers.Command("network", "inspect", id)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -142,7 +142,7 @@ func TestNetworkInspect(t *testing.T) {
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
 						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-						assert.Equal(t, dc[0].Name, data.Get("basenet"))
+						assert.Equal(t, dc[0].Name, data.Labels().Get("basenet"))
 					},
 				}
 			},
@@ -153,7 +153,7 @@ func TestNetworkInspect(t *testing.T) {
 			// This is bizarre, as it is working in the match exact id test - and there does not seem to be a particular reason for that
 			Require: require.Not(require.Windows),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Get("basenet"), "--format", "{{ .Id }}"))
+				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Labels().Get("basenet"), "--format", "{{ .Id }}"))
 				return helpers.Command("network", "inspect", id[0:25])
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
@@ -163,7 +163,7 @@ func TestNetworkInspect(t *testing.T) {
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
 						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-						assert.Equal(t, dc[0].Name, data.Get("basenet"))
+						assert.Equal(t, dc[0].Name, data.Labels().Get("basenet"))
 					},
 				}
 			},
@@ -174,15 +174,15 @@ func TestNetworkInspect(t *testing.T) {
 			// This is bizarre, as it is working in the match exact id test - and there does not seem to be a particular reason for that
 			Require: require.Not(require.Windows),
 			Setup: func(data test.Data, helpers test.Helpers) {
-				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Get("basenet"), "--format", "{{ .Id }}"))
+				id := strings.TrimSpace(helpers.Capture("network", "inspect", data.Labels().Get("basenet"), "--format", "{{ .Id }}"))
 				helpers.Ensure("network", "create", id[0:12])
-				data.Set("netname", id[0:12])
+				data.Labels().Set("netname", id[0:12])
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("network", "remove", data.Get("netname"))
+				helpers.Anyhow("network", "remove", data.Labels().Get("netname"))
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("network", "inspect", data.Get("netname"))
+				return helpers.Command("network", "inspect", data.Labels().Get("netname"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -191,7 +191,7 @@ func TestNetworkInspect(t *testing.T) {
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
 						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-						assert.Equal(t, dc[0].Name, data.Get("netname"))
+						assert.Equal(t, dc[0].Name, data.Labels().Get("netname"))
 					},
 				}
 			},

--- a/cmd/nerdctl/network/network_list_linux_test.go
+++ b/cmd/nerdctl/network/network_list_linux_test.go
@@ -31,12 +31,12 @@ func TestNetworkLsFilter(t *testing.T) {
 	testCase := nerdtest.Setup()
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		data.Set("identifier", data.Identifier())
-		data.Set("label", "mylabel=label-1")
-		data.Set("net1", data.Identifier("1"))
-		data.Set("net2", data.Identifier("2"))
-		data.Set("netID1", helpers.Capture("network", "create", "--label="+data.Get("label"), data.Get("net1")))
-		data.Set("netID2", helpers.Capture("network", "create", data.Get("net2")))
+		data.Labels().Set("identifier", data.Identifier())
+		data.Labels().Set("label", "mylabel=label-1")
+		data.Labels().Set("net1", data.Identifier("1"))
+		data.Labels().Set("net2", data.Identifier("2"))
+		data.Labels().Set("netID1", helpers.Capture("network", "create", "--label="+data.Labels().Get("label"), data.Labels().Get("net1")))
+		data.Labels().Set("netID2", helpers.Capture("network", "create", data.Labels().Get("net2")))
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -48,7 +48,7 @@ func TestNetworkLsFilter(t *testing.T) {
 		{
 			Description: "filter label",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("network", "ls", "--quiet", "--filter", "label="+data.Get("label"))
+				return helpers.Command("network", "ls", "--quiet", "--filter", "label="+data.Labels().Get("label"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -56,7 +56,7 @@ func TestNetworkLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, info)
 						netNames := map[string]struct{}{
-							data.Get("netID1")[:12]: {},
+							data.Labels().Get("netID1")[:12]: {},
 						}
 
 						for _, name := range lines {
@@ -70,7 +70,7 @@ func TestNetworkLsFilter(t *testing.T) {
 		{
 			Description: "filter name",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("network", "ls", "--quiet", "--filter", "name="+data.Get("net2"))
+				return helpers.Command("network", "ls", "--quiet", "--filter", "name="+data.Labels().Get("net2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -78,7 +78,7 @@ func TestNetworkLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, info)
 						netNames := map[string]struct{}{
-							data.Get("netID2")[:12]: {},
+							data.Labels().Get("netID2")[:12]: {},
 						}
 
 						for _, name := range lines {

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -40,11 +40,11 @@ func TestNetworkRemove(t *testing.T) {
 			Setup: func(data test.Data, helpers test.Helpers) {
 				identifier := data.Identifier()
 				helpers.Ensure("network", "create", identifier)
-				data.Set("netID", nerdtest.InspectNetwork(helpers, identifier).ID)
+				data.Labels().Set("netID", nerdtest.InspectNetwork(helpers, identifier).ID)
 				helpers.Ensure("run", "--rm", "--net", identifier, "--name", identifier, testutil.CommonImage)
 				// Verity the network is here
-				_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
-				assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
+				assert.NilError(t, err, "failed to find network br-"+data.Labels().Get("netID")[:12], "%v")
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("network", "rm", data.Identifier())
@@ -56,7 +56,7 @@ func TestNetworkRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
-						_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found", info)
 					},
 				}
@@ -81,14 +81,14 @@ func TestNetworkRemove(t *testing.T) {
 			Description: "Network remove by id",
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier())
-				data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
+				data.Labels().Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
 				helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
 				// Verity the network is here
-				_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
-				assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
+				assert.NilError(t, err, "failed to find network br-"+data.Labels().Get("netID")[:12], "%v")
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("network", "rm", data.Get("netID"))
+				return helpers.Command("network", "rm", data.Labels().Get("netID"))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("network", "rm", data.Identifier())
@@ -97,7 +97,7 @@ func TestNetworkRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
-						_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found", info)
 					},
 				}
@@ -107,14 +107,14 @@ func TestNetworkRemove(t *testing.T) {
 			Description: "Network remove by short id",
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", data.Identifier())
-				data.Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
+				data.Labels().Set("netID", nerdtest.InspectNetwork(helpers, data.Identifier()).ID)
 				helpers.Ensure("run", "--rm", "--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
 				// Verity the network is here
-				_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
-				assert.NilError(t, err, "failed to find network br-"+data.Get("netID")[:12], "%v")
+				_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
+				assert.NilError(t, err, "failed to find network br-"+data.Labels().Get("netID")[:12], "%v")
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("network", "rm", data.Get("netID")[:12])
+				return helpers.Command("network", "rm", data.Labels().Get("netID")[:12])
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("network", "rm", data.Identifier())
@@ -123,7 +123,7 @@ func TestNetworkRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
-						_, err := netlink.LinkByName("br-" + data.Get("netID")[:12])
+						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found", info)
 					},
 				}

--- a/cmd/nerdctl/system/system_events_linux_test.go
+++ b/cmd/nerdctl/system/system_events_linux_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func testEventFilterExecutor(data test.Data, helpers test.Helpers) test.TestableCommand {
-	cmd := helpers.Command("events", "--filter", data.Get("filter"), "--format", "json")
+	cmd := helpers.Command("events", "--filter", data.Labels().Get("filter"), "--format", "json")
 	// 3 seconds is too short on slow rig (EL8)
 	cmd.WithTimeout(10 * time.Second)
 	cmd.Background()
@@ -48,11 +48,13 @@ func TestEventFilters(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeTimeout,
-					Output:   expect.Contains(data.Get("output")),
+					Output:   expect.Contains(data.Labels().Get("output")),
 				}
 			},
-			Data: test.WithData("filter", "event=START").
-				Set("output", "\"Status\":\"start\""),
+			Data: test.WithLabels(map[string]string{
+				"filter": "event=START",
+				"output": "\"Status\":\"start\"",
+			}),
 		},
 		{
 			Description: "StartEventFilter",
@@ -60,11 +62,13 @@ func TestEventFilters(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeTimeout,
-					Output:   expect.Contains(data.Get("output")),
+					Output:   expect.Contains(data.Labels().Get("output")),
 				}
 			},
-			Data: test.WithData("filter", "event=start").
-				Set("output", "tatus\":\"start\""),
+			Data: test.WithLabels(map[string]string{
+				"filter": "event=start",
+				"output": "tatus\":\"start\"",
+			}),
 		},
 		{
 			Description: "UnsupportedEventFilter",
@@ -73,11 +77,13 @@ func TestEventFilters(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeTimeout,
-					Output:   expect.Contains(data.Get("output")),
+					Output:   expect.Contains(data.Labels().Get("output")),
 				}
 			},
-			Data: test.WithData("filter", "event=unknown").
-				Set("output", "\"Status\":\"unknown\""),
+			Data: test.WithLabels(map[string]string{
+				"filter": "event=unknown",
+				"output": "\"Status\":\"unknown\"",
+			}),
 		},
 		{
 			Description: "StatusFilter",
@@ -85,11 +91,13 @@ func TestEventFilters(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeTimeout,
-					Output:   expect.Contains(data.Get("output")),
+					Output:   expect.Contains(data.Labels().Get("output")),
 				}
 			},
-			Data: test.WithData("filter", "status=start").
-				Set("output", "tatus\":\"start\""),
+			Data: test.WithLabels(map[string]string{
+				"filter": "status=start",
+				"output": "tatus\":\"start\"",
+			}),
 		},
 		{
 			Description: "UnsupportedStatusFilter",
@@ -98,11 +106,13 @@ func TestEventFilters(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeTimeout,
-					Output:   expect.Contains(data.Get("output")),
+					Output:   expect.Contains(data.Labels().Get("output")),
 				}
 			},
-			Data: test.WithData("filter", "status=unknown").
-				Set("output", "\"Status\":\"unknown\""),
+			Data: test.WithLabels(map[string]string{
+				"filter": "status=unknown",
+				"output": "\"Status\":\"unknown\"",
+			}),
 		},
 	}
 

--- a/cmd/nerdctl/system/system_prune_linux_test.go
+++ b/cmd/nerdctl/system/system_prune_linux_test.go
@@ -48,12 +48,12 @@ func TestSystemPrune(t *testing.T) {
 				helpers.Ensure("run", "-v", fmt.Sprintf("%s:/volume", data.Identifier()),
 					"--net", data.Identifier(), "--name", data.Identifier(), testutil.CommonImage)
 
-				data.Set("anonIdentifier", anonIdentifier)
+				data.Labels().Set("anonIdentifier", anonIdentifier)
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("network", "rm", data.Identifier())
 				helpers.Anyhow("volume", "rm", data.Identifier())
-				helpers.Anyhow("volume", "rm", data.Get("anonIdentifier"))
+				helpers.Anyhow("volume", "rm", data.Labels().Get("anonIdentifier"))
 				helpers.Anyhow("rm", "-f", data.Identifier())
 			},
 			Command: test.Command("system", "prune", "-f", "--volumes", "--all"),
@@ -66,7 +66,7 @@ func TestSystemPrune(t *testing.T) {
 						images := helpers.Capture("images")
 						containers := helpers.Capture("ps", "-a")
 						assert.Assert(t, strings.Contains(volumes, data.Identifier()), volumes)
-						assert.Assert(t, !strings.Contains(volumes, data.Get("anonIdentifier")), volumes)
+						assert.Assert(t, !strings.Contains(volumes, data.Labels().Get("anonIdentifier")), volumes)
 						assert.Assert(t, !strings.Contains(containers, data.Identifier()), containers)
 						assert.Assert(t, !strings.Contains(networks, data.Identifier()), networks)
 						assert.Assert(t, !strings.Contains(images, testutil.CommonImage), images)

--- a/cmd/nerdctl/volume/volume_inspect_test.go
+++ b/cmd/nerdctl/volume/volume_inspect_test.go
@@ -65,8 +65,8 @@ func TestVolumeInspect(t *testing.T) {
 		vol := nerdtest.InspectVolume(helpers, data.Identifier("first"))
 		err := createFileWithSize(vol.Mountpoint, size)
 		assert.NilError(t, err, "File creation failed")
-		data.Set("vol1", data.Identifier("first"))
-		data.Set("vol2", data.Identifier("second"))
+		data.Labels().Set("vol1", data.Identifier("first"))
+		data.Labels().Set("vol2", data.Identifier("second"))
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -93,15 +93,15 @@ func TestVolumeInspect(t *testing.T) {
 		{
 			Description: "success",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", data.Get("vol1"))
+				return helpers.Command("volume", "inspect", data.Labels().Get("vol1"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.Contains(data.Get("vol1")),
+						expect.Contains(data.Labels().Get("vol1")),
 						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc))+info)
-							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name)+info)
+							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name)+info)
 							assert.Assert(t, dc[0].Labels == nil, fmt.Sprintf("expected labels to be nil and were %v", dc[0].Labels)+info)
 						}),
 					),
@@ -111,12 +111,12 @@ func TestVolumeInspect(t *testing.T) {
 		{
 			Description: "inspect labels",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", data.Get("vol2"))
+				return helpers.Command("volume", "inspect", data.Labels().Get("vol2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.Contains(data.Get("vol2")),
+						expect.Contains(data.Labels().Get("vol2")),
 						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							labels := *dc[0].Labels
 							assert.Assert(t, len(labels) == 2, fmt.Sprintf("two results, not %d", len(labels)))
@@ -131,12 +131,12 @@ func TestVolumeInspect(t *testing.T) {
 			Description: "inspect size",
 			Require:     require.Not(nerdtest.Docker),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", "--size", data.Get("vol1"))
+				return helpers.Command("volume", "inspect", "--size", data.Labels().Get("vol1"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.Contains(data.Get("vol1")),
+						expect.Contains(data.Labels().Get("vol1")),
 						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, dc[0].Size == size, fmt.Sprintf("expected size to be %d (was %d)", size, dc[0].Size))
 						}),
@@ -147,17 +147,17 @@ func TestVolumeInspect(t *testing.T) {
 		{
 			Description: "multi success",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", data.Get("vol1"), data.Get("vol2"))
+				return helpers.Command("volume", "inspect", data.Labels().Get("vol1"), data.Labels().Get("vol2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.Contains(data.Get("vol1")),
-						expect.Contains(data.Get("vol2")),
+						expect.Contains(data.Labels().Get("vol1")),
+						expect.Contains(data.Labels().Get("vol2")),
 						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 2, fmt.Sprintf("two results, not %d", len(dc)))
-							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name))
-							assert.Assert(t, dc[1].Name == data.Get("vol2"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol2"), dc[1].Name))
+							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name))
+							assert.Assert(t, dc[1].Name == data.Labels().Get("vol2"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol2"), dc[1].Name))
 						}),
 					),
 				}
@@ -166,17 +166,17 @@ func TestVolumeInspect(t *testing.T) {
 		{
 			Description: "part success multi",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", "invalid∞", "nonexistent", data.Get("vol1"))
+				return helpers.Command("volume", "inspect", "invalid∞", "nonexistent", data.Labels().Get("vol1"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errdefs.ErrNotFound, errdefs.ErrInvalidArgument},
 					Output: expect.All(
-						expect.Contains(data.Get("vol1")),
+						expect.Contains(data.Labels().Get("vol1")),
 						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
 							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
-							assert.Assert(t, dc[0].Name == data.Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Get("vol1"), dc[0].Name))
+							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name))
 						}),
 					),
 				}

--- a/cmd/nerdctl/volume/volume_list_test.go
+++ b/cmd/nerdctl/volume/volume_list_test.go
@@ -122,22 +122,22 @@ func TestVolumeLsFilter(t *testing.T) {
 		err = createFileWithSize(nerdtest.InspectVolume(helpers, vol4).Mountpoint, 1024000)
 		assert.NilError(t, err, "File creation failed")
 
-		data.Set("vol1", vol1)
-		data.Set("vol2", vol2)
-		data.Set("vol3", vol3)
-		data.Set("vol4", vol4)
-		data.Set("mainlabel", "mylabel")
-		data.Set("label1", label1)
-		data.Set("label2", label2)
-		data.Set("label3", label3)
-		data.Set("label4", label4)
+		data.Labels().Set("vol1", vol1)
+		data.Labels().Set("vol2", vol2)
+		data.Labels().Set("vol3", vol3)
+		data.Labels().Set("vol4", vol4)
+		data.Labels().Set("mainlabel", "mylabel")
+		data.Labels().Set("label1", label1)
+		data.Labels().Set("label2", label2)
+		data.Labels().Set("label3", label3)
+		data.Labels().Set("label4", label4)
 
 	}
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
-		helpers.Anyhow("volume", "rm", "-f", data.Get("vol1"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("vol2"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("vol3"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("vol4"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("vol1"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("vol2"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("vol3"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("vol4"))
 	}
 	testCase.SubTests = []*test.Case{
 		{
@@ -149,10 +149,10 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 4, "expected at least 4 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
-							data.Get("vol2"): {},
-							data.Get("vol3"): {},
-							data.Get("vol4"): {},
+							data.Labels().Get("vol1"): {},
+							data.Labels().Get("vol2"): {},
+							data.Labels().Get("vol3"): {},
+							data.Labels().Get("vol4"): {},
 						}
 						var numMatches = 0
 						for _, name := range lines {
@@ -170,7 +170,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving label=mainlabel",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Get("mainlabel"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Labels().Get("mainlabel"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -178,9 +178,9 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
-							data.Get("vol2"): {},
-							data.Get("vol3"): {},
+							data.Labels().Get("vol1"): {},
+							data.Labels().Get("vol2"): {},
+							data.Labels().Get("vol3"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
@@ -193,7 +193,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving label=mainlabel=label2",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Get("label2"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Labels().Get("label2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -201,7 +201,7 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least 1 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol2"): {},
+							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
@@ -214,7 +214,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving label=mainlabel=",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Get("mainlabel")+"=")
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Labels().Get("mainlabel")+"=")
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -227,7 +227,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving label=mainlabel=label1 and label=mainlabel=label2",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Get("label1"), "--filter", "label="+data.Get("label2"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Labels().Get("label1"), "--filter", "label="+data.Labels().Get("label2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -240,7 +240,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving label=mainlabel and label=grouplabel=label4",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Get("mainlabel"), "--filter", "label="+data.Get("label4"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "label="+data.Labels().Get("mainlabel"), "--filter", "label="+data.Labels().Get("label4"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -248,8 +248,8 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
-							data.Get("vol2"): {},
+							data.Labels().Get("vol1"): {},
+							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
@@ -262,7 +262,7 @@ func TestVolumeLsFilter(t *testing.T) {
 		{
 			Description: "Retrieving name=volume1",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "name="+data.Get("vol1"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "name="+data.Labels().Get("vol1"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -270,7 +270,7 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least 1 line"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
+							data.Labels().Get("vol1"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
@@ -285,7 +285,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			// Nerdctl filter behavior is broken
 			Require: nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3452"),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "ls", "--quiet", "--filter", "name="+data.Get("vol1"), "--filter", "name="+data.Get("vol2"))
+				return helpers.Command("volume", "ls", "--quiet", "--filter", "name="+data.Labels().Get("vol1"), "--filter", "name="+data.Labels().Get("vol2"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
@@ -293,8 +293,8 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
-							data.Get("vol2"): {},
+							data.Labels().Get("vol1"): {},
+							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
@@ -316,8 +316,8 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol2"): {},
-							data.Get("vol4"): {},
+							data.Labels().Get("vol2"): {},
+							data.Labels().Get("vol4"): {},
 						}
 						var tab = tabutil.NewReader("VOLUME NAME\tDIRECTORY\tSIZE")
 						var err = tab.ParseHeader(lines[0])
@@ -347,8 +347,8 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol2"): {},
-							data.Get("vol4"): {},
+							data.Labels().Get("vol2"): {},
+							data.Labels().Get("vol4"): {},
 						}
 						var tab = tabutil.NewReader("VOLUME NAME\tDIRECTORY\tSIZE")
 						var err = tab.ParseHeader(lines[0])
@@ -378,8 +378,8 @@ func TestVolumeLsFilter(t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
 						volNames := map[string]struct{}{
-							data.Get("vol1"): {},
-							data.Get("vol3"): {},
+							data.Labels().Get("vol1"): {},
+							data.Labels().Get("vol3"): {},
 						}
 						var tab = tabutil.NewReader("VOLUME NAME\tDIRECTORY\tSIZE")
 						var err = tab.ParseHeader(lines[0])

--- a/cmd/nerdctl/volume/volume_namespace_test.go
+++ b/cmd/nerdctl/volume/volume_namespace_test.go
@@ -35,14 +35,14 @@ func TestVolumeNamespace(t *testing.T) {
 
 	// Create a volume in a different namespace
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		data.Set("root_namespace", data.Identifier())
-		data.Set("root_volume", data.Identifier())
+		data.Labels().Set("root_namespace", data.Identifier())
+		data.Labels().Set("root_volume", data.Identifier())
 		helpers.Ensure("--namespace", data.Identifier(), "volume", "create", data.Identifier())
 	}
 
 	// Cleanup once done
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
-		if data.Get("root_namespace") != "" {
+		if data.Labels().Get("root_namespace") != "" {
 			helpers.Anyhow("--namespace", data.Identifier(), "volume", "remove", data.Identifier())
 			helpers.Anyhow("namespace", "remove", data.Identifier())
 		}
@@ -52,7 +52,7 @@ func TestVolumeNamespace(t *testing.T) {
 		{
 			Description: "inspect another namespace volume should fail",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "inspect", data.Get("root_volume"))
+				return helpers.Command("volume", "inspect", data.Labels().Get("root_volume"))
 			},
 			Expected: test.Expects(1, []error{
 				errdefs.ErrNotFound,
@@ -61,7 +61,7 @@ func TestVolumeNamespace(t *testing.T) {
 		{
 			Description: "removing another namespace volume should fail",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "remove", data.Get("root_volume"))
+				return helpers.Command("volume", "remove", data.Labels().Get("root_volume"))
 			},
 			Expected: test.Expects(1, []error{
 				errdefs.ErrNotFound,
@@ -75,9 +75,9 @@ func TestVolumeNamespace(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.DoesNotContain(data.Get("root_volume")),
+						expect.DoesNotContain(data.Labels().Get("root_volume")),
 						func(stdout string, info string, t *testing.T) {
-							helpers.Ensure("--namespace", data.Get("root_namespace"), "volume", "inspect", data.Get("root_volume"))
+							helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))
 						},
 					),
 				}
@@ -87,17 +87,17 @@ func TestVolumeNamespace(t *testing.T) {
 			Description: "create with the same name should work, then delete it",
 			NoParallel:  true,
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("volume", "create", data.Get("root_volume"))
+				return helpers.Command("volume", "create", data.Labels().Get("root_volume"))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
-				helpers.Anyhow("volume", "rm", data.Get("root_volume"))
+				helpers.Anyhow("volume", "rm", data.Labels().Get("root_volume"))
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: func(stdout string, info string, t *testing.T) {
-						helpers.Ensure("volume", "inspect", data.Get("root_volume"))
-						helpers.Ensure("volume", "rm", data.Get("root_volume"))
-						helpers.Ensure("--namespace", data.Get("root_namespace"), "volume", "inspect", data.Get("root_volume"))
+						helpers.Ensure("volume", "inspect", data.Labels().Get("root_volume"))
+						helpers.Ensure("volume", "rm", data.Labels().Get("root_volume"))
+						helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))
 					},
 				}
 			},

--- a/cmd/nerdctl/volume/volume_prune_linux_test.go
+++ b/cmd/nerdctl/volume/volume_prune_linux_test.go
@@ -41,18 +41,18 @@ func TestVolumePrune(t *testing.T) {
 			"-v", namedBusy+":/namedbusyvolume",
 			"-v", anonIDBusy+":/anonbusyvolume", testutil.CommonImage)
 
-		data.Set("anonIDBusy", anonIDBusy)
-		data.Set("anonIDDangling", anonIDDangling)
-		data.Set("namedBusy", namedBusy)
-		data.Set("namedDangling", namedDangling)
+		data.Labels().Set("anonIDBusy", anonIDBusy)
+		data.Labels().Set("anonIDDangling", anonIDDangling)
+		data.Labels().Set("namedBusy", namedBusy)
+		data.Labels().Set("namedDangling", namedDangling)
 	}
 
 	var cleanup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("rm", "-f", data.Identifier())
-		helpers.Anyhow("volume", "rm", "-f", data.Get("anonIDBusy"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("anonIDDangling"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("namedBusy"))
-		helpers.Anyhow("volume", "rm", "-f", data.Get("namedDangling"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("anonIDBusy"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("anonIDDangling"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("namedBusy"))
+		helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("namedDangling"))
 	}
 
 	testCase := nerdtest.Setup()
@@ -69,15 +69,15 @@ func TestVolumePrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.DoesNotContain(data.Get("anonIDBusy")),
-						expect.Contains(data.Get("anonIDDangling")),
-						expect.DoesNotContain(data.Get("namedBusy")),
-						expect.DoesNotContain(data.Get("namedDangling")),
+						expect.DoesNotContain(data.Labels().Get("anonIDBusy")),
+						expect.Contains(data.Labels().Get("anonIDDangling")),
+						expect.DoesNotContain(data.Labels().Get("namedBusy")),
+						expect.DoesNotContain(data.Labels().Get("namedDangling")),
 						func(stdout string, info string, t *testing.T) {
-							helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
-							helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
-							helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
-							helpers.Ensure("volume", "inspect", data.Get("namedDangling"))
+							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
+							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
+							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))
+							helpers.Ensure("volume", "inspect", data.Labels().Get("namedDangling"))
 						},
 					),
 				}
@@ -92,15 +92,15 @@ func TestVolumePrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						expect.DoesNotContain(data.Get("anonIDBusy")),
-						expect.Contains(data.Get("anonIDDangling")),
-						expect.DoesNotContain(data.Get("namedBusy")),
-						expect.Contains(data.Get("namedDangling")),
+						expect.DoesNotContain(data.Labels().Get("anonIDBusy")),
+						expect.Contains(data.Labels().Get("anonIDDangling")),
+						expect.DoesNotContain(data.Labels().Get("namedBusy")),
+						expect.Contains(data.Labels().Get("namedDangling")),
 						func(stdout string, info string, t *testing.T) {
-							helpers.Ensure("volume", "inspect", data.Get("anonIDBusy"))
-							helpers.Fail("volume", "inspect", data.Get("anonIDDangling"))
-							helpers.Ensure("volume", "inspect", data.Get("namedBusy"))
-							helpers.Fail("volume", "inspect", data.Get("namedDangling"))
+							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
+							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
+							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))
+							helpers.Fail("volume", "inspect", data.Labels().Get("namedDangling"))
 						},
 					),
 				}

--- a/cmd/nerdctl/volume/volume_remove_linux_test.go
+++ b/cmd/nerdctl/volume/volume_remove_linux_test.go
@@ -89,17 +89,17 @@ func TestVolumeRemove(t *testing.T) {
 					}
 				}
 				assert.Assert(t, anonName != "", "Failed to find anonymous volume id", inspect)
-				data.Set("anonName", anonName)
+				data.Labels().Set("anonName", anonName)
 			},
 
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
-				helpers.Anyhow("volume", "rm", "-f", data.Get("anonName"))
+				helpers.Anyhow("volume", "rm", "-f", data.Labels().Get("anonName"))
 			},
 
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				// Try to remove that anon volume
-				return helpers.Command("volume", "rm", data.Get("anonName"))
+				return helpers.Command("volume", "rm", data.Labels().Get("anonName"))
 			},
 
 			Expected: test.Expects(1, []error{errdefs.ErrFailedPrecondition}, nil),

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -109,7 +109,7 @@ that this name is then visible in the list of containers.
 
 To achieve that, you should write your own `Manager`, leveraging test `Data`.
 
-Here is an example, where we are using `data.Get("sometestdata")`.
+Here is an example, where we are using `data.Labels().Get("sometestdata")`.
 
 ```go
 package main
@@ -133,7 +133,7 @@ func TestMyThing(t *testing.T) {
 
 	// Declare your test
 	myTest := &test.Case{
-		Data:        test.WithData("sometestdata", "blah"),
+		Data:        test.WithLabels(map[string]string{"sometestdata": "blah"}),
 		Command:     test.Command("info"),
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
@@ -143,7 +143,7 @@ func TestMyThing(t *testing.T) {
 					errdefs.ErrNotFound,
 				},
 				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Get("sometestdata"), info)
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
 				},
 			}
 		},
@@ -157,7 +157,7 @@ func TestMyThing(t *testing.T) {
 
 `Data` is provided to allow storing mutable key-value information that pertain to the test.
 
-While it can be provided through `test.WithData(key string, value string)`,
+While it can be provided through `test.WithLabels(map[string]string{key: value})`,
 inside the testcase definition, it can also be dynamically manipulated inside `Setup`, or `Command`.
 
 Note that `Data` additionally exposes the following functions:
@@ -244,9 +244,9 @@ func TestMyThing(t *testing.T) {
 
 	// Declare your test
 	myTest := &test.Case{
-		Data:        test.WithData("sometestdata", "blah"),
+		Data:        test.WithLabels(map[string]string{"sometestdata": "blah"}),
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			return helpers.Command("run", "--name", data.Get("sometestdata"))
+			return helpers.Command("run", "--name", data.Labels().Get("sometestdata"))
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
@@ -256,7 +256,7 @@ func TestMyThing(t *testing.T) {
 					errdefs.ErrNotFound,
 				},
 				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Get("sometestdata"), info)
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
 				},
 			}
 		},
@@ -325,7 +325,7 @@ func TestMyThing(t *testing.T) {
 
 	// Declare your test
 	myTest := &test.Case{
-		Data:        test.WithData("sometestdata", "blah"),
+		Data:        test.WithLabels(map[string]string{"sometestdata": "blah"}),
 		Setup: func(data *test.Data, helpers test.Helpers){
 			helpers.Ensure("volume", "create", "foo")
 			helpers.Ensure("volume", "create", "bar")
@@ -335,7 +335,7 @@ func TestMyThing(t *testing.T) {
 			helpers.Anyhow("volume", "rm", "bar")
 		},
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			return helpers.Command("run", "--name", data.Identifier()+data.Get("sometestdata"))
+			return helpers.Command("run", "--name", data.Identifier()+data.Labels().Get("sometestdata"))
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
@@ -345,7 +345,7 @@ func TestMyThing(t *testing.T) {
 					errdefs.ErrNotFound,
 				},
 				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Get("sometestdata"), info)
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
 				},
 			}
 		},

--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -61,12 +61,15 @@ linters:
     revive:
       enable-all-rules: true
       rules:
+        - name: max-public-structs
+          # Default is 5
+          arguments: 7
         - name: cognitive-complexity
           # Default is 7
-          arguments: [60]
+          arguments: [100]
         - name: function-length
           # Default is 50, 75
-          arguments: [80, 200]
+          arguments: [80, 220]
         - name: cyclomatic
           # Default is 10
           arguments: [30]

--- a/mod/tigron/expect/doc.md
+++ b/mod/tigron/expect/doc.md
@@ -169,7 +169,7 @@ To achieve that, you should write your own `test.Manager` instead of using the h
 A manager is a simple function which only role is to return a `test.Expected` struct.
 The `test.Manager` signature makes available `test.Data` and `test.Helpers` to you.
 
-Here is an example, where we are using `data.Get("sometestdata")`.
+Here is an example, where we are using `data.Labels().Get("sometestdata")`.
 
 ```go
 package main
@@ -191,7 +191,7 @@ func TestMyThing(t *testing.T) {
         // Do things...
         // ...
         // Save this for later
-        data.Set("something", "lalala")
+        data.Labels().Set("something", "lalala")
     }
 
     // Attach a command to run
@@ -210,7 +210,7 @@ func TestMyThing(t *testing.T) {
                 t.Helper()
 
                 // Retrieve the data that was set during the Setup phase.
-                assert.Assert(t, stdout == data.Get("sometestdata"), info)
+                assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
             },
         }
     }

--- a/mod/tigron/internal/formatter/formatter.go
+++ b/mod/tigron/internal/formatter/formatter.go
@@ -108,7 +108,10 @@ func chunk(s string, maxLength, maxLines int) []string {
 	}
 
 	if len(chunks) > maxLines {
-		chunks = append(chunks[0:maxLines], "...")
+		abbreviator := "..."
+		chunks = append(
+			append(chunks[0:maxLines/2], abbreviator+strings.Repeat(spacer, maxLength-len(abbreviator))),
+			chunks[len(chunks)-maxLines/2:]...)
 	} else if len(chunks) == 0 {
 		chunks = []string{strings.Repeat(spacer, maxLength)}
 	}

--- a/mod/tigron/test/case.go
+++ b/mod/tigron/test/case.go
@@ -233,7 +233,7 @@ func (test *Case) Run(t *testing.T) {
 				"\n\n" + formatter.Table(
 					[][]any{
 						{startDecorator, fmt.Sprintf("%q: starting test!", test.t.Name())},
-						{"cwd", test.Data.TempDir()},
+						{"temp", test.Data.TempDir()},
 						{"config", string(debugConfig)},
 						{"data", string(debugData)},
 					},

--- a/mod/tigron/test/case.go
+++ b/mod/tigron/test/case.go
@@ -19,7 +19,9 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
@@ -71,6 +73,7 @@ const (
 	setupDecorator  = "🏗"
 	subinDecorator  = "⤵️"
 	suboutDecorator = "↩️"
+	tempDecorator   = "⏳"
 )
 
 // Run prepares and executes the test, and any possible subtests.
@@ -115,7 +118,7 @@ func (test *Case) Run(t *testing.T) {
 		}
 
 		// Inherit and attach Data and Config
-		test.Data = configureData(test.t, test.Data, parentData)
+		test.Data = newData(test.t, test.Data, parentData)
 		test.Config = configureConfig(test.Config, parentConfig)
 
 		var custCom CustomizableCommand
@@ -125,9 +128,13 @@ func (test *Case) Run(t *testing.T) {
 			custCom = registeredTestable.CustomCommand(test, test.t)
 		}
 
-		custCom.WithCwd(test.Data.TempDir())
+		// Separate cwd from the temp directory
+		custCom.WithCwd(test.t.TempDir())
 		custCom.withT(test.t)
-		custCom.withTempDir(test.Data.TempDir())
+		// Set the command tempdir to another temp location.
+		// This is required for the current extension mechanism to allow creation of command dependent configuration
+		// assets. Note that this is a different location than both CWD and Data.Temp().Path().
+		custCom.withTempDir(test.t.TempDir())
 		custCom.withEnv(test.Env)
 		custCom.withConfig(test.Config)
 
@@ -229,18 +236,28 @@ func (test *Case) Run(t *testing.T) {
 			debugConfig, _ := json.MarshalIndent(test.Config.(*config).config, "", "  ")
 			debugData, _ := json.MarshalIndent(test.Data.(*data).labels, "", "  ")
 
+			// Show the files in the temp directory BEFORE the command is executed
+			tempFiles := []string{}
+
+			if files, err := os.ReadDir(test.Data.Temp().Path()); err == nil {
+				for _, file := range files {
+					tempFiles = append(tempFiles, file.Name())
+				}
+			}
+
 			test.t.Log(
 				"\n\n" + formatter.Table(
 					[][]any{
 						{startDecorator, fmt.Sprintf("%q: starting test!", test.t.Name())},
-						{"temp", test.Data.TempDir()},
+						{tempDecorator, test.Data.Temp().Dir()},
+						{"", strings.Join(tempFiles, "\n")},
 						{"config", string(debugConfig)},
-						{"data", string(debugData)},
+						{"labels", string(debugData)},
 					},
 					"=",
 				) + "\n",
 			)
-
+			// FIXME: so, the expected function will run BEFORE the command
 			cmd.Run(test.Expected(test.Data, test.helpers))
 		}
 

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -142,6 +142,10 @@ func (gc *GenericCommand) WithBlacklist(env []string) {
 	gc.cmd.EnvBlackList = env
 }
 
+func (gc *GenericCommand) WithWhitelist(env []string) {
+	gc.cmd.EnvWhiteList = env
+}
+
 func (gc *GenericCommand) WithTimeout(timeout time.Duration) {
 	gc.cmd.Timeout = timeout
 }

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -65,6 +65,7 @@ type CustomizableCommand interface {
 	// Note that this will override any variable defined in the embedding environment
 	withEnv(env map[string]string)
 	// withTempDir specifies a temporary directory to use
+	// FIXME: this is only required because of the current command extension mechanism
 	withTempDir(path string)
 	// WithConfig allows passing custom config properties from the test to the base command
 	withConfig(config Config)

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -39,6 +39,10 @@ const (
 	exitDecorator           = "⚠️"
 	stdoutDecorator         = "🟢"
 	stderrDecorator         = "🟠"
+	timeoutDecorator        = "⏰"
+	cwdDecorator            = "📁"
+	envDecorator            = "🌱"
+	sigDecorator            = "⚡"
 )
 
 // CustomizableCommand is an interface meant for people who want to heavily customize the base
@@ -193,12 +197,18 @@ func (gc *GenericCommand) Run(expect *Expected) {
 		}
 
 		if result.Signal != nil {
-			debug = append(debug, []any{"Signal", result.Signal.String()})
+			debug = append(debug, []any{"", sigDecorator + " " + result.Signal.String()})
+		}
+
+		duration := result.Duration.String()
+		if result.Duration < time.Second {
+			duration = "<1s"
 		}
 
 		debug = append(debug,
-			[]any{"Limit", gc.cmd.Timeout},
-			[]any{"Environ", strings.Join(result.Environ, "\n")},
+			[]any{envDecorator, strings.Join(result.Environ, "\n")},
+			[]any{timeoutDecorator, duration + " (limit: " + gc.cmd.Timeout.String() + ")"},
+			[]any{cwdDecorator, gc.cmd.WorkingDir},
 		)
 	}
 

--- a/mod/tigron/test/consts.go
+++ b/mod/tigron/test/consts.go
@@ -1,0 +1,26 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package test
+
+const (
+	// FilePermissionsDefault specifies the default creation mode for temporary files.
+	// Note that umask will affect these.
+	FilePermissionsDefault = 0o644
+	// DirPermissionsDefault specifies the default creation mode for temporary directories.
+	// Note that umask will affect these.
+	DirPermissionsDefault = 0o755
+)

--- a/mod/tigron/test/data.go
+++ b/mod/tigron/test/data.go
@@ -19,9 +19,13 @@ package test
 import (
 	"crypto/sha256"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
-	"testing"
+
+	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 const (
@@ -30,27 +34,173 @@ const (
 	identifierSignatureLength = 8
 )
 
-// WithData returns a data object with a certain key value set.
-func WithData(key, value string) Data {
-	dat := &data{}
-	dat.Set(key, value)
+// WithLabels returns a Data object with specific key value labels set.
+func WithLabels(in map[string]string) Data {
+	dat := &data{
+		labels: &labels{
+			inMap: in,
+		},
+		temp: &temp{},
+	}
 
 	return dat
 }
 
-// Contains the implementation of the Data interface.
-func configureData(t *testing.T, seedData, parent Data) Data {
+type labels struct {
+	inMap map[string]string
+}
+
+func (lb *labels) Get(key string) string {
+	return lb.inMap[key]
+}
+
+func (lb *labels) Set(key, value string) {
+	lb.inMap[key] = value
+}
+
+type temp struct {
+	tempDir string
+	t       tig.T
+}
+
+func (tp *temp) Load(key ...string) string {
+	tp.t.Helper()
+
+	pth := filepath.Join(append([]string{tp.tempDir}, key...)...)
+
+	//nolint:gosec // Fine in the context of testing
+	content, err := os.ReadFile(pth)
+
+	assertive.ErrorIsNil(
+		assertive.WithSilentSuccess(tp.t),
+		err,
+		fmt.Sprintf("Loading file %q must succeed", pth),
+	)
+
+	return string(content)
+}
+
+func (tp *temp) Exists(key ...string) {
+	tp.t.Helper()
+
+	pth := filepath.Join(append([]string{tp.tempDir}, key...)...)
+
+	_, err := os.Stat(pth)
+
+	assertive.ErrorIsNil(
+		assertive.WithSilentSuccess(tp.t),
+		err,
+		fmt.Sprintf("File %q must exist", pth),
+	)
+}
+
+func (tp *temp) Save(value string, key ...string) string {
+	tp.t.Helper()
+
+	tp.Dir(key[:len(key)-1]...)
+
+	pth := filepath.Join(append([]string{tp.tempDir}, key...)...)
+
+	err := os.WriteFile(
+		pth,
+		[]byte(value),
+		FilePermissionsDefault,
+	)
+
+	assertive.ErrorIsNil(
+		assertive.WithSilentSuccess(tp.t),
+		err,
+		fmt.Sprintf("Saving file %q must succeed", filepath.Join(key...)),
+	)
+
+	return pth
+}
+
+func (tp *temp) Dir(key ...string) string {
+	tp.t.Helper()
+
+	pth := filepath.Join(append([]string{tp.tempDir}, key...)...)
+	err := os.MkdirAll(pth, DirPermissionsDefault)
+
+	assertive.ErrorIsNil(
+		assertive.WithSilentSuccess(tp.t),
+		err,
+		fmt.Sprintf("Creating directory %q must succeed", pth),
+	)
+
+	return pth
+}
+
+func (tp *temp) Path(key ...string) string {
+	tp.t.Helper()
+
+	return filepath.Join(append([]string{tp.tempDir}, key...)...)
+}
+
+type data struct {
+	temp   DataTemp
+	labels DataLabels
+	testID func(suffix ...string) string
+}
+
+func (dt *data) Identifier(suffix ...string) string {
+	return dt.testID(suffix...)
+}
+
+func (dt *data) Labels() DataLabels {
+	return dt.labels
+}
+
+func (dt *data) Temp() DataTemp {
+	return dt.temp
+}
+
+// Contains the implementation of the Data interface
+//
+//nolint:varnamelen
+func newData(t tig.T, seed, parent Data) Data {
 	t.Helper()
 
-	if seedData == nil {
-		seedData = &data{}
+	t = assertive.WithSilentSuccess(t)
+
+	seedMap := map[string]string{}
+
+	if seed != nil {
+		if inLab, ok := seed.Labels().(*labels); ok {
+			seedMap = inLab.inMap
+		}
 	}
 
-	//nolint:forcetypeassert
+	if parent != nil {
+		for k, v := range parent.Labels().(*labels).inMap {
+			// Only copy keys that are not set already
+			if _, ok := seedMap[k]; !ok {
+				seedMap[k] = v
+			}
+		}
+	}
+
+	// NOTE: certain systems will use the path dirname to decide how they name resources.
+	// t.TempDir() will always return /tmp/TestTempDir2153252249/001, meaning these systems will all
+	// use the identical 001 part. This is true for compose specifically.
+	// Appending the base test identifier here would guarantee better unicity.
+	// Note though that Windows will barf if >256 characters, so, hashing...
+	// Small caveat: identically named tests in different modules WILL still end-up with the same last segment.
+	tempDir := filepath.Join(
+		t.TempDir(),
+		fmt.Sprintf("%x", sha256.Sum256([]byte(t.Name())))[0:identifierSignatureLength],
+	)
+
+	assertive.ErrorIsNil(t, os.MkdirAll(tempDir, DirPermissionsDefault))
+
 	dat := &data{
-		// Note: implementation dependent
-		labels:  seedData.(*data).labels,
-		tempDir: t.TempDir(),
+		labels: &labels{
+			inMap: seedMap,
+		},
+		temp: &temp{
+			tempDir: tempDir,
+			t:       t,
+		},
 		testID: func(suffix ...string) string {
 			suffix = append([]string{t.Name()}, suffix...)
 
@@ -58,51 +208,7 @@ func configureData(t *testing.T, seedData, parent Data) Data {
 		},
 	}
 
-	if parent != nil {
-		dat.adopt(parent)
-	}
-
 	return dat
-}
-
-type data struct {
-	labels  map[string]string
-	testID  func(suffix ...string) string
-	tempDir string
-}
-
-func (dt *data) Get(key string) string {
-	return dt.labels[key]
-}
-
-func (dt *data) Set(key, value string) Data {
-	if dt.labels == nil {
-		dt.labels = map[string]string{}
-	}
-
-	dt.labels[key] = value
-
-	return dt
-}
-
-func (dt *data) Identifier(suffix ...string) string {
-	return dt.testID(suffix...)
-}
-
-func (dt *data) TempDir() string {
-	return dt.tempDir
-}
-
-func (dt *data) adopt(parent Data) {
-	// Note: implementation dependent
-	if castData, ok := parent.(*data); ok {
-		for k, v := range castData.labels {
-			// Only copy keys that are not set already
-			if _, ok := dt.labels[k]; !ok {
-				dt.Set(k, v)
-			}
-		}
-	}
 }
 
 func defaultIdentifierHashing(names ...string) string {

--- a/mod/tigron/test/data_test.go
+++ b/mod/tigron/test/data_test.go
@@ -24,34 +24,45 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 )
 
-func TestDataBasic(t *testing.T) {
+func TestLabels(t *testing.T) {
 	t.Parallel()
 
-	dataObj := WithData("test", "create")
+	dataLabels := WithLabels(map[string]string{"test": "create"}).Labels()
 
-	assertive.IsEqual(t, dataObj.Get("test"), "create")
-	assertive.IsEqual(t, dataObj.Get("doesnotexist"), "")
+	assertive.IsEqual(t, dataLabels.Get("test"), "create")
+	assertive.IsEqual(t, dataLabels.Get("doesnotexist"), "")
 
-	dataObj.Set("test", "set")
-	assertive.IsEqual(t, dataObj.Get("test"), "set")
+	dataLabels.Set("test", "set")
+	assertive.IsEqual(t, dataLabels.Get("test"), "set")
+
+	dataLabels.Set("test", "reset")
+	assertive.IsEqual(t, dataLabels.Get("test"), "reset")
 }
 
-func TestDataTempDir(t *testing.T) {
+func TestTemp(t *testing.T) {
 	t.Parallel()
 
-	dataObj := configureData(t, nil, nil)
+	dataObj := newData(t, nil, nil)
 
-	one := dataObj.TempDir()
-	two := dataObj.TempDir()
+	one := dataObj.Temp().Path()
+	two := dataObj.Temp().Path()
 
 	assertive.IsEqual(t, one, two)
 	assertive.IsNotEqual(t, one, "")
+
+	t.Run("verify that subtest has an independent TempDir", func(t *testing.T) {
+		t.Parallel()
+
+		dataObj = newData(t, nil, nil)
+		three := dataObj.Temp().Path()
+		assertive.IsNotEqual(t, one, three)
+	})
 }
 
 func TestDataIdentifier(t *testing.T) {
 	t.Parallel()
 
-	dataObj := configureData(t, nil, nil)
+	dataObj := newData(t, nil, nil)
 
 	one := dataObj.Identifier()
 	two := dataObj.Identifier()
@@ -68,7 +79,7 @@ func TestDataIdentifierThatIsReallyReallyReallyReallyReallyReallyReallyReallyRea
 ) {
 	t.Parallel()
 
-	dataObj := configureData(t, nil, nil)
+	dataObj := newData(t, nil, nil)
 
 	one := dataObj.Identifier()
 	two := dataObj.Identifier()

--- a/mod/tigron/test/funct.go
+++ b/mod/tigron/test/funct.go
@@ -25,8 +25,11 @@ type Evaluator func(data Data, helpers Helpers) (bool, string)
 // or Requirement.
 type Butler func(data Data, helpers Helpers)
 
+// TODO: when we will break API:
+// - remove the info parameter
+// - move to tig.T
+
 // A Comparator is the function signature to implement for the Output property of an Expected.
-// TODO: when we will break API, remove the info parameter.
 type Comparator func(stdout, info string, t *testing.T)
 
 // A Manager is the function signature meant to produce expectations for a command.

--- a/pkg/testutil/nerdtest/ca/ca.go
+++ b/pkg/testutil/nerdtest/ca/ca.go
@@ -69,8 +69,7 @@ func New(data test.Data, t *testing.T) *CA {
 		BasicConstraintsValid: true,
 	}
 
-	dir, err := os.MkdirTemp(data.TempDir(), "ca")
-	assert.NilError(t, err)
+	dir := data.Temp().Dir("ca")
 	keyPath := filepath.Join(dir, "ca.key")
 	certPath := filepath.Join(dir, "ca.cert")
 	writePair(t, keyPath, certPath, cert, cert, key, key)

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -130,7 +130,7 @@ func (nc *nerdCommand) prep() {
 	if customDCConfig := nc.GenericCommand.Config.Read(DockerConfig); customDCConfig != "" {
 		if !nc.hasWrittenDockerConfig {
 			dest := filepath.Join(nc.Env["DOCKER_CONFIG"], "config.json")
-			err := os.WriteFile(dest, []byte(customDCConfig), 0400)
+			err := os.WriteFile(dest, []byte(customDCConfig), test.FilePermissionsDefault)
 			assert.NilError(nc.T(), err, "failed to write custom docker config json file for test")
 			nc.hasWrittenDockerConfig = true
 		}
@@ -174,7 +174,7 @@ func (nc *nerdCommand) prep() {
 		if nc.Config.Read(NerdctlToml) != "" {
 			if !nc.hasWrittenToml {
 				dest := nc.Env["NERDCTL_TOML"]
-				err := os.WriteFile(dest, []byte(nc.Config.Read(NerdctlToml)), 0400)
+				err := os.WriteFile(dest, []byte(nc.Config.Read(NerdctlToml)), test.FilePermissionsDefault)
 				assert.NilError(nc.T(), err, "failed to write NerdctlToml")
 				nc.hasWrittenToml = true
 			}

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -82,17 +82,14 @@ func newNerdCommand(conf test.Config, t *testing.T) *nerdCommand {
 	}
 
 	ret.WithBinary(binary)
-	// Not interested in these - and insulate us from parent environment side effects
-	ret.WithBlacklist([]string{
-		"LS_COLORS",
-		"DOCKER_CONFIG",
-		"CONTAINERD_SNAPSHOTTER",
-		"NERDCTL_TOML",
-		"CONTAINERD_ADDRESS",
-		"CNI_PATH",
-		"NETCONFPATH",
-		"NERDCTL_EXPERIMENTAL",
-		"NERDCTL_HOST_GATEWAY_IP",
+	ret.WithWhitelist([]string{
+		"PATH",
+		"HOME",
+		"XDG_*",
+		// Windows needs ProgramData, AppData, etc
+		"Program*",
+		"PROGRAM*",
+		"APPDATA",
 	})
 	return ret
 }

--- a/pkg/testutil/nerdtest/registry/common.go
+++ b/pkg/testutil/nerdtest/registry/common.go
@@ -19,8 +19,6 @@ package registry
 import (
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -71,9 +69,7 @@ func (ba *BasicAuth) Params(data test.Data) []string {
 	if ba.HtFile == "" && ba.Username != "" && ba.Password != "" {
 		pass := ba.Password
 		encryptedPass, _ := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
-		tmpDir, _ := os.MkdirTemp(data.TempDir(), "htpasswd")
-		ba.HtFile = filepath.Join(tmpDir, "htpasswd")
-		_ = os.WriteFile(ba.HtFile, []byte(fmt.Sprintf(`%s:%s`, ba.Username, string(encryptedPass[:]))), 0600)
+		ba.HtFile = data.Temp().Save(fmt.Sprintf(`%s:%s`, ba.Username, string(encryptedPass[:])), "htpasswd")
 	}
 	ret := []string{
 		"--env", "REGISTRY_AUTH=htpasswd",

--- a/pkg/testutil/nerdtest/registry/docker.go
+++ b/pkg/testutil/nerdtest/registry/docker.go
@@ -96,7 +96,7 @@ func NewDockerRegistry(data test.Data, helpers test.Helpers, currentCA *ca.CA, p
 	// FIXME: in the future, we will want to further manipulate hosts toml file from the test
 	// This should then return the struct, instead of saving it on its own
 	hostsDir, err := func() (string, error) {
-		hDir, err := os.MkdirTemp(data.TempDir(), "certs.d")
+		hDir := data.Temp().Dir("certs.d")
 		assert.NilError(helpers.T(), err, fmt.Errorf("failed creating directory certs.d: %w", err))
 
 		if currentCA != nil {

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -342,7 +342,7 @@ var Private = &test.Requirement{
 		// We need this to happen NOW and not in setup, as otherwise cleanup with operate on the default namespace
 		namespace := data.Identifier("private")
 		helpers.Write(Namespace, test.ConfigValue(namespace))
-		data.Set("_deletenamespace", namespace)
+		data.Labels().Set("_deletenamespace", namespace)
 		// FIXME: is this necessary? Should NoParallel be subsumed into config?
 		helpers.Write(modePrivate, enabled)
 		return true, "private mode creates a dedicated namespace for nerdctl, and disable parallelism for docker"
@@ -356,7 +356,7 @@ var Private = &test.Requirement{
 				helpers.Ensure(append([]string{"rm", "-f"}, strings.Split(containerList, "\n")...)...)
 			}
 			helpers.Ensure("system", "prune", "-f", "--all", "--volumes")
-			helpers.Anyhow("namespace", "remove", data.Get("_deletenamespace"))
+			helpers.Anyhow("namespace", "remove", data.Labels().Get("_deletenamespace"))
 		}
 	},
 }

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
@@ -46,58 +47,54 @@ func IsDocker() bool {
 // InspectContainer is a helper that can be used inside custom commands or Setup
 func InspectContainer(helpers test.Helpers, name string) dockercompat.Container {
 	helpers.T().Helper()
-	var dc []dockercompat.Container
+	var res dockercompat.Container
 	cmd := helpers.Command("container", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, info string, t *testing.T) {
-			err := json.Unmarshal([]byte(stdout), &dc)
-			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-		},
+		Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, _ string, t tig.T) {
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
+			res = dc[0]
+		}),
 	})
-	return dc[0]
+	return res
 }
 
 func InspectVolume(helpers test.Helpers, name string) native.Volume {
 	helpers.T().Helper()
-	var dc []native.Volume
+	var res native.Volume
 	cmd := helpers.Command("volume", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, info string, t *testing.T) {
-			err := json.Unmarshal([]byte(stdout), &dc)
-			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-		},
+		Output: expect.JSON([]native.Volume{}, func(dc []native.Volume, _ string, t tig.T) {
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
+			res = dc[0]
+		}),
 	})
-	return dc[0]
+	return res
 }
 
 func InspectNetwork(helpers test.Helpers, name string) dockercompat.Network {
 	helpers.T().Helper()
-	var dc []dockercompat.Network
+	var res dockercompat.Network
 	cmd := helpers.Command("network", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, info string, t *testing.T) {
-			err := json.Unmarshal([]byte(stdout), &dc)
-			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-		},
+		Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, _ string, t tig.T) {
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
+			res = dc[0]
+		}),
 	})
-	return dc[0]
+	return res
 }
 
 func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
 	helpers.T().Helper()
-	var dc []dockercompat.Image
+	var res dockercompat.Image
 	cmd := helpers.Command("image", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, info string, t *testing.T) {
-			err := json.Unmarshal([]byte(stdout), &dc)
-			assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-		},
+		Output: expect.JSON([]dockercompat.Image{}, func(dc []dockercompat.Image, _ string, t tig.T) {
+			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
+			res = dc[0]
+		}),
 	})
-	return dc[0]
+	return res
 }
 
 const (


### PR DESCRIPTION
Blocked by #4111

From testing experience on nerdctl, many tests do require temporary resources (Dockerfiles, compose.yml, etc), and routinely redo the same thing over and over (create separate temp dir, write file, remove temp dir).
At best this adds a lot of boilerplate / helpers functions - at worst, the resources are not properly cleaned-up, or not well isolated from other tests.

The first commit changes the Data interface to allow temp files manipulation (Load, Save, Path, Dir, Exists), and more clearly separates `labels` and temporary resources.

The changes in tigron are minimal, but since the interface does change, the second commit does modify all current nerdctl tests that are making use of data labels.
Alongside this, some tests and helpers will now leverage the new temp file manipulation, along with some other minor cleanup in helpers and builder tests.

The PR looks big because of that ^. 

Finally note that:
- command cwd and temporary directory will no longer be the same
- temporary dir generation has been altered so that basename is sha-ed after the test name to ensure better unicity (to be usable for compose)