### PR TITLE
[Tigron] API cleanup

### DIFF
--- a/cmd/nerdctl/builder/builder_build_oci_layout_test.go
+++ b/cmd/nerdctl/builder/builder_build_oci_layout_test.go
@@ -100,14 +100,13 @@ CMD ["echo", "test-nerdctl-build-context-oci-layout"]`
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					assert.Assert(
 						t,
 						strings.Contains(
 							helpers.Capture("run", "--rm", data.Identifier("child")),
 							"test-nerdctl-build-context-oci-layout",
 						),
-						info,
 					)
 				},
 			}

--- a/cmd/nerdctl/builder/builder_build_oci_layout_test.go
+++ b/cmd/nerdctl/builder/builder_build_oci_layout_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -100,7 +101,7 @@ CMD ["echo", "test-nerdctl-build-context-oci-layout"]`
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					assert.Assert(
 						t,
 						strings.Contains(

--- a/cmd/nerdctl/builder/builder_build_test.go
+++ b/cmd/nerdctl/builder/builder_build_test.go
@@ -342,7 +342,7 @@ COPY %s /`, testFileName)
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							// Expecting testFileName to exist inside the output target directory
 							assert.Equal(t, data.Temp().Load(testFileName), testContent, "file content is identical")
 						},
@@ -356,7 +356,7 @@ COPY %s /`, testFileName)
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							assert.Equal(t, data.Temp().Load(testFileName), testContent, "file content is identical")
 						},
 					}
@@ -894,7 +894,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							files, err := os.ReadDir(data.Temp().Path("dir-for-bom"))
 							assert.NilError(t, err, "failed to read directory")
 
@@ -926,7 +926,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							files, err := os.ReadDir(data.Temp().Path("dir-for-prov"))
 							assert.NilError(t, err, "failed to read directory")
 
@@ -959,7 +959,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							// Check if any file in the directory matches the SBOM file pattern
 							files, err := os.ReadDir(data.Temp().Path("dir-for-attest"))
 							assert.NilError(t, err, "failed to read directory")

--- a/cmd/nerdctl/builder/builder_build_test.go
+++ b/cmd/nerdctl/builder/builder_build_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/buildkitutil"
 	"github.com/containerd/nerdctl/v2/pkg/platformutil"
@@ -342,7 +343,7 @@ COPY %s /`, testFileName)
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							// Expecting testFileName to exist inside the output target directory
 							assert.Equal(t, data.Temp().Load(testFileName), testContent, "file content is identical")
 						},
@@ -356,7 +357,7 @@ COPY %s /`, testFileName)
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							assert.Equal(t, data.Temp().Load(testFileName), testContent, "file content is identical")
 						},
 					}
@@ -894,7 +895,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							files, err := os.ReadDir(data.Temp().Path("dir-for-bom"))
 							assert.NilError(t, err, "failed to read directory")
 
@@ -926,7 +927,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							files, err := os.ReadDir(data.Temp().Path("dir-for-prov"))
 							assert.NilError(t, err, "failed to read directory")
 
@@ -959,7 +960,7 @@ func TestBuildAttestation(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							// Check if any file in the directory matches the SBOM file pattern
 							files, err := os.ReadDir(data.Temp().Path("dir-for-attest"))
 							assert.NilError(t, err, "failed to read directory")

--- a/cmd/nerdctl/compose/compose_config_test.go
+++ b/cmd/nerdctl/compose/compose_config_test.go
@@ -113,7 +113,7 @@ services:
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: 0,
-			Output: func(stdout, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				assert.Assert(t, data.Labels().Get("hash") != stdout, "hash should be different")
 			},
 		}

--- a/cmd/nerdctl/compose/compose_config_test.go
+++ b/cmd/nerdctl/compose/compose_config_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -113,7 +114,7 @@ services:
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: 0,
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Assert(t, data.Labels().Get("hash") != stdout, "hash should be different")
 			},
 		}

--- a/cmd/nerdctl/compose/compose_cp_linux_test.go
+++ b/cmd/nerdctl/compose/compose_cp_linux_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -77,7 +78,7 @@ services:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						copied := data.Temp().Load("test-file2")
 						assert.Equal(t, copied, testFileContent)
 					},

--- a/cmd/nerdctl/compose/compose_cp_linux_test.go
+++ b/cmd/nerdctl/compose/compose_cp_linux_test.go
@@ -77,7 +77,7 @@ services:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						copied := data.Temp().Load("test-file2")
 						assert.Equal(t, copied, testFileContent)
 					},

--- a/cmd/nerdctl/compose/compose_create_linux_test.go
+++ b/cmd/nerdctl/compose/compose_create_linux_test.go
@@ -64,7 +64,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")
@@ -121,7 +121,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")
@@ -133,7 +133,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc1", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout, info string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")

--- a/cmd/nerdctl/compose/compose_create_linux_test.go
+++ b/cmd/nerdctl/compose/compose_create_linux_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -64,7 +65,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")
@@ -121,7 +122,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc0", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")
@@ -133,7 +134,7 @@ services:
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "ps", "svc1", "-a")
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
 				assert.Assert(t,
 					strings.Contains(stdout, "created") || strings.Contains(stdout, "Created"),
 					"stdout should contain `created`")

--- a/cmd/nerdctl/compose/compose_images_linux_test.go
+++ b/cmd/nerdctl/compose/compose_images_linux_test.go
@@ -106,7 +106,7 @@ volumes:
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "images", "--format", "json")
 			},
 			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.All(
-				expect.JSON([]composeContainerPrintable{}, func(printables []composeContainerPrintable, s string, t tig.T) {
+				expect.JSON([]composeContainerPrintable{}, func(printables []composeContainerPrintable, t tig.T) {
 					assert.Equal(t, len(printables), 2)
 				}),
 				expect.Contains(`"ContainerName":"wordpress"`, `"ContainerName":"db"`),
@@ -118,7 +118,7 @@ volumes:
 				return helpers.Command("compose", "-f", data.Labels().Get("composeYaml"), "images", "--format", "json", "wordpress")
 			},
 			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.All(
-				expect.JSON([]composeContainerPrintable{}, func(printables []composeContainerPrintable, s string, t tig.T) {
+				expect.JSON([]composeContainerPrintable{}, func(printables []composeContainerPrintable, t tig.T) {
 					assert.Equal(t, len(printables), 1)
 				}),
 				expect.Contains(`"ContainerName":"wordpress"`),

--- a/cmd/nerdctl/compose/compose_rm_linux_test.go
+++ b/cmd/nerdctl/compose/compose_rm_linux_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -78,7 +79,7 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						wp := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "wordpress")
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
 						comp := expect.Match(regexp.MustCompile("Up|running"))
@@ -97,7 +98,7 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						wp := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "wordpress")
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
 						expect.DoesNotContain("wordpress")(wp, t)
@@ -114,7 +115,7 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
 						expect.DoesNotContain("db")(db, t)
 					},

--- a/cmd/nerdctl/compose/compose_rm_linux_test.go
+++ b/cmd/nerdctl/compose/compose_rm_linux_test.go
@@ -78,12 +78,12 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						wp := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "wordpress")
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
 						comp := expect.Match(regexp.MustCompile("Up|running"))
-						comp(wp, "", t)
-						comp(db, "", t)
+						comp(wp, t)
+						comp(db, t)
 					},
 				}
 			},
@@ -97,11 +97,11 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						wp := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "wordpress")
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
-						expect.DoesNotContain("wordpress")(wp, "", t)
-						expect.Match(regexp.MustCompile("Up|running"))(db, "", t)
+						expect.DoesNotContain("wordpress")(wp, t)
+						expect.Match(regexp.MustCompile("Up|running"))(db, t)
 					},
 				}
 			},
@@ -114,9 +114,9 @@ volumes:
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						db := helpers.Capture("compose", "-f", data.Labels().Get("yamlPath"), "ps", "db")
-						expect.DoesNotContain("db")(db, "", t)
+						expect.DoesNotContain("db")(db, t)
 					},
 				}
 			},

--- a/cmd/nerdctl/compose/compose_start_linux_test.go
+++ b/cmd/nerdctl/compose/compose_start_linux_test.go
@@ -61,12 +61,12 @@ services:
 		return &test.Expected{
 			ExitCode: 0,
 			Errors:   nil,
-			Output: func(stdout, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				svc0 := helpers.Capture("compose", "-f", data.Temp().Path("compose.yaml"), "ps", "svc0")
 				svc1 := helpers.Capture("compose", "-f", data.Temp().Path("compose.yaml"), "ps", "svc1")
 				comp := expect.Match(regexp.MustCompile("Up|running"))
-				comp(svc0, "", t)
-				comp(svc1, "", t)
+				comp(svc0, t)
+				comp(svc1, t)
 			},
 		}
 	}

--- a/cmd/nerdctl/compose/compose_start_linux_test.go
+++ b/cmd/nerdctl/compose/compose_start_linux_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -61,7 +62,7 @@ services:
 		return &test.Expected{
 			ExitCode: 0,
 			Errors:   nil,
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				svc0 := helpers.Capture("compose", "-f", data.Temp().Path("compose.yaml"), "ps", "svc0")
 				svc1 := helpers.Capture("compose", "-f", data.Temp().Path("compose.yaml"), "ps", "svc1")
 				comp := expect.Match(regexp.MustCompile("Up|running"))

--- a/cmd/nerdctl/compose/compose_up_test.go
+++ b/cmd/nerdctl/compose/compose_up_test.go
@@ -94,7 +94,7 @@ services:
 		return &test.Expected{
 			ExitCode: 0,
 			Errors:   nil,
-			Output: func(stdout, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				assert.Equal(t, data.Temp().Load("foo", "test"), "hi\n")
 			},
 		}

--- a/cmd/nerdctl/compose/compose_up_test.go
+++ b/cmd/nerdctl/compose/compose_up_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -94,7 +95,7 @@ services:
 		return &test.Expected{
 			ExitCode: 0,
 			Errors:   nil,
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Equal(t, data.Temp().Load("foo", "test"), "hi\n")
 			},
 		}

--- a/cmd/nerdctl/container/container_attach_linux_test.go
+++ b/cmd/nerdctl/container/container_attach_linux_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -64,7 +65,7 @@ func TestAttach(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
@@ -93,7 +94,7 @@ func TestAttach(t *testing.T) {
 			Errors:   []error{errors.New("read detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -125,7 +126,7 @@ func TestAttachDetachKeys(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
@@ -153,7 +154,7 @@ func TestAttachDetachKeys(t *testing.T) {
 			Errors:   []error{errors.New("read detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -182,7 +183,7 @@ func TestAttachForAutoRemovedContainer(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
@@ -202,7 +203,7 @@ func TestAttachForAutoRemovedContainer(t *testing.T) {
 			ExitCode: 42,
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, !strings.Contains(helpers.Capture("ps", "-a"), data.Identifier()))
 				},
 			),
@@ -226,7 +227,7 @@ func TestAttachNoStdin(t *testing.T) {
 		cmd.Feed(bytes.NewReader([]byte{16, 17})) // Ctrl-p, Ctrl-q to detach (https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "{{.State.Running}}", data.Identifier()), "true"))
 			},
 		})
@@ -243,7 +244,7 @@ func TestAttachNoStdin(t *testing.T) {
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: 0, // Since it's a normal exit and not detach.
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				logs := helpers.Capture("logs", data.Identifier())
 				assert.Assert(t, !strings.Contains(logs, "should-not-appear"))
 			},

--- a/cmd/nerdctl/container/container_attach_linux_test.go
+++ b/cmd/nerdctl/container/container_attach_linux_test.go
@@ -64,7 +64,7 @@ func TestAttach(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
@@ -93,7 +93,7 @@ func TestAttach(t *testing.T) {
 			Errors:   []error{errors.New("read detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -125,7 +125,7 @@ func TestAttachDetachKeys(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
@@ -153,7 +153,7 @@ func TestAttachDetachKeys(t *testing.T) {
 			Errors:   []error{errors.New("read detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -182,8 +182,8 @@ func TestAttachForAutoRemovedContainer(t *testing.T) {
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
 			Errors:   []error{errors.New("read detach keys")},
-			Output: func(stdout string, info string, t *testing.T) {
-				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"), info)
+			Output: func(stdout string, t *testing.T) {
+				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 			},
 		})
 	}
@@ -202,7 +202,7 @@ func TestAttachForAutoRemovedContainer(t *testing.T) {
 			ExitCode: 42,
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, !strings.Contains(helpers.Capture("ps", "-a"), data.Identifier()))
 				},
 			),
@@ -226,7 +226,7 @@ func TestAttachNoStdin(t *testing.T) {
 		cmd.Feed(bytes.NewReader([]byte{16, 17})) // Ctrl-p, Ctrl-q to detach (https://en.wikipedia.org/wiki/C0_and_C1_control_codes)
 		cmd.Run(&test.Expected{
 			ExitCode: 0,
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "{{.State.Running}}", data.Identifier()), "true"))
 			},
 		})
@@ -243,7 +243,7 @@ func TestAttachNoStdin(t *testing.T) {
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: 0, // Since it's a normal exit and not detach.
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				logs := helpers.Capture("logs", data.Identifier())
 				assert.Assert(t, !strings.Contains(logs, "should-not-appear"))
 			},

--- a/cmd/nerdctl/container/container_commit_linux_test.go
+++ b/cmd/nerdctl/container/container_commit_linux_test.go
@@ -41,7 +41,7 @@ func TestKubeCommitSave(t *testing.T) {
 		nerdtest.KubeCtlCommand(helpers, "wait", "pod", identifier, "--for=condition=ready", "--timeout=1m").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "exec", identifier, "--", "mkdir", "-p", "/tmp/whatever").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "get", "pods", identifier, "-o", "jsonpath={ .status.containerStatuses[0].containerID }").Run(&test.Expected{
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				containerID = strings.TrimPrefix(stdout, "containerd://")
 			},
 		})
@@ -73,7 +73,7 @@ func TestKubeCommitSave(t *testing.T) {
 
 				cmd = nerdtest.KubeCtlCommand(helpers, "get", "pods", tID, "-o", "jsonpath={ .status.hostIPs[0].ip }")
 				cmd.Run(&test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						registryIP = stdout
 					},
 				})

--- a/cmd/nerdctl/container/container_commit_linux_test.go
+++ b/cmd/nerdctl/container/container_commit_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -41,7 +42,7 @@ func TestKubeCommitSave(t *testing.T) {
 		nerdtest.KubeCtlCommand(helpers, "wait", "pod", identifier, "--for=condition=ready", "--timeout=1m").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "exec", identifier, "--", "mkdir", "-p", "/tmp/whatever").Run(&test.Expected{})
 		nerdtest.KubeCtlCommand(helpers, "get", "pods", identifier, "-o", "jsonpath={ .status.containerStatuses[0].containerID }").Run(&test.Expected{
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				containerID = strings.TrimPrefix(stdout, "containerd://")
 			},
 		})
@@ -73,7 +74,7 @@ func TestKubeCommitSave(t *testing.T) {
 
 				cmd = nerdtest.KubeCtlCommand(helpers, "get", "pods", tID, "-o", "jsonpath={ .status.hostIPs[0].ip }")
 				cmd.Run(&test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						registryIP = stdout
 					},
 				})

--- a/cmd/nerdctl/container/container_commit_test.go
+++ b/cmd/nerdctl/container/container_commit_test.go
@@ -121,7 +121,7 @@ func TestZstdCommit(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.JSON([]native.Image{}, func(images []native.Image, s string, t tig.T) {
+					Output: expect.JSON([]native.Image{}, func(images []native.Image, t tig.T) {
 						assert.Equal(t, len(images), 1)
 						assert.Equal(helpers.T(), images[0].Manifest.Layers[len(images[0].Manifest.Layers)-1].MediaType, "application/vnd.docker.image.rootfs.diff.tar.zstd")
 					}),

--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -235,7 +235,7 @@ func TestIssue2993(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("is already used by ID")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 1)
@@ -282,7 +282,7 @@ func TestIssue2993(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 0)
@@ -363,10 +363,10 @@ func TestUsernsMappingCreateCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							assert.NilError(t, err, "Failed to get container host UID")
-							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"), info)
+							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
 					}
 				},

--- a/cmd/nerdctl/container/container_create_linux_test.go
+++ b/cmd/nerdctl/container/container_create_linux_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -235,7 +236,7 @@ func TestIssue2993(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("is already used by ID")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 1)
@@ -282,7 +283,7 @@ func TestIssue2993(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						containersDirs, err := os.ReadDir(data.Labels().Get(containersPathKey))
 						assert.NilError(t, err)
 						assert.Equal(t, len(containersDirs), 0)
@@ -363,7 +364,7 @@ func TestUsernsMappingCreateCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							assert.NilError(t, err, "Failed to get container host UID")
 							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))

