### PR TITLE
[Regression] [Tigron]: fix prepend args

### DIFF
--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -160,7 +160,7 @@ func (gc *GenericCommand) WithTimeout(timeout time.Duration) {
 }
 
 func (gc *GenericCommand) PrependArgs(args ...string) {
-	gc.cmd.PrependArgs = args
+	gc.cmd.PrependArgs = append(gc.cmd.PrependArgs, args...)
 }
 
 func (gc *GenericCommand) Background() {


### PR DESCRIPTION
Presumably the regression was introduced when I got rid of icmd.

This went unnoticed so far because we never make use of this in a way that would trigger a problem (eg: multiple successive calls to `PrependArgs`).
It would happen if we were using some of the advanced helpers (eg: config `HostsDir`, which we do not - yet).

I just noticed it while looking for something else and re-reading that part.

Clearly, cleanup of `test.Command` (post icmd) is overdue, but at least this patch should be merged now.