### PR TITLE
CI: drop almalinux-9

### DIFF
--- a/.github/workflows/workflow-flaky.yml
+++ b/.github/workflows/workflow-flaky.yml
@@ -19,10 +19,8 @@ jobs:
       # EL8 is used for testing compatibility with cgroup v1.
       # Unfortunately, EL8 is hard to debug for M1 users (as Lima+M1+EL8 is not runnable because of page size),
       # and it currently shows numerous issues.
-      # Thus, EL9 is also added as target (for a limited time?) so that we can figure out which issues are EL8 specific,
-      # and which issues could be reproduced on EL9 as well (which would be easier to debug).
       matrix:
-        guest: ["almalinux-8", "almalinux-9"]
+        guest: ["almalinux-8"]
         target: ["rootful", "rootless"]
     with:
       timeout: 60


### PR DESCRIPTION
The server seems unstable

```
$ curl -OSL https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  8  468M    8 38.1M    0     0  7523k      0  0:01:03  0:00:05  0:00:58 6914k
curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
```