### PR TITLE
[CI]: fix canary version matching

### DIFF
--- a/hack/build-integration-canary.sh
+++ b/hack/build-integration-canary.sh
@@ -276,9 +276,10 @@ canary::build::integration(){
     fi
 
     while read -r line; do
-      # Extract value after "=" from a possible dockerfile `ARG XXX_VERSION`
+      # Extract value after "=" from a possible dockerfile `ARG XXX_VERSION`, stripping out @ suffixes
       old_version=$(echo "$line" | grep "ARG ${shortsafename}_VERSION=") || true
       old_version="${old_version##*=}"
+      old_version="${old_version%%@*}"
       [ "$old_version" != "" ] || continue
       # If the Dockerfile version does NOT start with a v, adapt to that
       [ "${old_version:0:1}" == "v" ] || higher_readable="${higher_readable:1}"


### PR DESCRIPTION
Since we introduced `@revision` segments in version in the Dockerfile, canary erroneously reports versions being updated:
```
[Fri Apr  4 20:39:42 UTC 2025] WARNING: Dependency BUILDG is going to use an updated version v0.4.1 (currently: v0.4.1@BINARY)
```

This is minor, and purely a matter of debugging information being correct.