### PR TITLE
manifest: normalize references by adding docker.io/library prefix

### DIFF
--- a/cmd/nerdctl/manifest/manifest_create_linux_test.go
+++ b/cmd/nerdctl/manifest/manifest_create_linux_test.go
@@ -92,7 +92,7 @@ func TestManifestCreate(t *testing.T) {
 				}
 			},
 			Data: test.WithLabels(map[string]string{
-				"output": "Created manifest list ",
+				"output": "Created manifest list docker.io/library/" + manifestListName,
 			}),
 		},
 		{
@@ -126,7 +126,7 @@ func TestManifestCreate(t *testing.T) {
 				}
 			},
 			Data: test.WithLabels(map[string]string{
-				"output": "Created manifest list",
+				"output": "Created manifest list docker.io/library/" + manifestListName + "-with-amend-flag",
 			}),
 		},
 	}

--- a/pkg/cmd/manifest/create.go
+++ b/pkg/cmd/manifest/create.go
@@ -82,5 +82,5 @@ func Create(ctx context.Context, listRef string, manifestRefs []string, options 
 		}
 	}
 
-	return listRef, nil
+	return parsedListRef.String(), nil
 }


### PR DESCRIPTION
normalize references by adding docker.io/library prefix in output

Fixes: #4468 