### PR TITLE
internal/filesystem consolidation, part 2 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,7 @@ linters:
     - revive
     # Gocritic
     - gocritic
+    - forbidigo
 
     # 3. We used to use these, but have now removed them
 
@@ -41,6 +42,12 @@ linters:
     # - nakedret
 
   settings:
+    forbidigo:
+      forbid:
+        # FIXME: there are still calls to os.WriteFile in tests under `cmd`
+        - pattern: ^os\.WriteFile.*$
+          pkg: github.com/containerd/nerdctl/v2/pkg
+          msg: os.WriteFile is neither atomic nor durable - use nerdctl filesystem.WriteFile instead
     staticcheck:
       checks:
         # Below is the default set

--- a/docs/dev/auditing_dockerfile.md
+++ b/docs/dev/auditing_dockerfile.md
@@ -255,7 +255,7 @@ On a warm cache, it is still over 150MB and 30+ seconds.
 In and of itself, this is hard to reduce, as we need these...
 
 Actions:
-- [ ] we could cache the module download location to reduce round-trips on modules that are shared accross
+- [ ] we could cache the module download location to reduce round-trips on modules that are shared across
 different projects
 - [ ] we are likely installing nerdctl modules six times - (once per architecture during the build phase, then once per
 ubuntu version and architecture during the tests runs (this is not even accounted for in the audit above)) - it should

--- a/docs/dev/store.md
+++ b/docs/dev/store.md
@@ -23,7 +23,7 @@ containers can be named the same), etc.
 However, storing data on the filesystem in a reliable way comes with challenges:
 - incomplete writes may happen (because of a system restart, or an application crash), leaving important structured files
 in a broken state
-- concurrent writes, or reading while writing would obviously be a problem as well, be it accross goroutines, or between
+- concurrent writes, or reading while writing would obviously be a problem as well, be it across goroutines, or between
 concurrent executions of the nerdctl binary, or embedded in a third-party application that does concurrently access resources
 
 The `pkg/store` package does provide a "storage" abstraction that takes care of these issues, generally providing

--- a/docs/dir.md
+++ b/docs/dir.md
@@ -65,7 +65,7 @@ Data volume
 
 Can be overridden with `nerdctl --cni-netconfpath=<NETCONFPATH>` flag and environment variable `$NETCONFPATH`.
 
-At the top-level of <NETCONFPATH>, network (files) are shared accross all namespaces.
+At the top-level of <NETCONFPATH>, network (files) are shared across all namespaces.
 Sub-folders inside <NETCONFPATH> are only available to the namespace bearing the same name,
 and its networks definitions are private.
 

--- a/pkg/buildkitutil/buildkitutil_test.go
+++ b/pkg/buildkitutil/buildkitutil_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 func TestBuildKitFile(t *testing.T) {
@@ -55,7 +57,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "only Dockerfile is present",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, DefaultDockerfileName), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, DefaultDockerfileName), []byte{}, 0644)
 			},
 			args:       args{".", ""},
 			wantAbsDir: tmp,
@@ -65,7 +67,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "only Containerfile is present",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{}, 0644)
 			},
 			args:       args{".", ""},
 			wantAbsDir: tmp,
@@ -75,11 +77,11 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "both Dockerfile and Containerfile are present",
 			prepare: func(t *testing.T) error {
-				var err = os.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{}, 0644)
+				var err = filesystem.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{}, 0644)
 				if err != nil {
 					return err
 				}
-				return os.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{}, 0644)
 			},
 			args:       args{".", ""},
 			wantAbsDir: tmp,
@@ -89,11 +91,11 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "Dockerfile and Containerfile have different contents",
 			prepare: func(t *testing.T) error {
-				var err = os.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{'d'}, 0644)
+				var err = filesystem.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{'d'}, 0644)
 				if err != nil {
 					return err
 				}
-				return os.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{'c'}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "Containerfile"), []byte{'c'}, 0644)
 			},
 			args:       args{".", ""},
 			wantAbsDir: tmp,
@@ -103,7 +105,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "Custom file is specfied",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, "CustomFile"), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "CustomFile"), []byte{}, 0644)
 			},
 			args:       args{".", "CustomFile"},
 			wantAbsDir: tmp,
