### PR TITLE
bugfix: Incorrect usage is displayed when running nerdctl without any command

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -61,7 +61,7 @@ var (
 // usage was derived from https://github.com/spf13/cobra/blob/v1.2.1/command.go#L491-L514
 func usage(c *cobra.Command) error {
 	s := "Usage: "
-	if c.Runnable() {
+	if c != c.Root() {
 		s += c.UseLine() + "\n"
 	} else {
 		s += c.CommandPath() + " [command]\n"


### PR DESCRIPTION
Fixes : #3185 