### PR TITLE
[CI] Update registry testing tooling

### DIFF
--- a/cmd/nerdctl/compose/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose/compose_run_linux_test.go
@@ -142,7 +142,7 @@ services:
 	}()
 
 	checkNginx := func() error {
-		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 10, false)
+		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 5, false)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ services:
 	}()
 
 	checkNginx := func() error {
-		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 10, false)
+		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 5, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/compose/compose_up_linux_test.go
+++ b/cmd/nerdctl/compose/compose_up_linux_test.go
@@ -100,7 +100,7 @@ COPY index.html /usr/share/nginx/html/index.html
 	base.ComposeCmd("-f", comp.YAMLFullPath(), "up", "-d", "--build").AssertOK()
 	defer base.ComposeCmd("-f", comp.YAMLFullPath(), "down", "-v").Run()
 
-	resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 50, false)
+	resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 5, false)
 	assert.NilError(t, err)
 	respBody, err := io.ReadAll(resp.Body)
 	assert.NilError(t, err)

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -653,7 +653,7 @@ func TestPortBindingWithCustomHost(t *testing.T) {
 					Errors:   []error{},
 					Output: expect.All(
 						func(stdout string, t tig.T) {
-							resp, err := nettestutil.HTTPGet(address, 30, false)
+							resp, err := nettestutil.HTTPGet(address, 5, false)
 							assert.NilError(t, err)
 
 							respBody, err := io.ReadAll(resp.Body)

--- a/cmd/nerdctl/container/container_run_network_base_test.go
+++ b/cmd/nerdctl/container/container_run_network_base_test.go
@@ -155,7 +155,7 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 			hostPort:         "7000-7005",
 			containerPort:    "80-85",
 			connectURLPort:   7001,
-			err:              "error after 30 attempts",
+			err:              "error after 5 attempts",
 			runShouldSuccess: true,
 		},
 		{
@@ -209,7 +209,7 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 				return
 			}
 
-			resp, err := nettestutil.HTTPGet(connectURL, 30, false)
+			resp, err := nettestutil.HTTPGet(connectURL, 5, false)
 			if tc.err != "" {
 				assert.ErrorContains(t, err, tc.err)
 				return

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -248,7 +248,7 @@ func TestRunPortWithNoHostPort(t *testing.T) {
 				return
 			}
 			connectURL := fmt.Sprintf("http://%s:%s", "127.0.0.1", paramsMap["portNumber"])
-			resp, err := nettestutil.HTTPGet(connectURL, 30, false)
+			resp, err := nettestutil.HTTPGet(connectURL, 5, false)
 			assert.NilError(t, err)
 			respBody, err := io.ReadAll(resp.Body)
 			assert.NilError(t, err)
@@ -333,7 +333,7 @@ func TestUniqueHostPortAssignement(t *testing.T) {
 
 			// Make HTTP GET request to container 1
 			connectURL1 := fmt.Sprintf("http://%s:%s", "127.0.0.1", port1)
-			resp1, err := nettestutil.HTTPGet(connectURL1, 30, false)
+			resp1, err := nettestutil.HTTPGet(connectURL1, 5, false)
 			assert.NilError(t, err)
 			respBody1, err := io.ReadAll(resp1.Body)
 			assert.NilError(t, err)
@@ -341,7 +341,7 @@ func TestUniqueHostPortAssignement(t *testing.T) {
 
 			// Make HTTP GET request to container 2
 			connectURL2 := fmt.Sprintf("http://%s:%s", "127.0.0.1", port2)
-			resp2, err := nettestutil.HTTPGet(connectURL2, 30, false)
+			resp2, err := nettestutil.HTTPGet(connectURL2, 5, false)
 			assert.NilError(t, err)
 			respBody2, err := io.ReadAll(resp2.Body)
 			assert.NilError(t, err)

--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -69,7 +69,7 @@ func TestRunRestart(t *testing.T) {
 		}
 		return nil
 	}
-	assert.NilError(t, check(30))
+	assert.NilError(t, check(5))
 
 	base.KillDaemon()
 	base.EnsureDaemonActive()

--- a/cmd/nerdctl/container/container_stop_linux_test.go
+++ b/cmd/nerdctl/container/container_stop_linux_test.go
@@ -66,14 +66,14 @@ func TestStopStart(t *testing.T) {
 		return nil
 	}
 
-	assert.NilError(t, check(30))
+	assert.NilError(t, check(5))
 	base.Cmd("stop", testContainerName).AssertOK()
 	base.Cmd("exec", testContainerName, "ps").AssertFail()
 	if check(1) == nil {
 		t.Fatal("expected to get an error")
 	}
 	base.Cmd("start", testContainerName).AssertOK()
-	assert.NilError(t, check(30))
+	assert.NilError(t, check(5))
 }
 
 func TestStopWithStopSignal(t *testing.T) {

--- a/cmd/nerdctl/container/multi_platform_linux_test.go
+++ b/cmd/nerdctl/container/multi_platform_linux_test.go
@@ -163,7 +163,7 @@ RUN uname -m > /usr/share/nginx/html/index.html
 	}
 
 	for testURL, expectedIndexHTML := range testCases {
-		resp, err := nettestutil.HTTPGet(testURL, 50, false)
+		resp, err := nettestutil.HTTPGet(testURL, 5, false)
 		assert.NilError(t, err)
 		respBody, err := io.ReadAll(resp.Body)
 		assert.NilError(t, err)

--- a/cmd/nerdctl/helpers/testing_linux.go
+++ b/cmd/nerdctl/helpers/testing_linux.go
@@ -74,7 +74,7 @@ func ComposeUp(t *testing.T, base *testutil.Base, dockerComposeYAML string, opts
 	base.Cmd("network", "inspect", fmt.Sprintf("%s_default", projectName)).AssertOK()
 
 	checkWordpress := func() error {
-		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 10, false)
+		resp, err := nettestutil.HTTPGet("http://127.0.0.1:8080", 5, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -130,8 +130,8 @@ CMD ["echo", "nerdctl-build-test-string"]
 			data.Temp().Save(dockerfile, "Dockerfile")
 			reg = nerdtest.RegistryWithNoAuth(data, helpers, 80, false)
 			reg.Setup(data, helpers)
-			testImageRef := fmt.Sprintf("%s/%s:%s",
-				reg.IP.String(), data.Identifier(), strings.Split(testutil.CommonImage, ":")[1])
+			testImageRef := fmt.Sprintf("%s/%s",
+				reg.IP.String(), data.Identifier())
 			buildCtx := data.Temp().Path()
 
 			helpers.Ensure("build", "-t", testImageRef, buildCtx)

--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -256,7 +256,7 @@ COPY index.html /usr/share/nginx/html/index.html
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			Output: func(stdout string, t tig.T) {
-				resp, err := nettestutil.HTTPGet("http://127.0.0.1:8081", 10, false)
+				resp, err := nettestutil.HTTPGet("http://127.0.0.1:8081", 5, false)
 				assert.NilError(t, err)
 				respBody, err := io.ReadAll(resp.Body)
 				assert.NilError(t, err)

--- a/mod/tigron/test/data.go
+++ b/mod/tigron/test/data.go
@@ -126,7 +126,7 @@ func (tp *temp) SaveToWriter(writer func(file io.Writer) error, key ...string) s
 	silentT := assertive.WithSilentSuccess(tp.t)
 
 	//nolint:gosec // it is fine
-	file, err := os.OpenFile(pth, os.O_CREATE, FilePermissionsDefault)
+	file, err := os.OpenFile(pth, os.O_CREATE|os.O_WRONLY, FilePermissionsDefault)
 	assertive.ErrorIsNil(
 		silentT,
 		err,

--- a/pkg/testutil/nerdtest/registry/cesanta.go
+++ b/pkg/testutil/nerdtest/registry/cesanta.go
@@ -201,7 +201,7 @@ func NewCesantaAuthServer(data test.Data, helpers test.Helpers, ca *testca.Cert,
 			scheme,
 			net.JoinHostPort(hostIP.String(), strconv.Itoa(port)),
 		),
-			10,
+			5,
 			true)
 		assert.NilError(helpers.T(), err, fmt.Errorf("failed starting auth container in a timely manner: %w", err))
 

--- a/pkg/testutil/nerdtest/registry/docker.go
+++ b/pkg/testutil/nerdtest/registry/docker.go
@@ -123,7 +123,7 @@ func NewDockerRegistry(data test.Data, helpers test.Helpers, currentCA *testca.C
 			scheme,
 			net.JoinHostPort(hostIP.String(), strconv.Itoa(port)),
 		),
-			10,
+			5,
 			true)
 		assert.NilError(helpers.T(), err, fmt.Errorf("failed starting docker registry in a timely manner: %w", err))
 	}

--- a/pkg/testutil/nerdtest/registry/kubo.go
+++ b/pkg/testutil/nerdtest/registry/kubo.go
@@ -72,7 +72,7 @@ func NewKuboRegistry(data test.Data, helpers test.Helpers, t *testing.T, current
 			scheme,
 			net.JoinHostPort(hostIP.String(), strconv.Itoa(port)),
 		),
-			30,
+			5,
 			true)
 		logs := helpers.Capture("logs", containerName)
 		assert.NilError(t, err, fmt.Errorf("failed starting kubo registry in a timely manner: %w - logs: %s", err, logs))

--- a/pkg/testutil/nettestutil/nettestutil.go
+++ b/pkg/testutil/nettestutil/nettestutil.go
@@ -48,7 +48,7 @@ func HTTPGet(urlStr string, attempts int, insecure bool) (*http.Response, error)
 		if err == nil {
 			return resp, nil
 		}
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 	}
 	return nil, fmt.Errorf("error after %d attempts: %w", attempts, err)
 }

--- a/pkg/testutil/testregistry/testregistry_linux.go
+++ b/pkg/testutil/testregistry/testregistry_linux.go
@@ -155,7 +155,7 @@ acl:
 			return cmd.Error
 		}
 		joined := net.JoinHostPort(hostIP.String(), strconv.Itoa(port))
-		_, err = nettestutil.HTTPGet(fmt.Sprintf("%s://%s/auth", scheme, joined), 30, true)
+		_, err = nettestutil.HTTPGet(fmt.Sprintf("%s://%s/auth", scheme, joined), 5, true)
 		return err
 	}()
 
