### PR TITLE
fix: nerdctl ps filter --status=created

### DIFF
--- a/cmd/nerdctl/system/system_events_linux_test.go
+++ b/cmd/nerdctl/system/system_events_linux_test.go
@@ -29,6 +29,7 @@ import (
 )
 
 func testEventFilterExecutor(data test.Data, helpers test.Helpers) test.TestableCommand {
+	helpers.Ensure("pull", testutil.CommonImage)
 	cmd := helpers.Command("events", "--filter", data.Labels().Get("filter"), "--format", "json")
 	// 3 seconds is too short on slow rig (EL8)
 	cmd.WithTimeout(10 * time.Second)


### PR DESCRIPTION
Issue:

```
sudo nerdctl ps -a --filter status=created
INFO[0000] containers %v[0xc0000e2000 0xc0000e20e0 0xc0000e21c0 0xc0000e22a0 0xc0000e2380 0xc0000e2460 0xc0000e2540 0xc0000e2620 0xc0000e2700] 
INFO[0000] filters %v[0xc0000e2000 0xc0000e20e0 0xc0000e21c0 0xc0000e22a0 0xc0000e2380 0xc0000e2460 0xc0000e2540 0xc0000e2620 0xc0000e2700] 
WARN[0000] no running task found: task 53fac80968c8b2f86a12bd5b8e99a043b80f5a7b2287b1e4e4db66f968a905ee not found 
WARN[0000] no running task found: task a250bf16efad4a9c2db89e82d76cdee1a466492d50a3411aa3da4276e1bc4ea8 not found 
WARN[0000] no running task found: task dc1e36498cefa97d40e9bdfea044365e836f9e711e24807b221dc64cbed34a48 not found 
WARN[0000] no running task found: task e97a33181bf251204fbb476ae10945e09269a01a938fcd861a1a14c31ca993c4 not found 
WARN[0000] no running task found: task eedd262ef9933cad2d04579355dd64287e46b948a997d90329f71888c882a24a not found 
INFO[0000] matches %v[]                                 
CONTAINER ID    IMAGE    COMMAND    CREATED    STATUS    PORTS    NAMES

```


Fix:

```
INFO[0000] contianer created                            
CONTAINER ID    IMAGE                                   COMMAND                   CREATED              STATUS     PORTS                                               NAMES
eedd262ef993    docker.io/library/alpine:latest         "/bin/sh"                 About an hour ago    Created                                                        test1
dc1e36498cef    docker.io/jenkins/jenkins:lts-jdk17     "/usr/bin/tini -- /u…"    6 hours ago          Created    0.0.0.0:8088->8080/tcp, 0.0.0.0:50000->50000/tcp    jenkins-dc1e3
a250bf16efad    docker.io/jenkins/jenkins:lts-jdk17     "/usr/bin/tini -- /u…"    6 hours ago          Created    0.0.0.0:8088->8080/tcp, 0.0.0.0:50000->50000/tcp    jenkins-a250b
e97a33181bf2    docker.io/jenkins/jenkins:lts-jdk17     "/usr/bin/tini -- /u…"    6 hours ago          Created    0.0.0.0:8088->8080/tcp, 0.0.0.0:50000->50000/tcp    jenkins-e97a3
53fac80968c8    docker.io/portainer/portainer:latest    "/portainer"              2 days ago           Created    0.0.0.0:9000->9000/tcp                              portainer-53fac
[shubhum@lima-finch nerdctl]$ sudo nerdctl ps -a --filter status=created --filter name=test1
INFO[0000] checking                                     
INFO[0000] contianer created                            
```