### PR TITLE
[CI]: rewrite some container and compose tests

### DIFF
--- a/cmd/nerdctl/compose/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose/compose_build_linux_test.go
@@ -17,17 +17,31 @@
 package compose
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestComposeBuild(t *testing.T) {
-	const imageSvc0 = "composebuild_svc0"
-	const imageSvc1 = "composebuild_svc1"
+	dockerfile := "FROM " + testutil.AlpineImage
 
-	dockerComposeYAML := fmt.Sprintf(`
+	testCase := nerdtest.Setup()
+
+	testCase.Require = nerdtest.Build
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		// Make sure we shard the image name to something unique to the test to avoid conflicts with other tests
+		imageSvc0 := data.Identifier("svc0")
+		imageSvc1 := data.Identifier("svc1")
+
+		// We are not going to run them, so, ports conflicts should not matter here
+		dockerComposeYAML := fmt.Sprintf(`
 services:
   svc0:
     build: .
@@ -43,31 +57,81 @@ services:
     - 8081:80
 `, imageSvc0, imageSvc1)
 
-	dockerfile := fmt.Sprintf(`FROM %s`, testutil.AlpineImage)
+		data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		data.Temp().Save(dockerfile, "Dockerfile")
 
-	testutil.RequiresBuild(t)
-	testutil.RegisterBuildCacheCleanup(t)
-	base := testutil.NewBase(t)
+		data.Labels().Set("composeYaml", data.Temp().Path("compose.yaml"))
+		data.Labels().Set("imageSvc0", imageSvc0)
+		data.Labels().Set("imageSvc1", imageSvc1)
+	}
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-	comp.WriteFile("Dockerfile", dockerfile)
-	projectName := comp.ProjectName()
-	t.Logf("projectName=%q", projectName)
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "build svc0",
+			NoParallel:  true,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("compose", "-f", data.Labels().Get("composeYaml"), "build", "svc0")
+			},
 
-	defer base.Cmd("rmi", imageSvc0).Run()
-	defer base.Cmd("rmi", imageSvc1).Run()
+			Command: test.Command("images"),
 
-	// 1. build only 1 service without triggering the dependency service build
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0").AssertOK()
-	base.Cmd("images").AssertOutContains(imageSvc0)
-	base.Cmd("images").AssertOutNotContains(imageSvc1)
-	// 2. build multiple services
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0", "svc1").AssertOK()
-	base.Cmd("images").AssertOutContains(imageSvc0)
-	base.Cmd("images").AssertOutContains(imageSvc1)
-	// 3. build all if no args are given
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "build").AssertOK()
-	// 4. fail if some services args not exist in compose.yml
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "build", "svc0", "svc100").AssertFail()
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					Output: expect.All(
+						expect.Contains(data.Labels().Get("imageSvc0")),
+						expect.DoesNotContain(data.Labels().Get("imageSvc1")),
+					),
+				}
+			},
+		},
+		{
+			Description: "build svc0 and svc1",
+			NoParallel:  true,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("compose", "-f", data.Labels().Get("composeYaml"), "build", "svc0", "svc1")
+			},
+
+			Command: test.Command("images"),
+
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					Output: expect.All(
+						expect.Contains(data.Labels().Get("imageSvc0")),
+						expect.Contains(data.Labels().Get("imageSvc1")),
+					),
+				}
+			},
+		},
+		{
+			Description: "build no arg",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "build")
+			},
+
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
+		{
+			Description: "build bogus",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command(
+					"compose",
+					"-f",
+					data.Labels().Get("composeYaml"),
+					"build",
+					"svc0",
+					"svc100",
+				)
+			},
+
+			Expected: test.Expects(1, []error{errors.New("no such service: svc100")}, nil),
+		},
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		if data.Labels().Get("imageSvc0") != "" {
+			helpers.Anyhow("rmi", data.Labels().Get("imageSvc0"), data.Labels().Get("imageSvc1"))
+		}
+	}
+
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/compose/compose_config_test.go
+++ b/cmd/nerdctl/compose/compose_config_test.go
@@ -18,141 +18,275 @@ package compose
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"gotest.tools/v3/assert"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestComposeConfig(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	var dockerComposeYAML = `
+	const dockerComposeYAML = `
 services:
   hello:
     image: alpine:3.13
 `
+	testCase := nerdtest.Setup()
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		data.Labels().Set("composeYaml", data.Temp().Path("compose.yaml"))
+	}
 
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "config").AssertOutContains("hello:")
-}
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "config contains service name",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "config")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("hello:")),
+		},
+		{
+			Description: "config --services is exactly service name",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command(
+					"compose",
+					"-f",
+					data.Labels().Get("composeYaml"),
+					"config",
+					"--services",
+				)
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("hello\n")),
+		},
+		{
+			Description: "config --hash=* contains service name",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "config", "--hash=*")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("hello")),
+		},
+	}
 
