### PR TITLE
Add loong64 as target for job-build + completion

### DIFF
--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -88,9 +88,10 @@ jobs:
           build linux arm64
           build windows
           build freebsd
+          # These architectures are not released, but we still verify that we can at least compile
           build darwin
           build linux arm 6
-          # These architectures are not released, but we still verify that we can at least compile
+          build linux loong64
           build linux ppc64le
           build linux riscv64
           build linux s390x

--- a/cmd/nerdctl/completion/completion.go
+++ b/cmd/nerdctl/completion/completion.go
@@ -164,6 +164,7 @@ func Platforms(cmd *cobra.Command, args []string, toComplete string) ([]string, 
 		"riscv64",
 		"ppc64le",
 		"s390x",
+		"loong64",
 		"386",
 		"arm",          // alias of "linux/arm/v7"
 		"linux/arm/v6", // "arm/v6" is invalid (interpreted as OS="arm", Arch="v7")

--- a/docs/multi-platform.md
+++ b/docs/multi-platform.md
@@ -16,6 +16,7 @@ $ sudo nerdctl run --privileged --rm tonistiigi/binfmt:master --install all
 $ ls -1 /proc/sys/fs/binfmt_misc/qemu*
 /proc/sys/fs/binfmt_misc/qemu-aarch64
 /proc/sys/fs/binfmt_misc/qemu-arm
+/proc/sys/fs/binfmt_misc/qemu-loongarch64
 /proc/sys/fs/binfmt_misc/qemu-mips64
 /proc/sys/fs/binfmt_misc/qemu-mips64el
 /proc/sys/fs/binfmt_misc/qemu-ppc64le


### PR DESCRIPTION
This is a small follow-up to the recent merge of loong64, actually building the arch on the CI as part of job-build and adding the arch for completion.