### PR TITLE
[CI]: remove arm/v7 from testing

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -34,13 +34,8 @@ jobs:
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
-          # `--install all` will only install emulation for architectures that cannot be natively executed
-          # Since some arm64 platforms do provide native fallback execution for 32 bits,
-          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
-          # To avoid that, we explicitly list the architectures we do want emulation for.
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
-          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run unit tests"
         run: go test -v ./pkg/...
       - name: "Run integration tests"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,13 +132,8 @@ jobs:
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
-          # `--install all` will only install emulation for architectures that cannot be natively executed
-          # Since some arm64 platforms do provide native fallback execution for 32 bits,
-          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
-          # To avoid that, we explicitly list the architectures we do want emulation for.
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
-          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run integration tests"
         run: docker run -t --rm --privileged test-integration ./hack/test-integration.sh -test.only-flaky=false
       - name: "Run integration tests (flaky)"
@@ -190,13 +185,8 @@ jobs:
           sudo losetup -lv
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
-          # `--install all` will only install emulation for architectures that cannot be natively executed
-          # Since some arm64 platforms do provide native fallback execution for 32 bits,
-          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
-          # To avoid that, we explicitly list the architectures we do want emulation for.
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
-          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Run integration tests"
         # The nested IPv6 network inside docker and qemu is complex and needs a bunch of sysctl config.
         # Therefore, it's hard to debug why the IPv6 tests fail in such an isolation layer.
@@ -265,13 +255,8 @@ jobs:
           fetch-depth: 1
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
-          # `--install all` will only install emulation for architectures that cannot be natively executed
-          # Since some arm64 platforms do provide native fallback execution for 32 bits,
-          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
-          # To avoid that, we explicitly list the architectures we do want emulation for.
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
-          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Expose GitHub Runtime variables for gha"
         uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124  # v3.1.0
       - name: "Prepare (network driver=slirp4netns, port driver=builtin)"
@@ -327,13 +312,8 @@ jobs:
           check-latest: true
       - name: "Register QEMU (tonistiigi/binfmt)"
         run: |
-          # `--install all` will only install emulation for architectures that cannot be natively executed
-          # Since some arm64 platforms do provide native fallback execution for 32 bits,
-          # armv7 emulation may or may not be installed, causing variance in the result of `uname -m`.
-          # To avoid that, we explicitly list the architectures we do want emulation for.
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
-          docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - name: "Prepare integration test environment"
         run: |
           # FIXME: remove expect when we are done removing unbuffer from tests


### PR DESCRIPTION
The corresponding tests serve little to no-purpose (eg: as for adding value specifically for armv7) and are being replaced by equivalent tests against `arm64`, `linux/arm64`, `linux/arm64/v8`.

We do not test any other (s390x, etc) while we could.

Since setting up emulation for arm/v7 is not entirely trivial (because of how tonis image works), suggesting we just get rid of this:
- remove the binfmt contorsions and likelyhood of tests failing locally
- remove the need for an alpine arm v7 availability (important for upcoming work on better controlling test images)
- arm/v7 is going the way of dinosaurs anyhow (even embedded these days gets v8) and our current testing is not doing much anyhow