### PR TITLE
[CI]: bump kind version 0.27

### DIFF
--- a/hack/build-integration-kubernetes.sh
+++ b/hack/build-integration-kubernetes.sh
@@ -22,8 +22,8 @@ readonly root
 . "$root/scripts/lib.sh"
 
 GO_VERSION=1.24
-KIND_VERSION=v0.24.0
-CNI_PLUGINS_VERSION=v1.5.1
+KIND_VERSION=v0.27.0
+CNI_PLUGINS_VERSION=v1.6.2
 
 [ "$(uname -m)" == "aarch64" ] && GOARCH=arm64 || GOARCH=amd64
 


### PR DESCRIPTION
Bump the kube testing environment to latest kind + containerd v2.
Thanks to @AkihiroSuda for pointing it out.