### PR TITLE
feat: add --no-stdin flag to container attach

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -686,8 +686,9 @@ Usage: `nerdctl attach CONTAINER`
 Flags:
 
 - :whale: `--detach-keys`: Override the default detach keys
+- :whale: `--no-stdin`: Do not attach STDIN
 
-Unimplemented `docker attach` flags: `--no-stdin`, `--sig-proxy`
+Unimplemented `docker attach` flags: `--sig-proxy`
 
 ### :whale: nerdctl container prune
 

--- a/pkg/cmd/container/attach.go
+++ b/pkg/cmd/container/attach.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 
 	"golang.org/x/term"
 
@@ -114,9 +115,12 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 			}
 			io.Cancel()
 		}
-		in, err := consoleutil.NewDetachableStdin(con, options.DetachKeys, closer)
-		if err != nil {
-			return err
+		var in io.Reader
+		if options.Stdin != nil {
+			in, err = consoleutil.NewDetachableStdin(con, options.DetachKeys, closer)
+			if err != nil {
+				return err
+			}
 		}
 		opt = cio.WithStreams(in, con, nil)
 	} else {


### PR DESCRIPTION
### Summary

This PR adds support for a new flag in the nerdctl container attach command:

```
--no-stdin: disables attaching stdin to the container
```
### Notes

We are not adding `--sig-proxy` in this PR due to a limitation in nerdctl: attach only works for containers started with `-it` ref - https://github.com/containerd/nerdctl/pull/2108
When `-it` is used, signals like Ctrl+C (SIGINT) are sent directly to the container process by the TTY, bypassing nerdctl.
As a result, `--sig-proxy=false` has no effect in such cases and cannot be used/tested reliably under current constraints.

### Testing
* Added an integration test to validate that input is not sent to the container when --no-stdin is used.
* Verified behavior across re-attached containers.