### PR TITLE
internal/filesystem consolidation, part 3 (no rename WriteFile, disaster recovery and rollbacks)

### DIFF
--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/nerdctl/v2/pkg"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 )
 
@@ -141,6 +142,12 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 		return types.GlobalCommandOptions{}, err
 	}
 	cdiSpecDirs, err := cmd.Flags().GetStringSlice("cdi-spec-dirs")
+	if err != nil {
+		return types.GlobalCommandOptions{}, err
+	}
+
+	// Point to dataRoot for filesystem-helpers implementing rollback / backups.
+	err = pkg.InitFS(dataRoot)
 	if err != nil {
 		return types.GlobalCommandOptions{}, err
 	}

--- a/pkg/fs.go
+++ b/pkg/fs.go
@@ -1,0 +1,27 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package pkg
+
+import "github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
+
+// InitFS will set the root location to store `internal/filesystem` ops files.
+// These files are used to allow `WriteFile` to backup and rollback content.
+// While they are transient in nature, they should still persist OS crashes / reboots, so, preferably under something
+// like XDGData, rather than tmp.
+func InitFS(path string) error {
+	return filesystem.SetFilesystemOpsDirectory(path)
+}

--- a/pkg/internal/filesystem/consts.go
+++ b/pkg/internal/filesystem/consts.go
@@ -16,14 +16,35 @@
 
 package filesystem
 
-import "io"
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
 
 const (
+	// Max size of path components
 	pathComponentMaxLength = 255
-	privateFilePermission  = 0o600
+	privateFilePermission  = os.FileMode(0o600)
+	privateDirPermission   = os.FileMode(0o700)
 )
 
 var (
 	// Lightweight indirection to ease testing
 	ioCopy = io.Copy
+
+	// Location (under XDG data home) used for markers and backups
+	filesystemOpsPath = "filesystem-ops"
+	// Suffix for markers and backup files
+	markerSuffix = "in-progress"
+	backupSuffix = "backup"
+
+	// holdLocation points to where markers and backup files will be held. This should NOT be let to /tmp,
+	// but instead be explicitly configured with SetFilesystemOpsDirectory.
+	holdLocation = os.TempDir()
 )
+
+func SetFilesystemOpsDirectory(path string) error {
+	holdLocation = filepath.Join(path, filesystemOpsPath)
+	return os.MkdirAll(holdLocation, privateDirPermission)
+}

