### PR TITLE
[Fix]: image delete in convert (#3510)

### DIFF
--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -208,8 +208,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 			return err
 		}
 		is := client.ImageService()
-		_ = is.Delete(ctx, newI.Name, images.SynchronousDelete())
-		finimg, err := is.Create(ctx, *newI)
+		finimg, err := is.Update(ctx, *newI)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hopefully, this should be the last one of these (fingers crossed).

This part of `convert` has the same code pattern as seen in `containerd.Convert`.

My understanding is this:
- we ask for deletion of the image known as `newI.Name`
- if asynchronous, it may kick in before we then call Create
- if synchronous, it _will_ happen before, for sure
- in both cases, if that image already existed, and if it shared any layer with the to-be-created image, these layers will be deleted (either directly by the call to delete, or maybe because of garbage collection)
- one way or the other, the then newly created image might then miss layers (triggering the `content digest not found` error)

I believe this understanding of how containerd API works is (at least partly) valid, as the prior series of patch have significantly reduced the symptoms.

As far as I can tell, the last place where we see this is  #3510 - which does presumably hit this code path.

I will run the CI a few times to confirm, and then that should fix #3510.

Note: obviously, containerd image store API is wildly confusing and hard to reason about (and possibly has bugs - at least `converter.Convert` seems broken). This has clearly tripped the most savvy people here. Suggesting we isolate it behind a simpler, tested, `nerdctl.ImageStore`, and prevent casual code from using the containerd store directly.