### PR TITLE
refactor: move BUILDKIT_HOST to buildkitutil

### DIFF
--- a/cmd/nerdctl/builder/builder_build.go
+++ b/cmd/nerdctl/builder/builder_build.go
@@ -19,7 +19,6 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 
@@ -263,13 +262,6 @@ func GetBuildkitHost(cmd *cobra.Command, namespace string) (string, error) {
 		return buildkitHost, nil
 	}
 
-	if buildkitHost := os.Getenv("BUILDKIT_HOST"); buildkitHost != "" {
-		if err := buildkitutil.PingBKDaemon(buildkitHost); err != nil {
-			return "", err
-		}
-		return buildkitHost, nil
-
-	}
 	return buildkitutil.GetBuildkitHost(namespace)
 }
 

--- a/pkg/buildkitutil/buildkitutil.go
+++ b/pkg/buildkitutil/buildkitutil.go
@@ -60,6 +60,13 @@ func BuildctlBaseArgs(buildkitHost string) []string {
 }
 
 func GetBuildkitHost(namespace string) (string, error) {
+	if buildkitHost := os.Getenv("BUILDKIT_HOST"); buildkitHost != "" {
+		if _, err := pingBKDaemon(buildkitHost); err != nil {
+			return "", err
+		}
+		return buildkitHost, nil
+	}
+
 	paths, err := getBuildkitHostCandidates(namespace)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Previously, only the build command would attempt to use the `BUILDKIT_HOST` environment variable, where as other usage of buildkitutil's GetBuildkitHost function would not

This split behavior can be confusing to users, so I think we should centralize the logic