### PR TITLE
oci-hook: add /usr/sbin:/sbin to PATH for iptables

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -540,6 +540,8 @@ func withNerdctlOCIHook(cmd string, args []string) (oci.SpecOpts, error) {
 	}
 
 	args = append([]string{cmd}, append(args, "internal", "oci-hook")...)
+	// sbin is appended for iptables https://github.com/containerd/nerdctl/discussions/1536
+	env := append(os.Environ(), "PATH="+os.Getenv("PATH")+":/usr/sbin:/sbin")
 	return func(_ context.Context, _ oci.Client, _ *containers.Container, s *specs.Spec) error {
 		if s.Hooks == nil {
 			s.Hooks = &specs.Hooks{}
@@ -548,14 +550,14 @@ func withNerdctlOCIHook(cmd string, args []string) (oci.SpecOpts, error) {
 		s.Hooks.CreateRuntime = append(s.Hooks.CreateRuntime, specs.Hook{
 			Path: cmd,
 			Args: crArgs,
-			Env:  os.Environ(),
+			Env:  env,
 		})
 		argsCopy := append([]string(nil), args...)
 		psArgs := append(argsCopy, "postStop")
 		s.Hooks.Poststop = append(s.Hooks.Poststop, specs.Hook{
 			Path: cmd,
 			Args: psArgs,
-			Env:  os.Environ(),
+			Env:  env,
 		})
 		return nil
 	}, nil


### PR DESCRIPTION
The directory of `iptables` is often missing in the default `$PATH`.

Fix #1536

Thanks to jeffrson for testing.