### PR TITLE
Mark kube target as flaky

### DIFF
--- a/.github/workflows/test-kube.yml
+++ b/.github/workflows/test-kube.yml
@@ -1,5 +1,5 @@
 # This pipeline purpose is solely meant to run a subset of our test suites against a kubernetes cluster
-name: kubernetes
+name: "[flaky, see #3988] kubernetes"
 
 on:
   push:


### PR DESCRIPTION
In light of the amount of failures we are getting, which are presumably a problem with async delete in CRI, and the fact we cannot easily swap out a different containerd version, suggesting we mark this target as flaky and just ignore it.