### PR TITLE
[CI]: cleanup, breakout 3: separate jobs

### DIFF
--- a/.github/workflows/job-test-unit.yml
+++ b/.github/workflows/job-test-unit.yml
@@ -80,3 +80,9 @@ jobs:
         name: "Run"
         run: |
           make test-unit
+
+      # On linux, also run with root
+      - if: ${{ env.GO_VERSION != '' && env.RUNNER_OS == 'Linux' }}
+        name: "Run: with root"
+        run: |
+          sudo make test-unit

--- a/.github/workflows/job-test-unit.yml
+++ b/.github/workflows/job-test-unit.yml
@@ -1,0 +1,82 @@
+# Note: freebsd tests are not ran here (see integration instead)
+name: test-unit
+
+on:
+  workflow_call:
+    inputs:
+      timeout:
+        required: true
+        type: number
+      go-version:
+        required: true
+        type: string
+      runner:
+        required: true
+        type: string
+      canary:
+        required: false
+        default: false
+        type: boolean
+      windows-cni-version:
+        required: true
+        type: string
+      linux-cni-version:
+        required: true
+        type: string
+      linux-cni-sha:
+        required: true
+        type: string
+
+env:
+  GOTOOLCHAIN: local
+  # Windows fails without this
+  CGO_ENABLED: 0
+
+jobs:
+  test-unit:
+    name: ${{ format('{0}{1}', inputs.runner, inputs.canary && ' (go canary)' || '') }}
+    timeout-minutes: ${{ inputs.timeout }}
+    runs-on: "${{ inputs.runner }}"
+    defaults:
+      run:
+        shell: bash
+
+    env:
+      GO_VERSION: ${{ inputs.go-version }}
+
+    steps:
+      - name: "Init: checkout"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 1
+
+      # If canary is requested, check for the latest unstable release
+      - if: ${{ inputs.canary }}
+        name: "Init (canary): retrieve GO_VERSION"
+        run: |
+          latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
+          printf "GO_VERSION=%s\n" "$latest_go" >> "$GITHUB_ENV"
+          [ "$latest_go" != "" ] || \
+            echo "::warning title=No canary go::There is currently no canary go version to test. Following steps will not run."
+
+      - if: ${{ env.GO_VERSION != '' }}
+        name: "Init: install go"
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+
+      # Install CNI
+      - if: ${{ env.GO_VERSION != '' }}
+        name: "Init: set up CNI"
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            GOPATH=$(go env GOPATH) WINCNI_VERSION=${{ inputs.windows-cni-version }} ./hack/provisioning/windows/cni.sh
+          elif [ "$RUNNER_OS" == "Linux" ]; then
+            ./hack/provisioning/linux/cni.sh "${{ inputs.linux-cni-version }}" "amd64" "${{ inputs.linux-cni-sha }}"
+          fi
+
+      - if: ${{ env.GO_VERSION != '' }}
+        name: "Run"
+        run: |
+          make test-unit

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -41,8 +41,6 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install linux/amd64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm64
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
-      - name: "Run unit tests"
-        run: go test -v ./pkg/...
       - name: "Run integration tests"
         run: docker run -t --rm --privileged test-integration ./hack/test-integration.sh -test.only-flaky=false
       - name: "Run integration tests (flaky)"

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -52,40 +52,31 @@ jobs:
             --target build-dependencies --build-arg CONTAINERD_VERSION=${CONTAINERD_VERSION} .
 
   test-unit:
-    # FIXME:
-    # Supposed to work: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-returning-a-json-data-type
-    # Apparently does not
-    # timeout-minutes: ${{ fromJSON(env.SHORT_TIMEOUT) }}
-    timeout-minutes: 10
-    name: unit | ${{ matrix.goos }}
-    runs-on: "${{ matrix.os }}"
-    defaults:
-      run:
-        shell: bash
+    name: "unit${{ inputs.hack }}"
+    uses: ./.github/workflows/job-test-unit.yml
     strategy:
       fail-fast: false
       matrix:
+        # Run on all supported platforms but freebsd
+        # Additionally run on canary for linux
         include:
