### PR TITLE
fix:fifo leak

### DIFF
--- a/pkg/cioutil/container_io.go
+++ b/pkg/cioutil/container_io.go
@@ -85,7 +85,9 @@ func (c *ncio) Close() error {
 
 		select {
 		case err := <-done:
-			return err
+			if err != nil {
+				lastErr = fmt.Errorf("faied to run cmd.wait: %w", err)
+			}
 		case <-time.After(binaryIOProcTermTimeout):
 
 			err := c.cmd.Process.Kill()


### PR DESCRIPTION
fix https://github.com/containerd/nerdctl/issues/4013

ci should use testCase.NoParallel = true to disable Parallel, I spend too much time on it😢
@AkihiroSuda  @apostasie  @brahmini7632