@@ -113,7 +115,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "Absolute path is specified along with custom file",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, "CustomFile"), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "CustomFile"), []byte{}, 0644)
 			},
 			args:       args{tmp, "CustomFile"},
 			wantAbsDir: tmp,
@@ -123,7 +125,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "Absolute path is specified along with Docker file",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, "Dockerfile"), []byte{}, 0644)
 			},
 			args:       args{tmp, "."},
 			wantAbsDir: tmp,
@@ -133,7 +135,7 @@ func TestBuildKitFile(t *testing.T) {
 		{
 			name: "Absolute path is specified with Container file in the path",
 			prepare: func(t *testing.T) error {
-				return os.WriteFile(filepath.Join(tmp, ContainerfileName), []byte{}, 0644)
+				return filesystem.WriteFile(filepath.Join(tmp, ContainerfileName), []byte{}, 0644)
 			},
 			args:       args{tmp, "."},
 			wantAbsDir: tmp,

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -41,6 +41,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -110,7 +111,7 @@ func Build(ctx context.Context, client *containerd.Client, options types.Builder
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile(options.IidFile, []byte(id), 0644); err != nil {
+		if err := filesystem.WriteFile(options.IidFile, []byte(id), 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
@@ -136,7 +137,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 					return err
 				}
 				defer os.RemoveAll(dir)
-				if err := os.WriteFile(filepath.Join(dir, "api"), []byte(ipfsAddress), 0600); err != nil {
+				if err := filesystem.WriteFile(filepath.Join(dir, "api"), []byte(ipfsAddress), 0600); err != nil {
 					return err
 				}
 				ipfsPath = dir

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -51,6 +51,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/load"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/logging"
@@ -951,7 +952,7 @@ func generateLogConfig(dataStore string, id string, logDriver string, logOpt []s
 		}
 
 		logConfigFilePath := logging.LogConfigFilePath(dataStore, ns, id)
-		if err = os.WriteFile(logConfigFilePath, logConfigB, 0600); err != nil {
+		if err = filesystem.WriteFile(logConfigFilePath, logConfigB, 0600); err != nil {
 			return logConfig, err
 		}
 

--- a/pkg/cmd/image/pull.go
+++ b/pkg/cmd/image/pull.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 	"github.com/containerd/nerdctl/v2/pkg/signutil"
@@ -62,7 +63,7 @@ func EnsureImage(ctx context.Context, client *containerd.Client, rawRef string, 
 				return nil, err
 			}
 			defer os.RemoveAll(dir)
-			if err := os.WriteFile(filepath.Join(dir, "api"), []byte(options.IPFSAddress), 0600); err != nil {
+			if err := filesystem.WriteFile(filepath.Join(dir, "api"), []byte(options.IPFSAddress), 0600); err != nil {
 				return nil, err
 			}
 			ipfsPath = dir

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -46,6 +46,7 @@ import (
 	nerdconverter "github.com/containerd/nerdctl/v2/pkg/imgutil/converter"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil/push"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
@@ -85,7 +86,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 				return err
 			}
 			defer os.RemoveAll(dir)
-			if err := os.WriteFile(filepath.Join(dir, "api"), []byte(options.IpfsAddress), 0600); err != nil {
+			if err := filesystem.WriteFile(filepath.Join(dir, "api"), []byte(options.IpfsAddress), 0600); err != nil {
 				return err
 			}
 			ipfsPath = dir

--- a/pkg/cmd/ipfs/registry_serve.go
+++ b/pkg/cmd/ipfs/registry_serve.go
@@ -24,6 +24,7 @@ import (
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
 )
 
@@ -35,7 +36,7 @@ func RegistryServe(options types.IPFSRegistryServeOptions) error {
 			return err
 		}
 		defer os.RemoveAll(dir)
-		if err := os.WriteFile(filepath.Join(dir, "api"), []byte(options.IPFSAddress), 0600); err != nil {
+		if err := filesystem.WriteFile(filepath.Join(dir, "api"), []byte(options.IPFSAddress), 0600); err != nil {
 			return err
 		}
 		ipfsPath = dir

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -18,7 +18,6 @@ package serviceparser
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -27,6 +26,7 @@ import (
 	"github.com/compose-spec/compose-go/v2/types"
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
@@ -521,7 +521,7 @@ configs:
 	assert.NilError(t, err)
 
 	for _, f := range []string{"secret1", "secret2", "secret3", "config1", "config2"} {
-		err = os.WriteFile(filepath.Join(project.WorkingDir, f), []byte("content-"+f), 0444)
+		err = filesystem.WriteFile(filepath.Join(project.WorkingDir, f), []byte("content-"+f), 0444)
 		assert.NilError(t, err)
 	}
 

--- a/pkg/containerutil/container_network_manager.go
+++ b/pkg/containerutil/container_network_manager.go
@@ -39,6 +39,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/mountutil"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
@@ -829,7 +830,7 @@ func writeEtcHostnameForContainer(globalOptions types.GlobalCommandOptions, host
 	}
 
 	hostnamePath := filepath.Join(stateDir, "hostname")
-	if err := os.WriteFile(hostnamePath, []byte(hostname+"\n"), 0644); err != nil {
+	if err := filesystem.WriteFile(hostnamePath, []byte(hostname+"\n"), 0644); err != nil {
 		return nil, err
 	}
 

--- a/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
+++ b/pkg/imgutil/dockerconfigresolver/credentialsstore_test.go
@@ -26,6 +26,7 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 )
 
@@ -92,7 +93,7 @@ func TestBrokenCredentialsStore(t *testing.T) {
 			description: "Pointing DOCKER_CONFIG at a directory containing am unparsable `config.json` will prevent instantiation",
 			setup: func() string {
 				tmpDir := createTempDir(t, 0700)
-				err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("porked"), 0600)
+				err := filesystem.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("porked"), 0600)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -143,7 +144,7 @@ func TestBrokenCredentialsStore(t *testing.T) {
 			description: "Pointing DOCKER_CONFIG at a directory containing an unreadable, valid `config.json` file will prevent instantiation",
 			setup: func() string {
 				tmpDir := createTempDir(t, 0700)
-				err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0600)
+				err := filesystem.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0600)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -159,7 +160,7 @@ func TestBrokenCredentialsStore(t *testing.T) {
 			description: "Pointing DOCKER_CONFIG at a directory containing a read-only, valid `config.json` file will NOT prevent saving credentials",
 			setup: func() string {
 				tmpDir := createTempDir(t, 0700)
-				err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0600)
+				err := filesystem.WriteFile(filepath.Join(tmpDir, "config.json"), []byte("{}"), 0600)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -215,7 +216,7 @@ func TestBrokenCredentialsStore(t *testing.T) {
 func writeContent(t *testing.T, content string) string {
 	t.Helper()
 	tmpDir := createTempDir(t, 0700)
-	err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(content), 0600)
+	err := filesystem.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(content), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/native"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 func TestContainerFromNative(t *testing.T) {
@@ -38,7 +39,7 @@ func TestContainerFromNative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
+	filesystem.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
 	defer os.RemoveAll(tempStateDir)
 
 	testcase := []struct {
@@ -313,7 +314,7 @@ func TestNetworkSettingsFromNative(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	os.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
+	filesystem.WriteFile(filepath.Join(tempStateDir, "resolv.conf"), []byte(""), 0644)
 	defer os.RemoveAll(tempStateDir)
 
 	testcase := []struct {

--- a/pkg/internal/filesystem/consts.go
+++ b/pkg/internal/filesystem/consts.go
@@ -16,7 +16,14 @@
 
 package filesystem
 
+import "io"
+
 const (
-	lockPermission         = 0o600
 	pathComponentMaxLength = 255
+	privateFilePermission  = 0o600
+)
+
+var (
+	// Lightweight indirection to ease testing
+	ioCopy = io.Copy
 )

--- a/pkg/internal/filesystem/lock.go
+++ b/pkg/internal/filesystem/lock.go
@@ -67,7 +67,7 @@ func commonlock(path string, mode lockType) (file *os.File, err error) {
 
 	file, err = os.Open(path)
 	if errors.Is(err, os.ErrNotExist) {
-		file, err = os.OpenFile(path, os.O_RDONLY|os.O_CREATE, lockPermission)
+		file, err = os.OpenFile(path, os.O_RDONLY|os.O_CREATE, privateFilePermission)
 	}
 
 	if err != nil {

--- a/pkg/internal/filesystem/os.go
+++ b/pkg/internal/filesystem/os.go
@@ -16,24 +16,8 @@
 
 package filesystem
 
-import (
-	"os"
-	"path/filepath"
-)
+import "os"
 
-func AtomicWrite(parent string, fileName string, perm os.FileMode, data []byte) error {
-	dest := filepath.Join(parent, fileName)
-	temp := filepath.Join(parent, ".temp."+fileName)
-
-	err := os.WriteFile(temp, data, perm)
-	if err != nil {
-		return err
-	}
-
-	err = os.Rename(temp, dest)
-	if err != nil {
-		return err
-	}
-
-	return nil
+func WriteFile(filename string, data []byte, perm os.FileMode) error {
+	return WriteFileWithRename(filename, data, perm)
 }

--- a/pkg/internal/filesystem/umask_test.go
+++ b/pkg/internal/filesystem/umask_test.go
@@ -1,0 +1,95 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem_test
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
+)
+
+func TestUmask(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not have a unix-style umask")
+	}
+
+	userHostReportedUmask, err := exec.Command("sh", "-c", "umask").CombinedOutput()
+	assert.NilError(t, err, fmt.Sprintf(
+		"umask command should succeed (output: %s)",
+		userHostReportedUmask,
+	))
+	expectedUmask, err := strconv.ParseInt(strings.TrimSpace(string(userHostReportedUmask)), 8, 0)
+	assert.NilError(
+		t,
+		err,
+		fmt.Sprintf("umask command should have returned parsable output (was: %s)", userHostReportedUmask),
+	)
+
+	userMask := filesystem.GetUmask()
+	assert.Equal(t, expectedUmask, int64(userMask), "system reported umask and implementation umask are the same")
+
+	userHostReportedUmask, err = exec.Command("sh", "-c", "umask").CombinedOutput()
+	assert.NilError(t, err)
+	expectedUmask, err = strconv.ParseInt(strings.TrimSpace(string(userHostReportedUmask)), 8, 0)
+	assert.NilError(t, err)
+
+	assert.Equal(t, expectedUmask, int64(userMask), "system reported umask has not changed")
+}
+
+func TestUmaskConcurrent(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not have a unix-style umask")
+	}
+
+	userHostReportedUmask, err := exec.Command("sh", "-c", "umask").Output()
+	assert.NilError(t, err)
+	expectedUmask, err := strconv.ParseInt(strings.TrimSpace(string(userHostReportedUmask)), 8, 0)
+	assert.NilError(t, err)
+
+	var counter int32 = 100
+
+	ch := make(chan uint32)
+
+	for range counter {
+		go func(ch chan uint32) {
+			u := filesystem.GetUmask()
+			if atomic.AddInt32(&counter, -1) == 0 {
+				ch <- u
+			}
+		}(ch)
+	}
+
+	ret := <-ch
+	assert.Equal(t, expectedUmask, int64(ret))
+	userHostReportedUmask, err = exec.Command("sh", "-c", "umask").Output()
+	assert.NilError(t, err)
+	newUmask, err := strconv.ParseInt(strings.TrimSpace(string(userHostReportedUmask)), 8, 0)
+	assert.NilError(t, err)
+	assert.Equal(t, newUmask, expectedUmask, "system reported umask has not changed")
+}

--- a/pkg/internal/filesystem/umask_unix.go
+++ b/pkg/internal/filesystem/umask_unix.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 /*
    Copyright The containerd Authors.
 
@@ -16,12 +18,8 @@
 
 package filesystem
 
-import "errors"
+import "syscall"
 
-var (
-	ErrLockFail          = errors.New("failed to acquire lock")
-	ErrUnlockFail        = errors.New("failed to release lock")
-	ErrLockIsNil         = errors.New("nil lock")
-	ErrInvalidPath       = errors.New("invalid path")
-	ErrFilesystemFailure = errors.New("filesystem error")
-)
+func umask(mask int) int {
+	return syscall.Umask(mask)
+}

--- a/pkg/internal/filesystem/umask_windows.go
+++ b/pkg/internal/filesystem/umask_windows.go
@@ -16,12 +16,6 @@
 
 package filesystem
 
-import "errors"
-
-var (
-	ErrLockFail          = errors.New("failed to acquire lock")
-	ErrUnlockFail        = errors.New("failed to release lock")
-	ErrLockIsNil         = errors.New("nil lock")
-	ErrInvalidPath       = errors.New("invalid path")
-	ErrFilesystemFailure = errors.New("filesystem error")
-)
+func umask(_ int) int {
+	return 0
+}

--- a/pkg/internal/filesystem/writefile_rename.go
+++ b/pkg/internal/filesystem/writefile_rename.go
@@ -1,0 +1,112 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// WriteFileWithRename is a drop-in replacement for os.WriteFile, with the same signature and almost identical behavior
+// (see note below on inodes).
+// Unlike os.WriteFile, it does provide extra guarantees:
+// - Atomicity (provided by rename - *mostly* atomic, except on OS crash, where rename behavior is undefined)
+// - Durability (sync-ed)
+// Note that:
+// - this does not provide Isolation (a locking mechanism needs to be used independently to enforce that)
+// - Consistency is orthogonal here, and high-level operations that expect it across a set of unrelated ops need to
+// implement locking, rollback, and disaster recovery
+// - this will change inode in case the file already exist - therefore, there are cases where this cannot be used
+// (specifically if a file is mounted inside a container) - these are the exception though, and in almost all cases,
+// this method should be preferred over os.WriteFile
+// Finally note that we do not do anything smart wrt symlinks.
+// User is expected to resolve symlink for the destination before calling this if needed.
+func WriteFileWithRename(filename string, data []byte, perm os.FileMode) error {
+	return CopyToFileWithRename(filename, bytes.NewBuffer(data), int64(len(data)), perm, time.Time{})
+}
+
+// CopyToFileWithRename is an atomic wrapper around io.Copy(file, reader). See notes above in WriteFile for details.
+func CopyToFileWithRename(filename string, reader io.Reader, dataSize int64, perm os.FileMode, mTime time.Time) (err error) {
+	var tmpFile *os.File
+	mustClose := true
+
+	defer func() {
+		// Close if we have not already
+		if mustClose {
+			err = errors.Join(err, tmpFile.Close())
+		}
+
+		// On error, wrap it into ErrFilesystemFailure (and ensure we don't leak temp files)
+		if err != nil {
+			if tmpFile != nil {
+				err = errors.Join(err, os.Remove(tmpFile.Name()))
+			}
+			err = errors.Join(ErrFilesystemFailure, err)
+		}
+	}()
+
+	// Ensure we set permission honoring umask to be compatible with os.WriteFile
+	perm = (^os.FileMode(GetUmask())) & perm
+
+	// Create a new temp file.
+	tmpFile, err = os.CreateTemp(filepath.Dir(filename), ".tmp-"+filepath.Base(filename))
+	if err != nil {
+		return err
+	}
+
+	// Set permissions
+	if err = os.Chmod(tmpFile.Name(), perm); err != nil {
+		return err
+	}
+
+	// Write data
+	n, err := ioCopy(tmpFile, reader)
+	if err == nil && n < dataSize {
+		return io.ErrShortWrite
+	}
+
+	if err != nil {
+		return err
+	}
+
+	// Sync it, ensuring the data cannot be lost
+	if err = tmpFile.Sync(); err != nil {
+		return err
+	}
+
+	// Close
+	if err = tmpFile.Close(); err != nil {
+		return err
+	}
+
+	mustClose = false
+
+	// Set mtime if requested
+	if !mTime.IsZero() {
+		if err = os.Chtimes(tmpFile.Name(), mTime, mTime); err != nil {
+			return err
+		}
+	}
+
+	// Rename to final destination (hopefully on the same volume)
+	// NOTE: this is atomic in *most* cases - it might not be if the OS crashes.
+	return os.Rename(tmpFile.Name(), filename)
+}

--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/logging/jsonfile"
 	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -72,7 +73,7 @@ func (jsonLogger *JSONLogger) Init(dataStore, ns, id string) error {
 		return err
 	}
 	if _, err := os.Stat(jsonFilePath); errors.Is(err, os.ErrNotExist) {
-		if writeErr := os.WriteFile(jsonFilePath, []byte{}, 0600); writeErr != nil {
+		if writeErr := filesystem.WriteFile(jsonFilePath, []byte{}, 0600); writeErr != nil {
 			return writeErr
 		}
 	}

--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -30,6 +30,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	ncdefaults "github.com/containerd/nerdctl/v2/pkg/defaults"
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 )
@@ -329,7 +330,7 @@ func TestNetworkWithDefaultNameAlreadyExists(t *testing.T) {
 
 	// Filename is irrelevant as long as it's not nerdctl's.
 	testConfFile := filepath.Join(cniConfTestDir, fmt.Sprintf("%s.conf", testutil.Identifier(t)))
-	err = os.WriteFile(testConfFile, buf.Bytes(), 0600)
+	err = filesystem.WriteFile(testConfFile, buf.Bytes(), 0600)
 	assert.NilError(t, err)
 
 	// Check network is detected.

--- a/pkg/netutil/store.go
+++ b/pkg/netutil/store.go
@@ -66,7 +66,7 @@ func fsWrite(e *CNIEnv, net *NetworkConfig) error {
 		if _, err := os.Stat(filename); err == nil {
 			return errdefs.ErrAlreadyExists
 		}
-		return os.WriteFile(filename, net.Bytes, 0644)
+		return filesystem.WriteFile(filename, net.Bytes, 0644)
 	})
 }
 

--- a/pkg/resolvconf/resolvconf.go
+++ b/pkg/resolvconf/resolvconf.go
@@ -36,6 +36,8 @@ import (
 	"sync"
 
 	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 const (
@@ -317,12 +319,12 @@ func Build(path string, dns, dnsSearch, dnsOptions []string) (*File, error) {
 		return nil, err
 	}
 
-	err = os.WriteFile(path, content.Bytes(), 0o644)
+	err = filesystem.WriteFile(path, content.Bytes(), 0o644)
 	if err != nil {
 		return nil, err
 	}
 
-	// os.WriteFile relies on syscall.Open. Unless there are ACLs, the effective mode of the file will be matched
+	// WriteFile relies on syscall.Open. Unless there are ACLs, the effective mode of the file will be matched
 	// against the current process umask.
 	// See https://www.man7.org/linux/man-pages/man2/open.2.html for details.
 	// Since we must make sure that these files are world readable, explicitly chmod them here.

--- a/pkg/store/filestore.go
+++ b/pkg/store/filestore.go
@@ -193,7 +193,7 @@ func (vs *fileStore) Set(data []byte, key ...string) error {
 		}
 	}
 
-	if err := filesystem.AtomicWrite(parent, fileName, vs.filePerm, data); err != nil {
+	if err := filesystem.WriteFileWithRename(filepath.Join(parent, fileName), data, vs.filePerm); err != nil {
 		return errors.Join(ErrSystemFailure, err)
 	}
 

--- a/pkg/store/filestore_test.go
+++ b/pkg/store/filestore_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 func TestFileStoreBasics(t *testing.T) {
@@ -60,16 +62,16 @@ func TestFileStoreBasics(t *testing.T) {
 
 	// Invalid keys
 	_, err = tempStore.Get("..")
-	assert.ErrorIs(t, err, ErrInvalidArgument, "unsupported characters or patterns should return ErrInvalidArgument")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath, "unsupported characters or patterns should return filesystem.ErrInvalidPath")
 
 	err = tempStore.Set([]byte("foo"), "..")
-	assert.ErrorIs(t, err, ErrInvalidArgument, "unsupported characters or patterns should return ErrInvalidArgument")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath, "unsupported characters or patterns should return filesystem.ErrInvalidPath")
 
 	err = tempStore.Delete("..")
-	assert.ErrorIs(t, err, ErrInvalidArgument, "unsupported characters or patterns should return ErrInvalidArgument")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath, "unsupported characters or patterns should return filesystem.ErrInvalidPath")
 
 	_, err = tempStore.List("..")
-	assert.ErrorIs(t, err, ErrInvalidArgument, "unsupported characters or patterns should return ErrInvalidArgument")
+	assert.ErrorIs(t, err, filesystem.ErrInvalidPath, "unsupported characters or patterns should return filesystem.ErrInvalidPath")
 
 	// Writing, reading, listing, deleting
 	err = tempStore.Set([]byte("foo"), "something")

--- a/pkg/testutil/compose.go
+++ b/pkg/testutil/compose.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	compose "github.com/compose-spec/compose-go/v2/types"
+
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 type ComposeDir struct {
@@ -33,7 +35,7 @@ type ComposeDir struct {
 }
 
 func (cd *ComposeDir) WriteFile(name, content string) {
-	if err := os.WriteFile(filepath.Join(cd.dir, name), []byte(content), 0644); err != nil {
+	if err := filesystem.WriteFile(filepath.Join(cd.dir, name), []byte(content), 0644); err != nil {
 		cd.t.Fatal(err)
 	}
 }

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
 
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest/platform"
@@ -126,7 +127,7 @@ func (nc *nerdCommand) prep() {
 	if customDCConfig := nc.GenericCommand.Config.Read(DockerConfig); customDCConfig != "" {
 		if !nc.hasWrittenDockerConfig {
 			dest := filepath.Join(nc.Env["DOCKER_CONFIG"], "config.json")
-			err := os.WriteFile(dest, []byte(customDCConfig), test.FilePermissionsDefault)
+			err := filesystem.WriteFile(dest, []byte(customDCConfig), test.FilePermissionsDefault)
 			assert.NilError(nc.T(), err, "failed to write custom docker config json file for test")
 			nc.hasWrittenDockerConfig = true
 		}
@@ -175,7 +176,7 @@ func (nc *nerdCommand) prep() {
 	if nc.Config.Read(NerdctlToml) != "" {
 		if !nc.hasWrittenToml {
 			dest := nc.Env["NERDCTL_TOML"]
-			err := os.WriteFile(dest, []byte(nc.Config.Read(NerdctlToml)), test.FilePermissionsDefault)
+			err := filesystem.WriteFile(dest, []byte(nc.Config.Read(NerdctlToml)), test.FilePermissionsDefault)
 			assert.NilError(nc.T(), err, "failed to write NerdctlToml")
 			nc.hasWrittenToml = true
 		}

--- a/pkg/testutil/testregistry/testregistry_linux.go
+++ b/pkg/testutil/testregistry/testregistry_linux.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest/platform"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
@@ -234,7 +235,7 @@ func (ba *BasicAuth) Params(base *testutil.Base) []string {
 		encryptedPass, _ := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
 		tmpDir, _ := os.MkdirTemp(base.T.TempDir(), "htpasswd")
 		ba.HtFile = filepath.Join(tmpDir, "htpasswd")
-		_ = os.WriteFile(ba.HtFile, []byte(fmt.Sprintf(`%s:%s`, ba.Username, string(encryptedPass[:]))), 0600)
+		_ = filesystem.WriteFile(ba.HtFile, []byte(fmt.Sprintf(`%s:%s`, ba.Username, string(encryptedPass[:]))), 0600)
 	}
 	ret := []string{
 		"--env", "REGISTRY_AUTH=htpasswd",

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -534,7 +534,7 @@ func M(m *testing.M) {
 		defer filesystem.Unlock(lock)
 
 		// Create marker file
-		err = os.WriteFile(testLockFile, []byte("prevent testing from running in parallel for subpackages integration tests"), 0o666)
+		err = filesystem.WriteFile(testLockFile, []byte("prevent testing from running in parallel for subpackages integration tests"), 0o666)
 		if err != nil {
 			log.L.WithError(err).Errorf("failed writing lock file %q", testLockFile)
 			return 1


### PR DESCRIPTION
This is the second part of the effort to consolidate filesystem operations into `internal/filesystem`.

Problem refresher: `os.FileWrite` is not atomic, nor durable.
This has led in the past to a variety of issues (files with broken content after interruption, missing data, etc).
Though we did fix these issues, contributors are reintroducing (and will reintroduce) `os.FileWrite` in new code, reintroducing these issues unless done carefully.

This PR does offer a compatible drop-in replacement for FileWrite (`filesystem.FileWrite`) that guarantees atomicity and durability and configures the linter to prevent uses of `os.FileWrite`

Note that `filesystem.FileWrite` uses file rename to guarantee atomicity, which does change the inode.
This is fine in most cases, except one (when we want to modify in-place a containerd-mounted file).

About changes in this PR:
- first commit is a trivial (unrelated) typo
- second commit does strengthen `FileWriteWithRename` to be fully compatible with os.WriteFile (specifically on permissions - which is why the new `umask` helpers are added) and to `sync`
- third commit does use forbidigo to blacklist `os.FileWrite`