### PR TITLE
[CI]: fix hardcode in TestImageHistory

### DIFF
--- a/cmd/nerdctl/image/image_history_test.go
+++ b/cmd/nerdctl/image/image_history_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
+	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
@@ -93,11 +94,6 @@ func TestImageHistory(t *testing.T) {
 					history, err := decode(stdout)
 					assert.NilError(t, err, info)
 					assert.Equal(t, len(history), 2, info)
-					assert.Equal(t, history[0].Size, "0B", info)
-					// FIXME: how is this going to age?
-					assert.Equal(t, history[0].CreatedSince, "4 years ago", info)
-					assert.Equal(t, history[0].Snapshot, "<missing>", info)
-					assert.Equal(t, history[0].Comment, "", info)
 
 					localTimeL1, _ := time.Parse(time.RFC3339, "2021-03-31T10:21:23-07:00")
 					localTimeL2, _ := time.Parse(time.RFC3339, "2021-03-31T10:21:21-07:00")
@@ -108,8 +104,13 @@ func TestImageHistory(t *testing.T) {
 					assert.Equal(t, compTime2.UTC().String(), localTimeL2.UTC().String(), info)
 					assert.Equal(t, history[1].CreatedBy, "/bin/sh -c #(nop) ADD file:3b16ffee2b26d8af5…", info)
 
+					assert.Equal(t, history[0].Size, "0B", info)
+					assert.Equal(t, history[0].CreatedSince, formatter.TimeSinceInHuman(compTime1), info)
+					assert.Equal(t, history[0].Snapshot, "<missing>", info)
+					assert.Equal(t, history[0].Comment, "", info)
+
 					assert.Equal(t, history[1].Size, "5.947MB", info)
-					assert.Equal(t, history[1].CreatedSince, "4 years ago", info)
+					assert.Equal(t, history[1].CreatedSince, formatter.TimeSinceInHuman(compTime2), info)
 					assert.Equal(t, history[1].Snapshot, "sha256:56bf55b8eed1f0b4794a30386e4d1d3da949c…", info)
 					assert.Equal(t, history[1].Comment, "", info)
 				}),

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -1,0 +1,71 @@
+package formatter
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestTimeSinceInHuman(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected string
+	}{
+		{
+			name:     "1 second ago",
+			input:    now.Add(-1 * time.Second),
+			expected: "1 second ago",
+		},
+		{
+			name:     "59 seconds ago",
+			input:    now.Add(-59 * time.Second),
+			expected: "59 seconds ago",
+		},
+		{
+			name:     "1 minute ago",
+			input:    now.Add(-1 * time.Minute),
+			expected: "About a minute ago",
+		},
+		{
+			name:     "1 hour ago",
+			input:    now.Add(-1 * time.Hour),
+			expected: "About an hour ago",
+		},
+		{
+			name:     "1 day ago",
+			input:    now.Add(-24 * time.Hour),
+			expected: "24 hours ago",
+		},
+		{
+			name:     "4 days ago",
+			input:    now.Add(-4 * 24 * time.Hour),
+			expected: "4 days ago",
+		},
+		{
+			name:     "1 year ago",
+			input:    now.Add(-365 * 24 * time.Hour),
+			expected: "12 months ago",
+		},
+		{
+			name:     "4 years ago",
+			input:    now.Add(-4 * 365 * 24 * time.Hour),
+			expected: "4 years ago",
+		},
+		{
+			name:     "zero duration",
+			input:    now,
+			expected: "Less than a second ago",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := TimeSinceInHuman(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Fix hardcoded `CreatedSince ` values in TestImageHistory .

## Related Issue 
 #4067 

## Change

- Replaced the fixed string value used in `assert.Equal` for the `CreatedSince` field with the value returned by the  `formatter.TimeSinceInHuman` function in relevant unit test cases.

- Added a unit test case for the `formatter.TimeSinceInHuman` function . 

## Others 

I noticed that other functions in `formatter.go` seem to have no unit tests . There may be a risk when these functions are changed . 
