### PR TITLE
[CI]: cleanup, breakout 2: small cleanups and fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 env:
-  GO_VERSION: 1.24.x
+  GO_VERSION: "1.24"
   GOTOOLCHAIN: local
 
 jobs:
@@ -48,7 +48,8 @@ jobs:
             . ./hack/provisioning/version/fetch.sh
             printf "GO_VERSION=%s\n" "$(go::canary::for::go-setup)" >> "$GITHUB_ENV"
           fi
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
@@ -66,7 +67,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -20,9 +20,11 @@ jobs:
         with:
           path: src/github.com/containerd/nerdctl
           fetch-depth: 100
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
           cache-dependency-path: src/github.com/containerd/nerdctl
       - uses: containerd/project-checks@d7751f3c375b8fe4a84c02a068184ee4c1f59bc4  # v1.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,11 @@ jobs:
       attestations: write  # for provenances
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-    - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+    - name: "Install go"
+      uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
       with:
-        go-version: 1.24.x
+        go-version: "1.24"
+        check-latest: true
     - name: "Compile binaries"
       run: make artifacts
     - name: "SHA256SUMS"

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -70,7 +70,8 @@ jobs:
 
           . ./hack/provisioning/version/fetch.sh
           printf "GO_VERSION=%s\n" "$(go::canary::for::go-setup)" >> "$GITHUB_ENV"
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
       - '**.md'
 
 env:
-  GO_VERSION: 1.24.x
+  GO_VERSION: "1.24"
   GOTOOLCHAIN: local
   SHORT_TIMEOUT: 5
   LONG_TIMEOUT: 60
@@ -76,7 +76,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
@@ -301,17 +302,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23.x", "1.24.x"]
+        go-version: ["1.23", "1.24"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ matrix.go-version }}
           check-latest: true
       - name: "build"
-        run: GO_VERSION="$(echo ${{ matrix.go-version }} | sed -e s/.x//)" make binaries
+        run: make binaries
 
   test-integration-docker-compatibility:
     timeout-minutes: 40
@@ -321,7 +323,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
@@ -357,7 +360,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+      - name: "Install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -428,8 +428,6 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       MODE: ${{ matrix.mode }}
-      # FIXME: this is only necessary to access the build cache. To remove with build cleanup.
-      CONTAINERD_VERSION: v2.0.5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
@@ -486,7 +484,7 @@ jobs:
           docker buildx create --name with-gha --use
           docker buildx build \
             --output=type=docker \
-            --cache-from type=gha,scope=amd64-${CONTAINERD_VERSION} \
+            --cache-from type=gha,scope=test-integration-dependencies-amd64 \
             -t test-integration --target "${TARGET}" \
             .
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -390,7 +390,7 @@ jobs:
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: /root/.vagrant.d
-          key: vagrant-${{ matrix.box }}
+          key: vagrant
       - name: Set up vagrant
         run: |
           # from https://github.com/containerd/containerd/blob/v2.0.2/.github/workflows/ci.yml#L583-L596

--- a/.github/workflows/tigron.yml
+++ b/.github/workflows/tigron.yml
@@ -9,7 +9,7 @@ on:
     paths: 'mod/tigron/**'
 
 env:
-  GO_VERSION: 1.24.x
+  GO_VERSION: "1.24"
   GOTOOLCHAIN: local
 
 jobs:


### PR DESCRIPTION
Commit 1: go-setup cleanups
- remove useless .x suffixes
- consistently enforce check latest
- consistent step title

Commit 2:
- remove freebsd broken var

Commit 3:
- fix EL8 cache path

On top of #4159 - broken out of #4154 