### PR TITLE
[CI] Build examples

### DIFF
--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -70,6 +70,8 @@ jobs:
             local goarm="${3:-}"
             local result
 
+            GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" go build ./examples/...
+
             github::timer::begin
 
             GOOS="$goos" GOARCH="$goarch" GOARM="$goarm" make binaries \


### PR DESCRIPTION
Add a makefile task (`examples`) to build any of the examples located under `examples/nerdctl-as-a-library`, and enable it on the CI.

The point is to ensure the provided `examples` are up to date with the codebase and do build.