### PR TITLE
Bump CI timeout

### DIFF
--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -102,7 +102,7 @@ jobs:
             canary: true
 
     with:
-      timeout: 45
+      timeout: 60
       runner: ${{ matrix.runner }}
       target: ${{ matrix.target }}
       binary: ${{ matrix.binary && matrix.binary || 'nerdctl' }}


### PR DESCRIPTION
Canary builds have been getting over 45 minutes lately.

Unclear to me why (and we may want to look into that later on), but meanwhile bumping the timeout to 60 mins to at least figure out if it is stuck or simply getting over.