### PR TITLE
testutil: bump up GolangImage to 1.23

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -768,3 +768,5 @@ func mirrorOf(s string) string {
 	// plain mirror, NOT stargz-converted images
 	return fmt.Sprintf("ghcr.io/stargz-containers/%s-org", s)
 }
+
+var GolangImage = mirrorOf("golang:1.23")

--- a/pkg/testutil/testutil_darwin.go
+++ b/pkg/testutil/testutil_darwin.go
@@ -31,5 +31,4 @@ var (
 	BusyboxImage     = "ghcr.io/containerd/busybox:1.36"
 	AlpineImage      = mirrorOf("alpine:3.13")
 	NginxAlpineImage = mirrorOf("nginx:1.19-alpine")
-	GolangImage      = mirrorOf("golang:1.18")
 )

--- a/pkg/testutil/testutil_freebsd.go
+++ b/pkg/testutil/testutil_freebsd.go
@@ -31,5 +31,4 @@ var (
 	BusyboxImage     = "ghcr.io/containerd/busybox:1.36"
 	AlpineImage      = mirrorOf("alpine:3.13")
 	NginxAlpineImage = mirrorOf("nginx:1.19-alpine")
-	GolangImage      = mirrorOf("golang:1.18")
 )

--- a/pkg/testutil/testutil_linux.go
+++ b/pkg/testutil/testutil_linux.go
@@ -30,7 +30,6 @@ var (
 	FluentdImage                = "fluent/fluentd:v1.17.0-debian-1.0"
 	KuboImage                   = mirrorOf("ipfs/kubo:v0.16.0")
 	SystemdImage                = "ghcr.io/containerd/stargz-snapshotter:0.15.1-kind"
-	GolangImage                 = mirrorOf("golang:1.18")
 
 	// Source: https://gist.github.com/cpuguy83/fcf3041e5d8fb1bb5c340915aabeebe0
 	NonDistBlobImage = "ghcr.io/cpuguy83/non-dist-blob:latest"

--- a/pkg/testutil/testutil_windows.go
+++ b/pkg/testutil/testutil_windows.go
@@ -53,7 +53,6 @@ const (
 )
 
 var (
-	GolangImage = mirrorOf("fixme-test-using-this-image-is-disabled-on-windows")
 	AlpineImage = mirrorOf("fixme-test-using-this-image-is-disabled-on-windows")
 
 	hypervContainer     bool


### PR DESCRIPTION
Fix #4214