### PR TITLE
Re-enable tigron lint on the CI & makefile copy-pasta fix

### DIFF
--- a/.github/workflows/workflow-tigron.yml
+++ b/.github/workflows/workflow-tigron.yml
@@ -58,16 +58,20 @@ jobs:
             brew install yamllint shellcheck
           fi
           echo "::endgroup::"
-      - if: ${{ env.GO_VERSION != '' && env.RUNNER_OS == 'Linux' && matrix.goos == '' }}
+      - if: ${{ env.GO_VERSION != '' && matrix.goos == '' }}
         name: "lint"
         env:
           NO_COLOR: true
         run: |
-          echo "::group:: lint"
-          cd mod/tigron
-          export LINT_COMMIT_RANGE="$(jq -r '.after + "..HEAD"' ${GITHUB_EVENT_PATH})"
-          make lint
-          echo "::endgroup::"
+          if [ "$RUNNER_OS" == Linux ]; then
+            echo "::group:: lint"
+            cd mod/tigron
+            export LINT_COMMIT_RANGE="$(jq -r '.after + "..HEAD"' ${GITHUB_EVENT_PATH})"
+            make lint
+            echo "::endgroup::"
+          else
+            echo "Lint is disabled on $RUNNER_OS"
+          fi
       - if: ${{ env.GO_VERSION != '' }}
         name: "test-unit"
         run: |

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ lint-licenses-all:
 		&& GOOS=linux make lint-licenses \
 		&& GOOS=windows make lint-licenses \
 		&& GOOS=freebsd make lint-licenses \
-		&& GOOS=darwin make lint-go
+		&& GOOS=darwin make lint-licenses
 	$(call footer, $@)
 
 ##########################
@@ -200,7 +200,7 @@ fix-go-all:
 		&& GOOS=linux make fix-go \
 		&& GOOS=windows make fix-go \
 		&& GOOS=freebsd make fix-go \
-		&& GOOS=darwin make lint-go
+		&& GOOS=darwin make fix-go
 	$(call footer, $@)
 
 fix-mod:


### PR DESCRIPTION
Tigron lint was mistakenly disabled on the CI (env.RUNNER_OS is decidedly unreliable).
Commit number 2 does fix (unrelated) copy-pasta mistake.