### PR TITLE
[CI]: tests cleanup

### DIFF
--- a/cmd/nerdctl/builder/builder_build_test.go
+++ b/cmd/nerdctl/builder/builder_build_test.go
@@ -110,6 +110,7 @@ CMD ["echo", "nerdctl-build-test-string"]`, testutil.CommonImage)
 				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rmi", "-f", data.Identifier("ignored"))
+					helpers.Anyhow("rmi", "-f", data.Identifier())
 				},
 				Expected: test.Expects(expect.ExitCodeGenericFail, nil, nil),
 			},

--- a/cmd/nerdctl/container/container_exec_linux_test.go
+++ b/cmd/nerdctl/container/container_exec_linux_test.go
@@ -65,6 +65,9 @@ func TestExecTTY(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage, "sleep", nerdtest.Infinity)
+
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+
 		data.Labels().Set("container_name", data.Identifier())
 	}
 

--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -352,6 +352,8 @@ func TestRunBindMountBind(t *testing.T) {
 			"top",
 		)
 
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier("container"))
+
 		// Save host rwDir location and container id for subtests
 		data.Labels().Set("container", data.Identifier("container"))
 		data.Labels().Set("rwDir", rwDir)


### PR DESCRIPTION
This is a tentative at fixing:
- #4144 
- #4119
- #3971

The hypothesis is that in very slow environments (eg: EL8 under pressure), containers started with `-d` may not have started by the time we are testing on them, resulting in unspecified behavior (whether this is a bug or not is a separate conversation to be evaluated case by case).

Besides enforcing verification that the container has started, this PR does take the occasion to do some cleanup:
- remove `-d` when not necessary
- use `CommonImage` instead of Alpine, or Nginx (when not necessary)
- remove spurious Cleanups when not necessary and replace with self-removing containers
- simplify syntax (remove spurious use of `WithArguments`, simplify expectations)
- more logically organize setup vs. command

I will restart the CI a few times to confirm that EL8 is no longer failing on these.