### PR TITLE
[FIX]: revert atomic write for logs

### DIFF
--- a/pkg/logging/json_logger.go
+++ b/pkg/logging/json_logger.go
@@ -33,7 +33,6 @@ import (
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
 	"github.com/containerd/log"
 
-	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/logging/jsonfile"
 	"github.com/containerd/nerdctl/v2/pkg/logging/tail"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -73,7 +72,8 @@ func (jsonLogger *JSONLogger) Init(dataStore, ns, id string) error {
 		return err
 	}
 	if _, err := os.Stat(jsonFilePath); errors.Is(err, os.ErrNotExist) {
-		if writeErr := filesystem.WriteFile(jsonFilePath, []byte{}, 0600); writeErr != nil {
+		// nolint:forbidigo
+		if writeErr := os.WriteFile(jsonFilePath, []byte{}, 0600); writeErr != nil {
 			return writeErr
 		}
 	}


### PR DESCRIPTION
It _seems_ like #4308 _maybe_ is wrecking logs.

While #4324 would fix it (by introducing a better version of WriteFile that does not rely on Rename), we should still fix this now for the current state of affairs.

Looking at CI now to confirm.