### PR TITLE
add healthcheck orchestration logic

### DIFF
--- a/cmd/nerdctl/compose/compose_start.go
+++ b/cmd/nerdctl/compose/compose_start.go
@@ -28,8 +28,10 @@ import (
 	"github.com/containerd/errdefs"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
+	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/compose"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
@@ -86,7 +88,7 @@ func startAction(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("service %q has no container to start", svcName)
 		}
 
-		if err := startContainers(ctx, client, containers); err != nil {
+		if err := startContainers(ctx, client, containers, &globalOptions); err != nil {
 			return err
 		}
 	}
@@ -94,7 +96,7 @@ func startAction(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func startContainers(ctx context.Context, client *containerd.Client, containers []containerd.Container) error {
+func startContainers(ctx context.Context, client *containerd.Client, containers []containerd.Container, globalOptions *types.GlobalCommandOptions) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, c := range containers {
 		c := c
@@ -112,7 +114,7 @@ func startContainers(ctx context.Context, client *containerd.Client, containers 
 			}
 
 			// in compose, always disable attach
-			if err := containerutil.Start(ctx, c, false, false, client, ""); err != nil {
+			if err := containerutil.Start(ctx, c, false, false, client, "", (*config.Config)(globalOptions)); err != nil {
 				return err
 			}
 			info, err := c.Info(ctx, containerd.WithoutRefreshedMetadata)

--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -279,10 +279,6 @@ func createOptions(cmd *cobra.Command) (types.ContainerCreateOptions, error) {
 	if err != nil {
 		return opt, err
 	}
-	opt.HealthStartInterval, err = cmd.Flags().GetDuration("health-start-interval")
-	if err != nil {
-		return opt, err
-	}
 	opt.NoHealthcheck, err = cmd.Flags().GetBool("no-healthcheck")
 	if err != nil {
 		return opt, err

--- a/cmd/nerdctl/container/container_health_check_linux_test.go
+++ b/cmd/nerdctl/container/container_health_check_linux_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
@@ -41,6 +42,11 @@ func TestContainerHealthCheckBasic(t *testing.T) {
 
 	// Docker CLI does not provide a standalone healthcheck command.
 	testCase.Require = require.Not(nerdtest.Docker)
+
+	// Skip systemd tests in rootless environment to bypass dbus permission issues
+	if rootlessutil.IsRootless() {
+		t.Skip("systemd healthcheck tests are skipped in rootless environment")
+	}
 
 	testCase.SubTests = []*test.Case{
 		{
@@ -138,6 +144,11 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 
 	// Docker CLI does not provide a standalone healthcheck command.
 	testCase.Require = require.Not(nerdtest.Docker)
+
+	// Skip systemd tests in rootless environment to bypass dbus permission issues
+	if rootlessutil.IsRootless() {
+		t.Skip("systemd healthcheck tests are skipped in rootless environment")
+	}
 
 	testCase.SubTests = []*test.Case{
 		{
@@ -600,5 +611,312 @@ func TestContainerHealthCheckAdvance(t *testing.T) {
 		},
 	}
 
+	testCase.Run(t)
+}
+
+func TestHealthCheck_SystemdIntegration_Basic(t *testing.T) {
+	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Docker)
+	// Skip systemd tests in rootless environment to bypass dbus permission issues
+	if rootlessutil.IsRootless() {
+		t.Skip("systemd healthcheck tests are skipped in rootless environment")
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "Basic healthy container with systemd-triggered healthcheck",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo healthy",
+					"--health-interval", "2s",
+					testutil.CommonImage, "sleep", "30")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				// Ensure proper cleanup of systemd units
+				helpers.Anyhow("stop", data.Identifier())
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: expect.All(func(stdout string, t tig.T) {
+						var h *healthcheck.Health
+
+						// Poll up to 5 times for health status
+						maxAttempts := 5
+						var finalStatus string
+
+						for i := 0; i < maxAttempts; i++ {
+							inspect := nerdtest.InspectContainer(helpers, data.Identifier())
+							h = inspect.State.Health
+
+							assert.Assert(t, h != nil, "expected health state to be present")
+							finalStatus = h.Status
+
+							// If healthy, break and pass the test
+							if finalStatus == "healthy" {
+								t.Log(fmt.Sprintf("Container became healthy on attempt %d/%d", i+1, maxAttempts))
+								break
+							}
+
+							// If unhealthy, fail immediately
+							if finalStatus == "unhealthy" {
+								assert.Assert(t, false, fmt.Sprintf("Container became unhealthy on attempt %d/%d, status: %s", i+1, maxAttempts, finalStatus))
+								return
+							}
+
+							// If not the last attempt, wait before retrying
+							if i < maxAttempts-1 {
+								t.Log(fmt.Sprintf("Attempt %d/%d: status is '%s', waiting 1 second before retry", i+1, maxAttempts, finalStatus))
+								time.Sleep(1 * time.Second)
+							}
+						}
+
+						if finalStatus != "healthy" {
+							assert.Assert(t, false, fmt.Sprintf("Container did not become healthy after %d attempts, final status: %s", maxAttempts, finalStatus))
+							return
+						}
+
+						assert.Assert(t, len(h.Log) > 0, "expected at least one health check log entry")
+					}),
+				}
+			},
+		},
+		{
+			Description: "Kill stops healthcheck execution and cleans up systemd timer",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo healthy",
+					"--health-interval", "1s",
+					testutil.CommonImage, "sleep", "30")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+				helpers.Ensure("kill", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				// Container is already killed, just remove it
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						// Get container info for verification
+						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
+						containerID := inspect.ID
+						h := inspect.State.Health
+
+						// Verify health state and logs exist
+						assert.Assert(t, h != nil, "expected health state to be present")
+						assert.Assert(t, len(h.Log) > 0, "expected at least one health check log entry")
+
+						// Ensure systemd timers are removed
+						result := helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+						result.Run(&test.Expected{
+							ExitCode: expect.ExitCodeNoCheck,
+							Output: func(stdout string, _ tig.T) {
+								assert.Assert(t, !strings.Contains(stdout, containerID),
+									"expected nerdctl healthcheck timer for container ID %s to be removed after container stop", containerID)
+							},
+						})
+					},
+				}
+			},
+		},
+		{
+			Description: "Remove cleans up systemd timer",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo healthy",
+					"--health-interval", "1s",
+					testutil.CommonImage, "sleep", "30")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+				helpers.Ensure("rm", "-f", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				// Container is already removed, no cleanup needed
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
+						containerID := inspect.ID
+
+						// Check systemd timers to ensure cleanup
+						result := helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+						result.Run(&test.Expected{
+							ExitCode: expect.ExitCodeNoCheck,
+							Output: func(stdout string, _ tig.T) {
+								// Verify systemd timer has been cleaned up by checking systemctl output
+								// We check that no timer contains our test identifier
+								assert.Assert(t, !strings.Contains(stdout, containerID),
+									"expected nerdctl healthcheck timer for container ID %s to be removed after container removal", containerID)
+							},
+						})
+					},
+				}
+			},
+		},
+		{
+			Description: "Stop cleans up systemd timer",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo healthy",
+					"--health-interval", "1s",
+					testutil.CommonImage, "sleep", "30")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+				helpers.Ensure("stop", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				// Container is already stopped, just remove it
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						// Get container info for verification
+						inspect := nerdtest.InspectContainer(helpers, data.Identifier())
+						containerID := inspect.ID
+
+						// Ensure systemd timers are removed
+						result := helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+						result.Run(&test.Expected{
+							ExitCode: expect.ExitCodeNoCheck,
+							Output: func(stdout string, _ tig.T) {
+								assert.Assert(t, !strings.Contains(stdout, containerID),
+									"expected nerdctl healthcheck timer for container ID %s to be removed after container stop", containerID)
+							},
+						})
+					},
+				}
+			},
+		},
+	}
+	testCase.Run(t)
+}
+
+func TestHealthCheck_SystemdIntegration_Advanced(t *testing.T) {
+	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Docker)
+	// Skip systemd tests in rootless environment to bypass dbus permission issues
+	if rootlessutil.IsRootless() {
+		t.Skip("systemd healthcheck tests are skipped in rootless environment")
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			// Tests that CreateTimer() successfully creates systemd timer units and
+			// RemoveTransientHealthCheckFiles() properly cleans up units when container stops.
+			Description: "Systemd timer unit creation and cleanup",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo healthy",
+					"--health-interval", "1s",
+					testutil.CommonImage, "sleep", "30")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("inspect", data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: expect.All(func(stdout string, t tig.T) {
+						// Get container ID and check systemd timer
+						containerInspect := nerdtest.InspectContainer(helpers, data.Identifier())
+						containerID := containerInspect.ID
+
+						// Check systemd timer
+						result := helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+						result.Run(&test.Expected{
+							ExitCode: expect.ExitCodeNoCheck,
+							Output: func(stdout string, _ tig.T) {
+								// Verify that a timer exists for this specific container
+								assert.Assert(t, strings.Contains(stdout, containerID),
+									"expected to find nerdctl healthcheck timer containing container ID: %s", containerID)
+							},
+						})
+						// Stop container and verify cleanup
+						helpers.Ensure("stop", data.Identifier())
+
+						// Check that timer is gone
+						result = helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+						result.Run(&test.Expected{
+							ExitCode: expect.ExitCodeNoCheck,
+							Output: func(stdout string, _ tig.T) {
+								assert.Assert(t, !strings.Contains(stdout, containerID),
+									"expected nerdctl healthcheck timer for container ID %s to be removed after container stop", containerID)
+							},
+						})
+					}),
+				}
+			},
+		},
+		{
+			Description: "Container restart recreates systemd timer",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "echo restart-test",
+					"--health-interval", "2s",
+					testutil.CommonImage, "sleep", "60")
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				// Get container ID for verification
+				containerInspect := nerdtest.InspectContainer(helpers, data.Identifier())
+				containerID := containerInspect.ID
+
+				// Step 1: Verify timer exists initially
+				result := helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+				result.Run(&test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, containerID),
+							"expected timer for container %s to exist initially", containerID)
+					},
+				})
+
+				// Step 2: Stop container
+				helpers.Ensure("stop", data.Identifier())
+
+				// Step 3: Verify timer is removed after stop
+				result = helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+				result.Run(&test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, !strings.Contains(stdout, containerID),
+							"expected timer for container %s to be removed after stop", containerID)
+					},
+				})
+
+				// Step 4: Restart container
+				helpers.Ensure("start", data.Identifier())
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+
+				// Step 5: Verify timer is recreated after restart - this is our final verification
+				return helpers.Custom("systemctl", "list-timers", "--all", "--no-pager")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						containerInspect := nerdtest.InspectContainer(helpers, data.Identifier())
+						containerID := containerInspect.ID
+						assert.Assert(t, strings.Contains(stdout, containerID),
+							"expected timer for container %s to be recreated after restart", containerID)
+					},
+				}
+			},
+		},
+	}
 	testCase.Run(t)
 }

