### PR TITLE
fix: remove trailing newline from log entries on last decode iteration

### DIFF
--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -401,9 +401,8 @@ func TestLogsFollowNoExtraneousLineFeed(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		// Create a container that outputs a message without a trailing newline
-		// and then sleeps to keep the container running for the logs -f command
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage,
-			"sh", "-c", "printf 'Hello without newline'; sleep 5")
+			"sh", "-c", "printf 'Hello without newline'")
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
@@ -412,7 +411,6 @@ func TestLogsFollowNoExtraneousLineFeed(t *testing.T) {
 
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
 		// Use logs -f to follow the logs
-		// The container will exit after 5 seconds, so we don't need an explicit timeout
 		// Arbitrary, but we need to wait until the logs show up
 		time.Sleep(3 * time.Second)
 		return helpers.Command("logs", "-f", data.Identifier())

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -413,6 +413,8 @@ func TestLogsFollowNoExtraneousLineFeed(t *testing.T) {
 	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
 		// Use logs -f to follow the logs
 		// The container will exit after 5 seconds, so we don't need an explicit timeout
+		// Arbitrary, but we need to wait until the logs show up
+		time.Sleep(3 * time.Second)
 		return helpers.Command("logs", "-f", data.Identifier())
 	}
 

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -394,6 +394,34 @@ func TestLogsWithDetails(t *testing.T) {
 	testCase.Run(t)
 }
 
+func TestLogsFollowNoExtraneousLineFeed(t *testing.T) {
+	testCase := nerdtest.Setup()
+	// This test verifies that `nerdctl logs -f` does not add extraneous line feeds
+	testCase.Require = require.Not(require.Windows)
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		// Create a container that outputs a message without a trailing newline
+		// and then sleeps to keep the container running for the logs -f command
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage,
+			"sh", "-c", "printf 'Hello without newline'; sleep 5")
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// Use logs -f to follow the logs
+		// The container will exit after 5 seconds, so we don't need an explicit timeout
+		return helpers.Command("logs", "-f", data.Identifier())
+	}
+
+	// Verify that the output is exactly "Hello without newline" without any additional line feeds
+	testCase.Expected = test.Expects(0, nil, expect.Equals("Hello without newline"))
+
+	testCase.Run(t)
+}
+
 func TestLogsWithStartContainer(t *testing.T) {
 	testCase := nerdtest.Setup()
 

--- a/pkg/logging/json_logger_test.go
+++ b/pkg/logging/json_logger_test.go
@@ -73,6 +73,7 @@ func TestReadRotatedJSONLog(t *testing.T) {
 		time.Sleep(1 * time.Millisecond)
 		logData, _ := json.Marshal(log)
 		file.Write(logData)
+		file.Write([]byte("\n"))
 
 		if line == 5 {
 			file.Close()
@@ -104,7 +105,7 @@ func TestReadRotatedJSONLog(t *testing.T) {
 	close(containerStopped)
 
 	if expectedStdout != stdoutBuf.String() {
-		t.Errorf("expected: %s, acoutal: %s", expectedStdout, stdoutBuf.String())
+		t.Errorf("expected: %s, actual: %s", expectedStdout, stdoutBuf.String())
 	}
 }
 

--- a/pkg/logging/jsonfile/jsonfile.go
+++ b/pkg/logging/jsonfile/jsonfile.go
@@ -54,7 +54,7 @@ func Encode(stdout <-chan string, stderr <-chan string, writer io.Writer) error 
 			Stream: name,
 		}
 		for logEntry := range dataChan {
-			e.Log = logEntry + "\n"
+			e.Log = logEntry
 			e.Time = time.Now().UTC()
 			encMu.Lock()
 			encErr := enc.Encode(e)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -255,7 +255,7 @@ func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, addres
 			var s string
 			s, err = r.ReadString('\n')
 			if len(s) > 0 {
-				dataChan <- strings.TrimSuffix(s, "\n")
+				dataChan <- s
 			}
 
 			if err != nil && err != io.EOF {


### PR DESCRIPTION
fix https://github.com/containerd/nerdctl/issues/4201