### PR TITLE
[FIX]: #4012 follow-ups (fixes and target test binaries)

### DIFF
--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -209,32 +209,24 @@ jobs:
             target: rootless
             runner: "ubuntu-22.04"
             arch: amd64
-            nerdctl: ""
-            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless
             arch: amd64
             runner: "ubuntu-24.04"
-            nerdctl: ""
-            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless
             arch: arm64
             runner: "ubuntu-24.04-arm"
-            nerdctl: ""
-            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
             target: rootless-port-slirp4netns
             arch: amd64
             runner: "ubuntu-24.04"
-            nerdctl: ""
-            comment: ""
           - ubuntu: 24.04
             containerd: v2.0.5
             rootlesskit: v2.3.4
@@ -296,10 +288,10 @@ jobs:
           fi
           echo "WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622}" >> "$GITHUB_ENV"
       - name: "Test (network driver=slirp4netns, port driver=builtin)"
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} -e NERDCTL=${NERDCTL} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false
+        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=false -test.target=${NERDCTL}
       - name: "Test (network driver=slirp4netns, port driver=builtin) (flaky)"
         if: matrix.nerdctl != 'nerdctl.gomodjail'
-        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} -e NERDCTL=${NERDCTL} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true
+        run: docker run -t --rm --privileged -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622} ${TEST_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh -test.only-flaky=true -test.target=${NERDCTL}
 
   test-integration-docker-compatibility:
     timeout-minutes: 40

--- a/Dockerfile.d/test-integration-rootless.sh
+++ b/Dockerfile.d/test-integration-rootless.sh
@@ -15,7 +15,6 @@
 #   limitations under the License.
 
 set -eux -o pipefail
-: "${NERDCTL:=}"
 if [[ "$(id -u)" = "0" ]]; then
   # Ensure securityfs is mounted for apparmor to work
   if ! mountpoint -q /sys/kernel/security; then
@@ -33,7 +32,7 @@ if [[ "$(id -u)" = "0" ]]; then
 
 	# Switch to the rootless user via SSH
 	systemctl start ssh
-	exec ssh -o StrictHostKeyChecking=no rootless@localhost NERDCTL="$NERDCTL" "$0" "$@"
+	exec ssh -o StrictHostKeyChecking=no rootless@localhost "$0" "$@"
 else
 	containerd-rootless-setuptool.sh install
 	if grep -q "options use-vc" /etc/resolv.conf; then
@@ -64,5 +63,5 @@ EOF
 	# Once ssh-ed, we lost the Dockerfile working dir, so, get back in the nerdctl checkout
 	cd /go/src/github.com/containerd/nerdctl
 	# We also lose the PATH (and SendEnv=PATH would require sshd config changes)
-	exec env PATH="/usr/local/go/bin:$PATH" NERDCTL="$NERDCTL" "$@"
+	exec env PATH="/usr/local/go/bin:$PATH" "$@"
 fi

--- a/cmd/nerdctl/builder/builder_builder_test.go
+++ b/cmd/nerdctl/builder/builder_builder_test.go
@@ -133,8 +133,7 @@ CMD ["echo", "nerdctl-test-builder-prune"]`, testutil.CommonImage)
 			{
 				Description: "Debug",
 				// `nerdctl builder debug` is currently incompatible with `docker buildx debug`.
-				// FIXME: fails with gomodjail: "timed out to access cache storage. other debug session is running?"
-				Require:    require.All(require.Not(nerdtest.Docker), require.Not(nerdtest.Gomodjail)),
+				Require:    require.All(require.Not(nerdtest.Docker)),
 				NoParallel: true,
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					dockerfile := fmt.Sprintf(`FROM %s

--- a/cmd/nerdctl/completion/completion_test.go
+++ b/cmd/nerdctl/completion/completion_test.go
@@ -17,6 +17,7 @@
 package completion
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
@@ -33,6 +34,11 @@ func TestMain(m *testing.M) {
 
 func TestCompletion(t *testing.T) {
 	nerdtest.Setup()
+
+	// Note: some functions need to be tested without the automatic --namespace nerdctl-test argument, so we need
+	// to retrieve the binary name.
+	// Note that we know this works already, so no need to assert err.
+	bin, _ := exec.LookPath(testutil.GetTarget())
 
 	testCase := &test.Case{
 		Require: require.Not(nerdtest.Docker),
@@ -158,17 +164,17 @@ func TestCompletion(t *testing.T) {
 				},
 			},
 			{
-				Description: "no namespace --cgroup-manager",
+				Description: "--cgroup-manager",
 				Require:     require.Not(require.Windows),
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Custom("nerdctl", "__complete", "--cgroup-manager", "")
+					return helpers.Command("__complete", "--cgroup-manager", "")
 				},
 				Expected: test.Expects(0, nil, expect.Contains("cgroupfs\n")),
 			},
 			{
-				Description: "no namespace empty",
+				Description: "empty",
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-					return helpers.Custom("nerdctl", "__complete", "")
+					return helpers.Command("__complete", "")
 				},
 				Expected: test.Expects(0, nil, expect.Contains("run\t")),
 			},
@@ -176,7 +182,7 @@ func TestCompletion(t *testing.T) {
 				Description: "namespace space empty",
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					// mind {"--namespace=nerdctl-test"} vs {"--namespace", "nerdctl-test"}
-					return helpers.Custom("nerdctl", "__complete", "--namespace", string(helpers.Read(nerdtest.Namespace)), "")
+					return helpers.Custom(bin, "__complete", "--namespace", string(helpers.Read(nerdtest.Namespace)), "")
 				},
 				Expected: test.Expects(0, nil, expect.Contains("run\t")),
 			},
