### PR TITLE
[cleanup]: golang linter QF1012 to enforce fmt.Fprintf usage

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,9 +53,6 @@ linters:
         - "-ST1022"
 
         ##### TODO: fix and enable these
-        # 4 occurrences.
-        # Use fmt.Fprintf(x, ...) instead of x.Write(fmt.Sprintf(...)) https://staticcheck.dev/docs/checks#QF1012
-        - "-QF1012"
         # 6 occurrences.
         # Apply De Morgan’s law https://staticcheck.dev/docs/checks#QF1001
         - "-QF1001"

--- a/pkg/logging/cri_logger_test.go
+++ b/pkg/logging/cri_logger_test.go
@@ -184,12 +184,12 @@ func TestReadLogsLimitsWithTimestamps(t *testing.T) {
 	count := 10000
 
 	for i := 0; i < count; i++ {
-		tmpfile.WriteString(fmt.Sprintf(logLineFmt, i))
+		fmt.Fprintf(tmpfile, logLineFmt, i)
 	}
 	tmpfile.WriteString(logLineNewLine)
 
 	for i := 0; i < count; i++ {
-		tmpfile.WriteString(fmt.Sprintf(logLineFmt, i))
+		fmt.Fprintf(tmpfile, logLineFmt, i)
 	}
 	tmpfile.WriteString(logLineNewLine)
 
@@ -271,11 +271,10 @@ func TestReadRotatedLog(t *testing.T) {
 		// Write the first three lines to log file
 		now := time.Now().Format(time.RFC3339Nano)
 		if line%2 == 0 {
-			file.WriteString(fmt.Sprintf(
-				"%s stdout P line%d\n", now, line))
+			fmt.Fprintf(file, "%s stdout P line%d\n", now, line)
+
 		} else {
-			file.WriteString(fmt.Sprintf(
-				"%s stderr P line%d\n", now, line))
+			fmt.Fprintf(file, "%s stderr P line%d\n", now, line)
 		}
 
 		time.Sleep(1 * time.Millisecond)


### PR DESCRIPTION
Enable staticcheck linter QF1012 to detect and replace `x.Write(fmt.Sprintf(...))` patterns
And updated non-compliant code.