### PR TITLE
[CI]: rewrite some compose tests

### DIFF
--- a/cmd/nerdctl/compose/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose/compose_build_linux_test.go
@@ -46,8 +46,6 @@ services:
   svc0:
     build: .
     image: %s
-    ports:
-    - 8080:80
     depends_on:
     - svc1
   svc1:

--- a/cmd/nerdctl/compose/compose_create_linux_test.go
+++ b/cmd/nerdctl/compose/compose_create_linux_test.go
@@ -32,8 +32,6 @@ import (
 
 func TestComposeCreate(t *testing.T) {
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -87,8 +85,6 @@ services:
 
 func TestComposeCreateDependency(t *testing.T) {
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -152,8 +148,6 @@ func TestComposeCreatePull(t *testing.T) {
 
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s

--- a/cmd/nerdctl/compose/compose_pull_linux_test.go
+++ b/cmd/nerdctl/compose/compose_pull_linux_test.go
@@ -26,14 +26,10 @@ import (
 func TestComposePullWithService(t *testing.T) {
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
 
   wordpress:
     image: %s
-    ports:
-      - 8080:80
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: exampleuser

--- a/cmd/nerdctl/compose/compose_restart_linux_test.go
+++ b/cmd/nerdctl/compose/compose_restart_linux_test.go
@@ -26,13 +26,9 @@ import (
 func TestComposeRestart(t *testing.T) {
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   wordpress:
     image: %s
-    ports:
-      - 8080:80
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: exampleuser

--- a/cmd/nerdctl/compose/compose_version_test.go
+++ b/cmd/nerdctl/compose/compose_version_test.go
@@ -19,20 +19,29 @@ package compose
 import (
 	"testing"
 
-	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestComposeVersion(t *testing.T) {
-	base := testutil.NewBase(t)
-	base.ComposeCmd("version").AssertOutContains("Compose version ")
+	testCase := nerdtest.Setup()
+	testCase.Command = test.Command("compose", "version")
+	testCase.Expected = test.Expects(0, nil, expect.Contains("Compose version "))
+	testCase.Run(t)
 }
 
 func TestComposeVersionShort(t *testing.T) {
-	base := testutil.NewBase(t)
-	base.ComposeCmd("version", "--short").AssertOK()
+	testCase := nerdtest.Setup()
+	testCase.Command = test.Command("compose", "version", "--short")
+	testCase.Expected = test.Expects(0, nil, nil)
+	testCase.Run(t)
 }
 
 func TestComposeVersionJson(t *testing.T) {
-	base := testutil.NewBase(t)
-	base.ComposeCmd("version", "--format", "json").AssertOutContains("{\"version\":\"")
+	testCase := nerdtest.Setup()
+	testCase.Command = test.Command("compose", "version", "--format", "json")
+	testCase.Expected = test.Expects(0, nil, expect.Contains("{\"version\":\""))
+	testCase.Run(t)
 }


### PR DESCRIPTION
This PR is rewriting some compose tests (as many as I can stomach in one sitting) to the new test framework.

Obviously I am mostly interested in:
- making them running parallel to reduce total CI runtime
- moving them out of the "with-retry" bucket

A few notes:
- removing `version: XYZ` in most cases from compose yml, as this is deprecated and is just printing additional noise
- removing ports being exposed when not necessary for the test (as this was hardcoded to 8080, it would prevent tests from running in parallel)
- no longer manually poke image name and instead use referenceutils to parse them properly when needed (in preparation for upgrading test images to digest-pinning)
- some tests have been consolidated into subtests (cut the additional cost on tear-up / tear-down when not needed)