### PR TITLE
Skip adding attest option to buildctl args if disabled=true

### DIFF
--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -404,6 +404,15 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 	for _, s := range strutil.DedupeStrSlice(options.Attest) {
 		optAttestType, optAttestAttrs, _ := strings.Cut(s, ",")
 		if strings.HasPrefix(optAttestType, "type=") {
+			if strings.HasPrefix(optAttestAttrs, "disabled=") {
+				disabled, err := strconv.ParseBool(strings.TrimPrefix(optAttestAttrs, "disabled="))
+				if err != nil {
+					return "", nil, false, "", nil, nil, fmt.Errorf("invalid value for attribute \"disabled\"")
+				}
+				if disabled {
+					continue
+				}
+			}
 			optAttestType := strings.TrimPrefix(optAttestType, "type=")
 			buildctlArgs = append(buildctlArgs, fmt.Sprintf("--opt=attest:%s=%s", optAttestType, optAttestAttrs))
 		} else {


### PR DESCRIPTION
This PR addresses part of the issue https://github.com/containerd/nerdctl/issues/4328 where, even if we pass --provenance=false to nerdctl, a provenance attestation was generated anyway. This PR skips passing the attestation flag to buildctl if disabled=true is set for the attestation flag.