### PR TITLE
[Tigron]: allow per-command environment override

### DIFF
--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -57,7 +57,7 @@ linters:
   settings:
     interfacebloat:
       # Default is 10
-      max: 13
+      max: 20
     revive:
       enable-all-rules: true
       rules:

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -126,6 +126,10 @@ func (gc *GenericCommand) Feed(r io.Reader) {
 	gc.cmd.Feed(r)
 }
 
+func (gc *GenericCommand) Setenv(key, value string) {
+	gc.cmd.Env[key] = value
+}
+
 func (gc *GenericCommand) WithFeeder(fun func() io.Reader) {
 	gc.cmd.WithFeeder(fun)
 }

--- a/mod/tigron/test/interfaces.go
+++ b/mod/tigron/test/interfaces.go
@@ -89,6 +89,8 @@ type TestableCommand interface {
 	WithCwd(path string)
 	// WithTimeout defines the execution timeout for a command.
 	WithTimeout(timeout time.Duration)
+	// Setenv allows to override a specific env variable directly for a specific command instead of test-wide
+	Setenv(key, value string)
 	// WithFeeder allows passing a reader to be fed to the command stdin.
 	WithFeeder(fun func() io.Reader)
 	// Feed allows passing a reader to be fed to the command stdin.


### PR DESCRIPTION
While `test.Case` allows declaration of custom environment variables, they must be set during the test declaration, apply to all commands, and cannot be altered during lifecycle operations (eg: Setup). This PR provides the ability to set variables for specific, individual commands.

Use-case seen in #4115
