### PR TITLE
[GOMODJAIL]: unconfine fsnotify and cdi

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/fahedouch/go-logrotate v0.3.0 //gomodjail:unconfined
 	github.com/fatih/color v1.18.0 //gomodjail:unconfined
 	github.com/fluent/fluent-logger-golang v1.9.0
-	github.com/fsnotify/fsnotify v1.9.0
+	github.com/fsnotify/fsnotify v1.9.0 //gomodjail:unconfined
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/ipfs/go-cid v0.5.0
 	github.com/klauspost/compress v1.18.0
@@ -69,7 +69,7 @@ require (
 	golang.org/x/text v0.24.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
-	tags.cncf.io/container-device-interface v1.0.1
+	tags.cncf.io/container-device-interface v1.0.1 //gomodjail:unconfined
 )
 
 require (


### PR DESCRIPTION
Looks like we might need these unconfined?

For reference, failures for these are documented in:
- https://github.com/containerd/nerdctl/issues/4182#issuecomment-2848008980 for fsnotify
- https://github.com/containerd/nerdctl/issues/4182#issuecomment-2848727417 for CDI
