### PR TITLE
[CI]: disable blkio test for older kernels

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -478,6 +478,11 @@ func TestContainerInspectBlkioSettings(t *testing.T) {
 		t.Skip("test requires root privilege to create a dummy device")
 	}
 
+	// See https://github.com/containerd/nerdctl/issues/4185
+	// It is unclear if this is truly a kernel version problem, a runc issue, or a distro (EL9) issue.
+	// For now, disable the test unless on a recent kernel.
+	testutil.RequireKernelVersion(t, ">= 6.0.0-0")
+
 	devPath := "/dev/dummy-zero"
 	// a dummy zero device: mknod /dev/dummy-zero c 1 5
 	helperCmd := exec.Command("mknod", []string{devPath, "c", "1", "5"}...)

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -484,6 +484,11 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 	testCase := nerdtest.Setup()
 	testCase.Require = nerdtest.Rootful
 
+	// See https://github.com/containerd/nerdctl/issues/4185
+	// It is unclear if this is truly a kernel version problem, a runc issue, or a distro (EL9) issue.
+	// For now, disable the test unless on a recent kernel.
+	testutil.RequireKernelVersion(t, ">= 6.0.0-0")
+
 	// Create dummy device path
 	dummyDev := "/dev/dummy-zero"
 

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -617,7 +617,9 @@ func RequireKernelVersion(t testing.TB, constraint string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	unameR, err := semver.NewVersion(infoutil.UnameR())
+	// EL kernel versions are not semver, so, cleanup first
+	un := strings.Split(infoutil.UnameR(), "-")[0]
+	unameR, err := semver.NewVersion(un)
 	if err != nil {
 		t.Skip(err)
 	}


### PR DESCRIPTION
See #4185 for what is known.

Also note this PR improves a bit `RequireKernelVersion` which is not working currently for EL kernels.