--- a/pkg/internal/filesystem/helpers.go
+++ b/pkg/internal/filesystem/helpers.go
@@ -1,0 +1,257 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	removeMarker = "remove"
+)
+
+func ensureRecovery(filename string) (err error) {
+	// Check for a marker file.
+	// No marker means all fine, nothing to be done.
+	// Any other error is a hard error.
+	var op string
+	if op, err = markerRead(filename); err != nil {
+		if os.IsNotExist(err) {
+			err = nil
+		}
+		return err
+	}
+
+	// We have a marker. We know we were interrupted.
+	// Check for a possible backup file.
+	var exists bool
+	if exists, err = backupExists(filename); err != nil {
+		return err
+	}
+
+	// If we have a backup, restore from it
+	if exists {
+		if err = backupRestore(filename); err != nil {
+			return err
+		}
+	} else {
+		// We do not see a backup.
+		// Do we have a final destination then?
+		_, err = os.Stat(filename)
+		// Any error but does not exist is a hard error.
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+
+		// If we do NOT have a destination, nothing to be done - we already took care of it, though we were interrupted
+		// mid-recovery.
+
+		// If we DO have a destination:
+		if err == nil {
+			// Either:
+			// - there was no original, so we need to remove it (marker contains `remove`)
+			// - or we were interrupted ALSO during the recovery attempt, after the backup restore above and before deleting the marker
+			// in which case we do NOT want to remove as the file has already been restored.
+			if op == removeMarker {
+				// Errors on remove are hard errors.
+				if err = os.Remove(filename); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// Ok, we successfully recovered, now, remove the marker and return
+	return markerRemove(filename)
+}
+
+// backupSave does perform a backup of the provided file at `path`.
+func backupSave(path string) error {
+	return internalCopy(path, backupLocation(path))
+}
+
+// backupRestore restores a file from its backup.
+// On success the backup is deleted.
+func backupRestore(path string) error {
+	err := internalCopy(backupLocation(path), path)
+	if err == nil {
+		err = os.Remove(backupLocation(path))
+	}
+
+	return err
+}
+
+// backupExists checks if a backup file exists for file located at `path`.
+func backupExists(path string) (bool, error) {
+	_, err := os.Stat(backupLocation(path))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return err == nil, err
+}
+
+// backupLocation returns the location of the backup for path.
+func backupLocation(path string) string {
+	return location(path) + backupSuffix
+}
+
+// markerCreate saves a marker file with the current time.
+// Markers are used to indicate an operation is in progress and allow for disaster recovery.
+func markerCreate(path string, op string) (err error) {
+	var marker *os.File
+	marker, err = os.OpenFile(markerLocation(path), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, privateFilePermission)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// If we errored on sync or close, remove the marker (ignore removal errors)
+		if err = errors.Join(err, marker.Close()); err != nil {
+			_ = markerRemove(path)
+		}
+	}()
+
+	_, err = marker.Write([]byte(op))
+	if err != nil {
+		return err
+	}
+
+	return marker.Sync()
+}
+
+// markerRead reads the content of a marker file if it exists (contains the time at which it was created).
+func markerRead(path string) (string, error) {
+	data, err := os.ReadFile(markerLocation(path))
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+// markerRemove deletes a marker file.
+func markerRemove(path string) error {
+	return os.Remove(markerLocation(path))
+}
+
+// markerLocation returns the location of the marker file for a given path.
+func markerLocation(path string) string {
+	return location(path) + markerSuffix
+}
+
+// location returns the filesystem-ops path associated with a given file (where marker and backups are located).
+// The location is unique (see hash), and shows the first 16 characters of the filename for readability.
+func location(path string) string {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+	pretty := base
+	// Ensure that we do not blow up filesystem length limits
+	if len(pretty) > 16 {
+		pretty = pretty[:16]
+	}
+	return filepath.Join(holdLocation, hash(dir)+"-"+pretty+"-"+hash(base)+"-")
+}
+
+// hash does return the first 8 characters of the shasum256 of the provided string.
+// Chances of collision are 50% with 77,000 *simultaneous* entries.
+func hash(s string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(s)))[0:8]
+}
+
+// internalCopy performs a simple copy from source to destination.
+// This in itself is not safe.
+func internalCopy(sourcePath, destinationPath string) (err error) {
+	var source *os.File
+
+	// Open source
+	source, err = os.OpenFile(sourcePath, os.O_RDONLY, privateFilePermission)
+	if err != nil {
+		return err
+	}
+
+	// Read file length
+	srcInfo, err := source.Stat()
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		err = errors.Join(err, source.Close())
+	}()
+
+	return fileWrite(source, srcInfo.Size(), destinationPath, privateFilePermission, srcInfo.ModTime())
+}
+
+// fileWrite performs a simple write to the destination file from the provided io.Reader.
+// This in itself is not safe.
+func fileWrite(source io.Reader, size int64, destinationPath string, perm os.FileMode, mTime time.Time) (err error) {
+	var destination *os.File
+	mustClose := true
+
+	// Open destination
+	destination, err = os.OpenFile(destinationPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		// Close if need be.
+		if mustClose {
+			err = errors.Join(err, destination.Close())
+		}
+
+		// Remove destination if we failed anywhere. Ignore removal failures.
+		if err != nil {
+			_ = os.Remove(destinationPath)
+		}
+	}()
+
+	// Copy over
+	var n int64
+	n, err = ioCopy(destination, source)
+	if err != nil {
+		return err
+	}
+
+	if n < size {
+		return io.ErrShortWrite
+	}
+
+	// Ensure data is committed
+	if err = destination.Sync(); err != nil {
+		return err
+	}
+
+	err = destination.Close()
+	mustClose = false
+	if err != nil {
+		return err
+	}
+
+	if !mTime.IsZero() {
+		err = os.Chtimes(destinationPath, mTime, mTime)
+	}
+
+	return err
+}

