### PR TITLE
feat: add support for com.docker.network.bridge.enable_icc network option

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1193,6 +1193,8 @@ Flags:
 - :whale: `-o, --opt`: Set driver specific options
   - :whale: `--opt=com.docker.network.driver.mtu=<MTU>`: Set the containers network MTU
   - :nerd_face: `--opt=mtu=<MTU>`: Alias of `--opt=com.docker.network.driver.mtu=<MTU>`
+  - :whale: `--opt=com.docker.network.bridge.enable_icc=<true/false>`: Enable or Disable inter-container connectivity
+  - :nerd_face: `--opt=icc=<true/false>`: Alias of `--opt=com.docker.network.bridge.enable_icc`
   - :whale: `--opt=macvlan_mode=(bridge)>`: Set macvlan network mode (default: bridge)
   - :whale: `--opt=ipvlan_mode=(l2|l3)`: Set IPvlan network mode (default: l2)
   - :nerd_face: `--opt=mode=(bridge|l2|l3)`: Alias of `--opt=macvlan_mode=(bridge)` and `--opt=ipvlan_mode=(l2|l3)`

--- a/pkg/netutil/cni_plugin_unix.go
+++ b/pkg/netutil/cni_plugin_unix.go
@@ -95,13 +95,18 @@ type firewallConfig struct {
 
 	// IngressPolicy is supported since firewall plugin v1.1.0.
 	// "same-bridge" mode replaces the deprecated "isolation" plugin.
+	// "isolated" mode has been added since firewall plugin v1.7.1
 	IngressPolicy string `json:"ingressPolicy,omitempty"`
 }
 
