### PR TITLE
TestRunWithLogBinary: workaround for "package slices is not in GOROOT"

### DIFF
--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -528,6 +528,8 @@ RUN echo '\
 
 
 RUN go mod init
+# Workaround for "package slices is not in GOROOT" https://github.com/containerd/nerdctl/issues/4214
+RUN go get github.com/containerd/containerd/v2@v2.0.5
 RUN go mod tidy
 RUN go build .
 


### PR DESCRIPTION
Fix #4214 as a quick workaround

This can be reverted after merging:
- #4215