### PR TITLE
[GOMODJAIL]: suggesting to replace indirect module syndtr/gocapability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -152,3 +152,5 @@ require (
 )
 
 replace github.com/containerd/nerdctl/mod/tigron v0.0.0 => ./mod/tigron
+
+replace github.com/syndtr/gocapability => ./internal/replace/gocapability

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
-github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tinylib/msgp v1.2.0 h1:0uKB/662twsVBpYUPbokj4sTSKhWFKB7LopO2kWK8lY=
 github.com/tinylib/msgp v1.2.0/go.mod h1:2vIGs3lcUo8izAATNobrCHevYZC/LMsJtw4JPiYPHro=
 github.com/urfave/cli v1.19.1/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/internal/replace/gocapability/LICENSE
+++ b/internal/replace/gocapability/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/internal/replace/gocapability/README.md
+++ b/internal/replace/gocapability/README.md
@@ -1,0 +1,26 @@
+# ./gocapability
+
+`./gocapability` is a replacement for https://github.com/syndtr/gocapability providing just
+what is currently required to fulfill:
+- https://github.com/cncf-tags/container-device-interface
+- via https://github.com/opencontainers/runtime-tools
+  (originally added as a dependency in the early days of opencontainers by RH Patel:
+https://github.com/opencontainers/runtime-tools/commit/b462307c920f3a3e4f9a294ebf716f160a08ed44#diff-daddc66424f674dc57b411e63fce1f1bd231a27a77e39d25c781b4a8ca6f6062)
+
+The original repository unfortunately makes unnecessary use of `init()`, resulting
+in systematically attempting to open and read `/proc/sys/kernel/cap_last_cap`
+even (especially) when not required.
+
+This issue affects any project linking it (runc, containerd, etc).
+
+It has been reported a year ago without reaction from the maintainer
+(https://github.com/syndtr/gocapability/issues/26), and the project
+looks very much abandoned at this point (maintainer seem to have all but vanished into crypto circa 2022).
+
+While the performance impact is likely marginal, the security impact, less so:
+for `gomodjail` to work, `gocapability` would have to be marked as unconfined,
+which is made even more problematic precisely because it seems abandoned
+(hence more likely to be taken over).
+
+As far as nerdctl is concerned, the only thing that we actually need from it is the static list of linux capabilities
+and consts, which this is providing.

--- a/internal/replace/gocapability/capability/list.go
+++ b/internal/replace/gocapability/capability/list.go
@@ -1,0 +1,126 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package capability
+
+type Cap int
+
+var capabilities = []string{
+	"chown",
+	"dac_override",
+	"dac_read_search",
+	"fowner",
+	"fsetid",
+	"kill",
+	"setgid",
+	"setuid",
+	"setpcap",
+	"linux_immutable",
+	"net_bind_service",
+	"net_broadcast",
+	"net_admin",
+	"net_raw",
+	"ipc_lock",
+	"ipc_owner",
+	"sys_module",
+	"sys_rawio",
+	"sys_chroot",
+	"sys_ptrace",
+	"sys_pacct",
+	"sys_admin",
+	"sys_boot",
+	"sys_nice",
+	"sys_resource",
+	"sys_time",
+	"sys_tty_config",
+	"mknod",
+	"lease",
+	"audit_write",
+	"audit_control",
+	"setfcap",
+	"mac_override",
+	"mac_admin",
+	"syslog",
+	"wake_alarm",
+	"block_suspend",
+	"audit_read",
+	"perfmon",
+	"bpf",
+	"checkpoint_restore",
+}
+
+// From https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h
+const (
+	CAP_CHOWN Cap = iota
+	CAP_DAC_OVERRIDE
+	CAP_DAC_READ_SEARCH
+	CAP_FOWNER
+	CAP_FSETID
+	CAP_KILL
+	CAP_SETGID
+	CAP_SETUID
+	CAP_SETPCAP
+	CAP_LINUX_IMMUTABLE
+	CAP_NET_BIND_SERVICE
+	CAP_NET_BROADCAST
+	CAP_NET_ADMIN
+	CAP_NET_RAW
+	CAP_IPC_LOCK
+	CAP_IPC_OWNER
+	CAP_SYS_MODULE
+	CAP_SYS_RAWIO
+	CAP_SYS_CHROOT
+	CAP_SYS_PTRACE
+	CAP_SYS_PACCT
+	CAP_SYS_ADMIN
+	CAP_SYS_BOOT
+	CAP_SYS_NICE
+	CAP_SYS_RESOURCE
+	CAP_SYS_TIME
+	CAP_SYS_TTY_CONFIG
+	CAP_MKNOD
+	CAP_LEASE
+	CAP_AUDIT_WRITE
+	CAP_AUDIT_CONTROL
+	CAP_SETFCAP
+	CAP_MAC_OVERRIDE
+	CAP_MAC_ADMIN
+	CAP_SYSLOG
+	CAP_WAKE_ALARM
+	CAP_BLOCK_SUSPEND
+	CAP_AUDIT_READ
+	CAP_PERFMON
+	CAP_BPF
+	CAP_CHECKPOINT_RESTORE
+)
+
+var CAP_LAST_CAP = Cap(63)
+
+func (c Cap) String() string {
+	if c < 0 || c > 40 {
+		return "unknown"
+	}
+
+	return capabilities[c]
+}
+
+func List() []Cap {
+	caps := make([]Cap, 40)
+	for i := range 40 {
+		caps[i] = Cap(i)
+	}
+	return caps
+}

--- a/internal/replace/gocapability/capability/list_test.go
+++ b/internal/replace/gocapability/capability/list_test.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package capability
+
+import (
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+func TestCapToString(t *testing.T) {
+	// Just a sanity check
+	assert.Equal(t, Cap(32).String(), "mac_override")
+}

--- a/internal/replace/gocapability/go.mod
+++ b/internal/replace/gocapability/go.mod
@@ -1,0 +1,3 @@
+module github.com/syndtr/gocapability
+
+go 1.23.0


### PR DESCRIPTION
See README for detailed rationale.

TL;DR:
This indirect dependency has an unavoidable `init()` routine that will systematically `openat` and `fcntl` (reading `/proc/sys/kernel/cap_last_cap`), even / while it is not necessary.
`gomodjail` will (righfully) block this, resulting in a series of loud warnings - or we would have to `unconfine` this dependency.
Precisely because this project has been abandoned for multiple years and the maintainer seem to have vanished, marking it unconfined feels exactly like the kind of things we should _not_ do - as a likely candidate for a supply chain compromise.

This PR suggests we replace it.
The only part we do need is mundane (the mere list of linux capabilities), which is what we implement here from https://github.com/torvalds/linux/blob/master/include/uapi/linux/capability.h

Note that the state of this dependency has already raised concerns enough that most recent contributors have closed their PRs over there, and at least RH Kolyshkin did fork it: https://github.com/kolyshkin/capability

An alternative future / better solution would be for opencontainers/runtime-tools to address this on their side, since the dependency is getting pulled by them:

![graph-main](https://github.com/user-attachments/assets/0e095265-fbea-44ad-8c40-7e57e988a760)