-func TestComposeConfigWithPrintService(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	var dockerComposeYAML = `
-services:
-  hello1:
-    image: alpine:3.13
-`
-
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--services").AssertOutExactly("hello1\n")
+	testCase.Run(t)
 }
 
 func TestComposeConfigWithPrintServiceHash(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	var dockerComposeYAML = `
+	const dockerComposeYAML = `
 services:
-  hello1:
+  hello:
     image: alpine:%s
 `
+	testCase := nerdtest.Setup()
 
-	comp := testutil.NewComposeDir(t, fmt.Sprintf(dockerComposeYAML, "3.13"))
-	defer comp.CleanUp()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(fmt.Sprintf(dockerComposeYAML, "3.13"), "compose.yaml")
 
-	// `--hash=*` is broken in Docker Compose v2.23.0: https://github.com/docker/compose/issues/11145
-	if base.Target == testutil.Nerdctl {
-		base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--hash=*").AssertOutContains("hello1")
+		hash := helpers.Capture(
+			"compose",
+			"-f",
+			data.Temp().Path("compose.yaml"),
+			"config",
+			"--hash=hello",
+		)
+
+		data.Labels().Set("hash", hash)
+
+		data.Temp().Save(fmt.Sprintf(dockerComposeYAML, "3.14"), "compose.yaml")
 	}
 
-	hash := base.ComposeCmd("-f", comp.YAMLFullPath(), "config", "--hash=hello1").Out()
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command(
+			"compose",
+			"-f",
+			data.Temp().Path("compose.yaml"),
+			"config",
+			"--hash=hello",
+		)
+	}
 
-	newComp := testutil.NewComposeDir(t, fmt.Sprintf(dockerComposeYAML, "3.14"))
-	defer newComp.CleanUp()
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: 0,
+			Output: func(stdout, info string, t *testing.T) {
+				assert.Assert(t, data.Labels().Get("hash") != stdout, "hash should be different")
+			},
+		}
+	}
 
-	newHash := base.ComposeCmd("-f", newComp.YAMLFullPath(), "config", "--hash=hello1").Out()
-	assert.Assert(t, hash != newHash)
+	testCase.Run(t)
 }
 
 func TestComposeConfigWithMultipleFile(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	var dockerComposeYAML = `
+	const dockerComposeBase = `
 services:
   hello1:
     image: alpine:3.13
 `
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-
-	comp.WriteFile("docker-compose.test.yml", `
+	const dockerComposeTest = `
 services:
   hello2:
     image: alpine:3.14
-`)
-	comp.WriteFile("docker-compose.override.yml", `
+`
+
+	const dockerComposeOverride = `
 services:
   hello1:
     image: alpine:3.14
-`)
+`
 
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "-f", filepath.Join(comp.Dir(), "docker-compose.test.yml"), "config").AssertOutContains("alpine:3.14")
-	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutExactly("hello1\n")
-	base.ComposeCmd("--project-directory", comp.Dir(), "config").AssertOutContains("alpine:3.14")
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(dockerComposeBase, "compose.yaml")
+		data.Temp().Save(dockerComposeTest, "docker-compose.test.yml")
+		data.Temp().Save(dockerComposeOverride, "docker-compose.override.yml")
+
+		data.Labels().Set("composeDir", data.Temp().Path())
+		data.Labels().Set("composeYaml", data.Temp().Path("compose.yaml"))
+		data.Labels().Set("composeYamlTest", data.Temp().Path("docker-compose.test.yml"))
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "config override",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command(
+					"compose",
+					"-f", data.Labels().Get("composeYaml"),
+					"-f", data.Labels().Get("composeYamlTest"),
+					"config",
+				)
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.All(
+				expect.Contains("alpine:3.13"),
+				expect.Contains("alpine:3.14"),
+				expect.Contains("hello1"),
+				expect.Contains("hello2"),
+			)),
+		},
+		{
+			Description: "project dir",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command(
+					"compose",
+					"--project-directory", data.Labels().Get("composeDir"), "config",
+				)
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("alpine:3.14")),
+		},
+		{
+			Description: "project dir services",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command(
+					"compose",
+					"--project-directory", data.Labels().Get("composeDir"), "config", "--services",
+				)
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("hello1\n")),
+		},
+	}
+
+	testCase.Run(t)
 }
 
 func TestComposeConfigWithComposeFileEnv(t *testing.T) {
-	base := testutil.NewBase(t)
-
-	var dockerComposeYAML = `
+	const dockerComposeBase = `
 services:
   hello1:
     image: alpine:3.13
 `
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-
-	comp.WriteFile("docker-compose.test.yml", `
+	const dockerComposeTest = `
 services:
   hello2:
     image: alpine:3.14
-`)
+`
 
-	base.Env = append(base.Env, "COMPOSE_FILE="+comp.YAMLFullPath()+","+filepath.Join(comp.Dir(), "docker-compose.test.yml"), "COMPOSE_PATH_SEPARATOR=,")
+	testCase := nerdtest.Setup()
 
-	base.ComposeCmd("config").AssertOutContains("alpine:3.14")
-	base.ComposeCmd("--project-directory", comp.Dir(), "config", "--services").AssertOutContainsAll("hello1\n", "hello2\n")
-	base.ComposeCmd("--project-directory", comp.Dir(), "config").AssertOutContains("alpine:3.14")
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(dockerComposeBase, "compose.yaml")
+		data.Temp().Save(dockerComposeTest, "docker-compose.test.yml")
+
+		data.Labels().Set("composeDir", data.Temp().Path())
+		data.Labels().Set("composeYaml", data.Temp().Path("compose.yaml"))
+		data.Labels().Set("composeYamlTest", data.Temp().Path("docker-compose.test.yml"))
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "env config",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command(
+					"compose",
+					"config",
+				)
+				cmd.Setenv("COMPOSE_FILE", data.Labels().Get("composeYaml")+","+data.Labels().Get("composeYamlTest"))
+				cmd.Setenv("COMPOSE_PATH_SEPARATOR", ",")
+				return cmd
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.All(
+				expect.Contains("alpine:3.13"),
+				expect.Contains("alpine:3.14"),
+				expect.Contains("hello1"),
+				expect.Contains("hello2"),
+			)),
+		},
+		{
+			Description: "env with project dir",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				cmd := helpers.Command(
+					"compose",
+					"--project-directory", data.Labels().Get("composeDir"),
+					"config",
+				)
+				cmd.Setenv("COMPOSE_FILE", data.Labels().Get("composeYaml")+","+data.Labels().Get("composeYamlTest"))
+				cmd.Setenv("COMPOSE_PATH_SEPARATOR", ",")
+				return cmd
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.All(
+				expect.Contains("alpine:3.13"),
+				expect.Contains("alpine:3.14"),
+				expect.Contains("hello1"),
+				expect.Contains("hello2"),
+			)),
+		},
+	}
+
+	testCase.Run(t)
 }
 
 func TestComposeConfigWithEnvFile(t *testing.T) {
-	base := testutil.NewBase(t)
-
 	const dockerComposeYAML = `
 services:
   hello:
     image: ${image}
 `
-
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-
-	envFile := filepath.Join(comp.Dir(), "env")
 	const envFileContent = `
 image: hello-world
 `
-	assert.NilError(t, os.WriteFile(envFile, []byte(envFileContent), 0644))
 
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "--env-file", envFile, "config").AssertOutContains("image: hello-world")
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		data.Temp().Save(envFileContent, "env")
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("compose",
+			"-f", data.Temp().Path("compose.yaml"),
+			"--env-file", data.Temp().Path("env"),
+			"config",
+		)
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("image: hello-world"))
+
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/compose/compose_create_linux_test.go
+++ b/cmd/nerdctl/compose/compose_create_linux_test.go
@@ -18,13 +18,19 @@ package compose
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestComposeCreate(t *testing.T) {
-	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
 version: '3.1'
 
@@ -33,22 +39,53 @@ services:
     image: %s
 `, testutil.AlpineImage)
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-	projectName := comp.ProjectName()
-	t.Logf("projectName=%q", projectName)
+	testCase := nerdtest.Setup()
 
