### PR TITLE
exec: wait for I/O completion before return

### DIFF
--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -134,6 +134,10 @@ func execActionWithContainer(ctx context.Context, client *containerd.Client, con
 		return nil
 	}
 	status := <-statusC
+
+	process.IO().Wait()
+	process.IO().Close()
+
 	code, _, err := status.Result()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes [#4380](https://github.com/containerd/nerdctl/issues/4380)