### PR TITLE
[URGENT] Fixing main cross-merge bustage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -128,7 +128,7 @@ linters:
         ##### P2: nice to have.
         - name: max-public-structs
           # 7 occurrences (at default 5). Might indicate overcrowding of public API.
-          arguments: [21]
+          arguments: [25]
         - name: confusing-results
           # 13 occurrences. Have named returns when the type stutters.
           # Makes it a bit easier to figure out function behavior just looking at signature.

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -288,7 +288,7 @@ func TestNetworkInspect(t *testing.T) {
 				helpers.Ensure("create", "--name", data.Identifier("nginx-container-2"), "--network", data.Identifier("nginx-network-1"), testutil.NginxAlpineImage)
 				helpers.Ensure("create", "--name", data.Identifier("nginx-container-on-diff-network"), "--network", data.Identifier("nginx-network-2"), testutil.NginxAlpineImage)
 				helpers.Ensure("start", data.Identifier("nginx-container-1"), data.Identifier("nginx-container-on-diff-network"))
-				data.Set("nginx-container-1-id", strings.Trim(helpers.Capture("inspect", data.Identifier("nginx-container-1"), "--format", "{{.Id}}"), "\n"))
+				data.Labels().Set("nginx-container-1-id", strings.Trim(helpers.Capture("inspect", data.Identifier("nginx-container-1"), "--format", "{{.Id}}"), "\n"))
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier("nginx-container-1"))
@@ -310,7 +310,7 @@ func TestNetworkInspect(t *testing.T) {
 						assert.Equal(t, dc[0].Name, data.Identifier("nginx-network-1"))
 						// Assert only the "running" containers on the same network are returned.
 						assert.Equal(t, 1, len(dc[0].Containers), "Expected a single container as per configuration, but got multiple.")
-						assert.Equal(t, data.Identifier("nginx-container-1"), dc[0].Containers[data.Get("nginx-container-1-id")].Name)
+						assert.Equal(t, data.Identifier("nginx-container-1"), dc[0].Containers[data.Labels().Get("nginx-container-1-id")].Name)
 					},
 				}
 			},


### PR DESCRIPTION
Some recent PR got merged simultaneously, while being incompatible with one another.
main is currently bust.

This PR addresses the issues:
- size of DockerCompat increased and busting the max-public-structs linter limit
- account for tigron `data` API change

tag @AkihiroSuda