-	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		compYamlPath := data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		data.Labels().Set("composeYaml", compYamlPath)
+	}
 
-	// 1.1 `compose create` should create service container (in `created` status)
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "create").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0", "-a").AssertOutContainsAny("Created", "created")
-	// 1.2 created container can be started by `compose start`
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "start").AssertOK()
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("compose", "-f", data.Temp().Path("compose.yaml"), "down", "-v")
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "`compose create` should work",
+			// These are sequential
+			NoParallel: true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "create")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
+		{
+			Description: "`compose create` should have created service container (in `created` status)",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+				assert.Assert(t,
+					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
+					"stdout should contain `created`")
+			}),
+		},
+		{
+			Description: "`created container can be started by `compose start`",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "start")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
+	}
+
+	testCase.Run(t)
 }
 
 func TestComposeCreateDependency(t *testing.T) {
-	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
 version: '3.1'
 
@@ -61,17 +98,54 @@ services:
     image: %s
 `, testutil.CommonImage, testutil.CommonImage)
 
-	comp := testutil.NewComposeDir(t, dockerComposeYAML)
-	defer comp.CleanUp()
-	projectName := comp.ProjectName()
-	t.Logf("projectName=%q", projectName)
+	testCase := nerdtest.Setup()
 
-	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		compYamlPath := data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		data.Labels().Set("composeYaml", compYamlPath)
+	}
 
-	// `compose create` should create containers for both services and their dependencies
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "create", "svc0").AssertOK()
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0", "-a").AssertOutContainsAny("Created", "created")
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc1", "-a").AssertOutContainsAny("Created", "created")
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("compose", "-f", data.Temp().Path("compose.yaml"), "down", "-v")
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "`compose create` should work",
+			// These are sequential
+			NoParallel: true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "create")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
+		{
+			Description: "`compose create` should have created svc0 (in `created` status)",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+				assert.Assert(t,
+					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
+					"stdout should contain `created`")
+			}),
+		},
+		{
+			Description: "`compose create` should have created svc1 (in `created` status)",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc1", "-a")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+				assert.Assert(t,
+					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
+					"stdout should contain `created`")
+			}),
+		},
+	}
+
+	testCase.Run(t)
 }
 
 func TestComposeCreatePull(t *testing.T) {

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -17,6 +17,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"runtime"
@@ -76,16 +77,29 @@ bar`
 // Tests whether `nerdctl logs` properly separates stdout/stderr output
 // streams for containers using the jsonfile logging driver:
 func TestLogsOutStreamsSeparated(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	containerName := testutil.Identifier(t)
+	testCase := nerdtest.Setup()
 
-	defer base.Cmd("rm", containerName).Run()
-	base.Cmd("run", "-d", "--name", containerName, testutil.CommonImage,
-		"sh", "-euc", "echo stdout1; echo stderr1 >&2; echo stdout2; echo stderr2 >&2").AssertOK()
-	time.Sleep(3 * time.Second)
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage,
+			"sh", "-euc", "echo stdout1; echo stderr1 >&2; echo stdout2; echo stderr2 >&2")
+	}
 