--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -841,6 +841,9 @@ func TestRunDomainname(t *testing.T) {
 }
 
 func TestRunHealthcheckFlags(t *testing.T) {
+	if rootlessutil.IsRootless() {
+		t.Skip("healthcheck tests are skipped in rootless environment")
+	}
 	testCase := nerdtest.Setup()
 
 	testCases := []struct {
@@ -990,6 +993,9 @@ func TestRunHealthcheckFlags(t *testing.T) {
 }
 
 func TestRunHealthcheckFromImage(t *testing.T) {
+	if rootlessutil.IsRootless() {
+		t.Skip("healthcheck tests are skipped in rootless environment")
+	}
 	nerdtest.Setup()
 
 	dockerfile := fmt.Sprintf(`FROM %s

--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -52,8 +52,7 @@ func ValidateHealthcheckFlags(options types.ContainerCreateOptions) error {
 		options.HealthInterval != 0 ||
 			options.HealthTimeout != 0 ||
 			options.HealthRetries != 0 ||
-			options.HealthStartPeriod != 0 ||
-			options.HealthStartInterval != 0
+			options.HealthStartPeriod != 0
 
 	if options.NoHealthcheck {
 		if options.HealthCmd != "" || healthFlagsSet {
@@ -73,9 +72,6 @@ func ValidateHealthcheckFlags(options types.ContainerCreateOptions) error {
 	}
 	if options.HealthStartPeriod < 0 {
 		return fmt.Errorf("--health-start-period cannot be negative")
-	}
-	if options.HealthStartInterval < 0 {
-		return fmt.Errorf("--health-start-interval cannot be negative")
 	}
 	return nil
 }

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -292,13 +292,12 @@ type ContainerCreateOptions struct {
 	ImagePullOpt ImagePullOptions
 
 	// Healthcheck related fields
-	HealthCmd           string
-	HealthInterval      time.Duration
-	HealthTimeout       time.Duration
-	HealthRetries       int
-	HealthStartPeriod   time.Duration
-	HealthStartInterval time.Duration
-	NoHealthcheck       bool
+	HealthCmd         string
+	HealthInterval    time.Duration
+	HealthTimeout     time.Duration
+	HealthRetries     int
+	HealthStartPeriod time.Duration
+	NoHealthcheck     bool
 
 	// UserNS name for user namespace mapping of container
 	UserNS string

--- a/pkg/cmd/compose/compose.go
+++ b/pkg/cmd/compose/compose.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cmd/volume"
 	"github.com/containerd/nerdctl/v2/pkg/composer"
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
 	"github.com/containerd/nerdctl/v2/pkg/ipfs"
@@ -156,7 +157,7 @@ func New(client *containerd.Client, globalOptions types.GlobalCommandOptions, op
 		return err
 	}
 
-	return composer.New(options, client)
+	return composer.New(options, client, (*config.Config)(&globalOptions))
 }
 
 func imageVerifyOptionsFromCompose(ps *serviceparser.Service) types.ImageVerifyOptions {

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -891,9 +891,6 @@ func withHealthcheck(options types.ContainerCreateOptions, ensuredImage *imgutil
 	if options.HealthStartPeriod != 0 {
 		hc.StartPeriod = options.HealthStartPeriod
 	}
-	if options.HealthStartInterval != 0 {
-		hc.StartInterval = options.HealthStartInterval
-	}
 
 	// If no healthcheck config is set (via CLI or image), return empty string so we skip adding to container config.
 	if reflect.DeepEqual(hc, &healthcheck.Healthcheck{}) {

--- a/pkg/cmd/container/health_check.go
+++ b/pkg/cmd/container/health_check.go
@@ -59,7 +59,6 @@ func HealthCheck(ctx context.Context, client *containerd.Client, container conta
 	hcConfig.Interval = timeoutWithDefault(hcConfig.Interval, healthcheck.DefaultProbeInterval)
 	hcConfig.Timeout = timeoutWithDefault(hcConfig.Timeout, healthcheck.DefaultProbeTimeout)
 	hcConfig.StartPeriod = timeoutWithDefault(hcConfig.StartPeriod, healthcheck.DefaultStartPeriod)
-	hcConfig.StartInterval = timeoutWithDefault(hcConfig.StartInterval, healthcheck.DefaultStartInterval)
 	if hcConfig.Retries == 0 {
 		hcConfig.Retries = healthcheck.DefaultProbeRetries
 	}

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -35,6 +35,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
@@ -109,6 +110,11 @@ func killContainer(ctx context.Context, container containerd.Container, signal s
 
 	if err := task.Kill(ctx, signal); err != nil {
 		return err
+	}
+
+	// Clean up healthcheck systemd units
+	if err := healthcheck.RemoveTransientHealthCheckFiles(ctx, container); err != nil {
+		log.G(ctx).Warnf("failed to clean up healthcheck units for container %s: %s", container.ID(), err)
 	}
 
 	// signal will be sent once resume is finished

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -34,6 +34,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
@@ -178,6 +179,11 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 
 		// Otherwise, nil the error so that we do not write the error label on the container
 		retErr = nil
+
+		// Clean up healthcheck systemd units
+		if err := healthcheck.RemoveTransientHealthCheckFiles(ctx, c); err != nil {
+			log.G(ctx).WithError(err).Warnf("failed to clean up healthcheck units for container %q", id)
+		}
 
 		// Now, delete the actual container
 		var delOpts []containerd.DeleteOpts

--- a/pkg/cmd/container/restart.go
+++ b/pkg/cmd/container/restart.go
@@ -23,6 +23,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )
@@ -38,7 +39,7 @@ func Restart(ctx context.Context, client *containerd.Client, containers []string
 			if err := containerutil.Stop(ctx, found.Container, options.Timeout, options.Signal); err != nil {
 				return err
 			}
-			if err := containerutil.Start(ctx, found.Container, false, false, client, ""); err != nil {
+			if err := containerutil.Start(ctx, found.Container, false, false, client, "", (*config.Config)(&options.GOption)); err != nil {
 				return err
 			}
 			_, err := fmt.Fprintln(options.Stdout, found.Req)

--- a/pkg/cmd/container/start.go
+++ b/pkg/cmd/container/start.go
@@ -23,6 +23,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )
@@ -40,7 +41,7 @@ func Start(ctx context.Context, client *containerd.Client, reqs []string, option
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			if err := containerutil.Start(ctx, found.Container, options.Attach, options.Interactive, client, options.DetachKeys); err != nil {
+			if err := containerutil.Start(ctx, found.Container, options.Attach, options.Interactive, client, options.DetachKeys, (*config.Config)(&options.GOptions)); err != nil {
 				return err
 			}
 			if !options.Attach {

--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )
 
@@ -38,6 +39,9 @@ func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt typ
 			}
 			if err := cleanupNetwork(ctx, found.Container, opt.GOptions); err != nil {
 				return fmt.Errorf("unable to cleanup network for container: %s", found.Req)
+			}
+			if err := healthcheck.RemoveTransientHealthCheckFiles(ctx, found.Container); err != nil {
+				return fmt.Errorf("unable to cleanup healthcheck timer for container: %s: %w", found.Req, err)
 			}
 			if err := containerutil.Stop(ctx, found.Container, opt.Timeout, opt.Signal); err != nil {
 				if errdefs.IsNotFound(err) {

--- a/pkg/cmd/container/unpause.go
+++ b/pkg/cmd/container/unpause.go
@@ -23,6 +23,7 @@ import (
 	containerd "github.com/containerd/containerd/v2/client"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 )
@@ -35,7 +36,7 @@ func Unpause(ctx context.Context, client *containerd.Client, reqs []string, opti
 			if found.MatchCount > 1 {
 				return fmt.Errorf("multiple IDs found with provided prefix: %s", found.Req)
 			}
-			if err := containerutil.Unpause(ctx, client, found.Container.ID()); err != nil {
+			if err := containerutil.Unpause(ctx, client, found.Container.ID(), (*config.Config)(&options.GOptions)); err != nil {
 				return err
 			}
 

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -30,6 +30,7 @@ import (
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/composer/serviceparser"
+	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/identifiers"
 	"github.com/containerd/nerdctl/v2/pkg/reflectutil"
 )
@@ -54,7 +55,7 @@ type Options struct {
 	IPFSAddress      string
 }
 
-func New(o Options, client *containerd.Client) (*Composer, error) {
+func New(o Options, client *containerd.Client, cfg *config.Config) (*Composer, error) {
 	if o.NerdctlCmd == "" {
 		return nil, errors.New("got empty nerdctl cmd")
 	}
@@ -119,6 +120,7 @@ func New(o Options, client *containerd.Client) (*Composer, error) {
 		Options: o,
 		project: project,
 		client:  client,
+		config:  cfg,
 	}
 
 	return c, nil
@@ -128,6 +130,7 @@ type Composer struct {
 	Options
 	project *compose.Project
 	client  *containerd.Client
+	config  *config.Config
 }
 
 func (c *Composer) createNerdctlCmd(ctx context.Context, args ...string) *exec.Cmd {

--- a/pkg/composer/pause.go
+++ b/pkg/composer/pause.go
@@ -83,7 +83,7 @@ func (c *Composer) Unpause(ctx context.Context, services []string, writer io.Wri
 	for _, container := range containers {
 		container := container
 		eg.Go(func() error {
-			if err := containerutil.Unpause(ctx, c.client, container.ID()); err != nil {
+			if err := containerutil.Unpause(ctx, c.client, container.ID(), c.config); err != nil {
 				return err
 			}
 			info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	DNS              []string `toml:"dns,omitempty"`
 	DNSOpts          []string `toml:"dns_opts,omitempty"`
 	DNSSearch        []string `toml:"dns_search,omitempty"`
+	DisableHCSystemd bool     `toml:"disable_hc_systemd"`
 }
 
 // New creates a default Config object statically,
@@ -71,5 +72,6 @@ func New() *Config {
 		DNS:              []string{},
 		DNSOpts:          []string{},
 		DNSSearch:        []string{},
+		DisableHCSystemd: false,
 	}
 }

--- a/pkg/healthcheck/executor.go
+++ b/pkg/healthcheck/executor.go
@@ -125,29 +125,47 @@ func updateHealthStatus(ctx context.Context, container containerd.Container, hcC
 		return fmt.Errorf("failed to read health state from labels: %w", err)
 	}
 	if currentHealth == nil {
+		// Determine if we should start in the start period workflow
+		hasStartPeriod := hcConfig.StartPeriod > 0
 		currentHealth = &HealthState{
 			Status:        Starting,
 			FailingStreak: 0,
+			InStartPeriod: hasStartPeriod,
 		}
 	}
 
-	// Check if still within start period
-	startPeriod := hcConfig.StartPeriod
+	// Get container info for start period check
 	info, err := container.Info(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get container info: %w", err)
 	}
 	containerCreated := info.CreatedAt
-	stillInStartPeriod := hcResult.Start.Sub(containerCreated) < startPeriod
 
-	// Update health status based on exit code
-	if hcResult.ExitCode == 0 {
-		currentHealth.Status = Healthy
-		currentHealth.FailingStreak = 0
-	} else if !stillInStartPeriod {
-		currentHealth.FailingStreak++
-		if currentHealth.FailingStreak >= hcConfig.Retries {
-			currentHealth.Status = Unhealthy
+	// Check if we're in start period workflow
+	inStartPeriodTime := hcResult.Start.Sub(containerCreated) < hcConfig.StartPeriod
+	inStartPeriodState := currentHealth.InStartPeriod
+
+	if inStartPeriodTime && inStartPeriodState {
+		// Start Period Workflow
+		if hcResult.ExitCode == 0 {
+			// First healthy result transitions us out of start period
+			currentHealth.Status = Healthy
+			currentHealth.FailingStreak = 0
+			currentHealth.InStartPeriod = false
+		}
+		// Ignore unhealthy results during start period
+	} else {
+		// Health Interval Workflow
+		if hcResult.ExitCode == 0 {
+			if currentHealth.Status != Healthy {
+				currentHealth.Status = Healthy
+				currentHealth.FailingStreak = 0
+			}
+		} else {
+			currentHealth.FailingStreak++
+			if currentHealth.FailingStreak >= hcConfig.Retries && currentHealth.Status != Unhealthy {
+				currentHealth.Status = Unhealthy
+			}
 		}
 	}
 

--- a/pkg/healthcheck/health.go
+++ b/pkg/healthcheck/health.go
@@ -43,7 +43,6 @@ const (
 	DefaultProbeInterval   = 30 * time.Second // Default interval between probe runs. Also applies before the first probe.
 	DefaultProbeTimeout    = 30 * time.Second // Max duration a single probe run may take before it's considered failed.
 	DefaultStartPeriod     = 0 * time.Second  // Grace period for container startup before health checks count as failures.
-	DefaultStartInterval   = 5 * time.Second  // Interval between checks during the start period.
 	DefaultProbeRetries    = 3                // Number of consecutive failures before marking container as unhealthy.
 	MaxLogEntries          = 5                // Maximum number of health check log entries to keep.
 	MaxOutputLenForInspect = 4096             // Max output length (in bytes) stored in health check logs during inspect. Longer outputs are truncated.
@@ -70,18 +69,18 @@ type HealthcheckResult struct {
 
 // Healthcheck represents the health check configuration
 type Healthcheck struct {
-	Test          []string      `json:"Test,omitempty"`          // Test is the check to perform that the container is healthy
-	Interval      time.Duration `json:"Interval,omitempty"`      // Interval is the time to wait between checks
-	Timeout       time.Duration `json:"Timeout,omitempty"`       // Timeout is the time to wait before considering the check to have hung
-	Retries       int           `json:"Retries,omitempty"`       // Retries is the number of consecutive failures needed to consider a container as unhealthy
-	StartPeriod   time.Duration `json:"StartPeriod,omitempty"`   // StartPeriod is the period for the container to initialize before the health check starts
-	StartInterval time.Duration `json:"StartInterval,omitempty"` // StartInterval is the time between health checks during the start period
+	Test        []string      `json:"Test,omitempty"`        // Test is the check to perform that the container is healthy
+	Interval    time.Duration `json:"Interval,omitempty"`    // Interval is the time to wait between checks
+	Timeout     time.Duration `json:"Timeout,omitempty"`     // Timeout is the time to wait before considering the check to have hung
+	Retries     int           `json:"Retries,omitempty"`     // Retries is the number of consecutive failures needed to consider a container as unhealthy
+	StartPeriod time.Duration `json:"StartPeriod,omitempty"` // StartPeriod is the period for the container to initialize before the health check starts
 }
 
 // HealthState stores the current health state of a container
 type HealthState struct {
 	Status        HealthStatus // Status is one of [Starting], [Healthy] or [Unhealthy]
 	FailingStreak int          // FailingStreak is the number of consecutive failures
+	InStartPeriod bool         // InStartPeriod indicates if we're in the start period workflow
 }
 
 // ToJSONString serializes HealthState to a JSON string for label storage

--- a/pkg/healthcheck/healthcheck_manager_darwin.go
+++ b/pkg/healthcheck/healthcheck_manager_darwin.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+
+	containerd "github.com/containerd/containerd/v2/client"
+
+	"github.com/containerd/nerdctl/v2/pkg/config"
+)
+
+// CreateTimer sets up the transient systemd timer and service for healthchecks.
+func CreateTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// StartTimer starts the healthcheck timer unit.
+func StartTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// RemoveTransientHealthCheckFiles stops and cleans up the transient timer and service.
+func RemoveTransientHealthCheckFiles(ctx context.Context, container containerd.Container) error {
+	return nil
+}
+
+// ForceRemoveTransientHealthCheckFiles forcefully stops and cleans up the transient timer and service
+// using just the container ID. This function is non-blocking and uses timeouts to prevent hanging
+// on systemd operations. On Darwin, this is a no-op since systemd is not available.
+func ForceRemoveTransientHealthCheckFiles(ctx context.Context, containerID string) error {
+	return nil
+}

--- a/pkg/healthcheck/healthcheck_manager_freebsd.go
+++ b/pkg/healthcheck/healthcheck_manager_freebsd.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+
+	containerd "github.com/containerd/containerd/v2/client"
+
+	"github.com/containerd/nerdctl/v2/pkg/config"
+)
+
+// CreateTimer sets up the transient systemd timer and service for healthchecks.
+func CreateTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// StartTimer starts the healthcheck timer unit.
+func StartTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// RemoveTransientHealthCheckFiles stops and cleans up the transient timer and service.
+func RemoveTransientHealthCheckFiles(ctx context.Context, container containerd.Container) error {
+	return nil
+}
+
+// ForceRemoveTransientHealthCheckFiles forcefully stops and cleans up the transient timer and service
+// using just the container ID. This function is non-blocking and uses timeouts to prevent hanging
+// on systemd operations. On Darwin, this is a no-op since systemd is not available.
+func ForceRemoveTransientHealthCheckFiles(ctx context.Context, containerID string) error {
+	return nil
+}

--- a/pkg/healthcheck/healthcheck_manager_linux.go
+++ b/pkg/healthcheck/healthcheck_manager_linux.go
@@ -1,0 +1,265 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/config"
+	"github.com/containerd/nerdctl/v2/pkg/defaults"
+	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+)
+
+// CreateTimer sets up the transient systemd timer and service for healthchecks.
+func CreateTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	hc := extractHealthcheck(ctx, container)
+	if hc == nil {
+		return nil
+	}
+	if shouldSkipHealthCheckSystemd(hc, cfg) {
+		return nil
+	}
+
+	containerID := container.ID()
+	log.G(ctx).Debugf("Creating healthcheck timer unit: %s", containerID)
+
+	cmdOpts := []string{}
+	if path := os.Getenv("PATH"); path != "" {
+		cmdOpts = append(cmdOpts, "--setenv=PATH="+path)
+	}
+
+	// Always use health-interval for timer frequency
+	cmdOpts = append(cmdOpts, "--unit", containerID, "--on-unit-inactive="+hc.Interval.String(), "--timer-property=AccuracySec=1s")
+
+	cmdOpts = append(cmdOpts, "nerdctl", "container", "healthcheck", containerID)
+	if log.G(ctx).Logger.IsLevelEnabled(log.DebugLevel) {
+		cmdOpts = append(cmdOpts, "--debug")
+	}
+
+	log.G(ctx).Debugf("creating healthcheck timer with: systemd-run %s", strings.Join(cmdOpts, " "))
+	run := exec.Command("systemd-run", cmdOpts...)
+	if out, err := run.CombinedOutput(); err != nil {
+		return fmt.Errorf("systemd-run failed: %w\noutput: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
+}
+
+// StartTimer starts the healthcheck timer unit.
+func StartTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	hc := extractHealthcheck(ctx, container)
+	if hc == nil {
+		return nil
+	}
+	if shouldSkipHealthCheckSystemd(hc, cfg) {
+		return nil
+	}
+
+	containerID := container.ID()
+	var conn *dbus.Conn
+	var err error
+	if rootlessutil.IsRootless() {
+		conn, err = dbus.NewUserConnectionContext(ctx)
+	} else {
+		conn, err = dbus.NewSystemConnectionContext(ctx)
+	}
+	if err != nil {
+		return fmt.Errorf("systemd DBUS connect error: %w", err)
+	}
+	defer conn.Close()
+
+	startChan := make(chan string)
+	unit := containerID + ".service"
+	if _, err := conn.RestartUnitContext(context.Background(), unit, "fail", startChan); err != nil {
+		return err
+	}
+	if msg := <-startChan; msg != "done" {
+		return fmt.Errorf("unexpected systemd restart result: %s", msg)
+	}
+	return nil
+}
+
+// RemoveTransientHealthCheckFiles stops and cleans up the transient timer and service.
+func RemoveTransientHealthCheckFiles(ctx context.Context, container containerd.Container) error {
+	hc := extractHealthcheck(ctx, container)
+	if hc == nil {
+		return nil
+	}
+
+	return ForceRemoveTransientHealthCheckFiles(ctx, container.ID())
+}
+
+// ForceRemoveTransientHealthCheckFiles forcefully stops and cleans up the transient timer and service
+// using just the container ID. This function is non-blocking and uses timeouts to prevent hanging
+// on systemd operations. It logs errors as warnings but continues cleanup attempts.
+func ForceRemoveTransientHealthCheckFiles(ctx context.Context, containerID string) error {
+	log.G(ctx).Debugf("Force removing healthcheck timer unit: %s", containerID)
+
+	// Create a timeout context for systemd operations
+	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	timer := containerID + ".timer"
+	service := containerID + ".service"
+
+	// Channel to collect any critical errors (though we'll continue cleanup regardless)
+	errChan := make(chan error, 3)
+
+	// Goroutine for DBUS connection and cleanup operations
+	go func() {
+		defer close(errChan)
+
+		var conn *dbus.Conn
+		var err error
+		if rootlessutil.IsRootless() {
+			conn, err = dbus.NewUserConnectionContext(ctx)
+		} else {
+			conn, err = dbus.NewSystemConnectionContext(ctx)
+		}
+		if err != nil {
+			log.G(ctx).Warnf("systemd DBUS connect error during force cleanup: %v", err)
+			errChan <- fmt.Errorf("systemd DBUS connect error: %w", err)
+			return
+		}
+		defer conn.Close()
+
+		// Stop timer with timeout
+		go func() {
+			select {
+			case <-timeoutCtx.Done():
+				log.G(ctx).Warnf("timeout stopping timer %s during force cleanup", timer)
+				return
+			default:
+				tChan := make(chan string, 1)
+				if _, err := conn.StopUnitContext(timeoutCtx, timer, "ignore-dependencies", tChan); err == nil {
+					select {
+					case msg := <-tChan:
+						if msg != "done" {
+							log.G(ctx).Warnf("timer stop message during force cleanup: %s", msg)
+						}
+					case <-timeoutCtx.Done():
+						log.G(ctx).Warnf("timeout waiting for timer stop confirmation: %s", timer)
+					}
+				} else {
+					log.G(ctx).Warnf("failed to stop timer %s during force cleanup: %v", timer, err)
+				}
+			}
+		}()
+
+		// Stop service with timeout
+		go func() {
+			select {
+			case <-timeoutCtx.Done():
+				log.G(ctx).Warnf("timeout stopping service %s during force cleanup", service)
+				return
+			default:
+				sChan := make(chan string, 1)
+				if _, err := conn.StopUnitContext(timeoutCtx, service, "ignore-dependencies", sChan); err == nil {
+					select {
+					case msg := <-sChan:
+						if msg != "done" {
+							log.G(ctx).Warnf("service stop message during force cleanup: %s", msg)
+						}
+					case <-timeoutCtx.Done():
+						log.G(ctx).Warnf("timeout waiting for service stop confirmation: %s", service)
+					}
+				} else {
+					log.G(ctx).Warnf("failed to stop service %s during force cleanup: %v", service, err)
+				}
+			}
+		}()
+
+		// Reset failed units (best effort, non-blocking)
+		go func() {
+			select {
+			case <-timeoutCtx.Done():
+				log.G(ctx).Warnf("timeout resetting failed unit %s during force cleanup", service)
+				return
+			default:
+				if err := conn.ResetFailedUnitContext(timeoutCtx, service); err != nil {
+					log.G(ctx).Warnf("failed to reset failed unit %s during force cleanup: %v", service, err)
+				}
+			}
+		}()
+
+		// Wait a short time for operations to complete, but don't block indefinitely
+		select {
+		case <-time.After(3 * time.Second):
+			log.G(ctx).Debugf("force cleanup operations completed for container %s", containerID)
+		case <-timeoutCtx.Done():
+			log.G(ctx).Warnf("force cleanup timed out for container %s", containerID)
+		}
+	}()
+
+	// Wait for the cleanup goroutine to finish or timeout
+	select {
+	case err := <-errChan:
+		if err != nil {
+			log.G(ctx).Warnf("force cleanup encountered errors but continuing: %v", err)
+		}
+	case <-timeoutCtx.Done():
+		log.G(ctx).Warnf("force cleanup timed out for container %s, but cleanup may continue in background", containerID)
+	}
+
+	// Always return nil - this function should never block the caller
+	// even if systemd operations fail or timeout
+	log.G(ctx).Debugf("force cleanup completed (non-blocking) for container %s", containerID)
+	return nil
+}
+
+func extractHealthcheck(ctx context.Context, container containerd.Container) *Healthcheck {
+	l, err := container.Labels(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Debugf("could not get labels for container %s", container.ID())
+		return nil
+	}
+	hcStr, ok := l[labels.HealthCheck]
+	if !ok || hcStr == "" {
+		return nil
+	}
+	hc, err := HealthCheckFromJSON(hcStr)
+	if err != nil {
+		log.G(ctx).WithError(err).Debugf("invalid healthcheck config on container %s", container.ID())
+		return nil
+	}
+	return hc
+}
+
+// shouldSkipHealthCheckSystemd determines if healthcheck timers should be skipped.
+func shouldSkipHealthCheckSystemd(hc *Healthcheck, cfg *config.Config) bool {
+	// Don't proceed if systemd is unavailable or disabled
+	if !defaults.IsSystemdAvailable() || cfg.DisableHCSystemd || rootlessutil.IsRootless() {
+		return true
+	}
+
+	// Don't proceed if health check is nil, empty, explicitly NONE or interval is 0.
+	if hc == nil || len(hc.Test) == 0 || hc.Test[0] == "NONE" || hc.Interval == 0 {
+		return true
+	}
+	return false
+}

--- a/pkg/healthcheck/healthcheck_manager_windows.go
+++ b/pkg/healthcheck/healthcheck_manager_windows.go
@@ -1,0 +1,47 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"context"
+
+	containerd "github.com/containerd/containerd/v2/client"
+
+	"github.com/containerd/nerdctl/v2/pkg/config"
+)
+
+// CreateTimer sets up the transient systemd timer and service for healthchecks.
+func CreateTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// StartTimer starts the healthcheck timer unit.
+func StartTimer(ctx context.Context, container containerd.Container, cfg *config.Config) error {
+	return nil
+}
+
+// RemoveTransientHealthCheckFiles stops and cleans up the transient timer and service.
+func RemoveTransientHealthCheckFiles(ctx context.Context, container containerd.Container) error {
+	return nil
+}
+
+// ForceRemoveTransientHealthCheckFiles forcefully stops and cleans up the transient timer and service
+// using just the container ID. This function is non-blocking and uses timeouts to prevent hanging
+// on systemd operations. On Windows, this is a no-op since systemd is not available.
+func ForceRemoveTransientHealthCheckFiles(ctx context.Context, containerID string) error {
+	return nil
+}


### PR DESCRIPTION
PR to add orchestration logic to nerdctl healthchecks

This PR uses systemd timers to orchestrate healthcheks in nerdctl without the need for a daemon process. Feature currently scoped for rootful linux systems.
