### PR TITLE
go.mod: github.com/syndtr/gocapability: gomodjail:unconfined

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -125,6 +125,7 @@ require (
 	github.com/smallstep/pkcs7 v0.1.1 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6 // indirect
+	//gomodjail:unconfined
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 	github.com/tinylib/msgp v1.2.0 // indirect
 	github.com/vbatts/tar-split v0.11.6 // indirect


### PR DESCRIPTION
So as to silence:
```
time=2025-05-07T12:27:22.202+09:00 level=WARN msg=***Blocked*** pid=36268 exe=/home/suda/.cache/gomodjail/1f381f194c2957
70/nerdctl syscall=openat entry=/home/suda/gopath/pkg/mod/github.com/syndtr/gocapability@v0.0.0-20200815063812-42c35b437
635/capability/capability_linux.go:53:github.com/syndtr/gocapability/capability.initLastCap module=github.com/syndtr/gocapability
```