### PR TITLE
fix: call wait before start

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -435,6 +435,12 @@ func runAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return err
+	}
+
 	if err := task.Start(ctx); err != nil {
 		return err
 	}
@@ -454,10 +460,6 @@ func runAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	statusC, err := task.Wait(ctx)
-	if err != nil {
-		return err
-	}
 	select {
 	// io.Wait() would return when either 1) the user detaches from the container OR 2) the container is about to exit.
 	//

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -279,7 +279,10 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 	if err != nil {
 		return err
 	}
-
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return err
+	}
 	if err := task.Start(ctx); err != nil {
 		return err
 	}
@@ -293,11 +296,6 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 	}
 	sigc := signalutil.ForwardAllSignals(ctx, task)
 	defer signalutil.StopCatch(sigc)
-
-	statusC, err := task.Wait(ctx)
-	if err != nil {
-		return err
-	}
 	select {
 	// io.Wait() would return when either 1) the user detaches from the container OR 2) the container is about to exit.
 	//


### PR DESCRIPTION
REF: https://github.com/containerd/containerd/blob/main/docs/getting-started.md#task-wait-and-start

> You always want to make sure you Wait before calling Start on a task. This makes sure that you do not encounter any races if the task has a simple program like /bin/true that exits promptly after calling start.

