### PR TITLE
mark go-iptables with gomodjail unconfined directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3
 	github.com/containernetworking/cni v1.3.0 //gomodjail:unconfined
 	github.com/containernetworking/plugins v1.7.1 //gomodjail:unconfined
-	github.com/coreos/go-iptables v0.8.0
+	github.com/coreos/go-iptables v0.8.0 //gomodjail:unconfined
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/cyphar/filepath-securejoin v0.4.1 //gomodjail:unconfined
 	github.com/distribution/reference v0.6.0


### PR DESCRIPTION
Tests running go-iptables are failing in gomodjail. Check https://github.com/containerd/nerdctl/actions/runs/15398147884/job/43324415587?pr=4097

```
        |         | 🟠 time=2025-06-02T17:16:11.957Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cach |
        |         | e/gomodjail/1f381f194c295770/nerdctl syscall=openat entry=/go/pkg/mod/github.com/coreos/go-iptab |
        |         | les@v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionStr |
        |         | ing module=github.com/coreos/go-iptables                                                         |
        |         | time=2025-06-02T17:16:11.957Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.957Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | ... 12 lines are being ignored...                                                                |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.958Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.958Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=openat entry=/go/pkg/mod/github.com/coreos/go-iptables |
        |         | @v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString |
        |         |  module=github.com/coreos/go-iptables                                                            |
        |         | time=2025-06-02T17:16:11.958Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.959Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.959Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time=2025-06-02T17:16:11.959Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=pidfd_open entry=/go/pkg/mod/github.com/coreos/go-ipta |
        |         | bles@v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionSt |
        |         | ring module=github.com/coreos/go-iptables                                                        |
        |         | time=2025-06-02T17:16:11.959Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=waitid entry=/go/pkg/mod/github.com/coreos/go-iptables |
        |         | @v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString |
        |         |  module=github.com/coreos/go-iptables                                                            |
        |         | time=2025-06-02T17:16:11.959Z level=WARN msg=***Blocked*** pid=86647 exe=/home/rootless/.cache/g |
        |         | omodjail/1f381f194c295770/nerdctl syscall=fcntl entry=/go/pkg/mod/github.com/coreos/go-iptables@ |
        |         | v0.8.0/iptables/iptables.go:659:github.com/coreos/go-iptables/iptables.getIptablesVersionString  |
        |         | module=github.com/coreos/go-iptables                                                             |
        |         | time="2025-06-02T17:16:11Z" level=fatal msg="failed to load networking flags: could not get ipta |
        |         | bles version: fork/exec /usr/sbin/iptables: bad file descriptor"      
```

@AkihiroSuda PTAL