### PR TITLE
fix: add shell completion for namespace commands

### DIFF
--- a/cmd/nerdctl/namespace/namespace_inspect.go
+++ b/cmd/nerdctl/namespace/namespace_inspect.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -27,12 +28,13 @@ import (
 
 func inspectCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "inspect NAMESPACE",
-		Short:         "Display detailed information on one or more namespaces.",
-		RunE:          inspectAction,
-		Args:          cobra.MinimumNArgs(1),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:               "inspect NAMESPACE",
+		Short:             "Display detailed information on one or more namespaces.",
+		RunE:              inspectAction,
+		ValidArgsFunction: namespaceInspectShellComplete,
+		Args:              cobra.MinimumNArgs(1),
+		SilenceUsage:      true,
+		SilenceErrors:     true,
 	}
 	cmd.Flags().StringP("format", "f", "", "Format the output using the given Go template, e.g, '{{json .}}'")
 	cmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -70,4 +72,9 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	return namespace.Inspect(ctx, client, args, options)
+}
+
+func namespaceInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// show namespace names
+	return completion.NamespaceNames(cmd, args, toComplete)
 }

--- a/cmd/nerdctl/namespace/namespace_remove.go
+++ b/cmd/nerdctl/namespace/namespace_remove.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -27,13 +28,14 @@ import (
 
 func removeCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "remove [flags] NAMESPACE [NAMESPACE...]",
-		Aliases:       []string{"rm"},
-		Args:          cobra.MinimumNArgs(1),
-		Short:         "Remove one or more namespaces",
-		RunE:          removeAction,
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:               "remove [flags] NAMESPACE [NAMESPACE...]",
+		Aliases:           []string{"rm"},
+		Args:              cobra.MinimumNArgs(1),
+		Short:             "Remove one or more namespaces",
+		RunE:              removeAction,
+		ValidArgsFunction: namespaceRemoveShellComplete,
+		SilenceUsage:      true,
+		SilenceErrors:     true,
 	}
 	cmd.Flags().BoolP("cgroup", "c", false, "delete the namespace's cgroup")
 	return cmd
@@ -68,4 +70,9 @@ func removeAction(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	return namespace.Remove(ctx, client, args, options)
+}
+
+func namespaceRemoveShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// show namespace names
+	return completion.NamespaceNames(cmd, args, toComplete)
 }

--- a/cmd/nerdctl/namespace/namespace_update.go
+++ b/cmd/nerdctl/namespace/namespace_update.go
@@ -19,6 +19,7 @@ package namespace
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -27,12 +28,13 @@ import (
 
 func updateCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "update [flags] NAMESPACE",
-		Short:         "Update labels for a namespace",
-		RunE:          updateAction,
-		Args:          cobra.MinimumNArgs(1),
-		SilenceUsage:  true,
-		SilenceErrors: true,
+		Use:               "update [flags] NAMESPACE",
+		Short:             "Update labels for a namespace",
+		RunE:              updateAction,
+		ValidArgsFunction: namespaceUpdateShellComplete,
+		Args:              cobra.MinimumNArgs(1),
+		SilenceUsage:      true,
+		SilenceErrors:     true,
 	}
 	cmd.Flags().StringArrayP("label", "l", nil, "Set labels for a namespace")
 	return cmd
@@ -66,4 +68,9 @@ func updateAction(cmd *cobra.Command, args []string) error {
 	defer cancel()
 
 	return namespace.Update(ctx, client, args[0], options)
+}
+
+func namespaceUpdateShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// show namespace names
+	return completion.NamespaceNames(cmd, args, toComplete)
 }


### PR DESCRIPTION
## Description

related Issue #3851 

Adds shell completion support for namespace commands (`inspect`, `remove`, `update`) to improve CLI user experience by enabling tab completion of existing namespace names.


