### PR TITLE
fix: Changing push test to serial for race conditions

### DIFF
--- a/cmd/nerdctl/image/image_push_linux_test.go
+++ b/cmd/nerdctl/image/image_push_linux_test.go
@@ -44,7 +44,7 @@ func TestPush(t *testing.T) {
 			require.Linux,
 			nerdtest.Registry,
 		),
-
+		NoParallel: true,
 		Setup: func(data test.Data, helpers test.Helpers) {
 			registryNoAuthHTTPRandom = nerdtest.RegistryWithNoAuth(data, helpers, 0, false)
 			registryNoAuthHTTPRandom.Setup(data, helpers)


### PR DESCRIPTION
Push images seems to have flakiness where some blobs are not there in the content store. Trying to see serializing the test reduces the issue. Its not a fix, but probably will reduce frequency.