### PR TITLE
fix stats for exited container and introduce some refacto

### DIFF
--- a/pkg/statsutil/stats.go
+++ b/pkg/statsutil/stats.go
@@ -69,15 +69,20 @@ type ContainerStats struct {
 }
 
 // NewStats is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L113-L116
-func NewStats(containerID string) *Stats {
-	return &Stats{StatsEntry: StatsEntry{ID: containerID}}
+func NewStats(containerID string, containerName string) *Stats {
+	return &Stats{StatsEntry: StatsEntry{ID: containerID, Name: containerName}}
 }
 
 // SetStatistics is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L87-L93
 func (cs *Stats) SetStatistics(s StatsEntry) {
 	cs.mutex.Lock()
 	defer cs.mutex.Unlock()
+	// The statsEntry ID and Name fields are already populated within the cs.StatsEntry
+	cStatsName := cs.StatsEntry.Name
+	cStatsID := cs.StatsEntry.ID
 	cs.StatsEntry = s
+	cs.StatsEntry.Name = cStatsName
+	cs.StatsEntry.ID = cStatsID
 }
 
 // GetStatistics is from https://github.com/docker/cli/blob/3fb4fb83dfb5db0c0753a8316f21aea54dab32c5/cli/command/container/formatter_stats.go#L95-L100


### PR DESCRIPTION
* Updated `statsutil.NewStats` to take both `containerID` and `containerName` as parameters, ensuring the container name is initialized in the stats entry before data collection. This simplifies the collection process by removing the need to fetch labels in each iteration.
=> Removed redundant code in the collect function, such as fetching container labels inside a loop, to make the logic more efficient.

* (fix https://github.com/containerd/nerdctl/issues/1415) Enhanced error handling in the `collect` function by adding a specific check for "no such file or directory" errors to avoid unnecessary error propagation (fix ticket) . The errors is not wrapped in the original [err](https://github.com/containernetworking/plugins/blob/v1.7.1/pkg/ns/ns_linux.go#L129). 