### PR TITLE
feat: Add container health check support [WIP]

### DIFF
--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -258,6 +258,37 @@ func createOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
 	}
 	// #endregion
 
+	// #region for healthcheck flags
+	opt.HealthCmd, err = cmd.Flags().GetString("health-cmd")
+	if err != nil {
+		return opt, err
+	}
+	opt.HealthInterval, err = cmd.Flags().GetDuration("health-interval")
+	if err != nil {
+		return opt, err
+	}
+	opt.HealthTimeout, err = cmd.Flags().GetDuration("health-timeout")
+	if err != nil {
+		return opt, err
+	}
+	opt.HealthRetries, err = cmd.Flags().GetInt("health-retries")
+	if err != nil {
+		return opt, err
+	}
+	opt.HealthStartPeriod, err = cmd.Flags().GetDuration("health-start-period")
+	if err != nil {
+		return opt, err
+	}
+	opt.HealthStartInterval, err = cmd.Flags().GetDuration("health-start-interval")
+	if err != nil {
+		return opt, err
+	}
+	opt.NoHealthcheck, err = cmd.Flags().GetBool("no-healthcheck")
+	if err != nil {
+		return opt, err
+	}
+	// #endregion
+
 	// #region for intel RDT flags
 	opt.RDTClass, err = cmd.Flags().GetString("rdt-class")
 	if err != nil {

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -234,6 +234,15 @@ func setCreateFlags(cmd *cobra.Command) {
 	// rootfs flags (from Podman)
 	cmd.Flags().Bool("rootfs", false, "The first argument is not an image but the rootfs to the exploded container")
 
+	// Health check flags
+	cmd.Flags().String("health-cmd", "", "Command to run to check health")
+	cmd.Flags().Duration("health-interval", 0, "Time between running the check (default: 30s)")
+	cmd.Flags().Duration("health-timeout", 0, "Maximum time to allow one check to run (default: 30s)")
+	cmd.Flags().Int("health-retries", 0, "Consecutive failures needed to report unhealthy")
+	cmd.Flags().Duration("health-start-period", 0, "Start period for the container to initialize before starting health-retries countdown")
+	cmd.Flags().Duration("health-start-interval", 0, "Time between running the check during the start period")
+	cmd.Flags().Bool("no-healthcheck", false, "Disable any container-specified HEALTHCHECK")
+
 	// #region env flags
 	// entrypoint needs to be StringArray, not StringSlice, to prevent "FOO=foo1,foo2" from being split to {"FOO=foo1", "foo2"}
 	// entrypoint StringArray is an internal implementation to support `nerdctl compose` entrypoint yaml filed with multiple strings

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -320,6 +320,16 @@ Metadata flags:
 - :whale: :blue_square: `--cidfile`: Write the container ID to the file
 - :nerd_face: `--pidfile`: file path to write the task's pid. The CLI syntax conforms to Podman convention.
 
+Health check flags:
+
+- :whale: :blue_square: `--health-cmd`: Command to run to check container health
+- :whale: :blue_square: `--health-interval`: Time between running the check (e.g., 30s, 1m)
+- :whale: :blue_square: `--health-timeout`: Time to wait before considering the check failed (e.g., 5s)
+- :whale: :blue_square: `--health-retries`: Number of failures before container is considered unhealthy
+- :whale: :blue_square: `--health-start-period`: Time to wait after container starts before running the first check (e.g., 10s)
+- :whale: :blue_square: `--health-start-interval`: Interval between checks during the start period
+- :whale: :blue_square: `--no-healthcheck`: Disable any health checks defined by image or CLI
+
 Logging flags:
 
 - :whale: `--log-driver=(json-file|journald|fluentd|syslog|none)`: Logging driver for the container (default `json-file`).
@@ -427,7 +437,7 @@ IPFS flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker run` flags:
-    `--device-cgroup-rule`, `--disable-content-trust`, `--expose`, `--health-*`, `--isolation`, `--no-healthcheck`,
+    `--device-cgroup-rule`, `--disable-content-trust`, `--expose`, `--isolation`,
     `--link*`, `--publish-all`, `--storage-opt`, `--volume-driver`
 
 ### :whale: :blue_square: nerdctl exec

--- a/docs/healthchecks.md
+++ b/docs/healthchecks.md
@@ -1,0 +1,30 @@
+# Health Check Support in nerdctl [WIP]
+
+`nerdctl` supports Docker-compatible health checks for containers, allowing users to monitor container health via a user-defined command.
+
+Health checks can be configured in multiple ways:
+
+1. At container creation time using nerdctl run or nerdctl create with --health-* flags
+2. At image build time using HEALTHCHECK in a Dockerfile
+3. In docker-compose.yaml files, if using nerdctl compose
+
+When a container is created, nerdctl determines the health check configuration based on the following priority:
+
+1. **CLI flags** take highest precedence (e.g., `--health-cmd`, etc.)
+2. If no CLI flags are set, nerdctl will use any health check defined in the image.
+3. If neither is present, no health check will be configured
+
+### Disabling Health Checks
+
+You can disable health checks using the following flag during container create/run:
+
+```bash
+--no-healthcheck
+```
+---
+
+### Example
+
+```bash
+nerdctl run --name web --health-cmd="curl -f http://localhost || exit 1" --health-interval=30s --health-timeout=5s --health-retries=3 nginx
+```

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -286,6 +286,15 @@ type ContainerCreateOptions struct {
 	// ImagePullOpt specifies image pull options which holds the ImageVerifyOptions for verifying the image.
 	ImagePullOpt ImagePullOptions
 
+	// Healthcheck related fields
+	HealthCmd           string
+	HealthInterval      time.Duration
+	HealthTimeout       time.Duration
+	HealthRetries       int
+	HealthStartPeriod   time.Duration
+	HealthStartInterval time.Duration
+	NoHealthcheck       bool
+
 	// UserNS name for user namespace mapping of container
 	UserNS string
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -1,0 +1,61 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// Healthcheck represents the health check configuration
+type Healthcheck struct {
+	// Test is the test to perform to check that the container is healthy
+	Test []string `json:"Test,omitempty"`
+
+	// Interval is the time to wait between checks
+	Interval time.Duration `json:"Interval,omitempty"`
+
+	// Timeout is the time to wait before considering the check to have hung
+	Timeout time.Duration `json:"Timeout,omitempty"`
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy
+	Retries int `json:"Retries,omitempty"`
+
+	// StartPeriod is the period for the container to initialize before the health check starts
+	StartPeriod time.Duration `json:"StartPeriod,omitempty"`
+
+	// StartInterval is the time between health checks during the start period
+	StartInterval time.Duration `json:"StartInterval,omitempty"`
+}
+
+// ToJSONString serializes a Healthcheck struct to a JSON string
+func ToJSONString(hc *Healthcheck) (string, error) {
+	b, err := json.Marshal(hc)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// Parse deserializes a JSON string into a Healthcheck struct
+func Parse(s string) (*Healthcheck, error) {
+	var hc Healthcheck
+	if err := json.Unmarshal([]byte(s), &hc); err != nil {
+		return nil, err
+	}
+	return &hc, nil
+}

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -22,15 +22,21 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"gotest.tools/v3/assert"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/images"
 
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
 func TestContainerFromNative(t *testing.T) {
@@ -40,6 +46,14 @@ func TestContainerFromNative(t *testing.T) {
 	}
 	os.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
 	defer os.RemoveAll(tempStateDir)
+
+	hc := &healthcheck.Healthcheck{
+		Test:        []string{"CMD-SHELL", "curl -f http://localhost || exit 1"},
+		Interval:    30000000000,
+		Timeout:     5000000000,
+		Retries:     3,
+		StartPeriod: 2000000000,
+	}
 
 	testcase := []struct {
 		name     string
@@ -298,6 +312,51 @@ func TestContainerFromNative(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "container with healthcheck label",
+			n: &native.Container{
+				Container: containers.Container{
+					Labels: map[string]string{
+						labels.HealthCheck: mustJSON(hc),
+					},
+				},
+				Spec: &specs.Spec{},
+				Process: &native.Process{
+					Status: containerd.Status{
+						Status: "running",
+					},
+				},
+			},
+			expected: &Container{
+				Created:  "0001-01-01T00:00:00Z",
+				Platform: "linux",
+				Mounts:   []MountPoint{},
+				State: &ContainerState{
+					Status:     "running",
+					Running:    true,
+					Pid:        0,
+					FinishedAt: "",
+				},
+				HostConfig: &HostConfig{
+					LogConfig:          loggerLogConfig{Driver: "json-file", Opts: map[string]string{}},
+					PortBindings:       nat.PortMap{},
+					GroupAdd:           []string{},
+					Tmpfs:              map[string]string{},
+					UTSMode:            "host",
+					LinuxBlkioSettings: getDefaultLinuxBlkioSettings(),
+				},
+				NetworkSettings: &NetworkSettings{
+					Ports:    &nat.PortMap{},
+					Networks: map[string]*NetworkEndpointSettings{},
+				},
+				Config: &Config{
+					Labels: map[string]string{
+						labels.HealthCheck: mustJSON(hc),
+					},
+					Healthcheck: hc,
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcase {
@@ -510,4 +569,104 @@ func TestCpuSettingsFromNative(t *testing.T) {
 			assert.DeepEqual(t, result, tc.expected)
 		})
 	}
+}
+
+func TestImageFromNative(t *testing.T) {
+	t.Run("parses RepoTags/Digests and RootFS Layers", func(t *testing.T) {
+		createdTime := time.Now().UTC()
+
+		img := native.Image{
+			Image: images.Image{
+				Name: "myrepo/myimage:custom",
+				Target: ocispec.Descriptor{
+					Digest: digest.Digest("sha256:targetdigest"),
+				},
+			},
+			ImageConfigDesc: ocispec.Descriptor{
+				Digest: digest.Digest("sha256:configdigest"),
+			},
+			ImageConfig: ocispec.Image{
+				RootFS: ocispec.RootFS{
+					Type:    "layers",
+					DiffIDs: []digest.Digest{"sha256:layer1", "sha256:layer2"},
+				},
+				History: []ocispec.History{
+					{
+						Created: &createdTime,
+						Author:  "test-author",
+						Comment: "test-comment",
+					},
+				},
+			},
+		}
+
+		out, err := ImageFromNative(&img)
+		assert.NilError(t, err)
+
+		// ID, tags, digests
+		assert.Equal(t, out.ID, "sha256:configdigest")
+		assert.Equal(t, out.RepoTags[0], "myrepo/myimage:custom")
+		assert.Equal(t, out.RepoDigests[0], "myrepo/myimage@sha256:targetdigest")
+
+		// RootFS
+		assert.DeepEqual(t, out.RootFS.Layers, []string{"sha256:layer1", "sha256:layer2"})
+
+		// History
+		assert.Equal(t, out.Author, "test-author")
+		assert.Equal(t, out.Comment, "test-comment")
+		assert.Equal(t, out.Created, createdTime.Format(time.RFC3339Nano))
+	})
+
+	t.Run("parses Healthcheck label", func(t *testing.T) {
+		testcases := []struct {
+			name     string
+			labels   map[string]string
+			expected *healthcheck.Healthcheck
+		}{
+			{
+				name: "Valid Healthcheck Label",
+				labels: map[string]string{
+					labels.HealthCheck: `{
+						"test": ["CMD-SHELL", "curl -f http://localhost/ || exit 1"],
+						"interval": 30000000000,
+						"timeout": 5000000000
+					}`,
+				},
+				expected: &healthcheck.Healthcheck{
+					Test:     []string{"CMD-SHELL", "curl -f http://localhost/ || exit 1"},
+					Interval: 30000000000,
+					Timeout:  5000000000,
+				},
+			},
+			{
+				name:     "No Healthcheck Label",
+				labels:   map[string]string{},
+				expected: nil,
+			},
+		}
+
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				img := native.Image{
+					ImageConfig: ocispec.Image{
+						Config: ocispec.ImageConfig{
+							Labels: tc.labels,
+						},
+					},
+				}
+
+				out, err := ImageFromNative(&img)
+				assert.NilError(t, err)
+				assert.DeepEqual(t, out.Config.Healthcheck, tc.expected)
+			})
+		}
+	})
+}
+
+func mustJSON(h *healthcheck.Healthcheck) string {
+	s, err := healthcheck.ToJSONString(h)
+	if err != nil {
+		panic(err)
+	}
+	return s
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -118,4 +118,7 @@ const (
 
 	// User is the username of the container
 	User = Prefix + "user"
+
+	// HealthCheck stores the health check configuration used to run health checks on the container
+	HealthCheck = Prefix + "healthcheck"
 )


### PR DESCRIPTION
This PR introduces support for Docker-compatible health check flags in `nerdctl run` and `nerdctl create`. Health check config is determined by:
1. CLI flags (highest precedence)
2. Image-defined health checks (if present)
3. No health check (default) 

Merged health check config is serialized and stored in an internal label  `nerdctl/healthcheck`.
When ensuring image, if health checks are defined in image, they are extracted and stored as image labels.
Added tests for image parsing, CLI flag validation and merging behavior.

TODO
1. Introduce health check function to perform the actual health checks and update container health status.
2. Orchestrate health checks using systemd

https://github.com/containerd/nerdctl/issues/4157