### PR TITLE
ci: install br_netfilter for test-in-lima jobs

### DIFF
--- a/.github/workflows/job-test-in-lima.yml
+++ b/.github/workflows/job-test-in-lima.yml
@@ -75,6 +75,10 @@ jobs:
           docker info
           docker version
 
+      - name: "Init: install br-netfilter in the guest VM"
+        run: |
+          lima sudo modprobe br-netfilter
+
       - name: "Init: expose GitHub Runtime variables for gha"
         uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124  # v3.1.0
 


### PR DESCRIPTION
In #4481, we added loading br_netfilter modules for jobs running in containers and host. However, I missed adding it for the jobs that run inside a lima VM causing certain tests (flaky almalinux) to fail.

cc @AkihiroSuda 