-	base.Cmd("logs", containerName).AssertOutStreamsExactly("stdout1\nstdout2\n", "stderr1\nstderr2\n")
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Arbitrary, but we need to wait until the logs show up
+		time.Sleep(3 * time.Second)
+		return helpers.Command("logs", data.Identifier())
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, []error{
+		//revive:disable:error-strings
+		errors.New("stderr1\nstderr2\n"),
+	}, expect.Equals("stdout1\nstdout2\n"))
+
+	testCase.Run(t)
 }
 
 func TestLogsWithInheritedFlags(t *testing.T) {

--- a/cmd/nerdctl/container/container_run_verify_linux_test.go
+++ b/cmd/nerdctl/container/container_run_verify_linux_test.go
@@ -20,38 +20,66 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/require"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
-	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest/registry"
 )
 
 func TestRunVerifyCosign(t *testing.T) {
-	testutil.RequireExecutable(t, "cosign")
-	testutil.DockerIncompatible(t)
-	testutil.RequiresBuild(t)
-	testutil.RegisterBuildCacheCleanup(t)
-	t.Parallel()
-
-	base := testutil.NewBase(t)
-	base.Env = append(base.Env, "COSIGN_PASSWORD=1")
-
-	keyPair := helpers.NewCosignKeyPair(t, "cosign-key-pair", "1")
-	reg := testregistry.NewWithNoAuth(base, 0, false)
-	t.Cleanup(func() {
-		keyPair.Cleanup()
-		reg.Cleanup(nil)
-	})
-
-	tID := testutil.Identifier(t)
-	testImageRef := fmt.Sprintf("127.0.0.1:%d/%s", reg.Port, tID)
 	dockerfile := fmt.Sprintf(`FROM %s
 CMD ["echo", "nerdctl-build-test-string"]
 	`, testutil.CommonImage)
 
-	buildCtx := helpers.CreateBuildContext(t, dockerfile)
+	testCase := nerdtest.Setup()
 
-	base.Cmd("build", "-t", testImageRef, buildCtx).AssertOK()
-	base.Cmd("push", testImageRef, "--sign=cosign", "--cosign-key="+keyPair.PrivateKey).AssertOK()
-	base.Cmd("run", "--rm", "--verify=cosign", "--cosign-key="+keyPair.PublicKey, testImageRef).AssertOK()
-	base.Cmd("run", "--rm", "--verify=cosign", "--cosign-key=dummy", testImageRef).AssertFail()
+	var reg *registry.Server
+
+	testCase.Require = require.All(
+		require.Binary("cosign"),
+		require.Not(nerdtest.Docker),
+		nerdtest.Build,
+		nerdtest.Registry,
+	)
+
+	testCase.Env["COSIGN_PASSWORD"] = "1"
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Temp().Save(dockerfile, "Dockerfile")
+		pri, pub := nerdtest.GenerateCosignKeyPair(data, helpers, "1")
+		reg = nerdtest.RegistryWithNoAuth(data, helpers, 0, false)
+		reg.Setup(data, helpers)
+
+		testImageRef := fmt.Sprintf("127.0.0.1:%d/%s", reg.Port, data.Identifier("push-cosign-image"))
+		helpers.Ensure("build", "-t", testImageRef, data.Temp().Path())
+		helpers.Ensure("push", testImageRef, "--sign=cosign", "--cosign-key="+pri)
+
+		data.Labels().Set("public_key", pub)
+		data.Labels().Set("image_ref", testImageRef)
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		if reg != nil {
+			reg.Cleanup(data, helpers)
+		}
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		helpers.Fail(
+			"run", "--rm", "--verify=cosign",
+			"--cosign-key=dummy",
+			data.Labels().Get("image_ref"))
+
+		return helpers.Command(
+			"run", "--rm", "--verify=cosign",
+			"--cosign-key="+data.Labels().Get("public_key"),
+			data.Labels().Get("image_ref"))
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, nil)
+
+	testCase.Run(t)
 }

