### PR TITLE
Pass along GITHUB_TOKEN to canary

### DIFF
--- a/.github/workflows/job-test-in-container.yml
+++ b/.github/workflows/job-test-in-container.yml
@@ -81,6 +81,8 @@ jobs:
           docker run --privileged --rm tonistiigi/binfmt --install linux/arm/v7
       - if: ${{ inputs.canary }}
         name: "Init (canary): prepare updated test image"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . ./hack/build-integration-canary.sh
           canary::build::integration

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
         go-version: "1.24"
         check-latest: true
     - name: "Compile binaries"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: make artifacts
     - name: "SHA256SUMS"
       run: |


### PR DESCRIPTION
We have been getting lots of 403 from Github lately.

This PR does pass along the GITHUB_TOKEN where it matters so we do authenticated requests.

(scripts are already wired to use the token if provided)