### PR TITLE
fix: allow containers to start using a large numbers of ports

### DIFF
--- a/cmd/nerdctl/compose/compose_port.go
+++ b/cmd/nerdctl/compose/compose_port.go
@@ -88,11 +88,18 @@ func portAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	dataStore, err := clientutil.DataStore(globalOptions.DataRoot, globalOptions.Address)
+	if err != nil {
+		return err
+	}
+
 	po := composer.PortOptions{
 		ServiceName: args[0],
 		Index:       index,
 		Port:        port,
 		Protocol:    protocol,
+		DataStore:   dataStore,
+		Namespace:   globalOptions.Namespace,
 	}
 
 	return c.Port(ctx, cmd.OutOrStdout(), po)

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/containerd/containerd/v2/defaults"
 	"github.com/containerd/containerd/v2/pkg/netns"
-	"github.com/containerd/errdefs"
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
@@ -409,21 +408,21 @@ func TestRunPort(t *testing.T) {
 	baseTestRunPort(t, testutil.NginxAlpineImage, testutil.NginxAlpineIndexHTMLSnippet, true)
 }
 
-func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
+func TestRunWithManyPortsThenCleanUp(t *testing.T) {
 	testCase := nerdtest.Setup()
 	// docker does not set label restriction to 4096 bytes
 	testCase.Require = require.Not(nerdtest.Docker)
 
 	testCase.SubTests = []*test.Case{
 		{
-			Description: "Run a container with invalid ports, and then clean up.",
+			Description: "Run a container with many ports, and then clean up.",
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("run", "--data-root", data.Temp().Path(), "--rm", "-p", "22200-22299:22200-22299", testutil.CommonImage)
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					ExitCode: 1,
-					Errors:   []error{errdefs.ErrInvalidArgument},
+					ExitCode: 0,
+					Errors:   []error{},
 					Output: func(stdout string, t tig.T) {
 						getAddrHash := func(addr string) string {
 							const addrHashLen = 8

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -35,6 +35,7 @@ Files:
 - `<CID>-json.log`: used by `nerdctl logs`
 - `oci-hook.*.log`: logs of the OCI hook
 - `lifecycle.json`: used to store stateful information about the container that can only be retrieved through OCI hooks
+- `network-config.json`: used to store port mapping information for containers run with the `-p` option.
 
 ### `<DATAROOT>/<ADDRHASH>/names/<NAMESPACE>`
 e.g. `/var/lib/nerdctl/1935db59/names/default`

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil/volumestore"
 	"github.com/containerd/nerdctl/v2/pkg/namestore"
+	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/store"
 )
 
@@ -191,6 +192,18 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		}
 
 		netOpts, err := containerutil.NetworkOptionsFromSpec(spec)
+		if err != nil {
+			retErr = err
+			return
+		}
+
+		portSlice, err := portutil.LoadPortMappings(dataStore, globalOptions.Namespace, id, containerLabels)
+		if err != nil {
+			retErr = err
+			return
+		}
+		netOpts.PortMappings = portSlice
+
 		if err == nil {
 			networkManager, err := containerutil.NewNetworkingOptionsManager(globalOptions, netOpts, client)
 			if err != nil {

--- a/pkg/composer/port.go
+++ b/pkg/composer/port.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
+	"github.com/containerd/nerdctl/v2/pkg/portutil"
 )
 
 // PortOptions has args for getting the public port of a given private port/protocol
@@ -31,6 +32,8 @@ type PortOptions struct {
 	Index       int
 	Port        int
 	Protocol    string
+	DataStore   string
+	Namespace   string
 }
 
 // Port gets the corresponding public port of a given private port/protocol
@@ -48,6 +51,13 @@ func (c *Composer) Port(ctx context.Context, writer io.Writer, po PortOptions) e
 			po.Index, len(containers), po.ServiceName)
 	}
 	container := containers[po.Index-1]
-
-	return containerutil.PrintHostPort(ctx, writer, container, po.Port, po.Protocol)
+	containerLabels, err := container.Labels(ctx)
+	if err != nil {
+		return err
+	}
+	ports, err := portutil.LoadPortMappings(po.DataStore, po.Namespace, container.ID(), containerLabels)
+	if err != nil {
+		return err
+	}
+	return containerutil.PrintHostPort(ctx, writer, container, po.Port, po.Protocol, ports)
 }

--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -893,12 +893,6 @@ func NetworkOptionsFromSpec(spec *specs.Spec) (types.NetworkOptions, error) {
 	}
 	opts.NetworkSlice = networks
 
-	if portsJSON := spec.Annotations[labels.Ports]; portsJSON != "" {
-		if err := json.Unmarshal([]byte(portsJSON), &opts.PortMappings); err != nil {
-			return opts, err
-		}
-	}
-
 	return opts, nil
 }
 

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
@@ -50,7 +51,6 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/labels/k8slabels"
-	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -59,16 +59,7 @@ import (
 
 // PrintHostPort writes to `writer` the public (HostIP:HostPort) of a given `containerPort/protocol` in a container.
 // if `containerPort < 0`, it writes all public ports of the container.
-func PrintHostPort(ctx context.Context, writer io.Writer, container containerd.Container, containerPort int, proto string) error {
-	l, err := container.Labels(ctx)
-	if err != nil {
-		return err
-	}
-	ports, err := portutil.ParsePortsLabel(l)
-	if err != nil {
-		return err
-	}
-
+func PrintHostPort(ctx context.Context, writer io.Writer, container containerd.Container, containerPort int, proto string, ports []cni.PortMapping) error {
 	if containerPort < 0 {
 		for _, p := range ports {
 			fmt.Fprintf(writer, "%d/%s -> %s:%d\n", p.ContainerPort, p.Protocol, p.HostIP, p.HostPort)

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -33,9 +33,7 @@ import (
 	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/errdefs"
-	"github.com/containerd/log"
-
-	"github.com/containerd/nerdctl/v2/pkg/portutil"
+	"github.com/containerd/go-cni"
 )
 
 func ContainerStatus(ctx context.Context, c containerd.Container) string {
@@ -112,11 +110,7 @@ func Ellipsis(str string, maxDisplayWidth int) string {
 	return str[:maxDisplayWidth-1] + "…"
 }
 
-func FormatPorts(labelMap map[string]string) string {
-	ports, err := portutil.ParsePortsLabel(labelMap)
-	if err != nil {
-		log.L.Error(err.Error())
-	}
+func FormatPorts(ports []cni.PortMapping) string {
 	if len(ports) == 0 {
 		return ""
 	}

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -33,6 +33,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/go-cni"
 
 	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
@@ -413,11 +414,17 @@ func TestNetworkSettingsFromNative(t *testing.T) {
 						Addrs:        []string{"10.0.4.30/24"},
 					},
 				},
+				PortMappings: []cni.PortMapping{
+					{
+						HostPort:      8075,
+						ContainerPort: 77,
+						Protocol:      "tcp",
+						HostIP:        "127.0.0.1",
+					},
+				},
 			},
 			s: &specs.Spec{
-				Annotations: map[string]string{
-					"nerdctl/ports": "[{\"HostPort\":8075,\"ContainerPort\":77,\"Protocol\":\"tcp\",\"HostIP\":\"127.0.0.1\"}]",
-				},
+				Annotations: map[string]string{},
 			},
 			expected: &NetworkSettings{
 				Ports: &nat.PortMap{

--- a/pkg/inspecttypes/native/container.go
+++ b/pkg/inspecttypes/native/container.go
@@ -21,6 +21,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/go-cni"
 )
 
 // Container corresponds to a containerd-native container object.
@@ -43,6 +44,7 @@ type NetNS struct {
 	// Zero means unset.
 	PrimaryInterface int            `json:"PrimaryInterface,omitempty"`
 	Interfaces       []NetInterface `json:"Interfaces,omitempty"`
+	PortMappings     []cni.PortMapping
 }
 
 // NetInterface wraps net.Interface for JSON marshallability.

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -57,6 +57,7 @@ const (
 	// Currently, the length of the slice must be 1.
 	Networks = Prefix + "networks"
 
+	// DEPRECATED : https://github.com/containerd/nerdctl/pull/4290
 	// Ports is a JSON-marshalled string of []cni.PortMapping .
 	Ports = Prefix + "ports"
 

--- a/pkg/netutil/networkstore/networkstore.go
+++ b/pkg/netutil/networkstore/networkstore.go
@@ -1,0 +1,110 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package networkstore
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/containerd/go-cni"
+
+	"github.com/containerd/nerdctl/v2/pkg/store"
+)
+
+const (
+	containersDirBaseName = "containers"
+	networkConfigName     = "network-config.json"
+)
+
+var ErrNetworkStore = errors.New("network-store error")
+
+func New(dataStore, namespace, containerID string) (ns *NetworkStore, err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Join(ErrNetworkStore, err)
+		}
+	}()
+
+	if dataStore == "" || namespace == "" || containerID == "" {
+		return nil, fmt.Errorf("either dataStore or namespace or containerID is empty")
+	}
+
+	st, err := store.New(filepath.Join(dataStore, containersDirBaseName, namespace, containerID), 0, 0o600)
+	if err != nil {
+		return nil, err
+	}
+
+	return &NetworkStore{
+		safeStore: st,
+	}, nil
+}
+
+type NetworkStore struct {
+	safeStore store.Store
+
+	PortMappings []cni.PortMapping
+}
+
+func (ns *NetworkStore) Acquire(portMappings []cni.PortMapping) (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Join(ErrNetworkStore, err)
+		}
+	}()
+
+	portsJSON, err := json.Marshal(portMappings)
+	if err != nil {
+		return fmt.Errorf("failed to marshal port mappings to JSON: %w", err)
+	}
+
+	return ns.safeStore.WithLock(func() error {
+		return ns.safeStore.Set(portsJSON, networkConfigName)
+	})
+}
+
+func (ns *NetworkStore) Load() (err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Join(ErrNetworkStore, err)
+		}
+	}()
+
+	return ns.safeStore.WithLock(func() error {
+		doesExist, err := ns.safeStore.Exists(networkConfigName)
+		if err != nil || !doesExist {
+			return err
+		}
+
+		data, err := ns.safeStore.Get(networkConfigName)
+		if err != nil {
+			if errors.Is(err, store.ErrNotFound) {
+				err = nil
+			}
+			return err
+		}
+
+		var ports []cni.PortMapping
+		if err := json.Unmarshal(data, &ports); err != nil {
+			return fmt.Errorf("failed to parse port mappings %v: %w", ports, err)
+		}
+		ns.PortMappings = ports
+
+		return err
+	})
+}

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -45,6 +45,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil/nettype"
 	"github.com/containerd/nerdctl/v2/pkg/ocihook/state"
+	"github.com/containerd/nerdctl/v2/pkg/portutil"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/store"
 )
