### PR TITLE
[CI]: pass github token to tasks querying the API

### DIFF
--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -41,6 +41,8 @@ jobs:
 
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve GO_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           . ./hack/github/action-helpers.sh
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"

--- a/.github/workflows/job-lint-go.yml
+++ b/.github/workflows/job-lint-go.yml
@@ -45,6 +45,8 @@ jobs:
 
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve GO_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
           printf "GO_VERSION=%s\n" "$latest_go" >> "$GITHUB_ENV"

--- a/.github/workflows/job-test-in-host.yml
+++ b/.github/workflows/job-test-in-host.yml
@@ -77,6 +77,8 @@ jobs:
 
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve latest go and containerd"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
           latest_containerd="$(. ./hack/provisioning/version/fetch.sh; github::project::latest "containerd/containerd")"

--- a/.github/workflows/job-test-unit.yml
+++ b/.github/workflows/job-test-unit.yml
@@ -53,6 +53,8 @@ jobs:
       # If canary is requested, check for the latest unstable release
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve GO_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
           printf "GO_VERSION=%s\n" "$latest_go" >> "$GITHUB_ENV"

--- a/.github/workflows/workflow-tigron.yml
+++ b/.github/workflows/workflow-tigron.yml
@@ -37,6 +37,8 @@ jobs:
           fetch-depth: 100
       - if: ${{ matrix.canary }}
         name: "Init (canary): retrieve GO_VERSION"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
           printf "GO_VERSION=%s\n" "$latest_go" >> "$GITHUB_ENV"


### PR DESCRIPTION
We are hitting Github throttling on some runs.

https://github.com/containerd/nerdctl/actions/runs/16476818588/job/46580573877?pr=4419#step:3:26

This PR does ensure we pass the token to tasks that query the API.

