### PR TITLE
[CI]: move away from raw github domain to API

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -68,3 +68,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/job-test-dependencies.yml
+++ b/.github/workflows/job-test-dependencies.yml
@@ -39,6 +39,8 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124  # v3.1.0
 
       - name: "Run: build dependencies for the integration test environment image"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Cache is sharded per-architecture
           arch=${{ env.RUNNER_ARCH == 'ARM64' && 'arm64' || 'amd64' }}
@@ -49,6 +51,7 @@ jobs:
             args=(--build-arg CONTAINERD_VERSION=${{ inputs.containerd-version }})
           fi
           docker buildx build \
+            --secret id=github_token,env=GITHUB_TOKEN \
             --cache-to type=gha,compression=zstd,mode=max,scope=test-integration-dependencies-"$arch" \
             --cache-from type=gha,scope=test-integration-dependencies-"$arch" \
             --target build-dependencies "${args[@]}" .

--- a/.github/workflows/job-test-in-container.yml
+++ b/.github/workflows/job-test-in-container.yml
@@ -86,6 +86,8 @@ jobs:
           canary::build::integration
       - if: ${{ ! inputs.canary }}
         name: "Init: prepare test image"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           buildargs=()
           # If the runner is old, use old ubuntu inside the container as well
@@ -104,6 +106,7 @@ jobs:
           arch=${{ env.RUNNER_ARCH == 'ARM64' && 'arm64' || 'amd64' }}
           docker buildx create --name with-gha --use
           docker buildx build \
+            --secret id=github_token,env=GITHUB_TOKEN \
             --output=type=docker \
             --cache-from type=gha,scope=test-integration-dependencies-"$arch" \
             -t "$target" --target "$target" \

--- a/.github/workflows/job-test-in-lima.yml
+++ b/.github/workflows/job-test-in-lima.yml
@@ -79,6 +79,8 @@ jobs:
         uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124  # v3.1.0
 
       - name: "Init: prepare integration tests"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
 
@@ -88,6 +90,7 @@ jobs:
           [ "$TARGET" = "rootless" ] && TARGET=test-integration-rootless || TARGET=test-integration
           docker buildx create --name with-gha --use
           docker buildx build \
+            --secret id=github_token,env=GITHUB_TOKEN \
             --output=type=docker \
             --cache-from type=gha,scope=test-integration-dependencies-amd64 \
             -t test-integration --target "${TARGET}" \

--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ TAR_OWNER0_FLAGS=--owner=0 --group=0
 TAR_FLATTEN_FLAGS=--transform 's/.*\///g'
 
 define make_artifact_full_linux
-	$(DOCKER) build --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) --build-arg GO_VERSION -f $(MAKEFILE_DIR)/Dockerfile $(MAKEFILE_DIR)
+	$(DOCKER) build --secret id=github_token,env=GITHUB_TOKEN --output type=tar,dest=$(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar --target out-full --platform $(1) --build-arg GO_VERSION -f $(MAKEFILE_DIR)/Dockerfile $(MAKEFILE_DIR)
 	gzip -9 $(CURDIR)/_output/nerdctl-full-$(VERSION_TRIMMED)-linux-$(1).tar
 endef
 

--- a/hack/scripts/lib.sh
+++ b/hack/scripts/lib.sh
@@ -226,9 +226,10 @@ github::settoken(){
 }
 
 github::request(){
-  local endpoint="$1"
+  local accept="$1"
+  local endpoint="$2"
   local args=(
-    "Accept: application/vnd.github+json"
+    "Accept: $accept"
     "X-GitHub-Api-Version: 2022-11-28"
   )
 
@@ -237,21 +238,30 @@ github::request(){
   http::get /dev/stdout https://api.github.com/"$endpoint" "${args[@]}"
 }
 
+github::file(){
+  local repo="$1"
+  local path="$2"
+  local ref="${3:-main}"
+  github::request "application/vnd.github.v3.raw" "repos/$repo/contents/$path?ref=$ref"
+}
+
 github::tags::latest(){
   local repo="$1"
-  github::request "repos/$repo/tags" | jq -rc .[0].name
+  github::request "application/vnd.github+json" "repos/$repo/tags" | jq -rc .[0].name
 }
 
 github::releases(){
   local repo="$1"
-  github::request "repos/$repo/releases" |
+  github::request "application/vnd.github+json" "repos/$repo/releases" |
     jq -rc .[]
 }
 
 github::releases::latest(){
   local repo="$1"
-  github::request "repos/$repo/releases/latest" | jq -rc .
+  github::request "application/vnd.github+json" "repos/$repo/releases/latest" | jq -rc .
 }
 
 log::init
 host::require jq tar curl shasum
+
+[[ "${1:-}" != "github"* ]] || "$@"


### PR DESCRIPTION
Fix (part of?) #4264
See ^ for context.

TL;DR: recent changes in GitHub rate limits (presumably https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/) now break the build for us, apparently for requests to raw.githubusercontent.

This PR does a couple of things:
- ensure we pass along the GITHUB_TOKEN into the Dockerfile so that we can authenticate GitHub queries
- provide a helper that can retrieve (authenticated) raw content from GitHub API instead of using the raw domain

Note that it is unclear if we are going to get throttled on other GitHub requests as well - but at least we now have the infrastructure in place to perform authenticated requests, so, we can change what needs be later on piece-meal.