--- a/cmd/nerdctl/image/image_encrypt_linux_test.go
+++ b/cmd/nerdctl/image/image_encrypt_linux_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
-	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
@@ -36,7 +35,6 @@ func TestImageEncryptJWE(t *testing.T) {
 	nerdtest.Setup()
 
 	var registry *testregistry.RegistryServer
-	var keyPair *testhelpers.JweKeyPair
 
 	const remoteImageKey = "remoteImageKey"
 
@@ -50,18 +48,20 @@ func TestImageEncryptJWE(t *testing.T) {
 		Cleanup: func(data test.Data, helpers test.Helpers) {
 			if registry != nil {
 				registry.Cleanup(nil)
-				keyPair.Cleanup()
 				helpers.Anyhow("rmi", "-f", data.Labels().Get(remoteImageKey))
 			}
 			helpers.Anyhow("rmi", "-f", data.Identifier("decrypted"))
 		},
 		Setup: func(data test.Data, helpers test.Helpers) {
+			pri, pub := nerdtest.GenerateJWEKeyPair(data, helpers)
+			data.Labels().Set("private", pri)
+			data.Labels().Set("public", pub)
+
 			base := testutil.NewBase(t)
 			registry = testregistry.NewWithNoAuth(base, 0, false)
-			keyPair = testhelpers.NewJWEKeyPair(t)
 			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
 			encryptImageRef := fmt.Sprintf("127.0.0.1:%d/%s:encrypted", registry.Port, data.Identifier())
-			helpers.Ensure("image", "encrypt", "--recipient=jwe:"+keyPair.Pub, testutil.CommonImage, encryptImageRef)
+			helpers.Ensure("image", "encrypt", "--recipient=jwe:"+pub, testutil.CommonImage, encryptImageRef)
 			inspector := helpers.Capture("image", "inspect", "--mode=native", "--format={{len .Index.Manifests}}", encryptImageRef)
 			assert.Equal(t, inspector, "1\n")
 			inspector = helpers.Capture("image", "inspect", "--mode=native", "--format={{json .Manifest.Layers}}", encryptImageRef)
@@ -74,8 +74,8 @@ func TestImageEncryptJWE(t *testing.T) {
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 			helpers.Fail("pull", data.Labels().Get(remoteImageKey))
 			helpers.Ensure("pull", "--quiet", "--unpack=false", data.Labels().Get(remoteImageKey))
-			helpers.Fail("image", "decrypt", "--key="+keyPair.Pub, data.Labels().Get(remoteImageKey), data.Identifier("decrypted")) // decryption needs prv key, not pub key
-			return helpers.Command("image", "decrypt", "--key="+keyPair.Prv, data.Labels().Get(remoteImageKey), data.Identifier("decrypted"))
+			helpers.Fail("image", "decrypt", "--key="+data.Labels().Get("public"), data.Labels().Get(remoteImageKey), data.Identifier("decrypted")) // decryption needs prv key, not pub key
+			return helpers.Command("image", "decrypt", "--key="+data.Labels().Get("private"), data.Labels().Get(remoteImageKey), data.Identifier("decrypted"))
 		},
 		Expected: test.Expects(0, nil, nil),
 	}

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -18,8 +18,6 @@ package image
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -30,17 +28,19 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
-	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
-	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest/registry"
 )
 
 func TestImagePullWithCosign(t *testing.T) {
+	dockerfile := fmt.Sprintf(`FROM %s
+CMD ["echo", "nerdctl-build-test-string"]
+	`, testutil.CommonImage)
+
 	nerdtest.Setup()
 
-	var registry *testregistry.RegistryServer
-	var keyPair *testhelpers.CosignKeyPair
+	var reg *registry.Server
 
 	testCase := &test.Case{
 		Require: require.All(
@@ -48,45 +48,47 @@ func TestImagePullWithCosign(t *testing.T) {
 			nerdtest.Build,
 			require.Binary("cosign"),
 			require.Not(nerdtest.Docker),
+			nerdtest.Registry,
 		),
+
 		Env: map[string]string{
 			"COSIGN_PASSWORD": "1",
 		},
-		Setup: func(data test.Data, helpers test.Helpers) {
-			keyPair = testhelpers.NewCosignKeyPair(t, "cosign-key-pair", "1")
-			base := testutil.NewBase(t)
-			registry = testregistry.NewWithNoAuth(base, 0, false)
-			testImageRef := fmt.Sprintf("%s:%d/%s", "127.0.0.1", registry.Port, data.Identifier())
-			dockerfile := fmt.Sprintf(`FROM %s
-CMD ["echo", "nerdctl-build-test-string"]
-	`, testutil.CommonImage)
 
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Temp().Save(dockerfile, "Dockerfile")
+			pri, pub := nerdtest.GenerateCosignKeyPair(data, helpers, "1")
+			reg = nerdtest.RegistryWithNoAuth(data, helpers, 0, false)
+			reg.Setup(data, helpers)
+			testImageRef := fmt.Sprintf("%s:%d/%s", "127.0.0.1", reg.Port, data.Identifier())
 			buildCtx := data.Temp().Path()
-			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-			assert.NilError(helpers.T(), err)
+
 			helpers.Ensure("build", "-t", testImageRef+":one", buildCtx)
 			helpers.Ensure("build", "-t", testImageRef+":two", buildCtx)
-			helpers.Ensure("push", "--sign=cosign", "--cosign-key="+keyPair.PrivateKey, testImageRef+":one")
-			helpers.Ensure("push", "--sign=cosign", "--cosign-key="+keyPair.PrivateKey, testImageRef+":two")
-			helpers.Ensure("rmi", "-f", testImageRef)
-			data.Labels().Set("imageref", testImageRef)
+			helpers.Ensure("push", "--sign=cosign", "--cosign-key="+pri, testImageRef+":one")
+			helpers.Ensure("push", "--sign=cosign", "--cosign-key="+pri, testImageRef+":two")
+
+			data.Labels().Set("public_key", pub)
+			data.Labels().Set("image_ref", testImageRef)
 		},
+
 		Cleanup: func(data test.Data, helpers test.Helpers) {
-			if keyPair != nil {
-				keyPair.Cleanup()
-			}
-			if registry != nil {
-				registry.Cleanup(nil)
-				testImageRef := fmt.Sprintf("%s:%d/%s", "127.0.0.1", registry.Port, data.Identifier())
+			if reg != nil {
+				reg.Cleanup(data, helpers)
+				testImageRef := data.Labels().Get("image_ref")
 				helpers.Anyhow("rmi", "-f", testImageRef+":one")
 				helpers.Anyhow("rmi", "-f", testImageRef+":two")
 			}
 		},
+
 		SubTests: []*test.Case{
 			{
 				Description: "Pull with the correct key",
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+keyPair.PublicKey, data.Labels().Get("imageref")+":one")
+					return helpers.Command(
+						"pull", "--quiet", "--verify=cosign",
+						"--cosign-key="+data.Labels().Get("public_key"),
+						data.Labels().Get("image_ref")+":one")
 				},
 				Expected: test.Expects(0, nil, nil),
 			},
@@ -96,8 +98,8 @@ CMD ["echo", "nerdctl-build-test-string"]
 					"COSIGN_PASSWORD": "2",
 				},
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					newKeyPair := testhelpers.NewCosignKeyPair(t, "cosign-key-pair-test", "2")
-					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+newKeyPair.PublicKey, data.Labels().Get("imageref")+":two")
+					_, pub := nerdtest.GenerateCosignKeyPair(data, helpers, "2")
+					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+pub, data.Labels().Get("image_ref")+":two")
 				},
 				Expected: test.Expects(12, nil, nil),
 			},