@@ -199,7 +205,7 @@ func TestCompletion(t *testing.T) {
 				Description: "namespace run -i",
 				Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 					// mind {"--namespace=nerdctl-test"} vs {"--namespace", "nerdctl-test"}
-					return helpers.Custom("nerdctl", "__complete", "--namespace", string(helpers.Read(nerdtest.Namespace)), "run", "-i", "")
+					return helpers.Custom(bin, "__complete", "--namespace", string(helpers.Read(nerdtest.Namespace)), "run", "-i", "")
 				},
 				Expected: test.Expects(0, nil, expect.Contains(testutil.CommonImage+"\n")),
 			},

--- a/cmd/nerdctl/compose/compose_up_test.go
+++ b/cmd/nerdctl/compose/compose_up_test.go
@@ -27,6 +27,7 @@ import (
 	"gotest.tools/v3/icmd"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // https://github.com/containerd/nerdctl/issues/1942
@@ -49,7 +50,8 @@ services:
 		ExitCode: 1,
 		Err:      `exec: \"invalid\": executable file not found in $PATH`,
 	}
-	if base.Target == testutil.Docker {
+	// Docker expected err is different
+	if nerdtest.IsDocker() {
 		expected.Err = `unknown or invalid runtime name: invalid`
 	}
 	c.Assert(expected)

--- a/cmd/nerdctl/container/container_cp_acid_linux_test.go
+++ b/cmd/nerdctl/container/container_cp_acid_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // This is a separate set of tests for cp specifically meant to test corner or extreme cases that do not fit in the normal testing rig
@@ -87,7 +88,7 @@ func TestCopyAcid(t *testing.T) {
 		setup()
 
 		expectedErr := containerutil.ErrTargetIsReadOnly.Error()
-		if testutil.GetTarget() == testutil.Docker {
+		if nerdtest.IsDocker() {
 			expectedErr = ""
 		}
 

--- a/cmd/nerdctl/container/container_cp_linux_test.go
+++ b/cmd/nerdctl/container/container_cp_linux_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // For the test matrix, see https://docs.docker.com/engine/reference/commandline/cp/
@@ -898,7 +899,7 @@ func cpTestHelper(t *testing.T, tg *testgroup) {
 				setup()
 
 				// If Docker, removes the err part of expectation
-				if testutil.GetTarget() == testutil.Docker {
+				if nerdtest.IsDocker() {
 					testCase.expect.Err = ""
 				}
 
@@ -938,7 +939,7 @@ func cpTestHelper(t *testing.T, tg *testgroup) {
 					cmd = base.Cmd("cp", containerStopped+":"+sourceSpec, destinationSpec)
 				}
 
-				if rootlessutil.IsRootless() && testutil.GetTarget() == testutil.Nerdctl {
+				if rootlessutil.IsRootless() && !nerdtest.IsDocker() {
 					cmd.Assert(
 						icmd.Expected{
 							ExitCode: 1,

--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -126,7 +126,7 @@ func TestCreateWithMACAddress(t *testing.T) {
 				assert.Assert(t, strings.Contains(res.Stdout(), expect), fmt.Sprintf("expected output to contain %q: %q", expect, res.Stdout()))
 				assert.Assert(t, res.ExitCode == 0, "Command should have succeeded")
 			} else {
-				if testutil.GetTarget() == testutil.Docker &&
+				if nerdtest.IsDocker() &&
 					(network == networkIPvlan || network == "container:whatever"+tID) {
 					// unlike nerdctl
 					// when using network ipvlan or container in Docker
@@ -137,7 +137,7 @@ func TestCreateWithMACAddress(t *testing.T) {
 				}
 
 				// See https://github.com/containerd/nerdctl/issues/3101
-				if testutil.GetTarget() == testutil.Docker &&
+				if nerdtest.IsDocker() &&
 					(network == networkBridge) {
 					expect = ""
 				}

--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -198,7 +198,7 @@ func TestContainerInspectState(t *testing.T) {
 	// nerdctl: run error produces a nil Task, so the Status is empty because Status comes from Task.
 	// docker : run error gives => `Status=created` as  in docker there is no a separation between container and Task.
 	errStatus := ""
-	if base.Target == testutil.Docker {
+	if nerdtest.IsDocker() {
 		errStatus = "created"
 	}
 	testCases := []testCase{
@@ -295,7 +295,7 @@ func TestContainerInspectHostConfigDefaults(t *testing.T) {
 
 	// Hostconfig default values differ with Docker.
 	// This is because we directly retrieve the configured values instead of using preset defaults.
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		hc.Driver = ""
 		hc.GroupAddSize = 0
 		hc.ShmSize = int64(67108864) // Docker default 64M
@@ -399,7 +399,7 @@ func TestContainerInspectHostConfigPID(t *testing.T) {
 
 	var hc hostConfigValues
 
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		hc.PidMode = "container:" + containerID1
 	} else {
 		hc.PidMode = containerID1
@@ -444,7 +444,7 @@ func TestContainerInspectDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		dir = "/dev/zero"
 	}
 

--- a/cmd/nerdctl/container/container_kill_linux_test.go
+++ b/cmd/nerdctl/container/container_kill_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	iptablesutil "github.com/containerd/nerdctl/v2/pkg/testutil/iptables"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // TestKillCleanupForwards runs a container that exposes a port and then kill it.
@@ -66,7 +67,7 @@ func TestKillCleanupForwards(t *testing.T) {
 
 	// define iptables chain name depending on the target (docker/nerdctl)
 	var chain string
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		chain = "DOCKER"
 	} else {
 		redirectChain := "CNI-HOSTPORT-DNAT"

--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 type psTestContainer struct {
@@ -146,7 +147,7 @@ func TestContainerList(t *testing.T) {
 
 		// there is some difference between nerdctl and docker in calculating the size of the container
 		expectedSize := "26.2MB (virtual "
-		if base.Target != testutil.Docker {
+		if !nerdtest.IsDocker() {
 			expectedSize = "25.0 MiB (virtual "
 		}
 

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -130,7 +130,8 @@ func TestRestartWithTime(t *testing.T) {
 func TestRestartWithSignal(t *testing.T) {
 	testCase := nerdtest.Setup()
 
-	testCase.Require = require.Not(nerdtest.Gomodjail) // FIXME
+	// FIXME: gomodjail signal handling is not working yet: https://github.com/AkihiroSuda/gomodjail/issues/51
+	testCase.Require = require.Not(nerdtest.Gomodjail)
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("rm", "-f", data.Identifier())

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -110,7 +110,7 @@ func TestRunCgroupV2(t *testing.T) {
 	update := []string{"update", "--cpu-quota", "42000", "--cpuset-mems", "0", "--cpu-period", "100000",
 		"--memory", "42m",
 		"--pids-limit", "42", "--cpu-shares", "2000", "--cpuset-cpus", "0-1"}
-	if base.Target == testutil.Docker && info.CgroupVersion == "2" && info.SwapLimit {
+	if nerdtest.IsDocker() && info.CgroupVersion == "2" && info.SwapLimit {
 		// Workaround for Docker with cgroup v2:
 		// > Error response from daemon: Cannot update container 67c13276a13dd6a091cdfdebb355aa4e1ecb15fbf39c2b5c9abee89053e88fce:
 		// > Memory limit should be smaller than already set memoryswap limit, update the memoryswap at the same time
@@ -450,7 +450,7 @@ func TestRunCgroupParent(t *testing.T) {
 	expected := filepath.Join(parent, id)
 	if info.CgroupDriver == "systemd" {
 		expected = filepath.Join(parent, fmt.Sprintf("nerdctl-%s", id))
-		if base.Target == testutil.Docker {
+		if nerdtest.IsDocker() {
 			expected = filepath.Join(parent, fmt.Sprintf("docker-%s", id))
 		}
 	}

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -382,7 +382,9 @@ func TestRunTTY(t *testing.T) {
 
 func TestRunSigProxy(t *testing.T) {
 	testCase := nerdtest.Setup()
-	testCase.Require = require.Not(nerdtest.Gomodjail) // FIXME
+
+	// FIXME: gomodjail signal handling is not working yet: https://github.com/AkihiroSuda/gomodjail/issues/51
+	testCase.Require = require.Not(nerdtest.Gomodjail)
 
 	testCase.SubTests = []*test.Case{
 		{

--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"gotest.tools/v3/poll"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 )
 
@@ -92,7 +93,7 @@ func TestRunRestart(t *testing.T) {
 
 func TestRunRestartWithOnFailure(t *testing.T) {
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
+	if !nerdtest.IsDocker() {
 		testutil.RequireContainerdPlugin(base, "io.containerd.internal.v1", "restart", []string{"on-failure"})
 	}
 	tID := testutil.Identifier(t)
@@ -113,7 +114,7 @@ func TestRunRestartWithOnFailure(t *testing.T) {
 
 func TestRunRestartWithUnlessStopped(t *testing.T) {
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
+	if !nerdtest.IsDocker() {
 		testutil.RequireContainerdPlugin(base, "io.containerd.internal.v1", "restart", []string{"unless-stopped"})
 	}
 	tID := testutil.Identifier(t)
@@ -137,7 +138,7 @@ func TestRunRestartWithUnlessStopped(t *testing.T) {
 
 func TestUpdateRestartPolicy(t *testing.T) {
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
+	if !nerdtest.IsDocker() {
 		testutil.RequireContainerdPlugin(base, "io.containerd.internal.v1", "restart", []string{"on-failure"})
 	}
 	tID := testutil.Identifier(t)
@@ -160,7 +161,7 @@ func TestUpdateRestartPolicy(t *testing.T) {
 // and check it can work correctly.
 func TestAddRestartPolicy(t *testing.T) {
 	base := testutil.NewBase(t)
-	if testutil.GetTarget() == testutil.Nerdctl {
+	if !nerdtest.IsDocker() {
 		testutil.RequireContainerdPlugin(base, "io.containerd.internal.v1", "restart", []string{"on-failure"})
 	}
 	tID := testutil.Identifier(t)

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -717,7 +717,7 @@ func TestRunAttachFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			actualOut := tc.testFunc(t, tc.testStr, tc.args)
 			errorMsg := fmt.Sprintf("%s failed;\nExpected: '%s'\nActual: '%s'", tc.name, tc.expectedOut, actualOut)
-			if testutil.GetTarget() == testutil.Docker {
+			if nerdtest.IsDocker() {
 				assert.Equal(t, true, strings.Contains(actualOut, tc.dockerOut), errorMsg)
 			} else {
 				assert.Equal(t, true, strings.Contains(actualOut, tc.expectedOut), errorMsg)
@@ -744,7 +744,7 @@ func TestRunQuiet(t *testing.T) {
 	}
 
 	// Docker and nerdctl image pulls are not 1:1.
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		sentinel = "Pull complete"
 	} else {
 		sentinel = "resolved"

--- a/cmd/nerdctl/container/container_stop_linux_test.go
+++ b/cmd/nerdctl/container/container_stop_linux_test.go
@@ -130,7 +130,7 @@ func TestStopCleanupForwards(t *testing.T) {
 
 	// define iptables chain name depending on the target (docker/nerdctl)
 	var chain string
-	if testutil.GetTarget() == testutil.Docker {
+	if nerdtest.IsDocker() {
 		chain = "DOCKER"
 	} else {
 		redirectChain := "CNI-HOSTPORT-DNAT"

--- a/cmd/nerdctl/login/login_linux_test.go
+++ b/cmd/nerdctl/login/login_linux_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testca"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/testregistry"
 )
@@ -76,7 +77,7 @@ func (ag *Client) Run(base *testutil.Base, host string) *testutil.Cmd {
 		ag.configPath, _ = os.MkdirTemp(base.T.TempDir(), "docker-config")
 	}
 	args := []string{"login"}
-	if base.Target == "nerdctl" {
+	if !nerdtest.IsDocker() {
 		args = append(args, "--debug-full")
 	}
 	args = append(args, ag.args...)

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -19,6 +19,7 @@ package network
 import (
 	"encoding/json"
 	"errors"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -248,7 +249,11 @@ func TestNetworkInspect(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: func(stdout string, info string, t *testing.T) {
-						cmd := helpers.Custom("nerdctl", "--namespace", data.Identifier())
+						// Note: some functions need to be tested without the automatic --namespace nerdctl-test argument, so we need
+						// to retrieve the binary name.
+						// Note that we know this works already, so no need to assert err.
+						bin, _ := exec.LookPath(testutil.GetTarget())
+						cmd := helpers.Custom(bin, "--namespace", data.Identifier())
 
 						com := cmd.Clone()
 						com.WithArgs("network", "inspect", data.Identifier())

--- a/cmd/nerdctl/system/system_info_test.go
+++ b/cmd/nerdctl/system/system_info_test.go
@@ -19,6 +19,7 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"os/exec"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
@@ -42,6 +44,11 @@ func testInfoComparator(stdout string, info string, t *testing.T) {
 
 func TestInfo(t *testing.T) {
 	testCase := nerdtest.Setup()
+
+	// Note: some functions need to be tested without the automatic --namespace nerdctl-test argument, so we need
+	// to retrieve the binary name.
+	// Note that we know this works already, so no need to assert err.
+	bin, _ := exec.LookPath(testutil.GetTarget())
 
 	testCase.SubTests = []*test.Case{
 		{
@@ -58,7 +65,7 @@ func TestInfo(t *testing.T) {
 			Description: "info with namespace",
 			Require:     require.Not(nerdtest.Docker),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Custom("nerdctl", "info")
+				return helpers.Custom(bin, "info")
 			},
 			Expected: test.Expects(0, nil, expect.Contains("Namespace:	default")),
 		},
@@ -69,7 +76,7 @@ func TestInfo(t *testing.T) {
 			},
 			Require: require.Not(nerdtest.Docker),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Custom("nerdctl", "info")
+				return helpers.Custom(bin, "info")
 			},
 			Expected: test.Expects(0, nil, expect.Contains("Namespace:	test")),
 		},

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -104,7 +104,7 @@ If you are going to use blanket destructive operations (like `prune`), please:
 and be sure that your namespace is named after the test id
 - remove the namespace in your test `Cleanup`
 - since docker does not support namespaces, be sure to:
-  - only enable `Parallel` if the target is NOT docker: `	if testutil.GetTarget() != testutil.Docker { t.Parallel() }`
+  - only enable `Parallel` if the target is NOT docker: `	if !nerdtest.IsDocker() { t.Parallel() }`
   - double check that what you do in the default namespace is safe
 
 #### Clean-up after (and before) yourself

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -110,10 +110,6 @@ type GenericCommand struct {
 	rawStdErr string
 }
 
-func (gc *GenericCommand) Binary() string {
-	return gc.cmd.Binary
-}
-
 func (gc *GenericCommand) WithBinary(binary string) {
 	gc.cmd.Binary = binary
 }

--- a/mod/tigron/test/interfaces.go
+++ b/mod/tigron/test/interfaces.go
@@ -101,8 +101,6 @@ type Helpers interface {
 // a Setup or Cleanup routine, and as the basis of any type of helper.
 // For more powerful use-cases outside of test cases, see below CustomizableCommand.
 type TestableCommand interface {
-	// Binary returns what binary to execute.
-	Binary() string
 	// WithBinary specifies what binary to execute.
 	WithBinary(binary string)
 	// WithArgs specifies the args to pass to the binary. Note that WithArgs can be used multiple

--- a/pkg/testutil/nerdtest/test.go
+++ b/pkg/testutil/nerdtest/test.go
@@ -57,7 +57,7 @@ func (ns *nerdctlSetup) AmbientRequirements(testCase *test.Case, t *testing.T) {
 		t.Skip("runner skips non-flaky tests in the flaky environment")
 	}
 
-	if getTarget() == targetDocker && testCase.Config.Read(modePrivate) == enabled {
+	if !isTargetNerdish() && testCase.Config.Read(modePrivate) == enabled {
 		// For docker, we do disable parallel since there is no namespace where we can isolate
 		testCase.NoParallel = true
 	}

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -19,6 +19,7 @@ package nerdtest
 import (
 	"encoding/json"
 	"net"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -44,7 +45,7 @@ const (
 )
 
 func IsDocker() bool {
-	return testutil.GetTarget() == "docker"
+	return strings.HasPrefix(filepath.Base(testutil.GetTarget()), "docker")
 }
 
 // InspectContainer is a helper that can be used inside custom commands or Setup


### PR DESCRIPTION
This addresses a few issues from #4012 as a follow-up.

Besides a couple of mundane fixes, the bulk of it focuses on the ability to test binaries that are not named `docker` nor `nerdctl`.

This feature is especially interesting:
- for people building forks, or custom cli on top of nerdctl as a library, that may use a different binary name
- for gomodjail variants of course
- for busy contributors or bisectors who want to be able to quickly test a bunch of differently named nerdctl binaries

Here is a list of things I wish I could test:
- `~/docker.xyz`
- `nerdctl.gomodjail`
- `lepton`
- `/somerandompath/nerdctl.xyz`

The proposal here is to expand on the existing `--test.target` flag, that currently only allows `docker` and `nerdctl`.

The upside is that it strictly minimizes the amount of change required by the rest of the test tooling, is strictly backward compatible, and does not introduce new knobs.

Of course we still need a way to differentiate between docker, and "nerdishctl" binaries (cli that are expected to behave like nerdctl), as we do have specialized test behavior.

We do that here by checking `strings.HasPrefix(filepath.Base(binary), "docker")`.

So:

`go test ./cmd/nerdctl/... -test.target=~/docker.xyz` is treated as docker, while any other variant above is treated as a "nerdishctl".

NOTE that:
- there were a bunch of hardcoded assumptions in the tests assuming that the binary was named `nerdctl`, so, they got modified
- the `Target` type and a couple of (now useless) consts have been removed

There is still some level of duplication between testutil / testutil/nerdtest - this is not new, and is transitory while we move to the new testing tooling - can be cleaned-up later on to keep this small.
