### PR TITLE
[CI]: rewrite logs tests

### DIFF
--- a/pkg/testutil/nerdtest/utilities_linux.go
+++ b/pkg/testutil/nerdtest/utilities_linux.go
@@ -68,7 +68,7 @@ func RunSigProxyContainer(signal os.Signal, exitOnSignal bool, args []string, da
 		if strings.Contains(out, ready) {
 			break
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 	}
 
 	return cmd


### PR DESCRIPTION
Commit 1 relaxes RunSigProxy refresh frequency.
Suspicion is that currently this is putting extra pressure on the runtime - especially for slow environments like EL.

Commit 2 rewrites all remaining logs tests with the new framework.

IMPORTANT NOTES:
- fix #4147
- some tests conditions have been made more stringent, since #4201 got fixed
- tests are disabled for Windows - it seems like logging for Windows only works intermittently
- this rewrite does away with `-d`, as this is a significant source of flakyness - if this is not acceptable and we do believe that all these tests **must** be run with `-d`, let me know and I will come up with something else

Note that while torturing tests, the following issues showed-up:
- #4243
- #4237
- and to a lesser extent: #4233

Because of these, logs tests may/will fail randomly.