### PR TITLE
[FIX]: fix issues in rmi code (including #4104 content digest not found)

### DIFF
--- a/pkg/cmd/image/remove.go
+++ b/pkg/cmd/image/remove.go
@@ -79,18 +79,22 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 
 			if cid, ok := runningImages[found.Image.Name]; ok {
 				if options.Force {
-					// FIXME: this is suspicious, but passing the opt seem to break some tests
-					// if err = is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
-					if err = is.Delete(ctx, found.Image.Name); err != nil {
-						return err
-					}
-					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Name)
-					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Target.Digest.String())
-
+					// This is a running image, so, we need to keep a ref on it so that containerd does not GC the layers
+					// First create the new image with an empty name
+					originalName := found.Image.Name
 					found.Image.Name = ":"
 					if _, err = is.Create(ctx, found.Image); err != nil {
 						return err
 					}
+
+					// Now, delete the original
+					if err = is.Delete(ctx, originalName, delOpts...); err != nil {
+						return err
+					}
+
+					fmt.Fprintf(options.Stdout, "Untagged: %s\n", originalName)
+					fmt.Fprintf(options.Stdout, "Untagged: %s@%s\n", originalName, found.Image.Target.Digest.String())
+
 					return nil
 				}
 				return fmt.Errorf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", found.Req, cid)
@@ -128,18 +132,22 @@ func Remove(ctx context.Context, client *containerd.Client, args []string, optio
 
 			if cid, ok := runningImages[found.Image.Name]; ok {
 				if options.Force {
-					// FIXME: this is suspicious, but passing the opt seem to break some tests
-					// if err = is.Delete(ctx, found.Image.Name, delOpts...); err != nil {
-					if err = is.Delete(ctx, found.Image.Name); err != nil {
-						return false, err
-					}
-					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Name)
-					fmt.Fprintf(options.Stdout, "Untagged: %s\n", found.Image.Target.Digest.String())
-
+					// This is a running image, so, we need to keep a ref on it so that containerd does not GC the layers
+					// First create the new image with an empty name
+					originalName := found.Image.Name
 					found.Image.Name = ":"
 					if _, err = is.Create(ctx, found.Image); err != nil {
 						return false, err
 					}
+
+					// Now, delete the original
+					if err = is.Delete(ctx, originalName, delOpts...); err != nil {
+						return false, err
+					}
+
+					fmt.Fprintf(options.Stdout, "Untagged: %s\n", originalName)
+					fmt.Fprintf(options.Stdout, "Untagged: %s@%s\n", originalName, found.Image.Target.Digest.String())
+
 					return false, nil
 				}
 				return false, fmt.Errorf("conflict: unable to delete %s (cannot be forced) - image is being used by running container %s", found.Req, cid)


### PR DESCRIPTION
There are multiple issues with the current code implementation:
1. it does not honor the `--async` flag at all - and will always remove (running) images `async`, never `sync`
2. since the image is recreated AFTER we call delete (so that we prevent deletion of the content used by running containers), the code is racy, as (presumably) deletion may or may not have already completed, resulting in the dreaded content digest not found
3. we create the updated image with name ":" - this unfortunately means that if there is already another unnamed image, containerd will refuse to create it

I do not know how to address point 3 - which I believe is already an issue currently (tracked in #4109).
Note that this patch will change the behavior wrt to this specific aspect. Currently, we fail to create the new image, but still asked for deletion of the old image, which will break things. With this patch, we fail on creation and do not delete the original.

I would still suggest we merge this here if the reviewers are happy with it.
It should fix #4104.