### PR TITLE
Add cleanup IO process after nerdctl stop

### DIFF
--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -385,6 +385,16 @@ func Stop(ctx context.Context, container containerd.Container, timeout *time.Dur
 		return err
 	}
 
+	// Cleanup the IO after a successful Stop
+	io := task.IO()
+	if io != nil {
+		defer func() {
+			if cerr := io.Close(); cerr != nil {
+				log.G(ctx).Warnf("failed to close IO for container %s: %v", container.ID(), cerr)
+			}
+		}()
+	}
+
 	status, err := task.Status(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fix #4315 
In the ``ctr`` and ``CRI`` call paths of ``containerd``, the remaining ``FIFO`` files ``(e.g., /run/containerd/fifo)`` are primarily cleaned up through the ``Delete`` interface of the ``task``. However, in the ``nerdctl stop`` path, this interface is not invoked, so an explicit call to ``io.Close`` is required to clean them up.