### PR TITLE
fix: BUILDKIT_HOST env parsing when doing system prune

### DIFF
--- a/cmd/nerdctl/builder/builder.go
+++ b/cmd/nerdctl/builder/builder.go
@@ -58,8 +58,7 @@ func pruneCommand() *cobra.Command {
 		SilenceErrors: true,
 	}
 
-	helpers.AddStringFlag(cmd, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address")
-
+	cmd.Flags().String("buildkit-host", "", "BuildKit address")
 	cmd.Flags().BoolP("all", "a", false, "Remove all unused build cache, not just dangling ones")
 	cmd.Flags().BoolP("force", "f", false, "Do not prompt for confirmation")
 	return cmd


### PR DESCRIPTION
Currently when we set "BUILDKIT_HOST" as env variable, nerdctl doesnt take that into consideration for system prune.

```
[root@lima-finch nerdctl]# export BUILDKIT_HOST=unix:///tmp/buildkit-env.sock 
[root@lima-finch nerdctl]# nerdctl system prune --all
INFO[0000] Using buildkit host from command line flag or environment variable. 
WARN[0000] BuildKit is not running. Build caches will not be pruned.  error="flag accessed but not defined: buildkit-host"
```

With the change:
```
[root@lima-finch nerdctl]# export BUILDKIT_HOST=unix:///tmp/buildkit-env.sock 
[root@lima-finch nerdctl]# nerdctl system prune --all
WARNING! This will remove:
  - all stopped containers
  - all networks not used by at least one container
  - all images without at least one container associated to them
  - all build cache
Are you sure you want to continue? [y/N] y
```

Note: helpers.AddStringFlag(cmd, "buildkit-host", nil, "", "BUILDKIT_HOST", "BuildKit address") this masks the logic for build commands but for prune command it doesn't work correctly

Would like to refactor not have the helper commands to parse it as this only works when we have the specific flag but for buildctl config BUILDKIT_HOST can be also set for commands which may not have the buildkit-host flag specifically: eg: system prune. Of we add other options like du etc for buildctl this will be also relevant