### PR TITLE
Provenance fixes

### DIFF
--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -404,6 +404,15 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 	for _, s := range strutil.DedupeStrSlice(options.Attest) {
 		optAttestType, optAttestAttrs, _ := strings.Cut(s, ",")
 		if strings.HasPrefix(optAttestType, "type=") {
+			if strings.HasPrefix(optAttestAttrs, "disabled=") {
+				disabled, err := strconv.ParseBool(strings.TrimPrefix(optAttestAttrs, "disabled="))
+				if err != nil {
+					return "", nil, false, "", nil, nil, fmt.Errorf("invalid value for attribute \"disabled\"")
+				}
+				if disabled {
+					continue
+				}
+			}
 			optAttestType := strings.TrimPrefix(optAttestType, "type=")
 			buildctlArgs = append(buildctlArgs, fmt.Sprintf("--opt=attest:%s=%s", optAttestType, optAttestAttrs))
 		} else {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -312,6 +312,10 @@ func readIndex(ctx context.Context, provider content.Provider, snapshotter snaps
 
 	// Iterate over manifest descriptors and read them all
 	for _, manifestDescriptor := range index.Manifests {
+		if isAttestationManifestDescriptor(manifestDescriptor) {
+			continue
+		}
+
 		manifest, err := readManifest(ctx, provider, snapshotter, manifestDescriptor)
 		if err != nil {
 			continue
@@ -418,4 +422,10 @@ func (x *imagePrinter) printImageSinglePlatform(desc ocispec.Descriptor, img ima
 		}
 	}
 	return nil
+}
+
+func isAttestationManifestDescriptor(desc ocispec.Descriptor) bool {
+	const manifestReferenceType = "vnd.docker.reference.type"
+	const attestationManifest = "attestation-manifest"
+	return desc.Annotations[manifestReferenceType] == attestationManifest
 }


### PR DESCRIPTION
This PR addresses https://github.com/containerd/nerdctl/issues/4328 by:
- Skipping provenance flag instead of passing --provenance=disabled=true to buildctl
- Skipping the listing of generated provenance manifest as a separate image when we run `nerdctl image ls` similar to Docker.