### PR TITLE
[CI]: removing net.core.somaxconn from test

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -263,7 +263,6 @@ func TestContainerInspectHostConfig(t *testing.T) {
 		"--read-only",
 		"--shm-size", "256m",
 		"--uts", "host",
-		"--sysctl", "net.core.somaxconn=1024",
 		"--runtime", "io.containerd.runc.v2",
 		testutil.AlpineImage, "sleep", "infinity").AssertOK()
 


### PR DESCRIPTION
See https://github.com/containerd/nerdctl/issues/4016

Currently, the test is flagged as running for rootless+cgroupv2, but it does fail on:
- debian on lima
- EL9 on lima

In that context, I am not sure what we are testing with it here.
Suggesting we remove that line - but of course open to any better alternative here?