@@ -340,7 +340,7 @@ func NewRegistry(base *testutil.Base, ca *testca.CA, port int, auth Auth, boundC
 			return "", cmd.Error
 		}
 
-		if _, err = nettestutil.HTTPGet(fmt.Sprintf("%s://%s:%s/v2", scheme, hostIP.String(), strconv.Itoa(port)), 30, true); err != nil {
+		if _, err = nettestutil.HTTPGet(fmt.Sprintf("%s://%s:%s/v2", scheme, hostIP.String(), strconv.Itoa(port)), 5, true); err != nil {
 			return "", err
 		}
 


### PR DESCRIPTION
Summer cleaning time. Going through my uncommitted local branches and fork' patches.

This one focuses on moving away from `testutil/testregistry` (meant for the old test tooling) to tigron-compatible `testutil/nerdtest/registry`.

Commit 1 fixes (my past stupidity) broken tigron testca handling.

Commit 2 does migrate tests - cleaning-up remaining calls to `testutil.NewBase(t)`.

Commit 3 does adjust `HTTPGet` repeat frequency and overall maximum number of checks (see commit message for details).

Commit 4 fixes issues with TestImageConvertNydusVerify

Note that unfortunately, some of these tests had not been running on the CI for some time (because of mixing tigron tests with `Base` tests).
Moving to the updated tooling for `registry` does re-enable them, revealing issues, specifically:
- #4332
- aftermath of embedded image lists PR

These are being fixed as part of these commits.