-          - os: windows-2022
-            goos: windows
-          - os: ubuntu-24.04
-            goos: linux
-          - os: macos-15
-            goos: darwin
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-        with:
-          fetch-depth: 1
-      - name: "Install go"
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b  # v5.4.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-      - if: ${{ matrix.goos=='windows' }}
-        name: "Set up CNI"
-        run: GOPATH=$(go env GOPATH) ./hack/provisioning/windows/cni.sh
-      - name: "Run unit tests"
-        run: make test-unit
+          - runner: "ubuntu-24.04"
+            canary: false
+          - runner: "macos-15"
+            canary: false
+          - runner: "windows-2025"
+            canary: false
+          - runner: "ubuntu-24.04"
+            canary: true
+    with:
+      runner: ${{ matrix.runner }}
+      canary: ${{ matrix.canary }}
+      # Windows routinely go over 5 minutes
+      timeout: 10
+      go-version: 1.24
+      windows-cni-version: v0.3.1
+      linux-cni-version: v1.7.1
+      linux-cni-sha: 1a28a0506bfe5bcdc981caf1a49eeab7e72da8321f1119b7be85f22621013098
 
   test-integration:
     needs: build-dependencies

--- a/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
+++ b/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
 func createTempDir(t *testing.T, mode os.FileMode) string {
@@ -40,12 +42,10 @@ func createTempDir(t *testing.T, mode os.FileMode) string {
 }
 
 func TestBrokenCredentialsStore(t *testing.T) {
-	if runtime.GOOS == "freebsd" {
-		// It is unclear why these tests are failing on FreeBSD, and if it is a problem with Vagrant or differences
-		// with FreeBSD
-		// Anyhow, this test is about extreme cases & conditions (filesystem errors wrt credentials loading).
-		t.Skip("skipping broken credential store tests for freebsd")
+	if !rootlessutil.IsRootless() {
+		t.Skip("test is for rootless")
 	}
+
 	if runtime.GOOS == "windows" {
 		// Same as above
 		t.Skip("test is not compatible with windows")

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
 
-const testBridgeIP = "10.1.100.1/24" // nolint:unused
+const testBridgeIP = "10.42.100.1/24" // nolint:unused
 
 const preExistingNetworkConfigTemplate = `
 {
@@ -278,8 +278,8 @@ func testDefaultNetworkCreationWithBridgeIP(t *testing.T) {
 	// Assert on bridge plugin configuration
 	assert.Equal(t, "bridge", bridgeConfig.Type)
 	// Assert on IPAM configuration
-	assert.Equal(t, "10.1.100.1", bridgeConfig.IPAM.Ranges[0][0].Gateway)
-	assert.Equal(t, "10.1.100.0/24", bridgeConfig.IPAM.Ranges[0][0].Subnet)
+	assert.Equal(t, "10.42.100.1", bridgeConfig.IPAM.Ranges[0][0].Gateway)
+	assert.Equal(t, "10.42.100.0/24", bridgeConfig.IPAM.Ranges[0][0].Subnet)
 	assert.Equal(t, "0.0.0.0/0", bridgeConfig.IPAM.Routes[0].Dst)
 	assert.Equal(t, "host-local", bridgeConfig.IPAM.Type)
 


### PR DESCRIPTION
On top of #4160 - breakout of #4154.

TL;DR: workflows have grown organically to the point of being hard to read and reason about.
This PR shows a sample of what is proposed in #4154 so that we can discuss here on a reasonably-sized PR.

The perceived problems are:
- workflow files are overcrowded
- there is a lot of duplication
- variables and versions are all over the place

The proposal is to have:
- top level `workflow-X` files that only contain calls to jobs and are responsible for passing along versions, meant to outline the overall structure of the CI
- individual `jobs-Y` files for the jobs, in their own "logical" file, where X describe clearly what the _function_ of the job is

This specific PR is limited to solely `unit testing` and provides a single `job` that will now take care of unit-testing, including for canary instead of having it duplicated in two places.

------------

There has been concerns over #4154 about the use of `inputs` for jobs.

I do personally find it better (which is why I am proposing it :-) ):
- explicit versions will be in one single place, instead of being duplicated accross
- I find it easier to read / more logical to manipulate `product-version-old` and  `product-version-stable`, as I feel it conveys the _intent_, rather than squinting on the difference between `ubuntu-24.04` and `ubuntu-22.04`

Evidently I appreciate this may boil down to a matter of personal taste and that we may not agree.

If there is indeed sentiment against using variables and a preference to just embed versions, fine with me - we can still have the rest (separation and cleanup of jobs and workflows).

LMK your thoughts.