--- a/pkg/internal/filesystem/writefile_rollback.go
+++ b/pkg/internal/filesystem/writefile_rollback.go
@@ -1,0 +1,89 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package filesystem
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"time"
+)
+
+// WriteFileWithRollback implements an atomic and durable file write operation with rollback.
+// The rollback callback may be called by higher-level operations in case there is a need to
+// revert changes as part of a more complex, multi-prong operation.
+// Note that with or without rollback, WriteFileWithRollback does ensure disaster recovery.
+func WriteFileWithRollback(filename string, data []byte, perm os.FileMode) (rollback func() error, err error) {
+	// Ensure there are no interrupted operations (leftover marker file and backup), or restore them if need be.
+	// If this is failing, we are dead in the water.
+	if err = ensureRecovery(filename); err != nil {
+		return nil, errors.Join(ErrFilesystemFailure, err)
+	}
+
+	// On error, call recovery to rollback changes.
+	defer func() {
+		if err != nil {
+			err = errors.Join(ErrFilesystemFailure, err, ensureRecovery(filename))
+		}
+	}()
+
+	// If the file does not exist
+	markerData := ""
+	if _, err = os.Stat(filename); err != nil {
+		// Any error but does not exist is a hard error.
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+		// Otherwise, rollback and marker is "remove"
+		markerData = removeMarker
+		rollback = func() error {
+			return os.Remove(filename)
+		}
+	} else {
+		// Destination exists.
+		// Rollback will be: restore data from the backup
+		rollback = func() error {
+			return backupRestore(filename)
+		}
+	}
+
+	// Create the marker. Failure to do so is a hard error.
+	if err = markerCreate(filename, markerData); err != nil {
+		return nil, err
+	}
+
+	// If the file exists, we need to back it up.
+	if markerData == "" {
+		// Back it up now.
+		if err = backupSave(filename); err != nil {
+			return nil, err
+		}
+	}
+
+	// Now, write the content to the destination.
+	if err = fileWrite(bytes.NewReader(data), int64(len(data)), filename, perm, time.Time{}); err != nil {
+		return nil, err
+	}
+
+	// Remove the marker.
+	if err = markerRemove(filename); err != nil {
+		return nil, err
+	}
+
+	// On success, return the rollback
+	return rollback, nil
+}

