### PR TITLE
[CI]: fix flaky diff test

### DIFF
--- a/cmd/nerdctl/container/container_diff_test.go
+++ b/cmd/nerdctl/container/container_diff_test.go
@@ -39,7 +39,7 @@ func TestDiff(t *testing.T) {
 	testCase.Require = require.Not(require.Windows)
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage,
+		helpers.Ensure("run", "--name", data.Identifier(), testutil.CommonImage,
 			"sh", "-euxc", "touch /a; touch /bin/b; rm /bin/base64")
 	}
 


### PR DESCRIPTION
On slow environments (EL8), starting with -d will be racy as there is no guarantee the script has run by the time we test.

Seen in #4176