### PR TITLE
[DOC]: clarify corner case on Tigron WithFeeder

### DIFF
--- a/mod/tigron/internal/com/command.go
+++ b/mod/tigron/internal/com/command.go
@@ -150,6 +150,7 @@ func (gc *Command) WithPTY(stdin, stdout, stderr bool) {
 // WithFeeder ensures that the provider function will be executed and its output fed to the command stdin.
 // WithFeeder, like Feed, can be used multiple times, and writes will be performed sequentially, in order.
 // This command has no effect if Run has already been called.
+// Note that if the `writer` function runs a forever loop, we will deadlock and just Wait() forever on the errgroup.
 func (gc *Command) WithFeeder(writers ...func() io.Reader) {
 	gc.writers = append(gc.writers, writers...)
 }


### PR DESCRIPTION
See #4231 for context.

I did erroneously believed that `errgroup` would cancel on their own when using a context WithTimeout (and then some misunderstanding on my part of go routines).

The bottom-line is: if a feeder function is passed that does continuously loop, we will deadlock and it does not seem there is anything to do.

This PR just clarifies that fact.

Maybe in the future tigron could offer a `WaitFor` parameter to feeder functions, that would automatically run in a loop, properly accounting for context timeout.