@@ -110,42 +112,44 @@ CMD ["echo", "nerdctl-build-test-string"]
 func TestImagePullPlainHttpWithDefaultPort(t *testing.T) {
 	nerdtest.Setup()
 
-	var registry *testregistry.RegistryServer
+	var reg *registry.Server
+	dockerfile := fmt.Sprintf(`FROM %s
+CMD ["echo", "nerdctl-build-test-string"]
+	`, testutil.CommonImage)
 
 	testCase := &test.Case{
 		Require: require.All(
 			require.Linux,
 			require.Not(nerdtest.Docker),
 			nerdtest.Build,
+			nerdtest.Registry,
 		),
-		Setup: func(data test.Data, helpers test.Helpers) {
-			base := testutil.NewBase(t)
-			registry = testregistry.NewWithNoAuth(base, 80, false)
-			testImageRef := fmt.Sprintf("%s/%s:%s",
-				registry.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-			dockerfile := fmt.Sprintf(`FROM %s
-CMD ["echo", "nerdctl-build-test-string"]
-	`, testutil.CommonImage)
 
+		Setup: func(data test.Data, helpers test.Helpers) {
+			data.Temp().Save(dockerfile, "Dockerfile")
+			reg = nerdtest.RegistryWithNoAuth(data, helpers, 80, false)
+			reg.Setup(data, helpers)
+			testImageRef := fmt.Sprintf("%s/%s:%s",
+				reg.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
 			buildCtx := data.Temp().Path()
-			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-			assert.NilError(helpers.T(), err)
+
 			helpers.Ensure("build", "-t", testImageRef, buildCtx)
 			helpers.Ensure("--insecure-registry", "push", testImageRef)
 			helpers.Ensure("rmi", "-f", testImageRef)
+
+			data.Labels().Set("image_ref", testImageRef)
 		},
+
 		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-			testImageRef := fmt.Sprintf("%s/%s:%s",
-				registry.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-			return helpers.Command("--insecure-registry", "pull", testImageRef)
+			return helpers.Command("--insecure-registry", "pull", data.Labels().Get("image_ref"))
 		},
+
 		Expected: test.Expects(0, nil, nil),
+
 		Cleanup: func(data test.Data, helpers test.Helpers) {
-			if registry != nil {
-				registry.Cleanup(nil)
-				testImageRef := fmt.Sprintf("%s/%s:%s",
-					registry.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
-				helpers.Anyhow("rmi", "-f", testImageRef)
+			if reg != nil {
+				reg.Cleanup(data, helpers)
+				helpers.Anyhow("rmi", "-f", data.Labels().Get("image_ref"))
 			}
 		},
 	}
@@ -165,6 +169,8 @@ func TestImagePullSoci(t *testing.T) {
 
 		// NOTE: these tests cannot be run in parallel, as they depend on the output of host `mount`
 		// They also feel prone to raciness...
+		NoParallel: true,
+
 		SubTests: []*test.Case{
 			{
 				Description: "Run without specifying SOCI index",
@@ -190,13 +196,14 @@ func TestImagePullSoci(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, _ string, t *testing.T) {
 							remoteSnapshotsInitialCount, _ := strconv.Atoi(data.Labels().Get("remoteSnapshotsInitialCount"))
 							remoteSnapshotsActualCount := strings.Count(stdout, "fuse.rawBridge")
 							assert.Equal(t,
 								data.Labels().Get("remoteSnapshotsExpectedCount"),
 								strconv.Itoa(remoteSnapshotsActualCount-remoteSnapshotsInitialCount),
-								info)
+								"expected remote snapshot count to match",
+							)
 						},
 					}
 				},
@@ -231,7 +238,7 @@ func TestImagePullSoci(t *testing.T) {
 							assert.Equal(t,
 								data.Labels().Get("remoteSnapshotsExpectedCount"),
 								strconv.Itoa(remoteSnapshotsActualCount-remoteSnapshotsInitialCount),
-								info)
+								"expected remote snapshot count to match")
 						},
 					}
 				},

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -17,6 +17,7 @@
 package network
 
 import (
+	"fmt"
 	"net"
 	"strings"
 	"testing"
@@ -26,7 +27,6 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
-	ipv6helper "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
@@ -100,8 +100,8 @@ func TestNetworkCreate(t *testing.T) {
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
 						_, subnet, _ := net.ParseCIDR(data.Labels().Get("subnetStr"))
-						ip := ipv6helper.FindIPv6(stdout)
-						assert.Assert(t, subnet.Contains(ip), info)
+						ip := nerdtest.FindIPv6(stdout)
+						assert.Assert(t, subnet.Contains(ip), fmt.Sprintf("subnet %s contains ip %s", subnet, ip))
 					},
 				}
 			},

--- a/pkg/testutil/testutil_freebsd.go
+++ b/pkg/testutil/testutil_freebsd.go
@@ -16,8 +16,6 @@
 
 package testutil
 
-import "fmt"
-
 const (
 	CommonImage = "docker.io/knast/freebsd:13-STABLE"
 
@@ -35,8 +33,3 @@ var (
 	NginxAlpineImage = mirrorOf("nginx:1.19-alpine")
 	GolangImage      = mirrorOf("golang:1.18")
 )
-
-func mirrorOf(s string) string {
-	// plain mirror, NOT stargz-converted images
-	return fmt.Sprintf("ghcr.io/stargz-containers/%s-org", s)
-}

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -16,15 +16,6 @@
 
 package testutil
 
-import (
-	"fmt"
-)
-
-func mirrorOf(s string) string {
-	// plain mirror, NOT stargz-converted images
-	return fmt.Sprintf("ghcr.io/stargz-containers/%s-org", s)
-}
-
 var (
 	BusyboxImage                = "ghcr.io/containerd/busybox:1.36"
 	AlpineImage                 = mirrorOf("alpine:3.13")

--- a/pkg/testutil/testutil_windows.go
+++ b/pkg/testutil/testutil_windows.go
@@ -43,9 +43,6 @@ const (
 	NginxAlpineImage            = "registry.k8s.io/e2e-test-images/nginx:1.14-2"
 	NginxAlpineIndexHTMLSnippet = "<title>Welcome to nginx!</title>"
 
-	GolangImage = "fixme-test-using-this-image-is-disabled-on-windows"
-	AlpineImage = "fixme-test-using-this-image-is-disabled-on-windows"
-
 	// This error string is expected when attempting to connect to a TCP socket
 	// for a service which actively refuses the connection.
 	// (e.g. attempting to connect using http to an https endpoint).
@@ -56,6 +53,9 @@ const (
 )
 
 var (
+	GolangImage = mirrorOf("fixme-test-using-this-image-is-disabled-on-windows")
+	AlpineImage = mirrorOf("fixme-test-using-this-image-is-disabled-on-windows")
+
 	hypervContainer     bool
 	hypervSupported     bool
 	hypervSupportedOnce sync.Once


### PR DESCRIPTION
I have been delaying engaging with compose and container tests so far because of the daunting amount of work...

But at this point, they are the number one contributor to overall slowness (and most of remaining flakyness).
Moving these will cut through the total runtime and make a dent in the bucket of "tests with retries".

~~Note that we should merge first, before this:~~
~~- #4111~~
~~- #4081~~
~~- #4116~~

~~and preferably #4114.~~

~~... as this PR does leverage some of the recent changes in Tigron (specifically temp files manipulation).~~

~~I will obviously take care of rebasing once they are in, though the last commit of this PR could be reviewed already at this point.~~

Note that this PR also adopt / cleans-up / remove deprecated helpers (some of them wrongly located under `./cmd`, some under `./pkg/testutil`).

I know it is painful to review large PRs like that, but I believe there is really no other way here - and at the end of the day, this is only tests - the CI being green is proof in the pudding.