### PR TITLE
[DEBUGGING]: evaluate what happens if we disable gotestsum retries

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -41,7 +41,7 @@ fi
 
 for arg in "$@"; do
   if [ "$arg" == "-test.only-flaky=true" ] || [ "$arg" == "-test.only-flaky" ]; then
-    args+=("--rerun-fails=$retries")
+#    args+=("--rerun-fails=$retries")
     break
   fi
 done


### PR DESCRIPTION
A lot of work has improved stability since I last tried this.
Though we still have some flaky tests in the "non-retry" bucket, we need more info at this point on the state of the "retry" bucket that is likely hiding more issues.

This is a debugging PR at this point, not meant to be merged.