### PR TITLE
[FIX] CNIEnv concurrency issue

### DIFF
--- a/pkg/netutil/store.go
+++ b/pkg/netutil/store.go
@@ -1,0 +1,100 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package netutil
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/containernetworking/cni/libcni"
+
+	"github.com/containerd/errdefs"
+
+	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+)
+
+// NOTE: libcni is not safe to use concurrently - or at least delegates concurrency management to the consumer.
+// Furthermore, CNIEnv (prior to this) is assuming the filesystem is ACID and other TOCTOU faults.
+// This small set of methods here are meant to isolate CNIEnv entirely from the filesystem.
+// This is NOT proper - we should instead use the Store implementation, which is the generic abstraction for ACID
+// operations - but for now that will do, waiting for a full rewrite of CNIEnv.
+
+func fsEnsureRoot(e *CNIEnv, namespace string) error {
+	path := e.NetconfPath
+	if namespace != "" {
+		path = filepath.Join(e.NetconfPath, namespace)
+	}
+	return os.MkdirAll(path, 0755)
+}
+
+func fsRemove(e *CNIEnv, net *NetworkConfig) error {
+	fn := func() error {
+		if err := os.RemoveAll(net.File); err != nil {
+			return err
+		}
+		return net.clean()
+	}
+	return lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), fn)
+}
+
+func fsExists(e *CNIEnv, name string) (bool, error) {
+	fi, err := os.Stat(getConfigPathForNetworkName(e, name))
+	return !os.IsNotExist(err) && !fi.IsDir(), err
+}
+
+func fsWrite(e *CNIEnv, net *NetworkConfig) error {
+	filename := getConfigPathForNetworkName(e, net.Name)
+	// FIXME: note that this is still problematic.
+	// Concurrent access may independently first figure out that a given network is missing, and while the lock
+	// here will prevent concurrent writes, one of the routines will fail.
+	// Consuming code MUST account for that scenario.
+	return lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
+		if _, err := os.Stat(filename); err == nil {
+			return errdefs.ErrAlreadyExists
+		}
+		return os.WriteFile(filename, net.Bytes, 0644)
+	})
+}
+
+func fsRead(e *CNIEnv) ([]*NetworkConfig, error) {
+	var nc []*NetworkConfig
+	var err error
+	err = lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
+		namespaced := []string{}
+		var common []string
+		common, err = libcni.ConfFiles(e.NetconfPath, []string{".conf", ".conflist", ".json"})
+		if err != nil {
+			return err
+		}
+		if e.Namespace != "" {
+			namespaced, err = libcni.ConfFiles(filepath.Join(e.NetconfPath, e.Namespace), []string{".conf", ".conflist", ".json"})
+			if err != nil {
+				return err
+			}
+		}
+		nc, err = cniLoad(append(common, namespaced...))
+		return err
+	})
+	return nc, err
+}
+
+func getConfigPathForNetworkName(e *CNIEnv, netName string) string {
+	if netName == DefaultNetworkName || e.Namespace == "" {
+		return filepath.Join(e.NetconfPath, "nerdctl-"+netName+".conflist")
+	}
+	return filepath.Join(e.NetconfPath, e.Namespace, "nerdctl-"+netName+".conflist")
+}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -103,11 +103,13 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 	// This below is a stopgap solution that just enforces a global lock
 	// Note this here is probably not enough, as concurrent CNI operations may happen outside of the scope of ocihooks
 	// through explicit calls to Remove, etc.
+	// Finally note that this is not the same (albeit similar) as libcni filesystem manipulation locking,
+	// hence the independent lock
 	err = os.MkdirAll(cniNetconfPath, 0o700)
 	if err != nil {
 		return err
 	}
-	lock, err := lockutil.Lock(filepath.Join(cniNetconfPath, ".nerdctl.lock"))
+	lock, err := lockutil.Lock(filepath.Join(cniNetconfPath, ".cni-concurrency.lock"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is (one of) the remaining issues in #3556

TL;DR: like in other places, we have been assuming that a filesystem is ACID and/or safe to use concurrently.
This has been solved generally by introducing the `Store` abstraction, providing a (somewhat (*)) ACID storage solution, and also ad-hoc fixed a bunch of _CNIEnv_ methods.

CNIEnv _should_ be rewritten generally, as it is baroque at this point, but this is a lot more work.
For now, this PR just isolates all methods touching the filesystem in an ad-hoc store file - hopefully to a similar result.

This should address some of the issues we have been seeing (eg: missing .conflist file).

(*) atomic writes are not guaranteed in case of operating system crash, and data is not guaranteed to be saved as we do not sync (yet).