-func newFirewallPlugin() *firewallConfig {
+func newFirewallPlugin(ingressPolicy string) *firewallConfig {
+	if ingressPolicy != "same-bridge" && ingressPolicy != "isolated" {
+		ingressPolicy = "same-bridge" // Default to "same-bridge" if invalid value provided
+	}
+
 	c := &firewallConfig{
 		PluginType:    "firewall",
-		IngressPolicy: "same-bridge",
+		IngressPolicy: ingressPolicy,
 	}
 	if rootlessutil.IsRootless() {
 		// https://github.com/containerd/nerdctl/issues/2818

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -99,6 +99,7 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 	case "bridge":
 		mtu := 0
 		iPMasq := true
+		icc := true
 		for opt, v := range opts {
 			switch opt {
 			case "mtu", "com.docker.network.driver.mtu":
@@ -108,6 +109,11 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 				}
 			case "ip-masq", "com.docker.network.bridge.enable_ip_masquerade":
 				iPMasq, err = strconv.ParseBool(v)
+				if err != nil {
+					return nil, err
+				}
+			case "icc", "com.docker.network.bridge.enable_icc":
+				icc, err = strconv.ParseBool(v)
 				if err != nil {
 					return nil, err
 				}
@@ -133,14 +139,29 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 		if ipv6 {
 			bridge.Capabilities["ips"] = true
 		}
+
+		// Determine the appropriate firewall ingress policy based on icc setting
+		ingressPolicy := "same-bridge" // Default policy
+		firewallPath := filepath.Join(e.Path, "firewall")
+		if !icc {
+			// Check if firewall plugin supports the "isolated" policy (v1.7.1+)
+			ok, err := FirewallPluginGEQVersion(firewallPath, "v1.7.1")
+			if err != nil {
+				log.L.WithError(err).Warnf("Failed to detect whether %q is newer than v1.7.1", firewallPath)
+			} else if ok {
+				ingressPolicy = "isolated"
+			} else {
+				log.L.Warnf("To use 'isolated' ingress policy, CNI plugin \"firewall\" (>= 1.7.1) needs to be installed in CNI_PATH (%q), see https://www.cni.dev/plugins/current/meta/firewall/", e.Path)
+			}
+		}
+
 		if internal {
-			plugins = []CNIPlugin{bridge, newFirewallPlugin(), newTuningPlugin()}
+			plugins = []CNIPlugin{bridge, newFirewallPlugin(ingressPolicy), newTuningPlugin()}
 		} else {
-			plugins = []CNIPlugin{bridge, newPortMapPlugin(), newFirewallPlugin(), newTuningPlugin()}
+			plugins = []CNIPlugin{bridge, newPortMapPlugin(), newFirewallPlugin(ingressPolicy), newTuningPlugin()}
 		}
 		if name != DefaultNetworkName {
-			firewallPath := filepath.Join(e.Path, "firewall")
-			ok, err := firewallPluginGEQ110(firewallPath)
+			ok, err := FirewallPluginGEQVersion(firewallPath, "v1.1.0")
 			if err != nil {
 				log.L.WithError(err).Warnf("Failed to detect whether %q is newer than v1.1.0", firewallPath)
 			}
@@ -291,7 +312,8 @@ func (e *CNIEnv) parseIPAMRanges(subnets []string, gateway, ipRange string, ipv6
 	return ranges, findIPv4, nil
 }
 
-func firewallPluginGEQ110(firewallPath string) (bool, error) {
+// FirewallPluginGEQVersion checks if the firewall plugin is greater than or equal to the specified version
+func FirewallPluginGEQVersion(firewallPath string, versionStr string) (bool, error) {
 	// TODO: guess true by default in 2023
 	guessed := false
 
@@ -320,8 +342,8 @@ func firewallPluginGEQ110(firewallPath string) (bool, error) {
 	if err != nil {
 		return guessed, fmt.Errorf("failed to guess the version of %q: %w", firewallPath, err)
 	}
-	ver110 := semver.MustParse("v1.1.0")
-	return ver.GreaterThan(ver110) || ver.Equal(ver110), nil
+	targetVer := semver.MustParse(versionStr)
+	return ver.GreaterThan(targetVer) || ver.Equal(targetVer), nil
 }
 
 // guessFirewallPluginVersion guess the version of the CNI firewall plugin (not the version of the implemented CNI spec).

--- a/pkg/netutil/netutil_windows.go
+++ b/pkg/netutil/netutil_windows.go
@@ -18,6 +18,7 @@ package netutil
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 
@@ -94,4 +95,8 @@ func (e *CNIEnv) generateIPAM(driver string, subnets []string, gatewayStr, ipRan
 		return nil, err
 	}
 	return ipam, nil
+}
+
+func FirewallPluginGEQVersion(firewallPath string, versionStr string) (bool, error) {
+	return false, errors.New("unsupported in windows")
 }


### PR DESCRIPTION
This PR adds support for docker compatible `com.docker.network.bridge.enable_icc` or `--icc` network create option. This option is used to enable/disable intercontainer connectivity. 

By default, any bridge network allows connectivity between containers attached to the same network, while containers in different networks are isolated. The enable_icc feature can be further used to enable/disable intra bridge container connectivity.

Requires firewall plugin >= **v1.7.1**

### Testing

1. Create a network with `com.docker.network.bridge.enable_icc` set to false, say `test-net`
2. Run a container and attach it to `test-net`
3. Run a second container and attach it to `test-net`
4. Ping from container 1 to container 2 should not succeed. 

```
sudo nerdctl network create  -o "com.docker.network.bridge.enable_icc=false" test-net          
254ddbe0ec1e5f3ed4b492876e2b6b9a051436b44c40d00ebd5e72bf7aa88435

sudo nerdctl run -d  --network test-net --name C1 ubuntu  sleep infinity  
6f22e651b9a4f3988e1ebce35f13806f65d0be942bfe9a2325c668a53cafcc9b

 sudo nerdctl run --network test-net alpine ping -c 1 -W 1 C1
PING C1 (10.4.4.4): 56 data bytes

--- C1 ping statistics ---
1 packets transmitted, 0 packets received, 100% packet loss
```

With icc=true, it will fallback to default behavior
```
sudo nerdctl network create  -o "com.docker.network.bridge.enable_icc=true" test-net1   
cf021853e2fd31f5ef29264e5fd834d45bf1ea364c3fef8ff60edec326899b77
 
sudo nerdctl run -d  --network test-net1 --name C2 ubuntu  sleep infinity  
2c95ae6ad9da8a07de97c609d9e65acdc95f3b343ea6e4c46ccd4c9b3df79b90

sudo nerdctl run --network test-net1 alpine ping -c 1 -W 1 C2
PING C2 (10.4.5.2): 56 data bytes
64 bytes from 10.4.5.2: seq=0 ttl=127 time=0.115 ms

--- C2 ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 0.115/0.115/0.115 ms
```