### PR TITLE
[DEBUGGING]: buildg time-out flaky issue (#4046)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,6 +250,9 @@ COPY docs /out/share/doc/nerdctl/docs
 RUN (cd /out && find ! -type d | sort | xargs sha256sum > /tmp/SHA256SUMS ) && \
   mv /tmp/SHA256SUMS /out/share/doc/nerdctl-full/SHA256SUMS && \
   chown -R 0:0 /out
+RUN git clone https://github.com/apostasie/buildg.git /tmp/buildg; cd /tmp/buildg; \
+    go build -o /out/bin/buildg .
+
 
 FROM scratch AS out-full
 COPY --from=build-full /out /


### PR DESCRIPTION
See https://github.com/containerd/nerdctl/issues/4046 Root cause is undiagnosed  / unclear, but it seems like in some circumstances, buildg command is too late to read from stdin.
This workaround introduces an arbitrary delay before writing to stdin, as a temporary solution to reduce test flakyness.