### PR TITLE
[REFACTOR]: consolidate filesystem ops into internal pkg

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -248,12 +248,12 @@ Config file ($NERDCTL_TOML): %s
 		}
 
 		// Since we store containers' stateful information on the filesystem per namespace, we need namespaces to be
-		// valid, safe path segments. This is enforced by store.ValidatePathComponent.
+		// valid, safe path segments.
 		// Note that the container runtime will further enforce additional restrictions on namespace names
 		// (containerd treats namespaces as valid identifiers - eg: alphanumericals + dash, starting with a letter)
 		// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#path-segment-names for
 		// considerations about path segments identifiers.
-		if err = store.ValidatePathComponent(globalOptions.Namespace); err != nil {
+		if err = store.IsFilesystemSafe(globalOptions.Namespace); err != nil {
 			return err
 		}
 		if appNeedsRootlessParentMain(cmd, args) {

--- a/pkg/composer/lock.go
+++ b/pkg/composer/lock.go
@@ -20,7 +20,7 @@ import (
 	"os"
 
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 //nolint:unused
@@ -39,10 +39,10 @@ func Lock(dataRoot string, address string) error {
 	if err != nil {
 		return err
 	}
-	locked, err = lockutil.Lock(dataStore)
+	locked, err = filesystem.Lock(dataStore)
 	return err
 }
 
 func Unlock() error {
-	return lockutil.Unlock(locked)
+	return filesystem.Unlock(locked)
 }

--- a/pkg/internal/filesystem/atomic.go
+++ b/pkg/internal/filesystem/atomic.go
@@ -1,0 +1,39 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func AtomicWrite(parent string, fileName string, perm os.FileMode, data []byte) error {
+	dest := filepath.Join(parent, fileName)
+	temp := filepath.Join(parent, ".temp."+fileName)
+
+	err := os.WriteFile(temp, data, perm)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(temp, dest)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/internal/filesystem/consts.go
+++ b/pkg/internal/filesystem/consts.go
@@ -1,0 +1,21 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+const (
+	pathComponentMaxLength = 255
+)

--- a/pkg/internal/filesystem/errors.go
+++ b/pkg/internal/filesystem/errors.go
@@ -1,0 +1,23 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import "errors"
+
+var (
+	ErrInvalidPath = errors.New("invalid path")
+)

--- a/pkg/internal/filesystem/lockutil_unix.go
+++ b/pkg/internal/filesystem/lockutil_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 /*
    Copyright The containerd Authors.
 
@@ -14,45 +16,56 @@
    limitations under the License.
 */
 
-package lockutil
+package filesystem
 
 import (
 	"fmt"
 	"os"
 
-	"golang.org/x/sys/windows"
+	"golang.org/x/sys/unix"
 
 	"github.com/containerd/log"
 )
 
 func WithDirLock(dir string, fn func() error) error {
-	dirFile, err := os.OpenFile(dir+".lock", os.O_CREATE, 0644)
+	_ = os.MkdirAll(dir, 0700)
+	dirFile, err := os.Open(dir)
 	if err != nil {
 		return err
 	}
 	defer dirFile.Close()
-	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	if err = windows.LockFileEx(windows.Handle(dirFile.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, ^uint32(0), ^uint32(0), new(windows.Overlapped)); err != nil {
+	if err := flock(dirFile, unix.LOCK_EX); err != nil {
 		return fmt.Errorf("failed to lock %q: %w", dir, err)
 	}
-
 	defer func() {
-		if err := windows.UnlockFileEx(windows.Handle(dirFile.Fd()), 0, ^uint32(0), ^uint32(0), new(windows.Overlapped)); err != nil {
+		if err := flock(dirFile, unix.LOCK_UN); err != nil {
 			log.L.WithError(err).Errorf("failed to unlock %q", dir)
 		}
 	}()
 	return fn()
 }
 
+func flock(f *os.File, flags int) error {
+	fd := int(f.Fd())
+	for {
+		err := unix.Flock(fd, flags)
+		if err == nil || err != unix.EINTR {
+			return err
+		}
+	}
+}
+
 func Lock(dir string) (*os.File, error) {
-	dirFile, err := os.OpenFile(dir+".lock", os.O_CREATE, 0644)
+	_ = os.MkdirAll(dir, 0700)
+	dirFile, err := os.Open(dir)
 	if err != nil {
 		return nil, err
 	}
-	// see https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
-	if err = windows.LockFileEx(windows.Handle(dirFile.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK, 0, ^uint32(0), ^uint32(0), new(windows.Overlapped)); err != nil {
-		return nil, fmt.Errorf("failed to lock %q: %w", dir, err)
+
+	if err = flock(dirFile, unix.LOCK_EX); err != nil {
+		return nil, err
 	}
+
 	return dirFile, nil
 }
 
@@ -61,5 +74,5 @@ func Unlock(locked *os.File) error {
 		_ = locked.Close()
 	}()
 
-	return windows.UnlockFileEx(windows.Handle(locked.Fd()), 0, ^uint32(0), ^uint32(0), new(windows.Overlapped))
+	return flock(locked, unix.LOCK_UN)
 }

--- a/pkg/internal/filesystem/path.go
+++ b/pkg/internal/filesystem/path.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"errors"
+	"strings"
+)
+
+var (
+	errForbiddenChars     = errors.New("forbidden characters in path component")
+	errForbiddenKeywords  = errors.New("forbidden keywords in path component")
+	errInvalidPathTooLong = errors.New("path component must be shorter than 256 characters")
+	errInvalidPathEmpty   = errors.New("path component cannot be empty")
+)
+
+// ValidatePathComponent will enforce os specific filename restrictions on a single path component.
+func ValidatePathComponent(pathComponent string) error {
+	// https://en.wikipedia.org/wiki/Comparison_of_file_systems#Limits
+	if len(pathComponent) > pathComponentMaxLength {
+		return errors.Join(ErrInvalidPath, errInvalidPathTooLong)
+	}
+
+	if strings.TrimSpace(pathComponent) == "" {
+		return errors.Join(ErrInvalidPath, errInvalidPathEmpty)
+	}
+
+	if err := validatePlatformSpecific(pathComponent); err != nil {
+		return errors.Join(ErrInvalidPath, err)
+	}
+
+	return nil
+}

--- a/pkg/internal/filesystem/path_unix.go
+++ b/pkg/internal/filesystem/path_unix.go
@@ -16,14 +16,14 @@
    limitations under the License.
 */
 
-package store
+package filesystem
 
 import (
 	"fmt"
 	"regexp"
 )
 
-// Note that Darwin has different restrictions - though, we do not support Darwin at this point...
+// Note that Darwin has different restrictions on colons.
 // https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names
 var (
 	disallowedKeywords = regexp.MustCompile(`^([.]|[.][.])$`)
@@ -32,11 +32,11 @@ var (
 
 func validatePlatformSpecific(pathComponent string) error {
 	if reservedCharacters.MatchString(pathComponent) {
-		return fmt.Errorf("identifier %q cannot contain any of the following characters: %q", pathComponent, reservedCharacters)
+		return fmt.Errorf("%w: %q (%q)", errForbiddenChars, pathComponent, reservedCharacters)
 	}
 
 	if disallowedKeywords.MatchString(pathComponent) {
-		return fmt.Errorf("identifier %q cannot be any of the reserved keywords: %q", pathComponent, disallowedKeywords)
+		return fmt.Errorf("%w: %q (%q)", errForbiddenKeywords, pathComponent, disallowedKeywords)
 	}
 
 	return nil

--- a/pkg/internal/filesystem/path_windows.go
+++ b/pkg/internal/filesystem/path_windows.go
@@ -14,9 +14,10 @@
    limitations under the License.
 */
 
-package store
+package filesystem
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -26,19 +27,21 @@ import (
 var (
 	disallowedKeywords = regexp.MustCompile(`(?i)^(con|prn|nul|aux|com[1-9¹²³]|lpt[1-9¹²³])([.].*)?$`)
 	reservedCharacters = regexp.MustCompile(`[\x{0}-\x{1f}<>:"/\\|?*]`)
+
+	errNoEndingSpaceDot = errors.New("component cannot end with a space or dot")
 )
 
 func validatePlatformSpecific(pathComponent string) error {
 	if reservedCharacters.MatchString(pathComponent) {
-		return fmt.Errorf("identifier %q cannot contain any of the following characters: %q", pathComponent, reservedCharacters)
+		return fmt.Errorf("%w: %q (%q)", errForbiddenChars, pathComponent, reservedCharacters)
 	}
 
 	if disallowedKeywords.MatchString(pathComponent) {
-		return fmt.Errorf("identifier %q cannot be any of the reserved keywords: %q", pathComponent, disallowedKeywords)
+		return fmt.Errorf("%w: %q (%q)", errForbiddenKeywords, pathComponent, disallowedKeywords)
 	}
 
 	if pathComponent[len(pathComponent)-1:] == "." || pathComponent[len(pathComponent)-1:] == " " {
-		return fmt.Errorf("identifier %q cannot end with a space or dot", pathComponent)
+		return fmt.Errorf("%w: %q", errNoEndingSpaceDot, pathComponent)
 	}
 
 	return nil

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -38,7 +38,7 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
 
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 const (
@@ -160,7 +160,7 @@ func getLockPath(dataStore, ns, id string) string {
 
 // WaitForLogger waits until the logger has finished executing and processing container logs
 func WaitForLogger(dataStore, ns, id string) error {
-	return lockutil.WithDirLock(getLockPath(dataStore, ns, id), func() error {
+	return filesystem.WithDirLock(getLockPath(dataStore, ns, id), func() error {
 		return nil
 	})
 }
@@ -314,7 +314,7 @@ func loggerFunc(dataStore string) (logging.LoggerFunc, error) {
 			// the logger will obtain an exclusive lock on a file until the container is
 			// stopped and the driver has finished processing all output,
 			// so that waiting log viewers can be signalled when the process is complete.
-			return lockutil.WithDirLock(loggerLock, func() error {
+			return filesystem.WithDirLock(loggerLock, func() error {
 				if err := ready(); err != nil {
 					return err
 				}

--- a/pkg/netutil/store.go
+++ b/pkg/netutil/store.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/containerd/errdefs"
 
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 // NOTE: libcni is not safe to use concurrently - or at least delegates concurrency management to the consumer.
@@ -48,7 +48,7 @@ func fsRemove(e *CNIEnv, net *NetworkConfig) error {
 		}
 		return net.clean()
 	}
-	return lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), fn)
+	return filesystem.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), fn)
 }
 
 func fsExists(e *CNIEnv, name string) (bool, error) {
@@ -62,7 +62,7 @@ func fsWrite(e *CNIEnv, net *NetworkConfig) error {
 	// Concurrent access may independently first figure out that a given network is missing, and while the lock
 	// here will prevent concurrent writes, one of the routines will fail.
 	// Consuming code MUST account for that scenario.
-	return lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
+	return filesystem.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
 		if _, err := os.Stat(filename); err == nil {
 			return errdefs.ErrAlreadyExists
 		}
@@ -73,7 +73,7 @@ func fsWrite(e *CNIEnv, net *NetworkConfig) error {
 func fsRead(e *CNIEnv) ([]*NetworkConfig, error) {
 	var nc []*NetworkConfig
 	var err error
-	err = lockutil.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
+	err = filesystem.WithDirLock(filepath.Join(e.NetconfPath, ".nerdctl.lock"), func() error {
 		namespaced := []string{}
 		var common []string
 		common, err = libcni.ConfFiles(e.NetconfPath, []string{".conf", ".conflist", ".json"})

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -38,8 +38,8 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/bypass4netnsutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
 	"github.com/containerd/nerdctl/v2/pkg/namestore"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
@@ -109,11 +109,11 @@ func Run(stdin io.Reader, stderr io.Writer, event, dataStore, cniPath, cniNetcon
 	if err != nil {
 		return err
 	}
-	lock, err := lockutil.Lock(filepath.Join(cniNetconfPath, ".cni-concurrency.lock"))
+	lock, err := filesystem.Lock(filepath.Join(cniNetconfPath, ".cni-concurrency.lock"))
 	if err != nil {
 		return err
 	}
-	defer lockutil.Unlock(lock)
+	defer filesystem.Unlock(lock)
 
 	opts, err := newHandlerOpts(&state, dataStore, cniPath, cniNetconfPath, bridgeIP)
 	if err != nil {

--- a/pkg/store/filestore_test.go
+++ b/pkg/store/filestore_test.go
@@ -17,8 +17,6 @@
 package store
 
 import (
-	"fmt"
-	"runtime"
 	"testing"
 	"time"
 
@@ -219,61 +217,4 @@ func TestFileStoreConcurrent(t *testing.T) {
 		return nil
 	})
 	assert.NilError(t, lErr, "locking should not error")
-}
-
-func TestFileStoreFilesystemRestrictions(t *testing.T) {
-	invalid := []string{
-		"/",
-		"/start",
-		"mid/dle",
-		"end/",
-		".",
-		"..",
-		"",
-		fmt.Sprintf("A%0255s", "A"),
-	}
-
-	valid := []string{
-		fmt.Sprintf("A%0254s", "A"),
-		"test",
-		"test-hyphen",
-		".start.dot",
-		"mid.dot",
-		"∞",
-	}
-
-	if runtime.GOOS == "windows" {
-		invalid = append(invalid, []string{
-			"\\start",
-			"mid\\dle",
-			"end\\",
-			"\\",
-			"\\.",
-			"com².whatever",
-			"lpT2",
-			"Prn.",
-			"nUl",
-			"AUX",
-			"A<A",
-			"A>A",
-			"A:A",
-			"A\"A",
-			"A|A",
-			"A?A",
-			"A*A",
-			"end.dot.",
-			"end.space ",
-		}...)
-	}
-
-	for _, v := range invalid {
-		err := ValidatePathComponent(v)
-		assert.ErrorIs(t, err, ErrInvalidArgument, v)
-	}
-
-	for _, v := range valid {
-		err := ValidatePathComponent(v)
-		assert.NilError(t, err, v)
-	}
-
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -44,7 +44,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
-	"github.com/containerd/nerdctl/v2/pkg/lockutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
@@ -524,14 +524,14 @@ func M(m *testing.M) {
 		os.Chmod(filepath.Dir(testLockFile), 0o777)
 
 		// Acquire lock
-		lock, err := lockutil.Lock(filepath.Dir(testLockFile))
+		lock, err := filesystem.Lock(filepath.Dir(testLockFile))
 		if err != nil {
 			log.L.WithError(err).Errorf("failed acquiring testing lock %q", filepath.Dir(testLockFile))
 			return 1
 		}
 
 		// Release...
-		defer lockutil.Unlock(lock)
+		defer filesystem.Unlock(lock)
 
 		// Create marker file
 		err = os.WriteFile(testLockFile, []byte("prevent testing from running in parallel for subpackages integration tests"), 0o666)


### PR DESCRIPTION
This suggests that we consolidate low-level filesystem related operations into one package (currently pepperred over under `lockutil` and `store`).

This includes path validation, atomic writes, locks.

Also suggesting that said package should be made internal. This is _not_ nerdctl API, but merely low-level primitives, and generally speaking the nerdctl API is just too big, exposing too much irrelevant stuff.

This refactor is in preparation for future PRs that will focus on:
- enhancing locks to be more flexible and allow locking of files AND dirs, and also allow for RO locks
- enhancements to atomic writefile to support in-place writing (current rename approach does change inode), with a rollback / disaster recovery mechanism
- consistently use atomic writes to ensure better resilience and data consistency
(they will be broken out of #4240 as well in small chuncks)

This PR here sticks with purely refactoring.