### PR TITLE
[Bugfix] Check if port is used in publish flag [duplicate of #2190]

### DIFF
--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -349,6 +349,61 @@ func TestUniqueHostPortAssignement(t *testing.T) {
 	}
 }
 
+func TestHostPortAlreadyInUse(t *testing.T) {
+	testCases := []struct {
+		hostPort      string
+		containerPort string
+	}{
+		{
+			hostPort:      "5000",
+			containerPort: "80/tcp",
+		},
+		{
+			hostPort:      "5000",
+			containerPort: "80/tcp",
+		},
+		{
+			hostPort:      "5000",
+			containerPort: "80/udp",
+		},
+		{
+			hostPort:      "5000",
+			containerPort: "80/sctp",
+		},
+	}
+
+	tID := testutil.Identifier(t)
+
+	for i, tc := range testCases {
+		tc := tc
+		tcName := fmt.Sprintf("%+v", tc)
+		t.Run(tcName, func(t *testing.T) {
+			if strings.Contains(tc.containerPort, "sctp") && rootlessutil.IsRootless() {
+				t.Skip("sctp is not supported in rootless mode")
+			}
+			testContainerName1 := fmt.Sprintf("%s-%d-1", tID, i)
+			testContainerName2 := fmt.Sprintf("%s-%d-2", tID, i)
+			base := testutil.NewBase(t)
+			t.Cleanup(func() {
+				base.Cmd("rm", "-f", testContainerName1, testContainerName2).AssertOK()
+			})
+			pFlag := fmt.Sprintf("%s:%s", tc.hostPort, tc.containerPort)
+			cmd1 := base.Cmd("run", "-d",
+				"--name", testContainerName1, "-p",
+				pFlag,
+				testutil.NginxAlpineImage)
+
+			cmd2 := base.Cmd("run", "-d",
+				"--name", testContainerName2, "-p",
+				pFlag,
+				testutil.NginxAlpineImage)
+
+			cmd1.AssertOK()
+			cmd2.AssertFail()
+		})
+	}
+}
+
 func TestRunPort(t *testing.T) {
 	baseTestRunPort(t, testutil.NginxAlpineImage, testutil.NginxAlpineIndexHTMLSnippet, true)
 }

--- a/pkg/portutil/port_allocate_other.go
+++ b/pkg/portutil/port_allocate_other.go
@@ -23,3 +23,7 @@ import "fmt"
 func portAllocate(protocol string, ip string, count uint64) (uint64, uint64, error) {
 	return 0, 0, fmt.Errorf("auto port allocate are not support Non-Linux platform yet")
 }
+
+func getUsedPorts(ip string, protocol string) (map[uint64]bool, error) {
+	return nil, nil
+}

--- a/pkg/portutil/portutil.go
+++ b/pkg/portutil/portutil.go
@@ -101,6 +101,16 @@ func ParseFlagP(s string) ([]cni.PortMapping, error) {
 		if err != nil {
 			return nil, fmt.Errorf("invalid hostPort: %s", hostPort)
 		}
+		var usedPorts map[uint64]bool
+		usedPorts, err = getUsedPorts(ip, proto)
+		if err != nil {
+			return nil, err
+		}
+		for i := startHostPort; i <= endHostPort; i++ {
+			if usedPorts[i] {
+				return nil, fmt.Errorf("bind for %s:%d failed: port is already allocated", ip, i)
+			}
+		}
 	}
 	if hostPort != "" && (endPort-startPort) != (endHostPort-startHostPort) {
 		if endPort != startPort {

--- a/pkg/portutil/procnet/procnet.go
+++ b/pkg/portutil/procnet/procnet.go
@@ -27,6 +27,7 @@ import (
 type NetworkDetail struct {
 	LocalIP   net.IP
 	LocalPort uint64
+	State     int
 }
 
 func Parse(data []string) (results []NetworkDetail) {
@@ -37,9 +38,19 @@ func Parse(data []string) (results []NetworkDetail) {
 		if err != nil {
 			continue
 		}
+
+		state := 0
+		if len(lineData) > 2 {
+			stateHex, err := strconv.ParseInt(lineData[3], 16, 32)
+			if err == nil {
+				state = int(stateHex)
+			}
+		}
+
 		results = append(results, NetworkDetail{
 			LocalIP:   ip,
 			LocalPort: uint64(port),
+			State:     state,
 		})
 	}
 	return results


### PR DESCRIPTION
This PR continues the work from #2190  (originally by @vsiravar) which checks for used ports while allocating host port in -p/--publish. The original PR is already approved and was just waiting for a rebase form the author. Most of the comments have already been addressed.

#### Addressing port cleanup on stop:
The original PR had some open discussion around handling port cleanups on container stop

> > 
> > 
> > I concur with it, but hold reservations about merging this PR. I believe we should first have nerdctl stop manage the release of ports.
> > The rest LGTM.
> 
> cc [vsiravar](https://github.com/vsiravar), could you please fix the `stop` ( it can be a different PR) so we can merge this accordingly? Thanks


This is now already being addressed with this PR https://github.com/containerd/nerdctl/pull/2839 as network cleanup is part of both container stop and kill 

Verified the fix:
```
 % sudo ./_output/nerdctl run -p 8080:80 --name=test -d nginx
57a24f8da7127aeacee8b888a90e0e4eda866b35513844620de4ad1d28200547

 % sudo ./_output/nerdctl run -p 8080:80  -d nginx
FATA[0000] failed to load networking flags: bind for :8080 failed: port is already allocated 

 % sudo nerdctl stop test
test

% sudo ./_output/nerdctl run -p 8080:80  -d nginx
4ad5ca030355b1eb537c3caa91dfd5a9944dd36e8dea1756a4334a986f96c682
```

Fixes: #2179 

cc @fahedouch @vsiravar 