--- a/cmd/nerdctl/container/container_create_test.go
+++ b/cmd/nerdctl/container/container_create_test.go
@@ -96,13 +96,13 @@ func TestCreateHyperVContainer(t *testing.T) {
 					helpers.Command("container", "inspect", data.Labels().Get("cID")).
 						Run(&test.Expected{
 							ExitCode: expect.ExitCodeNoCheck,
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								var dc []dockercompat.Container
 								err := json.Unmarshal([]byte(stdout), &dc)
 								if err != nil || len(dc) == 0 {
 									return
 								}
-								assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n"+info)
+								assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n")
 								ran = dc[0].State.Status == "exited"
 							},
 						})

--- a/cmd/nerdctl/container/container_create_test.go
+++ b/cmd/nerdctl/container/container_create_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -96,7 +97,7 @@ func TestCreateHyperVContainer(t *testing.T) {
 					helpers.Command("container", "inspect", data.Labels().Get("cID")).
 						Run(&test.Expected{
 							ExitCode: expect.ExitCodeNoCheck,
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								var dc []dockercompat.Container
 								err := json.Unmarshal([]byte(stdout), &dc)
 								if err != nil || len(dc) == 0 {

--- a/cmd/nerdctl/container/container_health_check_test.go
+++ b/cmd/nerdctl/container/container_health_check_test.go
@@ -77,7 +77,7 @@ func TestContainerHealthCheckBasic(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state to be present")
@@ -150,7 +150,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -185,7 +185,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -214,7 +214,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -242,7 +242,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -267,7 +267,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						assert.Assert(t, inspect.State.Health == nil, "expected health to be nil with --no-healthcheck")
 					}),
@@ -290,7 +290,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_, _ string, t *testing.T) {
+					Output: expect.All(func(_ string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -320,7 +320,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -350,7 +350,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -382,7 +382,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_, _ string, t *testing.T) {
+					Output: expect.All(func(_ string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -417,7 +417,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_, _ string, t *testing.T) {
+					Output: expect.All(func(_ string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -444,7 +444,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_, _ string, t *testing.T) {
+					Output: expect.All(func(_ string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -480,7 +480,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -512,7 +512,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -540,7 +540,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout, _ string, t *testing.T) {
+					Output: expect.All(func(stdout string, t *testing.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")

--- a/cmd/nerdctl/container/container_health_check_test.go
+++ b/cmd/nerdctl/container/container_health_check_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -77,7 +78,7 @@ func TestContainerHealthCheckBasic(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state to be present")
@@ -150,7 +151,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -185,7 +186,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -214,7 +215,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -242,7 +243,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -267,7 +268,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						assert.Assert(t, inspect.State.Health == nil, "expected health to be nil with --no-healthcheck")
 					}),
@@ -290,7 +291,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_ string, t *testing.T) {
+					Output: expect.All(func(_ string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -320,7 +321,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -350,7 +351,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -382,7 +383,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_ string, t *testing.T) {
+					Output: expect.All(func(_ string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -417,7 +418,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_ string, t *testing.T) {
+					Output: expect.All(func(_ string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -444,7 +445,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(_ string, t *testing.T) {
+					Output: expect.All(func(_ string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -480,7 +481,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -512,7 +513,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")
@@ -540,7 +541,7 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: expect.All(func(stdout string, t *testing.T) {
+					Output: expect.All(func(stdout string, t tig.T) {
 						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 						h := inspect.State.Health
 						assert.Assert(t, h != nil, "expected health state")

--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -688,7 +689,7 @@ func TestContainerListStatusFilter(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("cID")), "No container found with status created")
 					},
 				}

--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -688,7 +688,7 @@ func TestContainerListStatusFilter(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("cID")), "No container found with status created")
 					},
 				}

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -189,7 +189,7 @@ bar
 				cmd := helpers.Custom("journalctl", "-xe")
 				cmd.Run(&test.Expected{
 					ExitCode: expect.ExitCodeNoCheck,
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						if stdout != "" {
 							works = true
 						}
@@ -456,7 +456,7 @@ func TestLogsTailFollowRotate(t *testing.T) {
 		return cmd
 	}
 
-	testCase.Expected = test.Expects(expect.ExitCodeTimeout, nil, func(stdout, info string, t *testing.T) {
+	testCase.Expected = test.Expects(expect.ExitCodeTimeout, nil, func(stdout string, t *testing.T) {
 		tailLogs := strings.Split(strings.TrimSpace(stdout), "\n")
 		for _, line := range tailLogs {
 			if line != "" {
@@ -603,10 +603,10 @@ func TestLogsWithStartContainer(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						finalLogsCount := strings.Count(stdout, "foo")
 						initialFooCount, _ := strconv.Atoi(data.Labels().Get("initialFooCount"))
-						assert.Assert(t, finalLogsCount > initialFooCount, "Expected 'foo' count to increase after restart", info)
+						assert.Assert(t, finalLogsCount > initialFooCount, "Expected 'foo' count to increase after restart")
 					},
 				}
 			},

--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -189,7 +190,7 @@ bar
 				cmd := helpers.Custom("journalctl", "-xe")
 				cmd.Run(&test.Expected{
 					ExitCode: expect.ExitCodeNoCheck,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						if stdout != "" {
 							works = true
 						}
@@ -456,7 +457,7 @@ func TestLogsTailFollowRotate(t *testing.T) {
 		return cmd
 	}
 
-	testCase.Expected = test.Expects(expect.ExitCodeTimeout, nil, func(stdout string, t *testing.T) {
+	testCase.Expected = test.Expects(expect.ExitCodeTimeout, nil, func(stdout string, t tig.T) {
 		tailLogs := strings.Split(strings.TrimSpace(stdout), "\n")
 		for _, line := range tailLogs {
 			if line != "" {
@@ -603,7 +604,7 @@ func TestLogsWithStartContainer(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						finalLogsCount := strings.Count(stdout, "foo")
 						initialFooCount, _ := strconv.Atoi(data.Labels().Get("initialFooCount"))
 						assert.Assert(t, finalLogsCount > initialFooCount, "Expected 'foo' count to increase after restart")

--- a/cmd/nerdctl/container/container_remove_linux_test.go
+++ b/cmd/nerdctl/container/container_remove_linux_test.go
@@ -51,7 +51,8 @@ func testContainerRmIptablesExecutor(data test.Data, helpers test.Helpers) test.
 	if rootlessutil.IsRootless() {
 		// In rootless mode, we need to enter the rootlesskit network namespace
 		if netns, err := rootlessutil.DetachedNetNS(); err != nil {
-			t.Fatalf("Failed to get detached network namespace: %v", err)
+			t.Log(fmt.Sprintf("Failed to get detached network namespace: %v", err))
+			t.FailNow()
 		} else {
 			if netns != "" {
 				// Use containerd-rootless-setuptool.sh to enter the RootlessKit namespace
@@ -85,7 +86,8 @@ func TestContainerRmIptables(t *testing.T) {
 				// Get a free port using portlock
 				port, err := portlock.Acquire(0)
 				if err != nil {
-					helpers.T().Fatalf("Failed to acquire port: %v", err)
+					helpers.T().Log(fmt.Sprintf("Failed to acquire port: %v", err))
+					helpers.T().FailNow()
 				}
 				data.Labels().Set("port", strconv.Itoa(port))
 

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -153,7 +154,7 @@ func TestRestartWithSignal(t *testing.T) {
 			Output: expect.All(
 				// Check that we saw SIGUSR1 inside the container
 				expect.Contains(nerdtest.SignalCaught),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					// Ensure the container was restarted
 					nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 					// Check the new pid is different

--- a/cmd/nerdctl/container/container_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_restart_linux_test.go
@@ -153,12 +153,12 @@ func TestRestartWithSignal(t *testing.T) {
 			Output: expect.All(
 				// Check that we saw SIGUSR1 inside the container
 				expect.Contains(nerdtest.SignalCaught),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					// Ensure the container was restarted
 					nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 					// Check the new pid is different
 					newpid := strconv.Itoa(nerdtest.InspectContainer(helpers, data.Identifier()).State.Pid)
-					assert.Assert(helpers.T(), newpid != data.Labels().Get("oldpid"), info)
+					assert.Assert(helpers.T(), newpid != data.Labels().Get("oldpid"))
 				},
 			),
 		}

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -315,7 +315,7 @@ func TestRunDevice(t *testing.T) {
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("exec", data.Labels().Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[1].Device)
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
 				lo1Read, err := os.ReadFile(lo[1].Device)
 				assert.NilError(t, err)
 				assert.Equal(t, string(bytes.Trim(lo1Read, "\x00")), "overwritten-lo1-content")
@@ -528,7 +528,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "{{.HostConfig.BlkioWeight}}", data.Identifier()), "150"))
 						},
 					),
@@ -550,7 +550,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioWeightDevice}}{{.Weight}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "100"))
 						},
@@ -579,7 +579,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceReadBps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "1048576"))
 						},
@@ -608,7 +608,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceWriteBps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "2097152"))
 						},
@@ -637,7 +637,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceReadIOps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "1000"))
 						},
@@ -666,7 +666,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceWriteIOps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "2000"))
 						},
@@ -701,7 +701,7 @@ func TestRunCPURealTimeSettingCgroupV1(t *testing.T) {
 			return &test.Expected{
 				ExitCode: 0,
 				Output: expect.All(
-					func(stdout string, info string, t *testing.T) {
+					func(stdout string, t *testing.T) {
 						rtRuntime := helpers.Capture("inspect", "--format", "{{.HostConfig.CPURealtimeRuntime}}", data.Identifier())
 						rtPeriod := helpers.Capture("inspect", "--format", "{{.HostConfig.CPURealtimePeriod}}", data.Identifier())
 						assert.Assert(t, strings.Contains(rtRuntime, "950000"))

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
@@ -315,7 +316,7 @@ func TestRunDevice(t *testing.T) {
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("exec", data.Labels().Get("id"), "sh", "-ec", "echo -n \"overwritten-lo1-content\">"+lo[1].Device)
 			},
-			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
 				lo1Read, err := os.ReadFile(lo[1].Device)
 				assert.NilError(t, err)
 				assert.Equal(t, string(bytes.Trim(lo1Read, "\x00")), "overwritten-lo1-content")
@@ -528,7 +529,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "{{.HostConfig.BlkioWeight}}", data.Identifier()), "150"))
 						},
 					),
@@ -550,7 +551,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioWeightDevice}}{{.Weight}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "100"))
 						},
@@ -579,7 +580,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceReadBps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "1048576"))
 						},
@@ -608,7 +609,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceWriteBps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "2097152"))
 						},
@@ -637,7 +638,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceReadIOps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "1000"))
 						},
@@ -666,7 +667,7 @@ func TestRunBlkioSettingCgroupV2(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspectOut := helpers.Capture("inspect", "--format", "{{range .HostConfig.BlkioDeviceWriteIOps}}{{.Rate}}{{end}}", data.Identifier())
 							assert.Assert(t, strings.Contains(inspectOut, "2000"))
 						},
@@ -701,7 +702,7 @@ func TestRunCPURealTimeSettingCgroupV1(t *testing.T) {
 			return &test.Expected{
 				ExitCode: 0,
 				Output: expect.All(
-					func(stdout string, t *testing.T) {
+					func(stdout string, t tig.T) {
 						rtRuntime := helpers.Capture("inspect", "--format", "{{.HostConfig.CPURealtimeRuntime}}", data.Identifier())
 						rtPeriod := helpers.Capture("inspect", "--format", "{{.HostConfig.CPURealtimePeriod}}", data.Identifier())
 						assert.Assert(t, strings.Contains(rtRuntime, "950000"))

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -548,7 +549,7 @@ func TestRunWithDetachKeys(t *testing.T) {
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -616,7 +617,7 @@ func TestIssue3568(t *testing.T) {
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -651,7 +652,7 @@ func TestPortBindingWithCustomHost(t *testing.T) {
 					ExitCode: 0,
 					Errors:   []error{},
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							resp, err := nettestutil.HTTPGet(address, 30, false)
 							assert.NilError(t, err)
 

--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -548,7 +548,7 @@ func TestRunWithDetachKeys(t *testing.T) {
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -616,7 +616,7 @@ func TestIssue3568(t *testing.T) {
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
 				expect.Contains("markmark"),
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),
@@ -651,7 +651,7 @@ func TestPortBindingWithCustomHost(t *testing.T) {
 					ExitCode: 0,
 					Errors:   []error{},
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							resp, err := nettestutil.HTTPGet(address, 30, false)
 							assert.NilError(t, err)
 

--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -307,7 +307,7 @@ func TestRunBindMountTmpfs(t *testing.T) {
 }
 
 func mountExistsWithOpt(mountPoint, mountOpt string) test.Comparator {
-	return func(stdout, info string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		lines := strings.Split(strings.TrimSpace(stdout), "\n")
 		mountOutput := []string{}
 		for _, line := range lines {

--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -307,7 +308,7 @@ func TestRunBindMountTmpfs(t *testing.T) {
 }
 
 func mountExistsWithOpt(mountPoint, mountOpt string) test.Comparator {
-	return func(stdout string, t *testing.T) {
+	return func(stdout string, t tig.T) {
 		lines := strings.Split(strings.TrimSpace(stdout), "\n")
 		mountOutput := []string{}
 		for _, line := range lines {

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -423,7 +424,7 @@ func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errdefs.ErrInvalidArgument},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						getAddrHash := func(addr string) string {
 							const addrHashLen = 8
 
@@ -938,7 +939,7 @@ func TestHostNetworkHostName(t *testing.T) {
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Custom("cat", "/etc/hostname").Run(&test.Expected{
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					data.Labels().Set("hostHostname", stdout)
 				},
 			})

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -423,7 +423,7 @@ func TestRunWithInvalidPortThenCleanUp(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errdefs.ErrInvalidArgument},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						getAddrHash := func(addr string) string {
 							const addrHashLen = 8
 
@@ -599,7 +599,6 @@ func TestSharedNetworkSetup(t *testing.T) {
 						Description: "Test network is shared",
 						Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 							return helpers.Command("exec", data.Labels().Get("container2"), "wget", "-qO-", "http://127.0.0.1:80")
-
 						},
 						Expected: test.Expects(0, nil, expect.Contains(testutil.NginxAlpineIndexHTMLSnippet)),
 					},
@@ -939,7 +938,7 @@ func TestHostNetworkHostName(t *testing.T) {
 		Require: require.Not(require.Windows),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Custom("cat", "/etc/hostname").Run(&test.Expected{
-				Output: func(stdout, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					data.Labels().Set("hostHostname", stdout)
 				},
 			})

--- a/cmd/nerdctl/container/container_run_soci_linux_test.go
+++ b/cmd/nerdctl/container/container_run_soci_linux_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -44,7 +45,7 @@ func TestRunSoci(t *testing.T) {
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Custom("mount").Run(&test.Expected{
 			ExitCode: 0,
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				data.Labels().Set("beforeCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 			},
 		})
@@ -60,12 +61,12 @@ func TestRunSoci(t *testing.T) {
 
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				var afterCount int
 				beforeCount, _ := strconv.Atoi(data.Labels().Get("beforeCount"))
 
 				helpers.Custom("mount").Run(&test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						afterCount = strings.Count(stdout, "fuse.rawBridge")
 					},
 				})

--- a/cmd/nerdctl/container/container_run_soci_linux_test.go
+++ b/cmd/nerdctl/container/container_run_soci_linux_test.go
@@ -44,7 +44,7 @@ func TestRunSoci(t *testing.T) {
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Custom("mount").Run(&test.Expected{
 			ExitCode: 0,
-			Output: func(stdout, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				data.Labels().Set("beforeCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 			},
 		})
@@ -60,12 +60,12 @@ func TestRunSoci(t *testing.T) {
 
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
-			Output: func(stdout, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				var afterCount int
 				beforeCount, _ := strconv.Atoi(data.Labels().Get("beforeCount"))
 
 				helpers.Custom("mount").Run(&test.Expected{
-					Output: func(stdout, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						afterCount = strings.Count(stdout, "fuse.rawBridge")
 					},
 				})

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -156,7 +156,7 @@ func TestRunExitCode(t *testing.T) {
 			Output: expect.All(
 				expect.Match(regexp.MustCompile("Exited [(]123[)][A-Za-z0-9 ]+"+data.Identifier("exit123"))),
 				expect.Match(regexp.MustCompile("Exited [(]0[)][A-Za-z0-9 ]+"+data.Identifier("exit0"))),
-				func(stdout, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Equal(t, nerdtest.InspectContainer(helpers, data.Identifier("exit0")).State.Status, "exited")
 					assert.Equal(t, nerdtest.InspectContainer(helpers, data.Identifier("exit123")).State.Status, "exited")
 				},
@@ -953,7 +953,7 @@ func TestRunHealthcheckFlags(t *testing.T) {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeSuccess,
 					Output: expect.All(
-						func(stdout, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							inspect := nerdtest.InspectContainer(helpers, tc.name)
 							hc := inspect.Config.Healthcheck
 							if tc.expectTest == nil {
@@ -1013,7 +1013,7 @@ HEALTHCHECK --interval=30s --timeout=10s CMD wget -q --spider http://localhost:8
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: expect.ExitCodeSuccess,
-						Output: expect.All(func(stdout, _ string, t *testing.T) {
+						Output: expect.All(func(stdout string, t *testing.T) {
 							inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 							hc := inspect.Config.Healthcheck
 							assert.Assert(t, hc != nil, "expected healthcheck config to be present")
@@ -1040,7 +1040,7 @@ HEALTHCHECK --interval=30s --timeout=10s CMD wget -q --spider http://localhost:8
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: expect.ExitCodeSuccess,
-						Output: expect.All(func(stdout, _ string, t *testing.T) {
+						Output: expect.All(func(stdout string, t *testing.T) {
 							inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 							hc := inspect.Config.Healthcheck
 							assert.Assert(t, hc != nil, "expected healthcheck config to be present")

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -156,7 +157,7 @@ func TestRunExitCode(t *testing.T) {
 			Output: expect.All(
 				expect.Match(regexp.MustCompile("Exited [(]123[)][A-Za-z0-9 ]+"+data.Identifier("exit123"))),
 				expect.Match(regexp.MustCompile("Exited [(]0[)][A-Za-z0-9 ]+"+data.Identifier("exit0"))),
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Equal(t, nerdtest.InspectContainer(helpers, data.Identifier("exit0")).State.Status, "exited")
 					assert.Equal(t, nerdtest.InspectContainer(helpers, data.Identifier("exit123")).State.Status, "exited")
 				},
@@ -953,7 +954,7 @@ func TestRunHealthcheckFlags(t *testing.T) {
 				return &test.Expected{
 					ExitCode: expect.ExitCodeSuccess,
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							inspect := nerdtest.InspectContainer(helpers, tc.name)
 							hc := inspect.Config.Healthcheck
 							if tc.expectTest == nil {
@@ -1013,7 +1014,7 @@ HEALTHCHECK --interval=30s --timeout=10s CMD wget -q --spider http://localhost:8
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: expect.ExitCodeSuccess,
-						Output: expect.All(func(stdout string, t *testing.T) {
+						Output: expect.All(func(stdout string, t tig.T) {
 							inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 							hc := inspect.Config.Healthcheck
 							assert.Assert(t, hc != nil, "expected healthcheck config to be present")
@@ -1040,7 +1041,7 @@ HEALTHCHECK --interval=30s --timeout=10s CMD wget -q --spider http://localhost:8
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: expect.ExitCodeSuccess,
-						Output: expect.All(func(stdout string, t *testing.T) {
+						Output: expect.All(func(stdout string, t tig.T) {
 							inspect := nerdtest.InspectContainer(helpers, data.Identifier())
 							hc := inspect.Config.Healthcheck
 							assert.Assert(t, hc != nil, "expected healthcheck config to be present")

--- a/cmd/nerdctl/container/container_run_user_linux_test.go
+++ b/cmd/nerdctl/container/container_run_user_linux_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -222,10 +223,11 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
-								t.Fatalf("Failed to get container host UID: %v", err)
+								t.Log(fmt.Sprintf("Failed to get container host UID: %v", err))
+								t.FailNow()
 							}
 							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
@@ -249,10 +251,11 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
-								t.Fatalf("Failed to get container host UID: %v", err)
+								t.Log(fmt.Sprintf("Failed to get container host UID: %v", err))
+								t.FailNow()
 							}
 							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
@@ -295,10 +298,11 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
-								t.Fatalf("Failed to get container host UID: %v", err)
+								t.Log(fmt.Sprintf("Failed to get container host UID: %v", err))
+								t.FailNow()
 							}
 							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
@@ -322,10 +326,11 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
-								t.Fatalf("Failed to get container host UID: %v", err)
+								t.Log(fmt.Sprintf("Failed to get container host UID: %v", err))
+								t.FailNow()
 							}
 							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
@@ -367,10 +372,11 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
-								t.Fatalf("Failed to get container host UID: %v", err)
+								t.Log(fmt.Sprintf("Failed to get container host UID: %v", err))
+								t.FailNow()
 							}
 							assert.Assert(t, actualHostUID == "0")
 						},

--- a/cmd/nerdctl/container/container_run_user_linux_test.go
+++ b/cmd/nerdctl/container/container_run_user_linux_test.go
@@ -222,12 +222,12 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
 								t.Fatalf("Failed to get container host UID: %v", err)
 							}
-							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"), info)
+							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
 					}
 				},
@@ -249,12 +249,12 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
 								t.Fatalf("Failed to get container host UID: %v", err)
 							}
-							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"), info)
+							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
 					}
 				},
@@ -295,12 +295,12 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
 								t.Fatalf("Failed to get container host UID: %v", err)
 							}
-							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"), info)
+							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
 					}
 				},
@@ -322,12 +322,12 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
 								t.Fatalf("Failed to get container host UID: %v", err)
 							}
-							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"), info)
+							assert.Assert(t, actualHostUID == data.Labels().Get("expectedHostUID"))
 						},
 					}
 				},
@@ -367,12 +367,12 @@ func TestUsernsMappingRunCmd(t *testing.T) {
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						ExitCode: 0,
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							actualHostUID, err := getContainerHostUID(helpers, data.Identifier())
 							if err != nil {
 								t.Fatalf("Failed to get container host UID: %v", err)
 							}
-							assert.Assert(t, actualHostUID == "0", info)
+							assert.Assert(t, actualHostUID == "0")
 						},
 					}
 				},

--- a/cmd/nerdctl/container/container_start_linux_test.go
+++ b/cmd/nerdctl/container/container_start_linux_test.go
@@ -67,7 +67,7 @@ func TestStartDetachKeys(t *testing.T) {
 			ExitCode: 0,
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
-				func(stdout string, info string, t *testing.T) {
+				func(stdout string, t *testing.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),

--- a/cmd/nerdctl/container/container_start_linux_test.go
+++ b/cmd/nerdctl/container/container_start_linux_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -67,7 +68,7 @@ func TestStartDetachKeys(t *testing.T) {
 			ExitCode: 0,
 			Errors:   []error{errors.New("detach keys")},
 			Output: expect.All(
-				func(stdout string, t *testing.T) {
+				func(stdout string, t tig.T) {
 					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
 				},
 			),

--- a/cmd/nerdctl/image/image_history_test.go
+++ b/cmd/nerdctl/image/image_history_test.go
@@ -90,49 +90,49 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "trunc, no quiet, human",
 				Command:     test.Command("image", "history", "--human=true", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					history, err := decode(stdout)
-					assert.NilError(t, err, info)
-					assert.Equal(t, len(history), 2, info)
+					assert.NilError(t, err, "decode should not fail")
+					assert.Equal(t, len(history), 2, "history should be 2 in length")
 
 					localTimeL1, _ := time.Parse(time.RFC3339, "2021-03-31T10:21:23-07:00")
 					localTimeL2, _ := time.Parse(time.RFC3339, "2021-03-31T10:21:21-07:00")
 					compTime1, _ := time.Parse(time.RFC3339, history[0].CreatedAt)
 					compTime2, _ := time.Parse(time.RFC3339, history[1].CreatedAt)
-					assert.Equal(t, compTime1.UTC().String(), localTimeL1.UTC().String(), info)
-					assert.Equal(t, history[0].CreatedBy, "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]", info)
-					assert.Equal(t, compTime2.UTC().String(), localTimeL2.UTC().String(), info)
-					assert.Equal(t, history[1].CreatedBy, "/bin/sh -c #(nop) ADD file:3b16ffee2b26d8af5…", info)
+					assert.Equal(t, compTime1.UTC().String(), localTimeL1.UTC().String())
+					assert.Equal(t, history[0].CreatedBy, "/bin/sh -c #(nop)  CMD [\"/bin/sh\"]")
+					assert.Equal(t, compTime2.UTC().String(), localTimeL2.UTC().String())
+					assert.Equal(t, history[1].CreatedBy, "/bin/sh -c #(nop) ADD file:3b16ffee2b26d8af5…")
 
-					assert.Equal(t, history[0].Size, "0B", info)
-					assert.Equal(t, history[0].CreatedSince, formatter.TimeSinceInHuman(compTime1), info)
-					assert.Equal(t, history[0].Snapshot, "<missing>", info)
-					assert.Equal(t, history[0].Comment, "", info)
+					assert.Equal(t, history[0].Size, "0B")
+					assert.Equal(t, history[0].CreatedSince, formatter.TimeSinceInHuman(compTime1))
+					assert.Equal(t, history[0].Snapshot, "<missing>")
+					assert.Equal(t, history[0].Comment, "")
 
-					assert.Equal(t, history[1].Size, "5.947MB", info)
-					assert.Equal(t, history[1].CreatedSince, formatter.TimeSinceInHuman(compTime2), info)
-					assert.Equal(t, history[1].Snapshot, "sha256:56bf55b8eed1f0b4794a30386e4d1d3da949c…", info)
-					assert.Equal(t, history[1].Comment, "", info)
+					assert.Equal(t, history[1].Size, "5.947MB")
+					assert.Equal(t, history[1].CreatedSince, formatter.TimeSinceInHuman(compTime2))
+					assert.Equal(t, history[1].Snapshot, "sha256:56bf55b8eed1f0b4794a30386e4d1d3da949c…")
+					assert.Equal(t, history[1].Comment, "")
 				}),
 			},
 			{
 				Description: "no human - dates and sizes and not prettyfied",
 				Command:     test.Command("image", "history", "--human=false", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					history, err := decode(stdout)
-					assert.NilError(t, err, info)
-					assert.Equal(t, history[0].Size, "0", info)
-					assert.Equal(t, history[0].CreatedSince, history[0].CreatedAt, info)
-					assert.Equal(t, history[1].Size, "5947392", info)
-					assert.Equal(t, history[1].CreatedSince, history[1].CreatedAt, info)
+					assert.NilError(t, err, "decode should not fail")
+					assert.Equal(t, history[0].Size, "0")
+					assert.Equal(t, history[0].CreatedSince, history[0].CreatedAt)
+					assert.Equal(t, history[1].Size, "5947392")
+					assert.Equal(t, history[1].CreatedSince, history[1].CreatedAt)
 				}),
 			},
 			{
 				Description: "no trunc - do not truncate sha or cmd",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					history, err := decode(stdout)
-					assert.NilError(t, err, info)
+					assert.NilError(t, err, "decode should not fail")
 					assert.Equal(t, history[1].Snapshot, "sha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a")
 					assert.Equal(t, history[1].CreatedBy, "/bin/sh -c #(nop) ADD file:3b16ffee2b26d8af5db152fcc582aaccd9e1ec9e3343874e9969a205550fe07d in / ")
 				}),
@@ -140,14 +140,14 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "Quiet has no effect with format, so, go no-json, no-trunc",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--quiet", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					assert.Equal(t, stdout, "<missing>\nsha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a\n")
 				}),
 			},
 			{
 				Description: "With quiet, trunc has no effect",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--quiet", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					assert.Equal(t, stdout, "<missing>\nsha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a\n")
 				}),
 			},

--- a/cmd/nerdctl/image/image_history_test.go
+++ b/cmd/nerdctl/image/image_history_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -90,7 +91,7 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "trunc, no quiet, human",
 				Command:     test.Command("image", "history", "--human=true", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					history, err := decode(stdout)
 					assert.NilError(t, err, "decode should not fail")
 					assert.Equal(t, len(history), 2, "history should be 2 in length")
@@ -118,7 +119,7 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "no human - dates and sizes and not prettyfied",
 				Command:     test.Command("image", "history", "--human=false", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					history, err := decode(stdout)
 					assert.NilError(t, err, "decode should not fail")
 					assert.Equal(t, history[0].Size, "0")
@@ -130,7 +131,7 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "no trunc - do not truncate sha or cmd",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--format=json", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					history, err := decode(stdout)
 					assert.NilError(t, err, "decode should not fail")
 					assert.Equal(t, history[1].Snapshot, "sha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a")
@@ -140,14 +141,14 @@ func TestImageHistory(t *testing.T) {
 			{
 				Description: "Quiet has no effect with format, so, go no-json, no-trunc",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--quiet", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					assert.Equal(t, stdout, "<missing>\nsha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a\n")
 				}),
 			},
 			{
 				Description: "With quiet, trunc has no effect",
 				Command:     test.Command("image", "history", "--human=false", "--no-trunc", "--quiet", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					assert.Equal(t, stdout, "<missing>\nsha256:56bf55b8eed1f0b4794a30386e4d1d3da949c25bcb5155e898097cd75dc77c2a\n")
 				}),
 			},

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -45,7 +46,7 @@ func TestImageInspectSimpleCases(t *testing.T) {
 			{
 				Description: "Contains some stuff",
 				Command:     test.Command("image", "inspect", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 					var dc []dockercompat.Image
 					err := json.Unmarshal([]byte(stdout), &dc)
 					assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -115,7 +116,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
 							assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -140,7 +141,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
 							assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -173,7 +174,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
 							assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -196,7 +197,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
 							assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -218,7 +219,7 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
 							assert.NilError(t, err, "Unable to unmarshal output\n")

--- a/cmd/nerdctl/image/image_inspect_test.go
+++ b/cmd/nerdctl/image/image_inspect_test.go
@@ -45,14 +45,14 @@ func TestImageInspectSimpleCases(t *testing.T) {
 			{
 				Description: "Contains some stuff",
 				Command:     test.Command("image", "inspect", testutil.CommonImage),
-				Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+				Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 					var dc []dockercompat.Image
 					err := json.Unmarshal([]byte(stdout), &dc)
-					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-					assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
-					assert.Assert(t, len(dc[0].RootFS.Layers) > 0, info)
-					assert.Assert(t, dc[0].Architecture != "", info)
-					assert.Assert(t, dc[0].Size > 0, info)
+					assert.NilError(t, err, "Unable to unmarshal output\n")
+					assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
+					assert.Assert(t, len(dc[0].RootFS.Layers) > 0, "there should be at least one rootfs layer\n")
+					assert.Assert(t, dc[0].Architecture != "", "architecture should be set\n")
+					assert.Assert(t, dc[0].Size > 0, "size should be > 0 \n")
 				}),
 			},
 			{
@@ -115,11 +115,11 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
-							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							assert.NilError(t, err, "Unable to unmarshal output\n")
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 							reference := dc[0].ID
 							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
 
@@ -140,11 +140,11 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
-							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							assert.NilError(t, err, "Unable to unmarshal output\n")
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 							reference := dc[0].ID
 							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
 
@@ -173,11 +173,11 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
-							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							assert.NilError(t, err, "Unable to unmarshal output\n")
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 							sha := strings.TrimPrefix(dc[0].RepoDigests[0], "busybox@sha256:")
 
 							for _, id := range []string{"doesnotexist", "doesnotexist:either", "busybox:bogustag"} {
@@ -196,11 +196,11 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
-							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+							assert.NilError(t, err, "Unable to unmarshal output\n")
+							assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 
 							for _, id := range []string{"∞∞∞∞∞∞∞∞∞∞", "busybox:∞∞∞∞∞∞∞∞∞∞"} {
 								cmd := helpers.Command("image", "inspect", id)
@@ -218,11 +218,11 @@ func TestImageInspectDifferentValidReferencesForTheSameImage(t *testing.T) {
 				Command:     test.Command("image", "inspect", "busybox", "busybox"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var dc []dockercompat.Image
 							err := json.Unmarshal([]byte(stdout), &dc)
-							assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-							assert.Equal(t, 2, len(dc), "Unexpectedly did not get 2 results\n"+info)
+							assert.NilError(t, err, "Unable to unmarshal output\n")
+							assert.Equal(t, 2, len(dc), "Unexpectedly did not get 2 results\n")
 							reference := nerdtest.InspectImage(helpers, "busybox")
 							assert.Equal(t, dc[0].ID, reference.ID)
 							assert.Equal(t, dc[1].ID, reference.ID)

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -50,16 +50,16 @@ func TestImages(t *testing.T) {
 				Command:     test.Command("images"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
-							assert.Assert(t, len(lines) >= 2, info)
+							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 							header := "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE"
 							if nerdtest.IsDocker() {
 								header = "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tSIZE"
 							}
 							tab := tabutil.NewReader(header)
 							err := tab.ParseHeader(lines[0])
-							assert.NilError(t, err, info)
+							assert.NilError(t, err, "ParseHeader should not fail\n")
 							found := false
 							for _, line := range lines[1:] {
 								repo, _ := tab.ReadRow(line, "REPOSITORY")
@@ -69,7 +69,7 @@ func TestImages(t *testing.T) {
 									break
 								}
 							}
-							assert.Assert(t, found, info)
+							assert.Assert(t, found, "we should have found an image\n")
 						},
 					}
 				},
@@ -81,12 +81,12 @@ func TestImages(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.Contains(testutil.CommonImage),
-							func(stdout string, info string, t *testing.T) {
+							func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) >= 2, info)
+								assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 								tab := tabutil.NewReader("NAME\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE")
 								err := tab.ParseHeader(lines[0])
-								assert.NilError(t, err, info)
+								assert.NilError(t, err, "ParseHeader should not fail\n")
 								found := false
 								for _, line := range lines[1:] {
 									name, _ := tab.ReadRow(line, "NAME")
@@ -96,7 +96,7 @@ func TestImages(t *testing.T) {
 									}
 								}
 
-								assert.Assert(t, found, info)
+								assert.Assert(t, found, "we should have found an image\n")
 							},
 						),
 					}
@@ -107,12 +107,12 @@ func TestImages(t *testing.T) {
 				Command:     test.Command("images", "--format", "'{{json .CreatedAt}}'"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
-							assert.Assert(t, len(lines) >= 2, info)
+							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 							createdTimes := lines
 							slices.Reverse(createdTimes)
-							assert.Assert(t, slices.IsSorted(createdTimes), info)
+							assert.Assert(t, slices.IsSorted(createdTimes), "created times should be sorted\n")
 						},
 					}
 				},
@@ -337,7 +337,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 				Command:     test.Command("--kube-hide-dupe", "images"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							var imageID string
 							var skipLine int
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
@@ -347,7 +347,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 							}
 							tab := tabutil.NewReader(header)
 							err := tab.ParseHeader(lines[0])
-							assert.NilError(t, err, info)
+							assert.NilError(t, err, "ParseHeader should not fail\n")
 							found := true
 							for i, line := range lines[1:] {
 								repo, _ := tab.ReadRow(line, "REPOSITORY")
@@ -368,7 +368,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 									break
 								}
 							}
-							assert.Assert(t, found, info)
+							assert.Assert(t, found, "We should have found the image\n")
 						},
 					}
 				},

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -50,7 +51,7 @@ func TestImages(t *testing.T) {
 				Command:     test.Command("images"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
 							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 							header := "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE"
@@ -81,7 +82,7 @@ func TestImages(t *testing.T) {
 					return &test.Expected{
 						Output: expect.All(
 							expect.Contains(testutil.CommonImage),
-							func(stdout string, t *testing.T) {
+							func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 								tab := tabutil.NewReader("NAME\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE")
@@ -107,7 +108,7 @@ func TestImages(t *testing.T) {
 				Command:     test.Command("images", "--format", "'{{json .CreatedAt}}'"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
 							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
 							createdTimes := lines
@@ -337,7 +338,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 				Command:     test.Command("--kube-hide-dupe", "images"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							var imageID string
 							var skipLine int
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -61,7 +61,7 @@ func TestLoadStdinFromPipe(t *testing.T) {
 			return &test.Expected{
 				Output: expect.All(
 					expect.Contains(fmt.Sprintf("Loaded image: %s:latest", identifier)),
-					func(stdout string, info string, t *testing.T) {
+					func(stdout string, t *testing.T) {
 						assert.Assert(t, strings.Contains(helpers.Capture("images"), identifier))
 					},
 				),

--- a/cmd/nerdctl/image/image_load_test.go
+++ b/cmd/nerdctl/image/image_load_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -61,7 +62,7 @@ func TestLoadStdinFromPipe(t *testing.T) {
 			return &test.Expected{
 				Output: expect.All(
 					expect.Contains(fmt.Sprintf("Loaded image: %s:latest", identifier)),
-					func(stdout string, t *testing.T) {
+					func(stdout string, t tig.T) {
 						assert.Assert(t, strings.Contains(helpers.Capture("images"), identifier))
 					},
 				),

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -84,10 +85,10 @@ func TestImagePrune(t *testing.T) {
 				identifier := data.Identifier()
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							assert.Assert(t, !strings.Contains(stdout, identifier))
 						},
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
 							assert.Assert(t, strings.Contains(imgList, identifier))
@@ -129,10 +130,10 @@ func TestImagePrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							assert.Assert(t, !strings.Contains(stdout, data.Identifier()))
 						},
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, strings.Contains(imgList, data.Identifier()))
 							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
@@ -169,14 +170,14 @@ LABEL version=0.1`, testutil.CommonImage)
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							assert.Assert(t, !strings.Contains(stdout, data.Identifier()))
 						},
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, strings.Contains(imgList, data.Identifier()))
 						},
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							prune := helpers.Capture("image", "prune", "--force", "--all", "--filter", "label=foo=bar")
 							assert.Assert(t, strings.Contains(prune, data.Identifier()))
 							imgList := helpers.Capture("images")
@@ -210,7 +211,7 @@ CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 				return &test.Expected{
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("imageID")),
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, strings.Contains(imgList, data.Labels().Get("imageID")))
 						},
@@ -229,7 +230,7 @@ CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 						return &test.Expected{
 							Output: expect.All(
 								expect.Contains(data.Labels().Get("imageID")),
-								func(stdout string, t *testing.T) {
+								func(stdout string, t tig.T) {
 									imgList := helpers.Capture("images")
 									assert.Assert(t, !strings.Contains(imgList, data.Labels().Get("imageID")), imgList)
 								},

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -84,13 +84,13 @@ func TestImagePrune(t *testing.T) {
 				identifier := data.Identifier()
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, !strings.Contains(stdout, identifier), info)
+						func(stdout string, t *testing.T) {
+							assert.Assert(t, !strings.Contains(stdout, identifier))
 						},
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
-							assert.Assert(t, strings.Contains(imgList, identifier), info)
+							assert.Assert(t, strings.Contains(imgList, identifier))
 						},
 					),
 				}
@@ -129,18 +129,18 @@ func TestImagePrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, !strings.Contains(stdout, data.Identifier()), info)
+						func(stdout string, t *testing.T) {
+							assert.Assert(t, !strings.Contains(stdout, data.Identifier()))
 						},
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							imgList := helpers.Capture("images")
-							assert.Assert(t, strings.Contains(imgList, data.Identifier()), info)
+							assert.Assert(t, strings.Contains(imgList, data.Identifier()))
 							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
 							helpers.Ensure("rm", "-f", data.Identifier())
 							removed := helpers.Capture("image", "prune", "--force", "--all")
-							assert.Assert(t, strings.Contains(removed, data.Identifier()), info)
+							assert.Assert(t, strings.Contains(removed, data.Identifier()))
 							imgList = helpers.Capture("images")
-							assert.Assert(t, !strings.Contains(imgList, data.Identifier()), info)
+							assert.Assert(t, !strings.Contains(imgList, data.Identifier()))
 						},
 					),
 				}
@@ -169,18 +169,18 @@ LABEL version=0.1`, testutil.CommonImage)
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					Output: expect.All(
-						func(stdout string, info string, t *testing.T) {
-							assert.Assert(t, !strings.Contains(stdout, data.Identifier()), info)
+						func(stdout string, t *testing.T) {
+							assert.Assert(t, !strings.Contains(stdout, data.Identifier()))
 						},
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							imgList := helpers.Capture("images")
-							assert.Assert(t, strings.Contains(imgList, data.Identifier()), info)
+							assert.Assert(t, strings.Contains(imgList, data.Identifier()))
 						},
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							prune := helpers.Capture("image", "prune", "--force", "--all", "--filter", "label=foo=bar")
-							assert.Assert(t, strings.Contains(prune, data.Identifier()), info)
+							assert.Assert(t, strings.Contains(prune, data.Identifier()))
 							imgList := helpers.Capture("images")
-							assert.Assert(t, !strings.Contains(imgList, data.Identifier()), info)
+							assert.Assert(t, !strings.Contains(imgList, data.Identifier()))
 						},
 					),
 				}
@@ -210,9 +210,9 @@ CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 				return &test.Expected{
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("imageID")),
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							imgList := helpers.Capture("images")
-							assert.Assert(t, strings.Contains(imgList, data.Labels().Get("imageID")), info)
+							assert.Assert(t, strings.Contains(imgList, data.Labels().Get("imageID")))
 						},
 					),
 				}
@@ -229,9 +229,9 @@ CMD ["echo", "nerdctl-test-image-prune-until"]`, testutil.CommonImage)
 						return &test.Expected{
 							Output: expect.All(
 								expect.Contains(data.Labels().Get("imageID")),
-								func(stdout string, info string, t *testing.T) {
+								func(stdout string, t *testing.T) {
 									imgList := helpers.Capture("images")
-									assert.Assert(t, !strings.Contains(imgList, data.Labels().Get("imageID")), imgList, info)
+									assert.Assert(t, !strings.Contains(imgList, data.Labels().Get("imageID")), imgList)
 								},
 							),
 						}

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -182,7 +183,7 @@ func TestImagePullSoci(t *testing.T) {
 				Setup: func(data test.Data, helpers test.Helpers) {
 					cmd := helpers.Custom("mount")
 					cmd.Run(&test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							data.Labels().Set("remoteSnapshotsInitialCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 						},
 					})
@@ -196,7 +197,7 @@ func TestImagePullSoci(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							remoteSnapshotsInitialCount, _ := strconv.Atoi(data.Labels().Get("remoteSnapshotsInitialCount"))
 							remoteSnapshotsActualCount := strings.Count(stdout, "fuse.rawBridge")
 							assert.Equal(t,
@@ -218,7 +219,7 @@ func TestImagePullSoci(t *testing.T) {
 				Setup: func(data test.Data, helpers test.Helpers) {
 					cmd := helpers.Custom("mount")
 					cmd.Run(&test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							data.Labels().Set("remoteSnapshotsInitialCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 						},
 					})
@@ -232,7 +233,7 @@ func TestImagePullSoci(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							remoteSnapshotsInitialCount, _ := strconv.Atoi(data.Labels().Get("remoteSnapshotsInitialCount"))
 							remoteSnapshotsActualCount := strings.Count(stdout, "fuse.rawBridge")
 							assert.Equal(t,

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -182,7 +182,7 @@ func TestImagePullSoci(t *testing.T) {
 				Setup: func(data test.Data, helpers test.Helpers) {
 					cmd := helpers.Custom("mount")
 					cmd.Run(&test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							data.Labels().Set("remoteSnapshotsInitialCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 						},
 					})
@@ -196,7 +196,7 @@ func TestImagePullSoci(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, _ string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							remoteSnapshotsInitialCount, _ := strconv.Atoi(data.Labels().Get("remoteSnapshotsInitialCount"))
 							remoteSnapshotsActualCount := strings.Count(stdout, "fuse.rawBridge")
 							assert.Equal(t,
@@ -218,7 +218,7 @@ func TestImagePullSoci(t *testing.T) {
 				Setup: func(data test.Data, helpers test.Helpers) {
 					cmd := helpers.Custom("mount")
 					cmd.Run(&test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							data.Labels().Set("remoteSnapshotsInitialCount", strconv.Itoa(strings.Count(stdout, "fuse.rawBridge")))
 						},
 					})
@@ -232,7 +232,7 @@ func TestImagePullSoci(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							remoteSnapshotsInitialCount, _ := strconv.Atoi(data.Labels().Get("remoteSnapshotsInitialCount"))
 							remoteSnapshotsActualCount := strings.Count(stdout, "fuse.rawBridge")
 							assert.Equal(t,

--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -200,7 +201,7 @@ func TestPush(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							blobURL := fmt.Sprintf("http://%s:%d/v2/%s/blobs/%s", registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), testutil.NonDistBlobDigest)
 							resp, err := http.Get(blobURL)
 							assert.Assert(t, err, "error making http request")
@@ -232,7 +233,7 @@ func TestPush(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, t *testing.T) {
+						Output: func(stdout string, t tig.T) {
 							blobURL := fmt.Sprintf("http://%s:%d/v2/%s/blobs/%s", registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), testutil.NonDistBlobDigest)
 							resp, err := http.Get(blobURL)
 							assert.Assert(t, err, "error making http request")

--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -200,7 +200,7 @@ func TestPush(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							blobURL := fmt.Sprintf("http://%s:%d/v2/%s/blobs/%s", registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), testutil.NonDistBlobDigest)
 							resp, err := http.Get(blobURL)
 							assert.Assert(t, err, "error making http request")
@@ -232,7 +232,7 @@ func TestPush(t *testing.T) {
 				},
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: func(stdout string, info string, t *testing.T) {
+						Output: func(stdout string, t *testing.T) {
 							blobURL := fmt.Sprintf("http://%s:%d/v2/%s/blobs/%s", registryNoAuthHTTPRandom.IP.String(), registryNoAuthHTTPRandom.Port, data.Identifier(), testutil.NonDistBlobDigest)
 							resp, err := http.Get(blobURL)
 							assert.Assert(t, err, "error making http request")

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -63,7 +63,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -83,7 +83,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.DoesNotContain(repoName),
 						})
@@ -108,7 +108,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -140,7 +140,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains("<none>"),
 						})
@@ -162,7 +162,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -184,7 +184,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							// a created container with removed image doesn't impact other `rmi` command
 							Output: expect.DoesNotContain(repoName, nginxRepoName),
@@ -212,7 +212,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -246,7 +246,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains("<none>"),
 						})
@@ -272,7 +272,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -293,7 +293,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.DoesNotContain(repoName),
 						})
@@ -336,10 +336,10 @@ func TestIssue3016(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("images", data.Labels().Get(tagIDKey)).Run(&test.Expected{
 							ExitCode: 0,
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								assert.Equal(t, len(strings.Split(stdout, "\n")), 2)
 							},
 						})
@@ -378,17 +378,17 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numTags+1, info)
+								assert.Assert(t, len(lines) == numTags+1)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numNoTags+1, info)
+								assert.Assert(t, len(lines) == numNoTags+1)
 							},
 						})
 					},
@@ -410,17 +410,17 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numTags+1, info)
+								assert.Assert(t, len(lines) == numTags+1)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numNoTags+2, info)
+								assert.Assert(t, len(lines) == numNoTags+2)
 							},
 						})
 					},
@@ -440,17 +440,17 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numTags, info)
+								assert.Assert(t, len(lines) == numTags)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numNoTags, info)
+								assert.Assert(t, len(lines) == numNoTags)
 							},
 						})
 					},
@@ -469,7 +469,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Command("--kube-hide-dupe", "rmi", stdout[0:12]).Run(&test.Expected{
 							ExitCode: 1,
 							Errors:   []error{errors.New("multiple IDs found with provided prefix: ")},
@@ -478,9 +478,9 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 							ExitCode: 0,
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numNoTags, info)
+								assert.Assert(t, len(lines) == numNoTags)
 							},
 						})
 					},
@@ -499,7 +499,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						imgID := strings.Split(stdout, "\n")
 						helpers.Command("--kube-hide-dupe", "rmi", imgID[0]).Run(&test.Expected{
 							ExitCode: 1,
@@ -509,9 +509,9 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 							ExitCode: 0,
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, info string, t *testing.T) {
+							Output: func(stdout string, t *testing.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
-								assert.Assert(t, len(lines) == numNoTags, info)
+								assert.Assert(t, len(lines) == numNoTags)
 							},
 						})
 					},

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -63,7 +64,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -83,7 +84,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.DoesNotContain(repoName),
 						})
@@ -108,7 +109,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -140,7 +141,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains("<none>"),
 						})
@@ -162,7 +163,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -184,7 +185,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							// a created container with removed image doesn't impact other `rmi` command
 							Output: expect.DoesNotContain(repoName, nginxRepoName),
@@ -212,7 +213,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -246,7 +247,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains("<none>"),
 						})
@@ -272,7 +273,7 @@ func TestRemove(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 1,
 					Errors:   []error{errors.New("image is being used")},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.Contains(repoName),
 						})
@@ -293,7 +294,7 @@ func TestRemove(t *testing.T) {
 			Command: test.Command("rmi", "-f", testutil.CommonImage),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
 							Output: expect.DoesNotContain(repoName),
 						})
@@ -336,10 +337,10 @@ func TestIssue3016(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("images", data.Labels().Get(tagIDKey)).Run(&test.Expected{
 							ExitCode: 0,
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								assert.Equal(t, len(strings.Split(stdout, "\n")), 2)
 							},
 						})
@@ -378,15 +379,15 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numTags+1)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numNoTags+1)
 							},
@@ -410,15 +411,15 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numTags+1)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numNoTags+2)
 							},
@@ -440,15 +441,15 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("--kube-hide-dupe", "images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numTags)
 							},
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numNoTags)
 							},
@@ -469,7 +470,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Command("--kube-hide-dupe", "rmi", stdout[0:12]).Run(&test.Expected{
 							ExitCode: 1,
 							Errors:   []error{errors.New("multiple IDs found with provided prefix: ")},
@@ -478,7 +479,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 							ExitCode: 0,
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numNoTags)
 							},
@@ -499,7 +500,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						imgID := strings.Split(stdout, "\n")
 						helpers.Command("--kube-hide-dupe", "rmi", imgID[0]).Run(&test.Expected{
 							ExitCode: 1,
@@ -509,7 +510,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 							ExitCode: 0,
 						})
 						helpers.Command("images").Run(&test.Expected{
-							Output: func(stdout string, t *testing.T) {
+							Output: func(stdout string, t tig.T) {
 								lines := strings.Split(strings.TrimSpace(stdout), "\n")
 								assert.Assert(t, len(lines) == numNoTags)
 							},

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	testhelpers "github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -48,7 +49,7 @@ func TestSaveContent(t *testing.T) {
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					rootfsPath := filepath.Join(data.Temp().Path(), "rootfs")
 					err := testhelpers.ExtractDockerArchive(filepath.Join(data.Temp().Path(), "out.tar"), rootfsPath)
 					assert.NilError(t, err)
@@ -188,7 +189,7 @@ func TestSaveMultipleImagesWithSameIDAndLoad(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						assert.Equal(t, strings.Count(stdout, data.Labels().Get("id")), 2)
 					},
 				}

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -48,7 +48,7 @@ func TestSaveContent(t *testing.T) {
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					rootfsPath := filepath.Join(data.Temp().Path(), "rootfs")
 					err := testhelpers.ExtractDockerArchive(filepath.Join(data.Temp().Path(), "out.tar"), rootfsPath)
 					assert.NilError(t, err)
@@ -188,7 +188,7 @@ func TestSaveMultipleImagesWithSameIDAndLoad(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   []error{},
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						assert.Equal(t, strings.Count(stdout, data.Labels().Get("id")), 2)
 					},
 				}

--- a/cmd/nerdctl/inspect/inspect_test.go
+++ b/cmd/nerdctl/inspect/inspect_test.go
@@ -23,6 +23,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -50,7 +51,7 @@ func TestInspectSimpleCase(t *testing.T) {
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					var inspectResult []json.RawMessage
 					err := json.Unmarshal([]byte(stdout), &inspectResult)
 					assert.NilError(t, err, "Unable to unmarshal output\n")

--- a/cmd/nerdctl/inspect/inspect_test.go
+++ b/cmd/nerdctl/inspect/inspect_test.go
@@ -50,23 +50,23 @@ func TestInspectSimpleCase(t *testing.T) {
 		},
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					var inspectResult []json.RawMessage
 					err := json.Unmarshal([]byte(stdout), &inspectResult)
-					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-					assert.Equal(t, len(inspectResult), 2, "Unexpectedly got multiple results\n"+info)
+					assert.NilError(t, err, "Unable to unmarshal output\n")
+					assert.Equal(t, len(inspectResult), 2, "Unexpectedly got multiple results\n")
 
 					var dci dockercompat.Image
 					err = json.Unmarshal(inspectResult[0], &dci)
-					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					assert.NilError(t, err, "Unable to unmarshal output\n")
 					inspecti := nerdtest.InspectImage(helpers, testutil.CommonImage)
-					assert.Equal(t, dci.ID, inspecti.ID, info)
+					assert.Equal(t, dci.ID, inspecti.ID, "id should match\n")
 
 					var dcc dockercompat.Container
 					err = json.Unmarshal(inspectResult[1], &dcc)
-					assert.NilError(t, err, "Unable to unmarshal output\n"+info)
+					assert.NilError(t, err, "Unable to unmarshal output\n")
 					inspectc := nerdtest.InspectContainer(helpers, data.Identifier())
-					assert.Assert(t, dcc.ID == inspectc.ID, info)
+					assert.Equal(t, dcc.ID, inspectc.ID, "id should match\n")
 				},
 			}
 		},

--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -254,12 +255,12 @@ COPY index.html /usr/share/nginx/html/index.html
 
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
-			Output: func(stdout string, t *testing.T) {
+			Output: func(stdout string, t tig.T) {
 				resp, err := nettestutil.HTTPGet("http://127.0.0.1:8081", 10, false)
 				assert.NilError(t, err)
 				respBody, err := io.ReadAll(resp.Body)
 				assert.NilError(t, err)
-				t.Logf("respBody=%q", respBody)
+				t.Log(fmt.Sprintf("respBody=%q", respBody))
 				assert.Assert(t, strings.Contains(string(respBody), data.Identifier("indexhtml")))
 			},
 		}
@@ -319,8 +320,9 @@ func composeUP(data test.Data, helpers test.Helpers, dockerComposeYAML string, o
 	if !wordpressWorking {
 		ccc := helpers.Capture("ps", "-a")
 		helpers.T().Log(ccc)
-		helpers.T().Error(helpers.Err("logs", projectName+"-wordpress-1"))
-		helpers.T().Fatalf("wordpress is not working %v", err)
+		helpers.T().Log(helpers.Err("logs", projectName+"-wordpress-1"))
+		helpers.T().Log(fmt.Sprintf("wordpress is not working %v", err))
+		helpers.T().FailNow()
 	}
 
 	helpers.Ensure("compose", "-f", comp.YAMLFullPath(), "down", "-v")

--- a/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_compose_linux_test.go
@@ -254,7 +254,7 @@ COPY index.html /usr/share/nginx/html/index.html
 
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
-			Output: func(stdout string, info string, t *testing.T) {
+			Output: func(stdout string, t *testing.T) {
 				resp, err := nettestutil.HTTPGet("http://127.0.0.1:8081", 10, false)
 				assert.NilError(t, err)
 				respBody, err := io.ReadAll(resp.Body)

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -39,7 +40,7 @@ func pushToIPFS(helpers test.Helpers, name string, opts ...string) string {
 	cmd := helpers.Command("push", "ipfs://"+name)
 	cmd.WithArgs(opts...)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, t *testing.T) {
+		Output: func(stdout string, t tig.T) {
 			lines := strings.Split(stdout, "\n")
 			assert.Equal(t, len(lines) >= 2, true)
 			ipfsCID = lines[len(lines)-2]

--- a/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
+++ b/cmd/nerdctl/ipfs/ipfs_registry_linux_test.go
@@ -39,7 +39,7 @@ func pushToIPFS(helpers test.Helpers, name string, opts ...string) string {
 	cmd := helpers.Command("push", "ipfs://"+name)
 	cmd.WithArgs(opts...)
 	cmd.Run(&test.Expected{
-		Output: func(stdout string, info string, t *testing.T) {
+		Output: func(stdout string, t *testing.T) {
 			lines := strings.Split(stdout, "\n")
 			assert.Equal(t, len(lines) >= 2, true)
 			ipfsCID = lines[len(lines)-2]

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -58,7 +59,7 @@ func TestNetworkCreate(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   nil,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("subnet")))
 						assert.Assert(t, !strings.Contains(data.Labels().Get("container2"), data.Labels().Get("subnet")))
 					},
@@ -98,7 +99,7 @@ func TestNetworkCreate(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						_, subnet, _ := net.ParseCIDR(data.Labels().Get("subnetStr"))
 						ip := nerdtest.FindIPv6(stdout)
 						assert.Assert(t, subnet.Contains(ip), fmt.Sprintf("subnet %s contains ip %s", subnet, ip))

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -58,9 +58,9 @@ func TestNetworkCreate(t *testing.T) {
 				return &test.Expected{
 					ExitCode: 0,
 					Errors:   nil,
-					Output: func(stdout string, info string, t *testing.T) {
-						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("subnet")), info)
-						assert.Assert(t, !strings.Contains(data.Labels().Get("container2"), data.Labels().Get("subnet")), info)
+					Output: func(stdout string, t *testing.T) {
+						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("subnet")))
+						assert.Assert(t, !strings.Contains(data.Labels().Get("container2"), data.Labels().Get("subnet")))
 					},
 				}
 			},
@@ -98,7 +98,7 @@ func TestNetworkCreate(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						_, subnet, _ := net.ParseCIDR(data.Labels().Get("subnetStr"))
 						ip := nerdtest.FindIPv6(stdout)
 						assert.Assert(t, subnet.Contains(ip), fmt.Sprintf("subnet %s contains ip %s", subnet, ip))

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -70,7 +70,7 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "none",
 			Require:     nerdtest.NerdctlNeedsFixing("no issue opened"),
 			Command:     test.Command("network", "inspect", "none"),
-			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
 				assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -82,7 +82,7 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "host",
 			Require:     nerdtest.NerdctlNeedsFixing("no issue opened"),
 			Command:     test.Command("network", "inspect", "host"),
-			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
 				assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -94,7 +94,7 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "bridge",
 			Require:     require.Not(require.Windows),
 			Command:     test.Command("network", "inspect", "bridge"),
-			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
 				assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -106,7 +106,7 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "nat",
 			Require:     require.Windows,
 			Command:     test.Command("network", "inspect", "nat"),
-			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
 				assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -123,7 +123,7 @@ func TestNetworkInspect(t *testing.T) {
 				helpers.Anyhow("network", "remove", "custom")
 			},
 			Command: test.Command("network", "inspect", "custom"),
-			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t tig.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
 				assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -140,7 +140,7 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -161,7 +161,7 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -189,7 +189,7 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n")
@@ -216,7 +216,7 @@ func TestNetworkInspect(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var dc []dockercompat.Network
 
 						err := json.Unmarshal([]byte(stdout), &dc)
@@ -249,7 +249,7 @@ func TestNetworkInspect(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						// Note: some functions need to be tested without the automatic --namespace nerdctl-test argument, so we need
 						// to retrieve the binary name.
 						// Note that we know this works already, so no need to assert err.
@@ -308,7 +308,7 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
 						assert.NilError(t, err, "Unable to unmarshal output\n")

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -70,11 +70,11 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "none",
 			Require:     nerdtest.NerdctlNeedsFixing("no issue opened"),
 			Command:     test.Command("network", "inspect", "none"),
-			Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
-				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				assert.NilError(t, err, "Unable to unmarshal output\n")
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 				assert.Equal(t, dc[0].Name, "none")
 			}),
 		},
@@ -82,11 +82,11 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "host",
 			Require:     nerdtest.NerdctlNeedsFixing("no issue opened"),
 			Command:     test.Command("network", "inspect", "host"),
-			Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
-				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				assert.NilError(t, err, "Unable to unmarshal output\n")
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 				assert.Equal(t, dc[0].Name, "host")
 			}),
 		},
@@ -94,11 +94,11 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "bridge",
 			Require:     require.Not(require.Windows),
 			Command:     test.Command("network", "inspect", "bridge"),
-			Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
-				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				assert.NilError(t, err, "Unable to unmarshal output\n")
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 				assert.Equal(t, dc[0].Name, "bridge")
 			}),
 		},
@@ -106,11 +106,11 @@ func TestNetworkInspect(t *testing.T) {
 			Description: "nat",
 			Require:     require.Windows,
 			Command:     test.Command("network", "inspect", "nat"),
-			Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
-				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				assert.NilError(t, err, "Unable to unmarshal output\n")
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 				assert.Equal(t, dc[0].Name, "nat")
 			}),
 		},
@@ -123,11 +123,11 @@ func TestNetworkInspect(t *testing.T) {
 				helpers.Anyhow("network", "remove", "custom")
 			},
 			Command: test.Command("network", "inspect", "custom"),
-			Expected: test.Expects(0, nil, func(stdout string, info string, t *testing.T) {
+			Expected: test.Expects(0, nil, func(stdout string, t *testing.T) {
 				var dc []dockercompat.Network
 				err := json.Unmarshal([]byte(stdout), &dc)
-				assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+				assert.NilError(t, err, "Unable to unmarshal output\n")
+				assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 				assert.Equal(t, dc[0].Name, "custom")
 			}),
 		},
@@ -140,11 +140,11 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
-						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+						assert.NilError(t, err, "Unable to unmarshal output\n")
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Labels().Get("basenet"))
 					},
 				}
@@ -161,11 +161,11 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
-						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+						assert.NilError(t, err, "Unable to unmarshal output\n")
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Labels().Get("basenet"))
 					},
 				}
@@ -189,11 +189,11 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
-						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+						assert.NilError(t, err, "Unable to unmarshal output\n")
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Labels().Get("netname"))
 					},
 				}
@@ -216,20 +216,20 @@ func TestNetworkInspect(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var dc []dockercompat.Network
 
 						err := json.Unmarshal([]byte(stdout), &dc)
-						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+						assert.NilError(t, err, "Unable to unmarshal output\n")
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						got := dc[0]
 
-						assert.Equal(t, got.Name, data.Identifier(), info)
-						assert.Equal(t, got.Labels["tag"], "testNetwork", info)
-						assert.Equal(t, len(got.IPAM.Config), 1, info)
-						assert.Equal(t, got.IPAM.Config[0].Subnet, testSubnet, info)
-						assert.Equal(t, got.IPAM.Config[0].Gateway, testGateway, info)
-						assert.Equal(t, got.IPAM.Config[0].IPRange, testIPRange, info)
+						assert.Equal(t, got.Name, data.Identifier())
+						assert.Equal(t, got.Labels["tag"], "testNetwork")
+						assert.Equal(t, len(got.IPAM.Config), 1)
+						assert.Equal(t, got.IPAM.Config[0].Subnet, testSubnet)
+						assert.Equal(t, got.IPAM.Config[0].Gateway, testGateway)
+						assert.Equal(t, got.IPAM.Config[0].IPRange, testIPRange)
 					},
 				}
 			},
@@ -249,7 +249,7 @@ func TestNetworkInspect(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						// Note: some functions need to be tested without the automatic --namespace nerdctl-test argument, so we need
 						// to retrieve the binary name.
 						// Note that we know this works already, so no need to assert err.
@@ -308,11 +308,11 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var dc []dockercompat.Network
 						err := json.Unmarshal([]byte(stdout), &dc)
-						assert.NilError(t, err, "Unable to unmarshal output\n"+info)
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+						assert.NilError(t, err, "Unable to unmarshal output\n")
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Identifier("nginx-network-1"))
 						// Assert only the "running" containers on the same network are returned.
 						assert.Equal(t, 1, len(dc[0].Containers), "Expected a single container as per configuration, but got multiple.")
@@ -341,8 +341,8 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, info string, t tig.T) {
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+					Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, t tig.T) {
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Identifier("network-1"))
 						assert.Equal(t, 1, len(dc[0].Containers), "Expected a single container as per configuration, but got multiple.")
 						assert.Equal(t, data.Identifier(), dc[0].Containers[data.Labels().Get("containerID")].Name)
@@ -368,8 +368,8 @@ func TestNetworkInspect(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, info string, t tig.T) {
-						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n"+info)
+					Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, t tig.T) {
+						assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results\n")
 						assert.Equal(t, dc[0].Name, data.Identifier("some-network"))
 						assert.Equal(t, 0, len(dc[0].Containers), "Expected no containers as per configuration, but got multiple.")
 					}),

--- a/cmd/nerdctl/network/network_list_linux_test.go
+++ b/cmd/nerdctl/network/network_list_linux_test.go
@@ -23,6 +23,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
@@ -52,7 +53,7 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least one line\n")
 						netNames := map[string]struct{}{
@@ -74,7 +75,7 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least one line\n")
 						netNames := map[string]struct{}{
@@ -96,7 +97,7 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1)
 						netNames := map[string]struct{}{

--- a/cmd/nerdctl/network/network_list_linux_test.go
+++ b/cmd/nerdctl/network/network_list_linux_test.go
@@ -52,16 +52,16 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, info)
+						assert.Assert(t, len(lines) >= 1, "expected at least one line\n")
 						netNames := map[string]struct{}{
 							data.Labels().Get("netID1")[:12]: {},
 						}
 
 						for _, name := range lines {
 							_, ok := netNames[name]
-							assert.Assert(t, ok, info)
+							assert.Assert(t, ok, "expected to find name\n")
 						}
 					},
 				}
@@ -74,16 +74,16 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, info)
+						assert.Assert(t, len(lines) >= 1, "expected at least one line\n")
 						netNames := map[string]struct{}{
 							data.Labels().Get("netID2")[:12]: {},
 						}
 
 						for _, name := range lines {
 							_, ok := netNames[name]
-							assert.Assert(t, ok, info)
+							assert.Assert(t, ok, "expected to find name\n")
 						}
 					},
 				}
@@ -96,16 +96,16 @@ func TestNetworkLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, info)
+						assert.Assert(t, len(lines) >= 1)
 						netNames := map[string]struct{}{
 							data.Labels().Get("netID2")[:12]: {},
 						}
 
 						for _, name := range lines {
 							_, ok := netNames[name]
-							assert.Assert(t, ok, info)
+							assert.Assert(t, ok)
 						}
 					},
 				}

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -24,6 +24,7 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -55,7 +56,7 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found")
 					},
@@ -96,7 +97,7 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found")
 					},
@@ -122,7 +123,7 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
 						assert.Error(t, err, "Link not found")
 					},

--- a/cmd/nerdctl/network/network_remove_linux_test.go
+++ b/cmd/nerdctl/network/network_remove_linux_test.go
@@ -55,9 +55,9 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
-						assert.Error(t, err, "Link not found", info)
+						assert.Error(t, err, "Link not found")
 					},
 				}
 			},
@@ -96,9 +96,9 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
-						assert.Error(t, err, "Link not found", info)
+						assert.Error(t, err, "Link not found")
 					},
 				}
 			},
@@ -122,9 +122,9 @@ func TestNetworkRemove(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						_, err := netlink.LinkByName("br-" + data.Labels().Get("netID")[:12])
-						assert.Error(t, err, "Link not found", info)
+						assert.Error(t, err, "Link not found")
 					},
 				}
 			},

--- a/cmd/nerdctl/system/system_info_test.go
+++ b/cmd/nerdctl/system/system_info_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/infoutil"
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
@@ -34,7 +35,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
-func testInfoComparator(stdout string, t *testing.T) {
+func testInfoComparator(stdout string, t tig.T) {
 	var dinf dockercompat.Info
 	err := json.Unmarshal([]byte(stdout), &dinf)
 	assert.NilError(t, err, "failed to unmarshal stdout")

--- a/cmd/nerdctl/system/system_info_test.go
+++ b/cmd/nerdctl/system/system_info_test.go
@@ -34,12 +34,12 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
-func testInfoComparator(stdout string, info string, t *testing.T) {
+func testInfoComparator(stdout string, t *testing.T) {
 	var dinf dockercompat.Info
 	err := json.Unmarshal([]byte(stdout), &dinf)
-	assert.NilError(t, err, "failed to unmarshal stdout"+info)
+	assert.NilError(t, err, "failed to unmarshal stdout")
 	unameM := infoutil.UnameM()
-	assert.Assert(t, dinf.Architecture == unameM, fmt.Sprintf("expected info.Architecture to be %q, got %q", unameM, dinf.Architecture)+info)
+	assert.Assert(t, dinf.Architecture == unameM, fmt.Sprintf("expected info.Architecture to be %q, got %q", unameM, dinf.Architecture))
 }
 
 func TestInfo(t *testing.T) {

--- a/cmd/nerdctl/system/system_prune_linux_test.go
+++ b/cmd/nerdctl/system/system_prune_linux_test.go
@@ -60,7 +60,7 @@ func TestSystemPrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						volumes := helpers.Capture("volume", "ls")
 						networks := helpers.Capture("network", "ls")
 						images := helpers.Capture("images")

--- a/cmd/nerdctl/system/system_prune_linux_test.go
+++ b/cmd/nerdctl/system/system_prune_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -60,7 +61,7 @@ func TestSystemPrune(t *testing.T) {
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
 					ExitCode: 0,
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						volumes := helpers.Capture("volume", "ls")
 						networks := helpers.Capture("network", "ls")
 						images := helpers.Capture("images")

--- a/cmd/nerdctl/volume/volume_inspect_test.go
+++ b/cmd/nerdctl/volume/volume_inspect_test.go
@@ -99,10 +99,10 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Labels().Get("vol1")),
-						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
-							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc))+info)
-							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name)+info)
-							assert.Assert(t, dc[0].Labels == nil, fmt.Sprintf("expected labels to be nil and were %v", dc[0].Labels)+info)
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
+							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
+							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name))
+							assert.Assert(t, dc[0].Labels == nil, fmt.Sprintf("expected labels to be nil and were %v", dc[0].Labels))
 						}),
 					),
 				}
@@ -117,7 +117,7 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Labels().Get("vol2")),
-						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
 							labels := *dc[0].Labels
 							assert.Assert(t, len(labels) == 2, fmt.Sprintf("two results, not %d", len(labels)))
 							assert.Assert(t, labels["foo"] == "fooval", fmt.Sprintf("label foo should be fooval, not %s", labels["foo"]))
@@ -137,7 +137,7 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Labels().Get("vol1")),
-						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
 							assert.Assert(t, dc[0].Size == size, fmt.Sprintf("expected size to be %d (was %d)", size, dc[0].Size))
 						}),
 					),
@@ -153,7 +153,7 @@ func TestVolumeInspect(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.Contains(data.Labels().Get("vol1"), data.Labels().Get("vol2")),
-						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
 							assert.Assert(t, len(dc) == 2, fmt.Sprintf("two results, not %d", len(dc)))
 							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name))
 							assert.Assert(t, dc[1].Name == data.Labels().Get("vol2"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol2"), dc[1].Name))
@@ -173,7 +173,7 @@ func TestVolumeInspect(t *testing.T) {
 					Errors:   []error{errdefs.ErrNotFound, errdefs.ErrInvalidArgument},
 					Output: expect.All(
 						expect.Contains(data.Labels().Get("vol1")),
-						expect.JSON([]native.Volume{}, func(dc []native.Volume, info string, t tig.T) {
+						expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
 							assert.Assert(t, len(dc) == 1, fmt.Sprintf("one result, not %d", len(dc)))
 							assert.Assert(t, dc[0].Name == data.Labels().Get("vol1"), fmt.Sprintf("expected name to be %q (was %q)", data.Labels().Get("vol1"), dc[0].Name))
 						}),

--- a/cmd/nerdctl/volume/volume_list_test.go
+++ b/cmd/nerdctl/volume/volume_list_test.go
@@ -56,9 +56,9 @@ func TestVolumeLsSize(t *testing.T) {
 		Command: test.Command("volume", "ls", "--size"),
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-					assert.Assert(t, len(lines) >= 4, "expected at least 4 lines"+info)
+					assert.Assert(t, len(lines) >= 4, "expected at least 4 lines")
 					volSizes := map[string]string{
 						data.Identifier("1"):     "100.0 KiB",
 						data.Identifier("2"):     "200.0 KiB",
@@ -68,7 +68,7 @@ func TestVolumeLsSize(t *testing.T) {
 					var numMatches = 0
 					var tab = tabutil.NewReader("VOLUME NAME\tDIRECTORY\tSIZE")
 					var err = tab.ParseHeader(lines[0])
-					assert.NilError(t, err, info)
+					assert.NilError(t, err, "ParseHeader should not fail\n")
 
 					for _, line := range lines {
 						name, _ := tab.ReadRow(line, "VOLUME NAME")
@@ -77,10 +77,10 @@ func TestVolumeLsSize(t *testing.T) {
 						if !ok {
 							continue
 						}
-						assert.Assert(t, size == expectSize, fmt.Sprintf("expected size %s for volume %s, got %s", expectSize, name, size)+info)
+						assert.Assert(t, size == expectSize, fmt.Sprintf("expected size %s for volume %s, got %s", expectSize, name, size))
 						numMatches++
 					}
-					assert.Assert(t, numMatches == len(volSizes), fmt.Sprintf("expected %d volumes, got: %d", len(volSizes), numMatches)+info)
+					assert.Assert(t, numMatches == len(volSizes), fmt.Sprintf("expected %d volumes, got: %d", len(volSizes), numMatches))
 				},
 			}
 		},
@@ -145,9 +145,9 @@ func TestVolumeLsFilter(t *testing.T) {
 			Command:     test.Command("volume", "ls", "--quiet"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 4, "expected at least 4 lines"+info)
+						assert.Assert(t, len(lines) >= 4, "expected at least 4 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 							data.Labels().Get("vol2"): {},
@@ -174,9 +174,9 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
+						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 							data.Labels().Get("vol2"): {},
@@ -184,7 +184,7 @@ func TestVolumeLsFilter(t *testing.T) {
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -197,15 +197,15 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, "expected at least 1 lines"+info)
+						assert.Assert(t, len(lines) >= 1, "expected at least 1 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -218,8 +218,8 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
-						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result"+info)
+					Output: func(stdout string, t *testing.T) {
+						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result")
 					},
 				}
 			},
@@ -231,8 +231,8 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
-						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result"+info)
+					Output: func(stdout string, t *testing.T) {
+						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result")
 					},
 				}
 			},
@@ -244,16 +244,16 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines"+info)
+						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -266,15 +266,15 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, "expected at least 1 line"+info)
+						assert.Assert(t, len(lines) >= 1, "expected at least 1 line")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -287,15 +287,15 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 1, "expected at least 1 line"+info)
+						assert.Assert(t, len(lines) >= 1, "expected at least 1 line")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -308,16 +308,16 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines"+info)
+						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 							data.Labels().Get("vol2"): {},
 						}
 						for _, name := range lines {
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -331,9 +331,9 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
+						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol2"): {},
 							data.Labels().Get("vol4"): {},
@@ -348,7 +348,7 @@ func TestVolumeLsFilter(t *testing.T) {
 								continue
 							}
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -362,9 +362,9 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
+						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol2"): {},
 							data.Labels().Get("vol4"): {},
@@ -379,7 +379,7 @@ func TestVolumeLsFilter(t *testing.T) {
 								continue
 							}
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}
@@ -393,9 +393,9 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
-						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines"+info)
+						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
 							data.Labels().Get("vol1"): {},
 							data.Labels().Get("vol3"): {},
@@ -410,7 +410,7 @@ func TestVolumeLsFilter(t *testing.T) {
 								continue
 							}
 							_, ok := volNames[name]
-							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name)+info)
+							assert.Assert(t, ok, fmt.Sprintf("unexpected volume %s found", name))
 						}
 					},
 				}

--- a/cmd/nerdctl/volume/volume_list_test.go
+++ b/cmd/nerdctl/volume/volume_list_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -56,7 +57,7 @@ func TestVolumeLsSize(t *testing.T) {
 		Command: test.Command("volume", "ls", "--size"),
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 			return &test.Expected{
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 					assert.Assert(t, len(lines) >= 4, "expected at least 4 lines")
 					volSizes := map[string]string{
@@ -145,7 +146,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			Command:     test.Command("volume", "ls", "--quiet"),
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 4, "expected at least 4 lines")
 						volNames := map[string]struct{}{
@@ -174,7 +175,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
@@ -197,7 +198,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least 1 lines")
 						volNames := map[string]struct{}{
@@ -218,7 +219,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result")
 					},
 				}
@@ -231,7 +232,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						assert.Assert(t, strings.TrimSpace(stdout) == "", "expected no result")
 					},
 				}
@@ -244,7 +245,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines")
 						volNames := map[string]struct{}{
@@ -266,7 +267,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least 1 line")
 						volNames := map[string]struct{}{
@@ -287,7 +288,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 1, "expected at least 1 line")
 						volNames := map[string]struct{}{
@@ -308,7 +309,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 2, "expected at least 2 lines")
 						volNames := map[string]struct{}{
@@ -331,7 +332,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
@@ -362,7 +363,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{
@@ -393,7 +394,7 @@ func TestVolumeLsFilter(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						var lines = strings.Split(strings.TrimSpace(stdout), "\n")
 						assert.Assert(t, len(lines) >= 3, "expected at least 3 lines")
 						volNames := map[string]struct{}{

--- a/cmd/nerdctl/volume/volume_namespace_test.go
+++ b/cmd/nerdctl/volume/volume_namespace_test.go
@@ -76,7 +76,7 @@ func TestVolumeNamespace(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("root_volume")),
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))
 						},
 					),
@@ -94,7 +94,7 @@ func TestVolumeNamespace(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, info string, t *testing.T) {
+					Output: func(stdout string, t *testing.T) {
 						helpers.Ensure("volume", "inspect", data.Labels().Get("root_volume"))
 						helpers.Ensure("volume", "rm", data.Labels().Get("root_volume"))
 						helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))

--- a/cmd/nerdctl/volume/volume_namespace_test.go
+++ b/cmd/nerdctl/volume/volume_namespace_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
@@ -76,7 +77,7 @@ func TestVolumeNamespace(t *testing.T) {
 				return &test.Expected{
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("root_volume")),
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))
 						},
 					),
@@ -94,7 +95,7 @@ func TestVolumeNamespace(t *testing.T) {
 			},
 			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 				return &test.Expected{
-					Output: func(stdout string, t *testing.T) {
+					Output: func(stdout string, t tig.T) {
 						helpers.Ensure("volume", "inspect", data.Labels().Get("root_volume"))
 						helpers.Ensure("volume", "rm", data.Labels().Get("root_volume"))
 						helpers.Ensure("--namespace", data.Labels().Get("root_namespace"), "volume", "inspect", data.Labels().Get("root_volume"))

--- a/cmd/nerdctl/volume/volume_prune_linux_test.go
+++ b/cmd/nerdctl/volume/volume_prune_linux_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -75,7 +76,7 @@ func TestVolumePrune(t *testing.T) {
 							data.Labels().Get("namedBusy"),
 							data.Labels().Get("namedDangling"),
 						),
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
 							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
 							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))
@@ -96,7 +97,7 @@ func TestVolumePrune(t *testing.T) {
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("anonIDBusy"), data.Labels().Get("namedBusy")),
 						expect.Contains(data.Labels().Get("anonIDDangling"), data.Labels().Get("namedDangling")),
-						func(stdout string, t *testing.T) {
+						func(stdout string, t tig.T) {
 							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
 							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
 							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))

--- a/cmd/nerdctl/volume/volume_prune_linux_test.go
+++ b/cmd/nerdctl/volume/volume_prune_linux_test.go
@@ -75,7 +75,7 @@ func TestVolumePrune(t *testing.T) {
 							data.Labels().Get("namedBusy"),
 							data.Labels().Get("namedDangling"),
 						),
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
 							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
 							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))
@@ -96,7 +96,7 @@ func TestVolumePrune(t *testing.T) {
 					Output: expect.All(
 						expect.DoesNotContain(data.Labels().Get("anonIDBusy"), data.Labels().Get("namedBusy")),
 						expect.Contains(data.Labels().Get("anonIDDangling"), data.Labels().Get("namedDangling")),
-						func(stdout string, info string, t *testing.T) {
+						func(stdout string, t *testing.T) {
 							helpers.Ensure("volume", "inspect", data.Labels().Get("anonIDBusy"))
 							helpers.Fail("volume", "inspect", data.Labels().Get("anonIDDangling"))
 							helpers.Ensure("volume", "inspect", data.Labels().Get("namedBusy"))

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -88,7 +88,7 @@ import (
 )
 
 func MyComparator(compare string) test.Comparator {
-	return func(stdout string, t *testing.T) {
+	return func(stdout string, t tig.T) {
 		t.Helper()
 		assert.Assert(t, stdout == compare)
 	}
@@ -138,7 +138,7 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}
@@ -251,7 +251,7 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}
@@ -340,7 +340,7 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}

--- a/docs/testing/tools.md
+++ b/docs/testing/tools.md
@@ -88,16 +88,12 @@ import (
 )
 
 func MyComparator(compare string) test.Comparator {
-	return func(stdout string, info string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
-		assert.Assert(t, stdout == compare, info)
+		assert.Assert(t, stdout == compare)
 	}
 }
 ```
-
-Note that you have access to an opaque `info` string.
-It contains relevant debugging information in case your comparator is going to fail,
-and you should make sure it is displayed.
 
 ### Advanced expectations
 
@@ -142,8 +138,8 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
+				Output: func(stdout string, t *testing.T) {
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}
 		},
@@ -255,8 +251,8 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
+				Output: func(stdout string, t *testing.T) {
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}
 		},
@@ -344,8 +340,8 @@ func TestMyThing(t *testing.T) {
 					errors.New("foobla"),
 					errdefs.ErrNotFound,
 				},
-				Output: func(stdout string, info string, t *testing.T) {
-					assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
+				Output: func(stdout string, t *testing.T) {
+					assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
 				},
 			}
 		},

--- a/mod/tigron/expect/comparators.go
+++ b/mod/tigron/expect/comparators.go
@@ -30,11 +30,11 @@ import (
 
 // All can be used as a parameter for expected.Output to group a set of comparators.
 func All(comparators ...test.Comparator) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 
 		for _, comparator := range comparators {
-			comparator(stdout, "", t)
+			comparator(stdout, t)
 		}
 	}
 }
@@ -42,7 +42,7 @@ func All(comparators ...test.Comparator) test.Comparator {
 // Contains can be used as a parameter for expected.Output and ensures a comparison string is found contained in the
 // output.
 func Contains(compare string, more ...string) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 
 		assertive.Contains(assertive.WithFailLater(t), stdout, compare, "Inspecting output (contains)")
@@ -55,7 +55,7 @@ func Contains(compare string, more ...string) test.Comparator {
 
 // DoesNotContain is to be used for expected.Output to ensure a comparison string is NOT found in the output.
 func DoesNotContain(compare string, more ...string) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 
 		assertive.DoesNotContain(assertive.WithFailLater(t), stdout, compare, "Inspecting output (does not contain)")
@@ -68,7 +68,7 @@ func DoesNotContain(compare string, more ...string) test.Comparator {
 
 // Equals is to be used for expected.Output to ensure it is exactly the output.
 func Equals(compare string) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 		assertive.IsEqual(assertive.WithFailLater(t), stdout, compare, "Inspecting output (equals)")
 	}
@@ -76,7 +76,7 @@ func Equals(compare string) test.Comparator {
 
 // Match is to be used for expected.Output to ensure we match a regexp.
 func Match(reg *regexp.Regexp) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 		assertive.Match(assertive.WithFailLater(t), stdout, reg, "Inspecting output (match)")
 	}
@@ -84,15 +84,15 @@ func Match(reg *regexp.Regexp) test.Comparator {
 
 // JSON allows to verify that the output can be marshalled into T, and optionally can be further verified by a provided
 // method.
-func JSON[T any](obj T, verifier func(T, string, tig.T)) test.Comparator {
-	return func(stdout, _ string, t *testing.T) {
+func JSON[T any](obj T, verifier func(T, tig.T)) test.Comparator {
+	return func(stdout string, t *testing.T) {
 		t.Helper()
 
 		err := json.Unmarshal([]byte(stdout), &obj)
 		assertive.ErrorIsNil(assertive.WithSilentSuccess(t), err, "Unmarshalling JSON from stdout must succeed")
 
 		if verifier != nil && err == nil {
-			verifier(obj, "Inspecting output (JSON)", t)
+			verifier(obj, t)
 		}
 	}
 }

--- a/mod/tigron/expect/comparators.go
+++ b/mod/tigron/expect/comparators.go
@@ -15,13 +15,12 @@
 */
 
 //revive:disable:package-comments // annoying false positive behavior
-//nolint:thelper // FIXME: remove when we move to tig.T
+
 package expect
 
 import (
 	"encoding/json"
 	"regexp"
-	"testing"
 
 	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 	"github.com/containerd/nerdctl/mod/tigron/test"
@@ -30,7 +29,7 @@ import (
 
 // All can be used as a parameter for expected.Output to group a set of comparators.
 func All(comparators ...test.Comparator) test.Comparator {
-	return func(stdout string, t *testing.T) {
+	return func(stdout string, t tig.T) {
 		t.Helper()
 
 		for _, comparator := range comparators {
@@ -42,33 +41,43 @@ func All(comparators ...test.Comparator) test.Comparator {
 // Contains can be used as a parameter for expected.Output and ensures a comparison string is found contained in the
 // output.
 func Contains(compare string, more ...string) test.Comparator {
-	return func(stdout string, t *testing.T) {
-		t.Helper()
+	return func(stdout string, testing tig.T) {
+		testing.Helper()
 
-		assertive.Contains(assertive.WithFailLater(t), stdout, compare, "Inspecting output (contains)")
+		assertive.Contains(assertive.WithFailLater(testing), stdout, compare, "Inspecting output (contains)")
 
 		for _, m := range more {
-			assertive.Contains(assertive.WithFailLater(t), stdout, m, "Inspecting output (contains)")
+			assertive.Contains(assertive.WithFailLater(testing), stdout, m, "Inspecting output (contains)")
 		}
 	}
 }
 
 // DoesNotContain is to be used for expected.Output to ensure a comparison string is NOT found in the output.
 func DoesNotContain(compare string, more ...string) test.Comparator {
-	return func(stdout string, t *testing.T) {
-		t.Helper()
+	return func(stdout string, testing tig.T) {
+		testing.Helper()
 
-		assertive.DoesNotContain(assertive.WithFailLater(t), stdout, compare, "Inspecting output (does not contain)")
+		assertive.DoesNotContain(
+			assertive.WithFailLater(testing),
+			stdout,
+			compare,
+			"Inspecting output (does not contain)",
+		)
 
 		for _, m := range more {
-			assertive.DoesNotContain(assertive.WithFailLater(t), stdout, m, "Inspecting output (does not contain)")
+			assertive.DoesNotContain(
+				assertive.WithFailLater(testing),
+				stdout,
+				m,
+				"Inspecting output (does not contain)",
+			)
 		}
 	}
 }
 
 // Equals is to be used for expected.Output to ensure it is exactly the output.
 func Equals(compare string) test.Comparator {
-	return func(stdout string, t *testing.T) {
+	return func(stdout string, t tig.T) {
 		t.Helper()
 		assertive.IsEqual(assertive.WithFailLater(t), stdout, compare, "Inspecting output (equals)")
 	}
@@ -76,7 +85,7 @@ func Equals(compare string) test.Comparator {
 
 // Match is to be used for expected.Output to ensure we match a regexp.
 func Match(reg *regexp.Regexp) test.Comparator {
-	return func(stdout string, t *testing.T) {
+	return func(stdout string, t tig.T) {
 		t.Helper()
 		assertive.Match(assertive.WithFailLater(t), stdout, reg, "Inspecting output (match)")
 	}
@@ -85,14 +94,14 @@ func Match(reg *regexp.Regexp) test.Comparator {
 // JSON allows to verify that the output can be marshalled into T, and optionally can be further verified by a provided
 // method.
 func JSON[T any](obj T, verifier func(T, tig.T)) test.Comparator {
-	return func(stdout string, t *testing.T) {
-		t.Helper()
+	return func(stdout string, testing tig.T) {
+		testing.Helper()
 
 		err := json.Unmarshal([]byte(stdout), &obj)
-		assertive.ErrorIsNil(assertive.WithSilentSuccess(t), err, "Unmarshalling JSON from stdout must succeed")
+		assertive.ErrorIsNil(assertive.WithSilentSuccess(testing), err, "Unmarshalling JSON from stdout must succeed")
 
 		if verifier != nil && err == nil {
-			verifier(obj, t)
+			verifier(obj, testing)
 		}
 	}
 }

--- a/mod/tigron/expect/comparators_test.go
+++ b/mod/tigron/expect/comparators_test.go
@@ -33,10 +33,10 @@ func TestExpect(t *testing.T) {
 	// TODO: write more tests once we can mock t in Comparator signature
 	t.Parallel()
 
-	expect.Contains("b")("a b c", "contains works", t)
-	expect.DoesNotContain("d")("a b c", "does not contain works", t)
-	expect.Equals("a b c")("a b c", "equals work", t)
-	expect.Match(regexp.MustCompile("[a-z ]+"))("a b c", "match works", t)
+	expect.Contains("b")("a b c", t)
+	expect.DoesNotContain("d")("a b c", t)
+	expect.Equals("a b c")("a b c", t)
+	expect.Match(regexp.MustCompile("[a-z ]+"))("a b c", t)
 
 	expect.All(
 		expect.Contains("b"),
@@ -45,7 +45,7 @@ func TestExpect(t *testing.T) {
 		expect.DoesNotContain("d", "e"),
 		expect.Equals("a b c"),
 		expect.Match(regexp.MustCompile("[a-z ]+")),
-	)("a b c", "all", t)
+	)("a b c", t)
 
 	type foo struct {
 		Foo map[string]string `json:"foo"`
@@ -59,9 +59,9 @@ func TestExpect(t *testing.T) {
 
 	assertive.ErrorIsNil(t, err)
 
-	expect.JSON(&foo{}, nil)(string(data), "json, no verifier", t)
+	expect.JSON(&foo{}, nil)(string(data), t)
 
-	expect.JSON(&foo{}, func(obj *foo, info string, t tig.T) {
-		assertive.IsEqual(t, obj.Foo["foo"], "bar", info)
-	})(string(data), "json, with verifier", t)
+	expect.JSON(&foo{}, func(obj *foo, t tig.T) {
+		assertive.IsEqual(t, obj.Foo["foo"], "bar")
+	})(string(data), t)
 }

--- a/mod/tigron/expect/doc.md
+++ b/mod/tigron/expect/doc.md
@@ -58,7 +58,7 @@ The following ready-made `test.Comparator` generators are provided:
 - `expect.Equals(string)`: strict equality
 - `expect.Match(*regexp.Regexp)`: regexp matching
 - `expect.All(comparators ...Comparator)`: allows to bundle together a bunch of other comparators
-- `expect.JSON[T any](obj T, verifier func(T, string, tig.T))`: allows to verify the output is valid JSON and optionally
+- `expect.JSON[T any](obj T, verifier func(T, tig.T))`: allows to verify the output is valid JSON and optionally
 pass `verifier(T, string, tig.T)` extra validation
 
 ### A complete example
@@ -93,8 +93,8 @@ func TestMyThing(t *testing.T) {
         expect.All(
             expect.Contains("out"),
             expect.DoesNotContain("something"),
-            expect.JSON(&Thing{}, func(obj *Thing, info string, t tig.T) {
-                assert.Equal(t, obj.Name, "something", info)
+            expect.JSON(&Thing{}, func(obj *Thing, t tig.T) {
+                assert.Equal(t, obj.Name, "something")
             }),
         ),
     )
@@ -131,7 +131,7 @@ func TestMyThing(t *testing.T) {
     myTest.Command = test.Custom("ls")
 
     // Set your expectations
-    myTest.Expected = test.Expects(0, nil, func(stdout, info string, t tig.T){
+    myTest.Expected = test.Expects(0, nil, func(stdout string, t tig.T){
         t.Helper()
         // Bla bla, do whatever advanced stuff and some asserts
     })
@@ -143,7 +143,7 @@ func TestMyThing(t *testing.T) {
 // You can of course generalize your comparator into a generator if it is going to be useful repeatedly
 
 func MyComparatorGenerator(param1, param2 any) test.Comparator {
-    return func(stdout, info string, t tig.T) {
+    return func(stdout string, t tig.T) {
         t.Helper()
         // Do your thing...
         // ...
@@ -154,10 +154,6 @@ func MyComparatorGenerator(param1, param2 any) test.Comparator {
 
 You can now pass along `MyComparator(comparisonString)` as the third parameter of `test.Expects`, or compose it with
 other comparators using `expect.All(MyComparator(comparisonString), OtherComparator(somethingElse))`
-
-Note that you have access to an opaque `info` string, that provides a brief formatted header message that assert
-will use in case of failure to provide context on the error.
-You may of course ignore it and write your own message.
 
 ### Advanced expectations
 
@@ -180,6 +176,7 @@ import (
 
     "gotest.tools/v3/assert"
 
+    "github.com/containerd/nerdctl/mod/tigron/tig"
     "github.com/containerd/nerdctl/mod/tigron/test"
 )
 
@@ -206,11 +203,11 @@ func TestMyThing(t *testing.T) {
             Errors: []error{
                 errors.New("foobla"),
             },
-            Output: func(stdout, info string, t tig.T) {
+            Output: func(stdout string, t tig.T) {
                 t.Helper()
 
                 // Retrieve the data that was set during the Setup phase.
-                assert.Assert(t, stdout == data.Labels().Get("sometestdata"), info)
+                assert.Assert(t, stdout == data.Labels().Get("sometestdata"))
             },
         }
     }

--- a/mod/tigron/internal/mocks/t.go
+++ b/mod/tigron/internal/mocks/t.go
@@ -48,6 +48,9 @@ type (
 
 	TTempDirIn  struct{}
 	TTempDirOut = string
+
+	TSkipIn  []any
+	TSkipOut struct{}
 )
 
 type MockT struct {
@@ -92,4 +95,10 @@ func (m *MockT) TempDir() string {
 	}
 
 	return ""
+}
+
+func (m *MockT) Skip(args ...any) {
+	if handler := m.Retrieve(); handler != nil {
+		handler.(mimicry.Function[TSkipIn, TSkipOut])(args)
+	}
 }

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -294,7 +294,6 @@ func (gc *GenericCommand) Run(expect *Expected) {
 		if expect.Output != nil {
 			expect.Output(
 				result.Stdout,
-				"",
 				gc.t,
 			)
 		}

--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -23,13 +23,13 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"testing"
 	"time"
 
 	"github.com/containerd/nerdctl/mod/tigron/internal"
 	"github.com/containerd/nerdctl/mod/tigron/internal/assertive"
 	"github.com/containerd/nerdctl/mod/tigron/internal/com"
 	"github.com/containerd/nerdctl/mod/tigron/internal/formatter"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 const (
@@ -59,7 +59,7 @@ type CustomizableCommand interface {
 	// default it pass any that is defined by WithEnv
 	WithBlacklist(env []string)
 	// T returns the current testing object
-	T() *testing.T
+	T() tig.T
 
 	// withEnv *copies* the passed map to the environment of the command to be executed
 	// Note that this will override any variable defined in the embedding environment
@@ -69,7 +69,7 @@ type CustomizableCommand interface {
 	withTempDir(path string)
 	// WithConfig allows passing custom config properties from the test to the base command
 	withConfig(config Config)
-	withT(t *testing.T)
+	withT(t tig.T)
 	// Clear does a clone, but will clear binary and arguments while retaining the env, or any other
 	// custom properties Gotcha: if genericCommand is embedded with a custom Run and an overridden
 	// clear to return the embedding type the result will be the embedding command, no longer the
@@ -102,7 +102,7 @@ type GenericCommand struct {
 	TempDir string
 	Env     map[string]string
 
-	t *testing.T
+	t tig.T
 
 	cmd   *com.Command
 	async bool
@@ -337,7 +337,7 @@ func (gc *GenericCommand) Clone() TestableCommand {
 	return &clone
 }
 
-func (gc *GenericCommand) T() *testing.T {
+func (gc *GenericCommand) T() tig.T {
 	return gc.t
 }
 
@@ -361,7 +361,7 @@ func (gc *GenericCommand) clear() TestableCommand {
 	return &comcopy
 }
 
-func (gc *GenericCommand) withT(t *testing.T) {
+func (gc *GenericCommand) withT(t tig.T) {
 	t.Helper()
 	gc.t = t
 }

--- a/mod/tigron/test/funct.go
+++ b/mod/tigron/test/funct.go
@@ -16,7 +16,9 @@
 
 package test
 
-import "testing"
+import (
+	"github.com/containerd/nerdctl/mod/tigron/tig"
+)
 
 // An Evaluator is a function that decides whether a test should run or not.
 type Evaluator func(data Data, helpers Helpers) (bool, string)
@@ -30,7 +32,7 @@ type Butler func(data Data, helpers Helpers)
 // - move to tig.T
 
 // A Comparator is the function signature to implement for the Output property of an Expected.
-type Comparator func(stdout string, t *testing.T)
+type Comparator func(stdout string, t tig.T)
 
 // A Manager is the function signature meant to produce expectations for a command.
 type Manager func(data Data, helpers Helpers) *Expected

--- a/mod/tigron/test/funct.go
+++ b/mod/tigron/test/funct.go
@@ -30,7 +30,7 @@ type Butler func(data Data, helpers Helpers)
 // - move to tig.T
 
 // A Comparator is the function signature to implement for the Output property of an Expected.
-type Comparator func(stdout, info string, t *testing.T)
+type Comparator func(stdout string, t *testing.T)
 
 // A Manager is the function signature meant to produce expectations for a command.
 type Manager func(data Data, helpers Helpers) *Expected

--- a/mod/tigron/test/helpers.go
+++ b/mod/tigron/test/helpers.go
@@ -17,9 +17,8 @@
 package test
 
 import (
-	"testing"
-
 	"github.com/containerd/nerdctl/mod/tigron/internal"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 // This is the implementation of Helpers
@@ -27,7 +26,7 @@ import (
 type helpersInternal struct {
 	cmdInternal CustomizableCommand
 
-	t *testing.T
+	t tig.T
 }
 
 // Ensure will run a command and make sure it is successful.
@@ -60,8 +59,7 @@ func (help *helpersInternal) Capture(args ...string) string {
 
 	help.t.Helper()
 	help.Command(args...).Run(&Expected{
-		//nolint:thelper
-		Output: func(stdout string, _ *testing.T) {
+		Output: func(stdout string, _ tig.T) {
 			ret = stdout
 		},
 	})
@@ -104,6 +102,6 @@ func (help *helpersInternal) Write(key ConfigKey, value ConfigValue) {
 	help.cmdInternal.write(key, value)
 }
 
-func (help *helpersInternal) T() *testing.T {
+func (help *helpersInternal) T() tig.T {
 	return help.t
 }

--- a/mod/tigron/test/helpers.go
+++ b/mod/tigron/test/helpers.go
@@ -61,7 +61,7 @@ func (help *helpersInternal) Capture(args ...string) string {
 	help.t.Helper()
 	help.Command(args...).Run(&Expected{
 		//nolint:thelper
-		Output: func(stdout, _ string, _ *testing.T) {
+		Output: func(stdout string, _ *testing.T) {
 			ret = stdout
 		},
 	})

--- a/mod/tigron/test/interfaces.go
+++ b/mod/tigron/test/interfaces.go
@@ -19,8 +19,9 @@ package test
 import (
 	"io"
 	"os"
-	"testing"
 	"time"
+
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 // DataLabels holds key-value test information set by the test authors.
@@ -93,7 +94,7 @@ type Helpers interface {
 	Write(key ConfigKey, value ConfigValue)
 
 	// T returns the current testing object.
-	T() *testing.T
+	T() tig.T
 }
 
 // The TestableCommand interface represents a low-level command to execute, typically to be compared

--- a/mod/tigron/test/test.go
+++ b/mod/tigron/test/test.go
@@ -17,13 +17,13 @@
 package test
 
 import (
-	"testing"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 // Testable TODO.
 type Testable interface {
-	CustomCommand(testCase *Case, t *testing.T) CustomizableCommand
-	AmbientRequirements(testCase *Case, t *testing.T)
+	CustomCommand(testCase *Case, t tig.T) CustomizableCommand
+	AmbientRequirements(testCase *Case, t tig.T)
 }
 
 // FIXME

--- a/mod/tigron/tig/t.go
+++ b/mod/tigron/tig/t.go
@@ -37,4 +37,5 @@ type T interface {
 	Log(args ...any)
 	Name() string
 	TempDir() string
+	Skip(args ...any)
 }

--- a/pkg/testutil/compose.go
+++ b/pkg/testutil/compose.go
@@ -18,25 +18,28 @@ package testutil
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/compose-spec/compose-go/v2/loader"
 	compose "github.com/compose-spec/compose-go/v2/types"
+
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 )
 
 type ComposeDir struct {
-	t            testing.TB
+	t            tig.T
 	dir          string
 	yamlBasePath string
 }
 
 func (cd *ComposeDir) WriteFile(name, content string) {
 	if err := filesystem.WriteFile(filepath.Join(cd.dir, name), []byte(content), 0644); err != nil {
-		cd.t.Fatal(err)
+		cd.t.Log(fmt.Sprintf("Failed to create file %v", err))
+		cd.t.FailNow()
 	}
 }
 
@@ -56,10 +59,11 @@ func (cd *ComposeDir) CleanUp() {
 	os.RemoveAll(cd.dir)
 }
 
-func NewComposeDir(t testing.TB, dockerComposeYAML string) *ComposeDir {
+func NewComposeDir(t tig.T, dockerComposeYAML string) *ComposeDir {
 	tmpDir, err := os.MkdirTemp("", "nerdctl-compose-test")
 	if err != nil {
-		t.Fatal(err)
+		t.Log(fmt.Sprintf("Failed to create temp dir: %v", err))
+		t.FailNow()
 	}
 	cd := &ComposeDir{
 		t:            t,

--- a/pkg/testutil/nerdtest/command.go
+++ b/pkg/testutil/nerdtest/command.go
@@ -17,15 +17,16 @@
 package nerdtest
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
@@ -49,7 +50,7 @@ func isTargetNerdish() bool {
 	return !strings.HasPrefix(filepath.Base(testutil.GetTarget()), "docker")
 }
 
-func newNerdCommand(conf test.Config, t *testing.T) *nerdCommand {
+func newNerdCommand(conf test.Config, t tig.T) *nerdCommand {
 	// Decide what binary we are running
 	var err error
 	var binary string
@@ -57,7 +58,8 @@ func newNerdCommand(conf test.Config, t *testing.T) *nerdCommand {
 
 	binary, err = exec.LookPath(trgt)
 	if err != nil {
-		t.Fatalf("unable to find binary %q: %v", trgt, err)
+		t.Log(fmt.Sprintf("unable to find binary %q: %v", trgt, err))
+		t.FailNow()
 	}
 
 	if isTargetNerdish() {
@@ -69,7 +71,8 @@ func newNerdCommand(conf test.Config, t *testing.T) *nerdCommand {
 		}
 	} else {
 		if err = exec.Command(binary, "compose", "version").Run(); err != nil {
-			t.Fatalf("docker does not support compose: %v", err)
+			t.Log(fmt.Sprintf("docker does not support compose: %v", err))
+			t.FailNow()
 		}
 	}
 

--- a/pkg/testutil/nerdtest/registry/cesanta.go
+++ b/pkg/testutil/nerdtest/registry/cesanta.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"testing"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -31,6 +30,7 @@ import (
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 	"github.com/containerd/nerdctl/mod/tigron/utils/testca"
 
 	"github.com/containerd/nerdctl/v2/pkg/inspecttypes/dockercompat"
@@ -95,7 +95,7 @@ func ensureContainerStarted(helpers test.Helpers, con string) {
 		helpers.Command("container", "inspect", con).
 			Run(&test.Expected{
 				ExitCode: expect.ExitCodeNoCheck,
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					var dc []dockercompat.Container
 					err := json.Unmarshal([]byte(stdout), &dc)
 					if err != nil || len(dc) == 0 {
@@ -115,7 +115,8 @@ func ensureContainerStarted(helpers test.Helpers, con string) {
 		helpers.T().Log(ins)
 		helpers.T().Log(lgs)
 		helpers.T().Log(ps)
-		helpers.T().Fatalf("container %s still not running after %d retries", con, 5)
+		helpers.T().Log(fmt.Sprintf("container %s still not running after %d retries", con, 5))
+		helpers.T().FailNow()
 	}
 }
 
@@ -178,7 +179,7 @@ func NewCesantaAuthServer(data test.Data, helpers test.Helpers, ca *testca.Cert,
 		helpers.Ensure("rm", "-f", containerName)
 		errPortRelease := portlock.Release(port)
 		if errPortRelease != nil {
-			helpers.T().Error(errPortRelease.Error())
+			helpers.T().Log(fmt.Sprintf("Failed to release port %d: %s", port, errPortRelease))
 		}
 	}
 
@@ -218,7 +219,7 @@ func NewCesantaAuthServer(data test.Data, helpers test.Helpers, ca *testca.Cert,
 		Setup:   setup,
 		Cleanup: cleanup,
 		Logs: func(data test.Data, helpers test.Helpers) {
-			helpers.T().Error(helpers.Err("logs", containerName))
+			helpers.T().Log(helpers.Err("logs", containerName))
 		},
 	}
 }

--- a/pkg/testutil/nerdtest/registry/cesanta.go
+++ b/pkg/testutil/nerdtest/registry/cesanta.go
@@ -95,13 +95,13 @@ func ensureContainerStarted(helpers test.Helpers, con string) {
 		helpers.Command("container", "inspect", con).
 			Run(&test.Expected{
 				ExitCode: expect.ExitCodeNoCheck,
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					var dc []dockercompat.Container
 					err := json.Unmarshal([]byte(stdout), &dc)
 					if err != nil || len(dc) == 0 {
 						return
 					}
-					assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n"+info)
+					assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n")
 					started = dc[0].State.Running
 				},
 			})

--- a/pkg/testutil/nerdtest/registry/docker.go
+++ b/pkg/testutil/nerdtest/registry/docker.go
@@ -135,7 +135,7 @@ func NewDockerRegistry(data test.Data, helpers test.Helpers, currentCA *testca.C
 		Cleanup: cleanup,
 		Setup:   setup,
 		Logs: func(data test.Data, helpers test.Helpers) {
-			helpers.T().Error(helpers.Err("logs", containerName))
+			helpers.T().Log(helpers.Err("logs", containerName))
 		},
 		HostsDir: hostsDir,
 	}

--- a/pkg/testutil/nerdtest/registry/kubo.go
+++ b/pkg/testutil/nerdtest/registry/kubo.go
@@ -85,7 +85,7 @@ func NewKuboRegistry(data test.Data, helpers test.Helpers, t *testing.T, current
 		Cleanup: cleanup,
 		Setup:   setup,
 		Logs: func(data test.Data, helpers test.Helpers) {
-			helpers.T().Error(helpers.Err("logs", containerName))
+			helpers.T().Log(helpers.Err("logs", containerName))
 		},
 	}
 }

--- a/pkg/testutil/nerdtest/test.go
+++ b/pkg/testutil/nerdtest/test.go
@@ -17,9 +17,8 @@
 package nerdtest
 
 import (
-	"testing"
-
 	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
 )
 
 var DockerConfig test.ConfigKey = "DockerConfig"
@@ -39,11 +38,11 @@ func Setup() *test.Case {
 type nerdctlSetup struct {
 }
 
-func (ns *nerdctlSetup) CustomCommand(testCase *test.Case, t *testing.T) test.CustomizableCommand {
+func (ns *nerdctlSetup) CustomCommand(testCase *test.Case, t tig.T) test.CustomizableCommand {
 	return newNerdCommand(testCase.Config, t)
 }
 
-func (ns *nerdctlSetup) AmbientRequirements(testCase *test.Case, t *testing.T) {
+func (ns *nerdctlSetup) AmbientRequirements(testCase *test.Case, t tig.T) {
 	// Ambient requirements, bail out now if these do not match
 	if environmentHasIPv6() && testCase.Config.Read(ipv6) != only {
 		t.Skip("runner skips non-IPv6 compatible tests in the IPv6 environment")

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -18,10 +18,10 @@ package nerdtest
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"path/filepath"
 	"strings"
-	"testing"
 	"time"
 
 	"gotest.tools/v3/assert"
@@ -113,7 +113,7 @@ func EnsureContainerStarted(helpers test.Helpers, con string) {
 		helpers.Command("container", "inspect", con).
 			Run(&test.Expected{
 				ExitCode: expect.ExitCodeNoCheck,
-				Output: func(stdout string, t *testing.T) {
+				Output: func(stdout string, t tig.T) {
 					var dc []dockercompat.Container
 					err := json.Unmarshal([]byte(stdout), &dc)
 					if err != nil || len(dc) == 0 {
@@ -133,7 +133,8 @@ func EnsureContainerStarted(helpers test.Helpers, con string) {
 		helpers.T().Log(ins)
 		helpers.T().Log(lgs)
 		helpers.T().Log(ps)
-		helpers.T().Fatalf("container %s still not running after %d retries", con, maxRetry)
+		helpers.T().Log(fmt.Sprintf("container %s still not running after %d retries", con, maxRetry))
+		helpers.T().FailNow()
 	}
 }
 

--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -54,7 +54,7 @@ func InspectContainer(helpers test.Helpers, name string) dockercompat.Container 
 	var res dockercompat.Container
 	cmd := helpers.Command("container", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, _ string, t tig.T) {
+		Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, t tig.T) {
 			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
 			res = dc[0]
 		}),
@@ -67,7 +67,7 @@ func InspectVolume(helpers test.Helpers, name string) native.Volume {
 	var res native.Volume
 	cmd := helpers.Command("volume", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: expect.JSON([]native.Volume{}, func(dc []native.Volume, _ string, t tig.T) {
+		Output: expect.JSON([]native.Volume{}, func(dc []native.Volume, t tig.T) {
 			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
 			res = dc[0]
 		}),
@@ -80,7 +80,7 @@ func InspectNetwork(helpers test.Helpers, name string) dockercompat.Network {
 	var res dockercompat.Network
 	cmd := helpers.Command("network", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, _ string, t tig.T) {
+		Output: expect.JSON([]dockercompat.Network{}, func(dc []dockercompat.Network, t tig.T) {
 			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
 			res = dc[0]
 		}),
@@ -93,7 +93,7 @@ func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
 	var res dockercompat.Image
 	cmd := helpers.Command("image", "inspect", name)
 	cmd.Run(&test.Expected{
-		Output: expect.JSON([]dockercompat.Image{}, func(dc []dockercompat.Image, _ string, t tig.T) {
+		Output: expect.JSON([]dockercompat.Image{}, func(dc []dockercompat.Image, t tig.T) {
 			assert.Equal(t, 1, len(dc), "Unexpectedly got multiple results")
 			res = dc[0]
 		}),
@@ -113,13 +113,13 @@ func EnsureContainerStarted(helpers test.Helpers, con string) {
 		helpers.Command("container", "inspect", con).
 			Run(&test.Expected{
 				ExitCode: expect.ExitCodeNoCheck,
-				Output: func(stdout string, info string, t *testing.T) {
+				Output: func(stdout string, t *testing.T) {
 					var dc []dockercompat.Container
 					err := json.Unmarshal([]byte(stdout), &dc)
 					if err != nil || len(dc) == 0 {
 						return
 					}
-					assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n"+info)
+					assert.Equal(t, len(dc), 1, "Unexpectedly got multiple results\n")
 					started = dc[0].State.Running
 				},
 			})


### PR DESCRIPTION
Following on tigron changes earlier this year, the `info` parameter in comparator functions became a no-op (as log output had been revamped for the better).

Also, the `tig.T` interface has been introduced to allow testing of tigron itself and replace the hard dependency on testing.T.

I have delayed pushing in these changes, as they are changing API (which is always disruptive) and I wanted to minimize churn.

It is time now though.
This PR is split in 2 commits:
- remove the no-op `info` parameter everywhere
- replace `*testing.T` by `tig.T` in tigron methods, and adapt tests to that

These changes should not have any sort of behavioral impact.

I know this is an annoyingly "large" PR, but hopefully there is not much to review.