### PR TITLE
[CI]: Bump lint timeout

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,7 +34,7 @@ jobs:
             goos: linux
             canary: true
     with:
-      timeout: 5
+      timeout: 10
       go-version: "1.24"
       runner: ubuntu-24.04
       # Note: in GitHub yaml world, if `matrix.canary` is undefined, and is passed to `inputs.canary`, the job


### PR DESCRIPTION
Lint on canary may get over the 5 minutes threshold and fail builds: https://github.com/containerd/nerdctl/actions/runs/16475362529/job/46575380244?pr=4417

This relaxes it to 10 minutes.