@@ -208,11 +209,11 @@ func newHandlerOpts(state *specs.State, dataStore, cniPath, cniNetconfPath, brid
 		}
 	}
 
-	if portsJSON := o.state.Annotations[labels.Ports]; portsJSON != "" {
-		if err := json.Unmarshal([]byte(portsJSON), &o.ports); err != nil {
-			return nil, err
-		}
+	ports, err := portutil.LoadPortMappings(o.dataStore, namespace, o.state.ID, o.state.Annotations)
+	if err != nil {
+		return nil, err
 	}
+	o.ports = ports
 
 	if ipAddress, ok := o.state.Annotations[labels.IPAddress]; ok {
 		o.containerIP = ipAddress

--- a/pkg/portutil/portutil_test.go
+++ b/pkg/portutil/portutil_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/containerd/go-cni"
 
-	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
@@ -142,81 +141,6 @@ func TestParseFlagPWithPlatformSpec(t *testing.T) {
 						got[len(got)-1].ContainerPort-got[0].ContainerPort,
 					)
 					for i := range len(got) {
-						assert.Equal(t, got[i].ContainerPort, tt.want[i].ContainerPort)
-						assert.Equal(t, got[i].Protocol, tt.want[i].Protocol)
-						assert.Equal(t, got[i].HostIP, tt.want[i].HostIP)
-					}
-				}
-			}
-		})
-	}
-}
-
-func TestParsePortsLabel(t *testing.T) {
-	tests := []struct {
-		name     string
-		labelMap map[string]string
-		want     []cni.PortMapping
-		wantErr  bool
-	}{
-		{
-			name: "normal",
-			labelMap: map[string]string{
-				labels.Ports: "[{\"HostPort\":12345,\"ContainerPort\":10000,\"Protocol\":\"tcp\",\"HostIP\":\"0.0.0.0\"}]",
-			},
-			want: []cni.PortMapping{
-				{
-					HostPort:      12345,
-					ContainerPort: 10000,
-					Protocol:      "tcp",
-					HostIP:        "0.0.0.0",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "empty ports (value empty)",
-			labelMap: map[string]string{
-				labels.Ports: "",
-			},
-			want:    []cni.PortMapping{},
-			wantErr: false,
-		},
-		{
-			name:     "empty ports (key not exists)",
-			labelMap: map[string]string{},
-			want:     []cni.PortMapping{},
-			wantErr:  false,
-		},
-		{
-			name: "parse error (wrong format)",
-			labelMap: map[string]string{
-				labels.Ports: "{\"HostPort\":12345,\"ContainerPort\":10000,\"Protocol\":\"tcp\",\"HostIP\":\"0.0.0.0\"}",
-			},
-			want:    nil,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParsePortsLabel(tt.labelMap)
-			if err != nil {
-				t.Log(err)
-				assert.Equal(t, true, tt.wantErr)
-			}
-			if !reflect.DeepEqual(got, tt.want) {
-				assert.Equal(t, len(got), len(tt.want))
-				if len(got) > 0 {
-					sort.Slice(got, func(i, j int) bool {
-						return got[i].HostPort < got[j].HostPort
-					})
-					assert.Equal(
-						t,
-						got[len(got)-1].HostPort-got[0].HostPort,
-						got[len(got)-1].ContainerPort-got[0].ContainerPort,
-					)
-					for i := range len(got) {
-						assert.Equal(t, got[i].HostPort, tt.want[i].HostPort)
 						assert.Equal(t, got[i].ContainerPort, tt.want[i].ContainerPort)
 						assert.Equal(t, got[i].Protocol, tt.want[i].Protocol)
 						assert.Equal(t, got[i].HostIP, tt.want[i].HostIP)


### PR DESCRIPTION
Suppose we have a compose.yaml that allocates a large numbers of ports as follows.

```
> cat compose.yaml
services:
  svc0:
    image: alpine
    command: "sleep infinity"
    ports:
      - '32000-32060:32000-32060'
```

When we run `nerdctl compose up -d` using this compose.yaml, we will get the following error.

```
FATA[0000] create container failed validation: containers.Labels: label key and value length (4711 bytes) greater than maximum size (4096 bytes), key: nerdctl/ports: invalid argument
FATA[0000] error while creating container haytok-svc0-1: error while creating container haytok-svc0-1: exit status 1
```

This issue is reported in the following issue.

- https://github.com/containerd/nerdctl/issues/4027

This issue is considered to be the same as the one with errors when trying to perform many port mappings, such as `nerdctl run -p 80:80 -p 81:81 ~ -p 1000:1000 ...`

The current implementation is processing to create a container with the information specified in `-p` to the label.
And as can be seen from the error message, as the number of ports to be port mapped increases, the creation of the container fails because it violates the limit of the maximum number of bytes on the containerd side that can be allocated for a label.

Therefore, this PR modifies the container creation process so that containers can be launched without having to assign the information specified in the `-p` option to the labels.

Specifically, port mapping information is stored in the following path, and when port mapping information is required, it is retrieved from this file.

```
<DATAROOT>/<ADDRHASH>/containers/<NAMESPACE>/<CID>/port-mappings.json
```