--- a/pkg/internal/filesystem/writefile_rollback_test.go
+++ b/pkg/internal/filesystem/writefile_rollback_test.go
@@ -1,0 +1,206 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+//nolint:forbidigo
+package filesystem
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRollbackForNonExistentFile(t *testing.T) {
+	// Test that calling the rollback after writing to a new existent file does remove the file
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "non-existent-file")
+
+	// Write to it and check that this went through
+	rollback, err := WriteFileWithRollback(fp, []byte("new content"), 0o600)
+	assert.NilError(t, err)
+	cn, _ := os.ReadFile(fp)
+	assert.Equal(t, string(cn), "new content")
+
+	// Roll it back and check it has been removed.
+	err = rollback()
+	assert.NilError(t, err)
+	_, err = os.ReadFile(fp)
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestRollbackForPreexistingFile(t *testing.T) {
+	// Test that calling the rollback after writing to a pre-existing file does restore the original
+
+	// Create a file with pre-existing content
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "pre-existing-file")
+	_ = os.WriteFile(fp, []byte("original content"), 0o600)
+	cn, _ := os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+
+	// Write to it and check that this went through
+	rollback, err := WriteFileWithRollback(fp, []byte("updated content"), 0o600)
+	assert.NilError(t, err)
+
+	cn, _ = os.ReadFile(fp)
+	assert.Equal(t, string(cn), "updated content")
+
+	// Roll it back and check we have the original
+	err = rollback()
+	assert.NilError(t, err)
+	cn, _ = os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+}
+
+func TestBackupFailure(t *testing.T) {
+	// Test that if backup is failing, a pre-existing file is restored to its original value.
+
+	// Create a file with pre-existing content
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "pre-existing-file")
+	_ = os.WriteFile(fp, []byte("original content"), 0o600)
+	cn, _ := os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+
+	fakeError := errors.New("fake error")
+	// Override ioCopy to simulate an error creating the backup
+	ioCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
+		return 0, fakeError
+	}
+
+	// Write. Check that we still have the original.
+	rollback, err := WriteFileWithRollback(fp, []byte("updated content"), 0o600)
+	assert.ErrorIs(t, err, fakeError)
+	assert.Assert(t, rollback == nil)
+	cn, _ = os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+}
+
+func TestWriteFailure(t *testing.T) {
+	// Test that if write to a non-existent file is failing, the file is deleted.
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "non-existent-file")
+
+	fakeError := errors.New("fake error")
+	// Override ioCopy to simulate an error while writing to the destination
+	// Note: since the file does not exist, there will be no backup
+	ioCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
+		return 0, fakeError
+	}
+
+	// Write. Check that the file has been removed
+	rollback, err := WriteFileWithRollback(fp, []byte("update"), 0o600)
+	assert.ErrorIs(t, err, fakeError)
+	assert.Assert(t, rollback == nil)
+	_, err = os.ReadFile(fp)
+	assert.Assert(t, os.IsNotExist(err))
+
+	// Restore io copy
+	ioCopy = io.Copy
+}
+
+func TestShortWriteFailure(t *testing.T) {
+	// Test that a write failing to write all content to a non-existent file will delete the file.
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "non-existent-file")
+
+	// Override ioCopy to simulate a short write
+	ioCopy = func(dst io.Writer, src io.Reader) (written int64, err error) {
+		return 1, nil
+	}
+
+	// Write. Check that we still have the original.
+	rollback, err := WriteFileWithRollback(fp, []byte("update"), 0o600)
+	assert.ErrorIs(t, err, io.ErrShortWrite)
+	assert.Assert(t, rollback == nil)
+	_, err = os.ReadFile(fp)
+	assert.Assert(t, os.IsNotExist(err))
+
+	// Restore io copy
+	ioCopy = io.Copy
+}
+
+func TestDisasterRecoveryFromBackup(t *testing.T) {
+	// Test that a file that has left-over backup and marker will get restored to its original content
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "pre-existing-file")
+	_ = os.WriteFile(fp, []byte("original content"), 0o600)
+
+	// Artificially create leftover marker
+	_ = markerCreate(fp, "")
+	// Artificially create leftover backup
+	_ = backupSave(fp)
+
+	// Pork the file, to simulate interrupted write with leftover marker and backup
+	_ = os.WriteFile(fp, []byte("porked"), 0o600)
+
+	// Now, see that disaster recovery got the backup
+	err := ensureRecovery(fp)
+	assert.NilError(t, err)
+
+	cn, _ := os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+}
+
+func TestDisasterRecoveryNoBackup1(t *testing.T) {
+	// Test that a previously non-existent file with a marker left-over will get deleted
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "non-existent-file")
+
+	// Artificially create leftover marker
+	_ = markerCreate(fp, removeMarker)
+
+	// Pork the file. mtime will be > marker mtime, meaning we expect the file to get deleted
+	_ = os.WriteFile(fp, []byte("porked"), 0o600)
+
+	err := ensureRecovery(fp)
+	assert.NilError(t, err)
+
+	_, err = os.ReadFile(fp)
+	assert.Assert(t, os.IsNotExist(err))
+}
+
+func TestDisasterRecoveryNoBackup2(t *testing.T) {
+	// Test that a file with a more recent marker leftover and no backup will be left untouched.
+
+	// Create file
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "pre-existing-file")
+	_ = os.WriteFile(fp, []byte("original content"), 0o600)
+
+	// Artificially create leftover marker
+	_ = markerCreate(fp, "")
+
+	err := ensureRecovery(fp)
+	assert.NilError(t, err)
+
+	cn, _ := os.ReadFile(fp)
+	assert.Equal(t, string(cn), "original content")
+}


### PR DESCRIPTION
This is part 3 of internal/FS series.

<!> unlike the previous PRs that were essentially consolidation and enforcing atomic writes, this here is more ambitious, and adds net new features (eg: rollbacks and disaster recovery) - as such, it _may_ be more controversial, so, open to discussion here, as usual <!>

This expands on the previous goal (Atomicity and Durability of `WriteFile`) by providing a new version of `WriteFile` that no longer relies on file renames - hence no longer changing inode - making it now 100% compatible with `os.WriteFile` and usable everywhere (including when files are mounted).

Furthermore, it also focuses on enabling _Consistency_, by introducing:
- disaster recovery:
  - if `WriteFile` fails, the file is immediately reverted to its previous version (or removed if it did not exist prior)
  - if `WriteFile` is hard interrupted for any reason, the _next_ `ReadFile` or `WriteFile` call will first revert it to its original content (or remove it if it did not exist)
- rollback: on a successful write, `WriteFileWithRollback` will return a rollback function that can revert changes

`rollback` should be used in the future to ensure higher-level operations _consistency_ and to facilitate cleanup in case of failures. This should make higher-level operations failures able to revert state / cleanup leftover easier.

I do appreciate this is additional complexity, and some of the code is not trivial.
But then:
- the complexity is already here in things like `container.Create` and other places that are manually rollbacking in a baroque / ad-hoc form
- IMHO this is what it takes to implement higher-level consistent data operations

Finally note that this changeset is purely internal to the `filesystem` package and does not change anything in the rest of nerdctl codebase.

Let me know your thoughts overall, and if this is desirable or not.