### PR TITLE
fix: Increase timeout for in-container tests 

### DIFF
--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -102,7 +102,7 @@ jobs:
             canary: true
 
     with:
-      timeout: 60
+      timeout: 80
       runner: ${{ matrix.runner }}
       target: ${{ matrix.target }}
       binary: ${{ matrix.binary && matrix.binary || 'nerdctl' }}


### PR DESCRIPTION
Increase timeout for in-container tests  due to slow hosts takin  a longer time