### PR TITLE
[CI] more tests cleanup

### DIFF
--- a/cmd/nerdctl/compose/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose/compose_build_linux_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestComposeBuild(t *testing.T) {
-	dockerfile := "FROM " + testutil.AlpineImage
+	dockerfile := "FROM " + testutil.CommonImage
 
 	testCase := nerdtest.Setup()
 

--- a/cmd/nerdctl/compose/compose_build_linux_test.go
+++ b/cmd/nerdctl/compose/compose_build_linux_test.go
@@ -51,8 +51,6 @@ services:
   svc1:
     build: .
     image: %s
-    ports:
-    - 8081:80
 `, imageSvc0, imageSvc1)
 
 		data.Temp().Save(dockerComposeYAML, "compose.yaml")

--- a/cmd/nerdctl/compose/compose_config_test.go
+++ b/cmd/nerdctl/compose/compose_config_test.go
@@ -25,15 +25,17 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 func TestComposeConfig(t *testing.T) {
-	const dockerComposeYAML = `
+	dockerComposeYAML := fmt.Sprintf(`
 services:
   hello:
-    image: alpine:3.13
-`
+    image: %s
+`, testutil.CommonImage)
+
 	testCase := nerdtest.Setup()
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/compose/compose_cp_linux_test.go
+++ b/cmd/nerdctl/compose/compose_cp_linux_test.go
@@ -31,8 +31,6 @@ import (
 
 func TestComposeCopy(t *testing.T) {
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s

--- a/cmd/nerdctl/compose/compose_create_linux_test.go
+++ b/cmd/nerdctl/compose/compose_create_linux_test.go
@@ -35,7 +35,7 @@ func TestComposeCreate(t *testing.T) {
 services:
   svc0:
     image: %s
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	testCase := nerdtest.Setup()
 
@@ -151,7 +151,7 @@ func TestComposeCreatePull(t *testing.T) {
 services:
   svc0:
     image: %s
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -161,12 +161,12 @@ services:
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").AssertOK()
 
 	// `compose create --pull never` should fail: no such image
-	base.Cmd("rmi", "-f", testutil.AlpineImage).Run()
+	base.Cmd("rmi", "-f", testutil.CommonImage).Run()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "create", "--pull", "never").AssertFail()
 	// `compose create --pull missing(default)|always` should succeed: image is pulled and container is created
-	base.Cmd("rmi", "-f", testutil.AlpineImage).Run()
+	base.Cmd("rmi", "-f", testutil.CommonImage).Run()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "create").AssertOK()
-	base.Cmd("rmi", "-f", testutil.AlpineImage).Run()
+	base.Cmd("rmi", "-f", testutil.CommonImage).Run()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "create", "--pull", "always").AssertOK()
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "svc0", "-a").AssertOutContainsAny("Created", "created")
 }
@@ -181,7 +181,7 @@ services:
     image: %s
 `, imageSvc0)
 
-	dockerfile := fmt.Sprintf(`FROM %s`, testutil.AlpineImage)
+	dockerfile := fmt.Sprintf(`FROM %s`, testutil.CommonImage)
 
 	testutil.RequiresBuild(t)
 	testutil.RegisterBuildCacheCleanup(t)

--- a/cmd/nerdctl/compose/compose_down_linux_test.go
+++ b/cmd/nerdctl/compose/compose_down_linux_test.go
@@ -34,14 +34,14 @@ services:
   test:
     image: %s
     command: "sleep infinity"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 		dockerComposeYAMLFull = fmt.Sprintf(`
 %s
   orphan:
     image: %s
     command: "sleep infinity"
-`, dockerComposeYAMLOrphan, testutil.AlpineImage)
+`, dockerComposeYAMLOrphan, testutil.CommonImage)
 	)
 
 	compOrphan := testutil.NewComposeDir(t, dockerComposeYAMLOrphan)
@@ -68,14 +68,14 @@ services:
   test:
     image: %s
     command: "sleep infinity"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 		dockerComposeYAMLFull = fmt.Sprintf(`
 %s
   orphan:
     image: %s
     command: "sleep infinity"
-`, dockerComposeYAMLOrphan, testutil.AlpineImage)
+`, dockerComposeYAMLOrphan, testutil.CommonImage)
 	)
 
 	compOrphan := testutil.NewComposeDir(t, dockerComposeYAMLOrphan)

