### PR TITLE
Allow compose exec concurrency

### DIFF
--- a/cmd/nerdctl/compose/compose_exec_linux_test.go
+++ b/cmd/nerdctl/compose/compose_exec_linux_test.go
@@ -279,6 +279,11 @@ services:
 		data.Labels().Set("projectName", strings.ToLower(filepath.Base(data.Temp().Dir())))
 
 		helpers.Ensure("compose", "-f", yamlPath, "up", "-d", "svc0")
+
+		// Make sure all containers are started so that /etc/hosts is consistent.
+		for _, index := range []string{"1", "2", "3"} {
+			nerdtest.EnsureContainerStarted(helpers, fmt.Sprintf("%s-svc0-%s", data.Labels().Get("projectName"), index))
+		}
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {

--- a/pkg/composer/exec.go
+++ b/pkg/composer/exec.go
@@ -49,6 +49,11 @@ type ExecOptions struct {
 // Exec executes a given command on a running container specified by
 // `ServiceName` (and `Index` if it has multiple instances).
 func (c *Composer) Exec(ctx context.Context, eo ExecOptions) error {
+	// Exec does not need to lock and should allow concurrency.
+	if err := Unlock(); err != nil {
+		return err
+	}
+
 	containers, err := c.Containers(ctx, eo.ServiceName)
 	if err != nil {
 		return fmt.Errorf("fail to get containers for service %s: %w", eo.ServiceName, err)


### PR DESCRIPTION
Fix #4371 
Fix #4373 (<- note that this is just a workaround and not addressing the root cause, which might be unfixable - see ticket for details)
