### PR TITLE
[QOL]: enhance error information for failing logURI

### DIFF
--- a/pkg/cioutil/container_io.go
+++ b/pkg/cioutil/container_io.go
@@ -176,7 +176,7 @@ func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, 
 			cmd.ExtraFiles = append(cmd.ExtraFiles, stdoutr, stderrr, w)
 
 			if err := cmd.Start(); err != nil {
-				return nil, fmt.Errorf("failed to start binary process with cmdArgs %v: %w", cmd.Args, err)
+				return nil, fmt.Errorf("failed to start binary process with cmdArgs %v (logURI: %s): %w", cmd.Args, logURI, err)
 			}
 
 			closers = append(closers, func() error { return cmd.Process.Kill() })


### PR DESCRIPTION
We likely have incomplete logic in how we handle borked loguri labels (see: #4018 for eg).

The current erroring is not helpful and we can't really derive anything out of it.

This PR suggests we add the actual logURI to help.