--- a/cmd/nerdctl/compose/compose_down_linux_test.go
+++ b/cmd/nerdctl/compose/compose_down_linux_test.go
@@ -30,8 +30,6 @@ func TestComposeDownRemoveUsedNetwork(t *testing.T) {
 
 	var (
 		dockerComposeYAMLOrphan = fmt.Sprintf(`
-version: '3.1'
-
 services:
   test:
     image: %s
@@ -66,8 +64,6 @@ func TestComposeDownRemoveOrphans(t *testing.T) {
 
 	var (
 		dockerComposeYAMLOrphan = fmt.Sprintf(`
-version: '3.1'
-
 services:
   test:
     image: %s

--- a/cmd/nerdctl/compose/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose/compose_exec_linux_test.go
@@ -34,8 +34,6 @@ import (
 
 func TestComposeExec(t *testing.T) {
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -179,8 +177,6 @@ services:
 func TestComposeExecTTY(t *testing.T) {
 	const expectedOutput = "speed 38400 baud"
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -267,8 +263,6 @@ services:
 
 func TestComposeExecWithIndex(t *testing.T) {
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s

--- a/cmd/nerdctl/compose/compose_kill_linux_test.go
+++ b/cmd/nerdctl/compose/compose_kill_linux_test.go
@@ -31,8 +31,6 @@ services:
 
   wordpress:
     image: %s
-    ports:
-      - 8080:80
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: exampleuser

--- a/cmd/nerdctl/compose/compose_kill_linux_test.go
+++ b/cmd/nerdctl/compose/compose_kill_linux_test.go
@@ -27,8 +27,6 @@ import (
 func TestComposeKill(t *testing.T) {
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
 
   wordpress:

--- a/cmd/nerdctl/compose/compose_pause_linux_test.go
+++ b/cmd/nerdctl/compose/compose_pause_linux_test.go
@@ -31,8 +31,6 @@ func TestComposePauseAndUnpause(t *testing.T) {
 	}
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s

--- a/cmd/nerdctl/compose/compose_port_linux_test.go
+++ b/cmd/nerdctl/compose/compose_port_linux_test.go
@@ -27,8 +27,6 @@ func TestComposePort(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -55,8 +53,6 @@ func TestComposePortFailure(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s

--- a/cmd/nerdctl/compose/compose_ps_linux_test.go
+++ b/cmd/nerdctl/compose/compose_ps_linux_test.go
@@ -32,8 +32,6 @@ import (
 func TestComposePs(t *testing.T) {
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   wordpress:
     image: %s
@@ -112,8 +110,6 @@ func TestComposePsJSON(t *testing.T) {
 
 	base := testutil.NewBase(t)
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   wordpress:
     image: %s

--- a/cmd/nerdctl/compose/compose_ps_linux_test.go
+++ b/cmd/nerdctl/compose/compose_ps_linux_test.go
@@ -62,7 +62,7 @@ services:
 volumes:
   wordpress:
   db:
-`, testutil.WordpressImage, testutil.MariaDBImage, testutil.AlpineImage)
+`, testutil.WordpressImage, testutil.MariaDBImage, testutil.CommonImage)
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
 	projectName := comp.ProjectName()
@@ -98,9 +98,9 @@ volumes:
 	time.Sleep(3 * time.Second)
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "wordpress").AssertOutWithFunc(assertHandler("wordpress_container", testutil.WordpressImage))
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "db").AssertOutWithFunc(assertHandler("db_container", testutil.MariaDBImage))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps").AssertOutNotContains(testutil.AlpineImage)
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "alpine", "-a").AssertOutWithFunc(assertHandler("alpine_container", testutil.AlpineImage))
-	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "-a", "--filter", "status=exited").AssertOutWithFunc(assertHandler("alpine_container", testutil.AlpineImage))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps").AssertOutNotContains(testutil.CommonImage)
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "alpine", "-a").AssertOutWithFunc(assertHandler("alpine_container", testutil.CommonImage))
+	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "-a", "--filter", "status=exited").AssertOutWithFunc(assertHandler("alpine_container", testutil.CommonImage))
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "ps", "--services", "-a").AssertOutContainsAll("wordpress\n", "db\n", "alpine\n")
 }
 

--- a/cmd/nerdctl/compose/compose_ps_linux_test.go
+++ b/cmd/nerdctl/compose/compose_ps_linux_test.go
@@ -36,8 +36,6 @@ services:
   wordpress:
     image: %s
     container_name: wordpress_container
-    ports:
-      - 8080:80
     environment:
       WORDPRESS_DB_HOST: db
       WORDPRESS_DB_USER: exampleuser

--- a/cmd/nerdctl/compose/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose/compose_run_linux_test.go
@@ -40,7 +40,6 @@ func TestComposeRun(t *testing.T) {
 	const expectedOutput = "speed 38400 baud"
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -120,7 +119,6 @@ func TestComposeRunWithServicePorts(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   web:
     image: %s
@@ -182,7 +180,6 @@ func TestComposeRunWithPublish(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   web:
     image: %s
@@ -242,7 +239,6 @@ func TestComposeRunWithEnv(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -274,7 +270,6 @@ func TestComposeRunWithUser(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -303,7 +298,6 @@ func TestComposeRunWithLabel(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -341,7 +335,6 @@ func TestComposeRunWithArgs(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -371,7 +364,6 @@ func TestComposeRunWithEntrypoint(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s
@@ -399,7 +391,6 @@ func TestComposeRunWithVolume(t *testing.T) {
 	containerName := testutil.Identifier(t)
 
 	dockerComposeYAML := fmt.Sprintf(`
-version: '3.1'
 services:
   alpine:
     image: %s

--- a/cmd/nerdctl/compose/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose/compose_run_linux_test.go
@@ -45,7 +45,7 @@ services:
     image: %s
     entrypoint:
       - stty
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	testCase := nerdtest.Setup()
 
@@ -246,7 +246,7 @@ services:
       - sh
       - -c
       - "echo $$FOO"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -276,7 +276,7 @@ services:
     entrypoint:
       - id
       - -u
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -306,7 +306,7 @@ services:
       - "dummy log"
     labels:
       - "foo=bar"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -340,7 +340,7 @@ services:
     image: %s
     entrypoint:
       - echo
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -369,7 +369,7 @@ services:
     image: %s
     entrypoint:
       - stty # should be changed
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -396,7 +396,7 @@ services:
     image: %s
     entrypoint:
     - stty # no meaning, just put any command
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -480,7 +480,7 @@ services:
 `, imageSvc0, keyPair.PublicKey, keyPair.PrivateKey,
 		imageSvc1, keyPair.PrivateKey, imageSvc2)
 
-	dockerfile := fmt.Sprintf(`FROM %s`, testutil.AlpineImage)
+	dockerfile := fmt.Sprintf(`FROM %s`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()

--- a/cmd/nerdctl/compose/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose/compose_up_linux_test.go
@@ -40,8 +40,6 @@ import (
 func TestComposeUp(t *testing.T) {
 	base := testutil.NewBase(t)
 	helpers.ComposeUp(t, base, fmt.Sprintf(`
-version: '3.1'
-
 services:
 
   wordpress:
@@ -117,8 +115,6 @@ func TestComposeUpNetWithStaticIP(t *testing.T) {
 	base := testutil.NewBase(t)
 	staticIP := "172.20.0.12"
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -155,8 +151,6 @@ func TestComposeUpMultiNet(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc0:
     image: %s
@@ -204,8 +198,6 @@ func TestComposeUpOsEnvVar(t *testing.T) {
 	base := testutil.NewBase(t)
 	const containerName = "nginxAlpine"
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   svc1:
     image: %s
@@ -237,8 +229,6 @@ func TestComposeUpDotEnvFile(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = `
-version: '3.1'
-
 services:
   svc3:
     image: ghcr.io/stargz-containers/nginx:$TAG
@@ -260,8 +250,6 @@ func TestComposeUpEnvFileNotFoundError(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = `
-version: '3.1'
-
 services:
   svc4:
     image: ghcr.io/stargz-containers/nginx:$TAG
@@ -284,8 +272,6 @@ func TestComposeUpWithScale(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   test:
     image: %s
@@ -307,8 +293,6 @@ func TestComposeIPAMConfig(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   foo:
     image: %s
@@ -337,8 +321,6 @@ func TestComposeUpRemoveOrphans(t *testing.T) {
 
 	var (
 		dockerComposeYAMLOrphan = fmt.Sprintf(`
-version: '3.1'
-
 services:
   test:
     image: %s
@@ -375,8 +357,6 @@ func TestComposeUpIdempotent(t *testing.T) {
 	base := testutil.NewBase(t)
 
 	var dockerComposeYAML = fmt.Sprintf(`
-version: '3.1'
-
 services:
   test:
     image: %s
@@ -399,7 +379,6 @@ func TestComposeUpWithExternalNetwork(t *testing.T) {
 	containerName2 := testutil.Identifier(t) + "-2"
 	networkName := testutil.Identifier(t) + "-network"
 	var dockerComposeYaml1 = fmt.Sprintf(`
-version: "3"
 services:
   %s:
     image: %s
@@ -413,7 +392,6 @@ networks:
     external: true
 `, containerName1, testutil.NginxAlpineImage, containerName1, networkName, networkName)
 	var dockerComposeYaml2 = fmt.Sprintf(`
-version: "3"
 services:
   %s:
     image: %s
@@ -457,8 +435,6 @@ func TestComposeUpWithBypass4netns(t *testing.T) {
 	testutil.RequireSystemService(t, "bypass4netnsd")
 	base := testutil.NewBase(t)
 	helpers.ComposeUp(t, base, fmt.Sprintf(`
-version: '3.1'
-
 services:
 
   wordpress:

--- a/cmd/nerdctl/compose/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose/compose_up_linux_test.go
@@ -276,7 +276,7 @@ services:
   test:
     image: %s
     command: "sleep infinity"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -303,7 +303,7 @@ networks:
     ipam:
       config:
         - subnet: 10.1.100.0/24
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()
@@ -325,14 +325,14 @@ services:
   test:
     image: %s
     command: "sleep infinity"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 		dockerComposeYAMLFull = fmt.Sprintf(`
 %s
   orphan:
     image: %s
     command: "sleep infinity"
-`, dockerComposeYAMLOrphan, testutil.AlpineImage)
+`, dockerComposeYAMLOrphan, testutil.CommonImage)
 	)
 
 	compOrphan := testutil.NewComposeDir(t, dockerComposeYAMLOrphan)
@@ -361,7 +361,7 @@ services:
   test:
     image: %s
     command: "sleep infinity"
-`, testutil.AlpineImage)
+`, testutil.CommonImage)
 
 	comp := testutil.NewComposeDir(t, dockerComposeYAML)
 	defer comp.CleanUp()

--- a/cmd/nerdctl/compose/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose/compose_up_linux_test.go
@@ -533,8 +533,6 @@ func TestComposeUpAbortOnContainerExit(t *testing.T) {
 services:
   %s:
     image: %s
-    ports:
-      - 8080:80
   %s:
     image: %s
     entrypoint: /bin/sh -c "exit 1"

--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -535,8 +534,7 @@ RUN groupadd -r test && useradd -r -g test test
 USER test
 `, testutil.UbuntuImage)
 
-			err := os.WriteFile(filepath.Join(data.Temp().Path(), "Dockerfile"), []byte(dockerfile), 0o600)
-			assert.NilError(helpers.T(), err)
+			data.Temp().Save(dockerfile, "Dockerfile")
 
 			helpers.Ensure("build", "-t", data.Identifier(), data.Temp().Path())
 			helpers.Ensure("create", "--name", data.Identifier(), "--user", "test", data.Identifier())

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -19,8 +19,6 @@ package image
 import (
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -149,8 +147,7 @@ LABEL version=0.1
 RUN echo "actually creating a layer so that docker sets the createdAt time"
 `, testutil.CommonImage)
 			buildCtx := data.Temp().Path()
-			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-			assert.NilError(helpers.T(), err)
+			data.Temp().Save(dockerfile, "Dockerfile")
 			data.Labels().Set("buildCtx", buildCtx)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {
@@ -296,8 +293,7 @@ func TestImagesFilterDangling(t *testing.T) {
 CMD ["echo", "nerdctl-build-notag-string"]
 	`, testutil.CommonImage)
 			buildCtx := data.Temp().Path()
-			err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-			assert.NilError(helpers.T(), err)
+			data.Temp().Save(dockerfile, "Dockerfile")
 			data.Labels().Set("buildCtx", buildCtx)
 		},
 		Cleanup: func(data test.Data, helpers test.Helpers) {

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -18,8 +18,6 @@ package image
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -72,8 +70,7 @@ func TestImagePrune(t *testing.T) {
 					`, testutil.CommonImage)
 
 				buildCtx := data.Temp().Path()
-				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-				assert.NilError(helpers.T(), err)
+				data.Temp().Save(dockerfile, "Dockerfile")
 				helpers.Ensure("build", buildCtx)
 				// After we rebuild with tag, docker will no longer show the <none> version from above
 				// Swapping order does not change anything.
@@ -120,8 +117,7 @@ func TestImagePrune(t *testing.T) {
 					`, testutil.CommonImage)
 
 				buildCtx := data.Temp().Path()
-				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-				assert.NilError(helpers.T(), err)
+				data.Temp().Save(dockerfile, "Dockerfile")
 				helpers.Ensure("build", buildCtx)
 				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
@@ -164,8 +160,7 @@ CMD ["echo", "nerdctl-test-image-prune-filter-label"]
 LABEL foo=bar
 LABEL version=0.1`, testutil.CommonImage)
 				buildCtx := data.Temp().Path()
-				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-				assert.NilError(helpers.T(), err)
+				data.Temp().Save(dockerfile, "Dockerfile")
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())
@@ -204,8 +199,7 @@ LABEL version=0.1`, testutil.CommonImage)
 RUN echo "Anything, so that we create actual content for docker to set the current time for CreatedAt"
 CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 				buildCtx := data.Temp().Path()
-				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-				assert.NilError(helpers.T(), err)
+				data.Temp().Save(dockerfile, "Dockerfile")
 				helpers.Ensure("build", "-t", data.Identifier(), buildCtx)
 				imgList := helpers.Capture("images")
 				assert.Assert(t, strings.Contains(imgList, data.Identifier()), "Missing "+data.Identifier())

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -19,7 +19,6 @@ package ipfs
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -138,8 +137,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 	`, data.Labels().Get(ipfsImageURLKey))
 
 				buildCtx := data.Temp().Path()
-				err := os.WriteFile(filepath.Join(buildCtx, "Dockerfile"), []byte(dockerfile), 0o600)
-				assert.NilError(helpers.T(), err)
+				data.Temp().Save(dockerfile, "Dockerfile")
 
 				helpers.Ensure("build", "-t", data.Identifier("built-image"), buildCtx)
 			},


### PR DESCRIPTION
~~On top of #4203 and #4209~~

In a shell:
- remove compose yaml `version` field (deprecated, only adds noise to the logs)
- remove useless port bindings preventing parallelization
- move some tests from `Alpine` to `Common`
- use data.Temp() for assets to simplify temp files handling