### PR TITLE
[CI]: re-enable tests following fixes

### DIFF
--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -269,15 +269,13 @@ RUN echo "actually creating a layer so that docker sets the createdAt time"
 			},
 			{
 				Description: "since=non-exists-image",
-				Require:     nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3511"),
 				Command:     test.Command("images", "--filter", "since=non-exists-image"),
-				Expected:    test.Expects(expect.ExitCodeGenericFail, []error{errors.New("No such image: ")}, nil),
+				Expected:    test.Expects(expect.ExitCodeGenericFail, []error{errors.New("no such image: ")}, nil),
 			},
 			{
 				Description: "before=non-exists-image",
-				Require:     nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3511"),
 				Command:     test.Command("images", "--filter", "before=non-exists-image"),
-				Expected:    test.Expects(expect.ExitCodeGenericFail, []error{errors.New("No such image: ")}, nil),
+				Expected:    test.Expects(expect.ExitCodeGenericFail, []error{errors.New("no such image: ")}, nil),
 			},
 		},
 	}

--- a/cmd/nerdctl/volume/volume_list_test.go
+++ b/cmd/nerdctl/volume/volume_list_test.go
@@ -282,8 +282,6 @@ func TestVolumeLsFilter(t *testing.T) {
 		},
 		{
 			Description: "Retrieving name=volume1 and name=volume2",
-			// Nerdctl filter behavior is broken
-			Require: nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/3452"),
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("volume", "ls", "--quiet", "--filter", "name="+data.Labels().Get("vol1"), "--filter", "name="+data.Labels().Get("vol2"))
 			},


### PR DESCRIPTION
Re-enabling some of the tests previously disabled for nerdctl as we merged corresponding fixes.