### PR TITLE
[CI BUST FIX]: fix docker target (disable docker testing for SigProxyFalse)

### DIFF
--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -423,6 +423,10 @@ func TestRunSigProxy(t *testing.T) {
 		{
 			Description: "SigProxyFalse",
 
+			// Docker behavior changed sometimes with Docker 27
+			// See https://github.com/containerd/nerdctl/issues/4219 for details
+			Require: require.Not(nerdtest.Docker),
+
 			Cleanup: func(data test.Data, helpers test.Helpers) {
 				helpers.Anyhow("rm", "-f", data.Identifier())
 			},


### PR DESCRIPTION
See #4219 for details.

Note that it is not 100% clear to me if docker fixed a legitimate issue and our test is wrong, or if this is unintended on their part.

One way or the other, disabling the test for now for docker so that we uncork the CI.

(fix #4219 )