### PR TITLE
[FIX]: tentatively fix concurrent access to locked CNI directory (#3783)

### DIFF
--- a/pkg/lockutil/lockutil_unix.go
+++ b/pkg/lockutil/lockutil_unix.go
@@ -28,6 +28,7 @@ import (
 )
 
 func WithDirLock(dir string, fn func() error) error {
+	_ = os.MkdirAll(dir, 0700)
 	dirFile, err := os.Open(dir)
 	if err != nil {
 		return err
@@ -55,6 +56,7 @@ func flock(f *os.File, flags int) error {
 }
 
 func Lock(dir string) (*os.File, error) {
+	_ = os.MkdirAll(dir, 0700)
 	dirFile, err := os.Open(dir)
 	if err != nil {
 		return nil, err

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -196,9 +196,9 @@ func testDefaultNetworkCreation(t *testing.T) {
 	}
 	err = filepath.Walk(cniConfTestDir, walkF)
 	assert.NilError(t, err)
-	assert.Assert(t, len(files) == 2) // files[0] is the entry for '.'
-	assert.Assert(t, filepath.Join(cniConfTestDir, files[1].Name()) == defaultNetConf.File)
-	assert.Assert(t, firstConfigModTime.Equal(files[1].ModTime()))
+	assert.Equal(t, len(files), 3) // files[0] is the entry for '.', files[1] is the lock
+	assert.Assert(t, filepath.Join(cniConfTestDir, files[2].Name()) == defaultNetConf.File)
+	assert.Assert(t, firstConfigModTime.Equal(files[2].ModTime()))
 }
 
 // Tests whether nerdctl properly creates the default network
@@ -295,9 +295,9 @@ func testDefaultNetworkCreationWithBridgeIP(t *testing.T) {
 	}
 	err = filepath.Walk(cniConfTestDir, walkF)
 	assert.NilError(t, err)
-	assert.Assert(t, len(files) == 2) // files[0] is the entry for '.'
-	assert.Assert(t, filepath.Join(cniConfTestDir, files[1].Name()) == defaultNetConf.File)
-	assert.Assert(t, firstConfigModTime.Equal(files[1].ModTime()))
+	assert.Equal(t, len(files), 3) // files[0] is the entry for '.', files[1] is the lock
+	assert.Assert(t, filepath.Join(cniConfTestDir, files[2].Name()) == defaultNetConf.File)
+	assert.Assert(t, firstConfigModTime.Equal(files[2].ModTime()))
 }
 
 // Tests whether nerdctl skips the creation of the default network if a

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -107,7 +107,7 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 	if err != nil {
 		return err
 	}
-	lock, err := lockutil.Lock(cniNetconfPath)
+	lock, err := lockutil.Lock(filepath.Join(cniNetconfPath, ".nerdctl.lock"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
See #3783 for discussion.

TL;DR: based on investigation above, the hypothesis is that other systems may add locks over the CNI directory.
Since we do as well, this seem to deadlock Cilium.

This patch is moving our lock for CNIEnv to a sub-directory (which appears to be the least disruptive option - see unhappy comment below :-) ), which should allow Cilium (and others) to go through.

HOWEVER:
- I believe this is a shortcoming of CNI plugins in the first place (ie: that they are enumerating the filesystem without locking), and we should not have to do that ourselves
- it is unclear to me if that will really fix the issue with Cilium, or if it is going to create **more** (as in: since we no longer prevent concurrent access, what will happen if both Cilium and nerdctl touch the same resources, ignoring each other lock?)

Nevertheless, it feels like the investigation in #3783 is conclusive enough, and this should _only_ enhance the situation at worse (even if it does not fix everything).

Suggesting we consider for inclusion in 2.0.5.