### PR TITLE
Enable linters for `enforce-switch-style` & `redundant-test-main-exit`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -185,9 +185,6 @@ linters:
           # 2605 occurrences. Kind of useful in itself, but unacceptable amount of effort to fix
           disabled: true
         - name: enforce-switch-style
-          # Many occurrences.
-          disabled: true
-
     depguard:
       rules:
         no-patent:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -184,7 +184,6 @@ linters:
         - name: add-constant
           # 2605 occurrences. Kind of useful in itself, but unacceptable amount of effort to fix
           disabled: true
-        - name: enforce-switch-style
     depguard:
       rules:
         no-patent:
@@ -195,7 +194,7 @@ linters:
         pkg:
           # pkg files must not depend on cobra nor anything in cmd
           files:
-            - '**/pkg/**/*.go'
+            - "**/pkg/**/*.go"
           deny:
             - pkg: github.com/spf13/cobra
               desc: pkg must not depend on cobra

--- a/cmd/nerdctl/compose/compose_pause_linux_test.go
+++ b/cmd/nerdctl/compose/compose_pause_linux_test.go
@@ -28,6 +28,7 @@ func TestComposePauseAndUnpause(t *testing.T) {
 	switch base.Info().CgroupDriver {
 	case "none", "":
 		t.Skip("requires cgroup (for pausing)")
+	default:
 	}
 
 	var dockerComposeYAML = fmt.Sprintf(`

--- a/cmd/nerdctl/compose/compose_pause_linux_test.go
+++ b/cmd/nerdctl/compose/compose_pause_linux_test.go
@@ -29,6 +29,7 @@ func TestComposePauseAndUnpause(t *testing.T) {
 	case "none", "":
 		t.Skip("requires cgroup (for pausing)")
 	default:
+		// NOP
 	}
 
 	var dockerComposeYAML = fmt.Sprintf(`

--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -40,6 +40,7 @@ func CreateCommand() *cobra.Command {
 	case "freebsd":
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl create` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
+	default:
 	}
 	var cmd = &cobra.Command{
 		Use:               "create [flags] IMAGE [COMMAND] [ARG...]",

--- a/cmd/nerdctl/container/container_create.go
+++ b/cmd/nerdctl/container/container_create.go
@@ -41,6 +41,7 @@ func CreateCommand() *cobra.Command {
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl create` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
 	default:
+		//NOP
 	}
 	var cmd = &cobra.Command{
 		Use:               "create [flags] IMAGE [COMMAND] [ARG...]",

--- a/cmd/nerdctl/container/container_diff.go
+++ b/cmd/nerdctl/container/container_diff.go
@@ -100,6 +100,7 @@ func diffAction(cmd *cobra.Command, args []string) error {
 				case fs.ChangeKindDelete:
 					fmt.Fprintln(options.Stdout, "D", change.Path)
 				default:
+					//NOP
 				}
 			}
 

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -58,6 +58,7 @@ func RunCommand() *cobra.Command {
 	case "freebsd":
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl run` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
+	default:
 	}
 	var cmd = &cobra.Command{
 		Use:               "run [flags] IMAGE [COMMAND] [ARG...]",

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -59,6 +59,7 @@ func RunCommand() *cobra.Command {
 		longHelp += "\n"
 		longHelp += "WARNING: `nerdctl run` is experimental on FreeBSD and currently requires `--net=none` (https://github.com/containerd/nerdctl/blob/main/docs/freebsd.md)"
 	default:
+		//NOP
 	}
 	var cmd = &cobra.Command{
 		Use:               "run [flags] IMAGE [COMMAND] [ARG...]",

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -53,6 +53,7 @@ func TestRunCgroupV2(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 
 	if !info.MemoryLimit {
@@ -152,6 +153,7 @@ func TestRunCgroupV1(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 	if !info.MemoryLimit {
 		t.Skip("test requires MemoryLimit")
@@ -195,6 +197,7 @@ func TestIssue3781(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 	containerName := testutil.Identifier(t)
 	base.Cmd("run", "-d", "--name", containerName, testutil.AlpineImage, "sleep", "infinity").AssertOK()
@@ -402,6 +405,7 @@ func TestRunCgroupConf(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 	if !info.MemoryLimit {
 		t.Skip("test requires MemoryLimit")
@@ -417,6 +421,7 @@ func TestRunCgroupParent(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 
 	containerName := testutil.Identifier(t)
@@ -476,6 +481,7 @@ func TestRunBlkioWeightCgroupV2(t *testing.T) {
 	switch info.CgroupDriver {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
+	default:
 	}
 	containerName := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", containerName).AssertOK()

--- a/cmd/nerdctl/container/container_run_cgroup_linux_test.go
+++ b/cmd/nerdctl/container/container_run_cgroup_linux_test.go
@@ -54,6 +54,7 @@ func TestRunCgroupV2(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 
 	if !info.MemoryLimit {
@@ -154,6 +155,7 @@ func TestRunCgroupV1(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 	if !info.MemoryLimit {
 		t.Skip("test requires MemoryLimit")
@@ -198,6 +200,7 @@ func TestIssue3781(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 	containerName := testutil.Identifier(t)
 	base.Cmd("run", "-d", "--name", containerName, testutil.AlpineImage, "sleep", "infinity").AssertOK()
@@ -406,6 +409,7 @@ func TestRunCgroupConf(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 	if !info.MemoryLimit {
 		t.Skip("test requires MemoryLimit")
@@ -422,6 +426,7 @@ func TestRunCgroupParent(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 
 	containerName := testutil.Identifier(t)
@@ -482,6 +487,7 @@ func TestRunBlkioWeightCgroupV2(t *testing.T) {
 	case "none", "":
 		t.Skip("test requires cgroup driver")
 	default:
+		//NOP
 	}
 	containerName := testutil.Identifier(t)
 	defer base.Cmd("rm", "-f", containerName).AssertOK()

--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -51,6 +51,7 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 		switch commands[2] {
 		case "cp":
 			return false
+		default:
 		}
 	case "compose":
 		if len(commands) < 3 {
@@ -59,7 +60,9 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 		switch commands[2] {
 		case "cp":
 			return false
+		default:
 		}
+	default:
 	}
 	return true
 }

--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -52,6 +52,7 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 		case "cp":
 			return false
 		default:
+			//NOP
 		}
 	case "compose":
 		if len(commands) < 3 {
@@ -61,8 +62,10 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 		case "cp":
 			return false
 		default:
+			//NOP
 		}
 	default:
+		//NOP
 	}
 	return true
 }

--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -96,7 +96,6 @@ linters:
             - "fmt.Fprintln"
             - "fmt.Fprintf"
         - name: redundant-test-main-exit
-          disabled: true
         - name: enforce-switch-style
           disabled: true
         - name: var-naming

--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -97,7 +97,6 @@ linters:
             - "fmt.Fprintf"
         - name: redundant-test-main-exit
         - name: enforce-switch-style
-          disabled: true
         - name: var-naming
           disabled: true
     depguard:

--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -95,8 +95,6 @@ linters:
             - "fmt.Fprint"
             - "fmt.Fprintln"
             - "fmt.Fprintf"
-        - name: redundant-test-main-exit
-        - name: enforce-switch-style
         - name: var-naming
           disabled: true
     depguard:

--- a/mod/tigron/internal/com/command.go
+++ b/mod/tigron/internal/com/command.go
@@ -281,6 +281,7 @@ func (gc *Command) Wait() (*Result, error) {
 		return gc.result, gc.exec.err
 	case gc.result != nil:
 		return gc.result, ErrExecAlreadyFinished
+	default:
 	}
 
 	// Cancel the context in any case now

--- a/mod/tigron/internal/com/command.go
+++ b/mod/tigron/internal/com/command.go
@@ -264,6 +264,7 @@ func (gc *Command) Run(parentCtx context.Context) error {
 
 		return err
 	default:
+		// NOP
 	}
 
 	return nil
@@ -282,6 +283,7 @@ func (gc *Command) Wait() (*Result, error) {
 	case gc.result != nil:
 		return gc.result, ErrExecAlreadyFinished
 	default:
+		// NOP
 	}
 
 	// Cancel the context in any case now
@@ -294,6 +296,7 @@ func (gc *Command) Wait() (*Result, error) {
 	select {
 	case <-gc.exec.context.Done():
 	default:
+		// NOP
 	}
 
 	// Wrap the results and return
@@ -361,6 +364,7 @@ func (gc *Command) wrap() error {
 	case context.Canceled:
 		err = errExecutionCancelled
 	default:
+		// NOP
 	}
 
 	// Stuff everything in Result and return err.

--- a/mod/tigron/internal/com/package_test.go
+++ b/mod/tigron/internal/com/package_test.go
@@ -25,10 +25,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Prep exit code
-	exitCode := 0
-	defer func() { os.Exit(exitCode) }()
-
 	var (
 		snapFile      *os.File
 		before, after []byte
@@ -39,11 +35,7 @@ func TestMain(m *testing.M) {
 		before, _ = highk.SnapshotOpenFiles(snapFile)
 	}
 
-	exitCode = m.Run()
-
-	if exitCode != 0 {
-		return
-	}
+	m.Run()
 
 	if os.Getenv("HIGHK_EXPERIMENTAL_FD") != "" {
 		after, _ = highk.SnapshotOpenFiles(snapFile)
@@ -55,15 +47,11 @@ func TestMain(m *testing.M) {
 			for _, file := range diff {
 				fmt.Fprintln(os.Stderr, file)
 			}
-
-			exitCode = 1
 		}
 	}
 
 	if err := highk.FindGoRoutines(); err != nil {
 		fmt.Fprintln(os.Stderr, "Leaking go routines")
 		fmt.Fprintln(os.Stderr, err.Error())
-
-		exitCode = 1
 	}
 }

--- a/mod/tigron/test/package_test.go
+++ b/mod/tigron/test/package_test.go
@@ -25,10 +25,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	// Prep exit code
-	exitCode := 0
-	defer func() { os.Exit(exitCode) }()
-
 	var (
 		snapFile      *os.File
 		before, after []byte
@@ -39,11 +35,7 @@ func TestMain(m *testing.M) {
 		before, _ = highk.SnapshotOpenFiles(snapFile)
 	}
 
-	exitCode = m.Run()
-
-	if exitCode != 0 {
-		return
-	}
+	m.Run()
 
 	if os.Getenv("HIGHK_EXPERIMENTAL_FD") != "" {
 		after, _ = highk.SnapshotOpenFiles(snapFile)
@@ -55,15 +47,11 @@ func TestMain(m *testing.M) {
 			for _, file := range diff {
 				fmt.Fprintln(os.Stderr, file)
 			}
-
-			exitCode = 1
 		}
 	}
 
 	if err := highk.FindGoRoutines(); err != nil {
 		fmt.Fprintln(os.Stderr, "Leaking go routines")
 		fmt.Fprintln(os.Stderr, os.Stderr, err.Error())
-
-		exitCode = 1
 	}
 }

--- a/pkg/api/types/cri/metadata_types.go
+++ b/pkg/api/types/cri/metadata_types.go
@@ -70,6 +70,7 @@ func (c *ContainerMetadata) UnmarshalJSON(data []byte) error {
 	case metadataVersion:
 		*c = ContainerMetadata(versioned.Metadata)
 		return nil
+	default:
 	}
 	return fmt.Errorf("unsupported version: %q", versioned.Version)
 }

--- a/pkg/api/types/cri/metadata_types.go
+++ b/pkg/api/types/cri/metadata_types.go
@@ -71,6 +71,7 @@ func (c *ContainerMetadata) UnmarshalJSON(data []byte) error {
 		*c = ContainerMetadata(versioned.Metadata)
 		return nil
 	default:
+		// NOP
 	}
 	return fmt.Errorf("unsupported version: %q", versioned.Version)
 }

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -390,6 +390,7 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 			buildctlArgs = append(buildctlArgs, "--opt=image-resolve-mode=pull")
 		case false:
 			buildctlArgs = append(buildctlArgs, "--opt=image-resolve-mode=local")
+		default:
 		}
 	}
 

--- a/pkg/cmd/builder/build.go
+++ b/pkg/cmd/builder/build.go
@@ -391,6 +391,7 @@ func generateBuildctlArgs(ctx context.Context, client *containerd.Client, option
 		case false:
 			buildctlArgs = append(buildctlArgs, "--opt=image-resolve-mode=local")
 		default:
+			// NOP
 		}
 	}
 

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -105,6 +105,7 @@ func killContainer(ctx context.Context, container containerd.Container, signal s
 	case containerd.Paused, containerd.Pausing:
 		paused = true
 	default:
+		// NOP
 	}
 
 	if err := task.Kill(ctx, signal); err != nil {

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -48,6 +48,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 	switch options.GOptions.Namespace {
 	case "moby":
 		log.G(ctx).Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d` or CRI")
+	default:
 	}
 
 	stopChannel := make(chan os.Signal, 1)

--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -49,6 +49,7 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 	case "moby":
 		log.G(ctx).Warn("Currently, `nerdctl logs` only supports containers created with `nerdctl run -d` or CRI")
 	default:
+		// NOP
 	}
 
 	stopChannel := make(chan os.Signal, 1)

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -250,6 +250,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 		switch imgVol {
 		case "/", "/dev", "/sys", "proc":
 			return nil, nil, nil, fmt.Errorf("invalid VOLUME: %q", imgVolRaw)
+		default:
 		}
 		if _, ok := mounted[imgVol]; ok {
 			continue

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -251,6 +251,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 		case "/", "/dev", "/sys", "proc":
 			return nil, nil, nil, fmt.Errorf("invalid VOLUME: %q", imgVolRaw)
 		default:
+			// NOP
 		}
 		if _, ok := mounted[imgVol]; ok {
 			continue

--- a/pkg/cmd/container/run_restart.go
+++ b/pkg/cmd/container/run_restart.go
@@ -32,6 +32,7 @@ func checkRestartCapabilities(ctx context.Context, client *containerd.Client, re
 	switch policySlice[0] {
 	case "", "no":
 		return true, nil
+	default:
 	}
 	res, err := client.IntrospectionService().Plugins(ctx, "id==restart")
 	if err != nil {
@@ -104,6 +105,7 @@ func UpdateContainerRestartPolicyLabel(ctx context.Context, client *containerd.C
 				desireStatus = containerd.Stopped
 			case containerd.Created:
 				desireStatus = containerd.Created
+			default:
 			}
 		}
 		updateOpts = append(updateOpts, restart.WithStatus(desireStatus))

--- a/pkg/cmd/container/run_restart.go
+++ b/pkg/cmd/container/run_restart.go
@@ -33,6 +33,7 @@ func checkRestartCapabilities(ctx context.Context, client *containerd.Client, re
 	case "", "no":
 		return true, nil
 	default:
+		// NOP
 	}
 	res, err := client.IntrospectionService().Plugins(ctx, "id==restart")
 	if err != nil {
@@ -106,6 +107,7 @@ func UpdateContainerRestartPolicyLabel(ctx context.Context, client *containerd.C
 			case containerd.Created:
 				desireStatus = containerd.Created
 			default:
+				// NOP
 			}
 		}
 		updateOpts = append(updateOpts, restart.WithStatus(desireStatus))

--- a/pkg/cmd/container/top_unix.go
+++ b/pkg/cmd/container/top_unix.go
@@ -175,8 +175,9 @@ func fieldsASCII(s string) []string {
 		switch r {
 		case '\t', '\n', '\f', '\r', ' ':
 			return true
+		default:
+			return false
 		}
-		return false
 	}
 	return strings.FieldsFunc(s, fn)
 }

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -179,6 +179,7 @@ func Convert(ctx context.Context, client *containerd.Client, srcRawRef, targetRa
 				Image: convertedRef,
 			}
 			return printConvertedImage(options.Stdout, options, res)
+		default:
 		}
 
 		if convertType != "overlaybd" {

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -94,6 +94,7 @@ func Inspect(ctx context.Context, client *containerd.Client, options types.Netwo
 				return err
 			}
 			result = append(result, compat)
+		default:
 		}
 	}
 

--- a/pkg/cmd/network/list.go
+++ b/pkg/cmd/network/list.go
@@ -173,6 +173,8 @@ func getNetworkFilterFuncs(filters []string) ([]func(*map[string]string) bool, [
 					}
 					return true
 				})
+			default:
+				continue
 			}
 			continue
 		}

--- a/pkg/cmd/system/events.go
+++ b/pkg/cmd/system/events.go
@@ -90,6 +90,7 @@ func generateEventFilter(filter, filterValue string) (func(e *EventOut) bool, er
 
 			return strings.EqualFold(string(e.Status), filterValue)
 		}, nil
+	default:
 	}
 
 	return nil, fmt.Errorf("%s is an invalid or unsupported filter", filter)

--- a/pkg/cmd/system/info.go
+++ b/pkg/cmd/system/info.go
@@ -96,6 +96,7 @@ func Info(ctx context.Context, client *containerd.Client, options types.SystemIn
 		return prettyPrintInfoNative(options.Stdout, infoNative)
 	case "dockercompat":
 		return prettyPrintInfoDockerCompat(options.Stdout, options.Stderr, infoCompat, options.GOptions)
+	default:
 	}
 	return nil
 }

--- a/pkg/cmd/volume/list.go
+++ b/pkg/cmd/volume/list.go
@@ -242,6 +242,8 @@ func getVolumeFilterFuncs(filters []string) ([]func(*map[string]string) bool, []
 					}
 					return true
 				})
+			default:
+				continue
 			}
 			continue
 		}

--- a/pkg/composer/pipetagger/pipetagger.go
+++ b/pkg/composer/pipetagger/pipetagger.go
@@ -64,6 +64,7 @@ func ChooseColorAttrs(tag string) []color.Attribute {
 		attrs = append(attrs, color.BgHiWhite)
 	case color.FgHiWhite:
 		attrs = append(attrs, color.BgHiBlack)
+	default:
 	}
 
 	return attrs

--- a/pkg/dnsutil/hostsstore/hosts.go
+++ b/pkg/dnsutil/hostsstore/hosts.go
@@ -61,6 +61,7 @@ LINE:
 				skip = true
 			case MarkerEnd:
 				sawMarkerEnd = true
+			default:
 			}
 		}
 		if !skip {

--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -235,6 +235,7 @@ func parseRuncVersion(runcVersionStdout []byte) (*dockercompat.ComponentVersion,
 		switch strings.TrimSpace(detail[0]) {
 		case "commit":
 			details["GitCommit"] = strings.TrimSpace(detail[1])
+		default:
 		}
 	}
 

--- a/pkg/infoutil/infoutil_unix.go
+++ b/pkg/infoutil/infoutil_unix.go
@@ -84,6 +84,7 @@ func distroName(r io.Reader) string {
 			name = v
 		case "VERSION":
 			version = v
+		default:
 		}
 	}
 	if name != "" {

--- a/pkg/ipcutil/ipcutil.go
+++ b/pkg/ipcutil/ipcutil.go
@@ -207,6 +207,8 @@ func GenerateIPCOpts(ctx context.Context, ipc IPC, client *containerd.Client) ([
 		}
 
 		opts = append(opts, withBindMountHostOtherSourceIPC(*targetConIPC.HostShmPath))
+	default:
+		return nil, fmt.Errorf("unknown ipc mode: %s", ipc.Mode)
 	}
 
 	return opts, nil
@@ -242,6 +244,8 @@ func withBindMountHostIPC(_ context.Context, _ oci.Client, _ *containers.Contain
 				Source:      p,
 				Options:     []string{"rbind", "nosuid", "noexec", "nodev"},
 			}
+		default:
+			continue
 		}
 	}
 	return nil

--- a/pkg/manifestutil/manifestutils.go
+++ b/pkg/manifestutil/manifestutils.go
@@ -211,6 +211,8 @@ func CreateManifestEntry(parsedRef *referenceutil.ImageReference, desc ocispec.D
 		entry.SchemaV2Manifest = manifest
 	case "OCIManifest":
 		entry.OCIManifest = manifest
+	default:
+		return manifesttypes.DockerManifestEntry{}, fmt.Errorf("unsupported media type: %s", desc.MediaType)
 	}
 
 	// Special handling for OCI manifests to match Docker output

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -136,6 +136,7 @@ func ProcessFlagV(s string, volStore volumestore.VolumeStore, createDir bool) (*
 			case "rbind", "bind":
 				fstype = "bind"
 				found = true
+			default:
 			}
 			if found {
 				break

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -328,6 +328,7 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 			case "bind-nonrecursive":
 				bindNonRecursive = true
 				continue
+			default:
 			}
 		}
 
@@ -386,7 +387,6 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 
 	// compose new fileds and join into a string
 	// to call legacy ProcessFlagTmpfs or ProcessFlagV function
-	fields = []string{}
 	options := []string{}
 	if rwOption != "" {
 		if rwOption == "readonly" {
@@ -416,6 +416,8 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 				options = append(options, "rbind")
 			}
 		}
+	default:
+		return nil, fmt.Errorf("invalid mount type '%s' must be a volume/bind/tmpfs", mountType)
 	}
 
 	if len(options) > 0 {
@@ -432,8 +434,9 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore) (*Processed, e
 	case Volume, Bind:
 		// createDir=false for --mount option to disallow creating directories on host if not found
 		return ProcessFlagV(fieldsStr, volStore, false)
+	default:
+		return nil, fmt.Errorf("invalid mount type '%s' must be a volume/bind/tmpfs", mountType)
 	}
-	return nil, fmt.Errorf("invalid mount type '%s' must be a volume/bind/tmpfs", mountType)
 }
 
 // copy from https://github.com/moby/moby/blob/085c6a98d54720e70b28354ccec6da9b1b9e7fcf/volume/mounts/linux_parser.go#L375

--- a/pkg/platformutil/binfmt.go
+++ b/pkg/platformutil/binfmt.go
@@ -38,8 +38,9 @@ func qemuArchFromOCIArch(ociArch string) (string, error) {
 		return "mips64el", nil // NOT typo
 	case "loong64":
 		return "loongarch64", nil // NOT typo
+	default:
+		return "", fmt.Errorf("unknown OCI architecture string: %q", ociArch)
 	}
-	return "", fmt.Errorf("unknown OCI architecture string: %q", ociArch)
 }
 
 func canExecProbably(s string) (bool, error) {

--- a/pkg/reflectutil/reflectutil.go
+++ b/pkg/reflectutil/reflectutil.go
@@ -58,6 +58,7 @@ func isEmpty(v reflect.Value) bool {
 	switch v.Kind() {
 	case reflect.Map, reflect.Slice:
 		return v.Len() == 0
+	default:
+		return false
 	}
-	return false
 }

--- a/pkg/snapshotterutil/socisource.go
+++ b/pkg/snapshotterutil/socisource.go
@@ -104,6 +104,7 @@ func SociAppendDefaultLabelsHandlerWrapper(indexDigest string, wrapper func(imag
 						c.Annotations[targetImageLayersSizeLabel] = strings.TrimSuffix(layerSizes, ",")
 					}
 				}
+			default:
 			}
 			return children, nil
 		})

--- a/pkg/snapshotterutil/socisource.go
+++ b/pkg/snapshotterutil/socisource.go
@@ -105,6 +105,7 @@ func SociAppendDefaultLabelsHandlerWrapper(indexDigest string, wrapper func(imag
 					}
 				}
 			default:
+				// NOP
 			}
 			return children, nil
 		})

--- a/pkg/statsutil/stats_linux.go
+++ b/pkg/statsutil/stats_linux.go
@@ -175,6 +175,7 @@ func calculateCgroupBlockIO(metrics *v1.Metrics) (uint64, uint64) {
 			blkRead = blkRead + bioEntry.Value
 		case 'w', 'W':
 			blkWrite = blkWrite + bioEntry.Value
+		default:
 		}
 	}
 	return blkRead, blkWrite

--- a/pkg/testutil/nerdtest/requirements.go
+++ b/pkg/testutil/nerdtest/requirements.go
@@ -177,6 +177,7 @@ var CGroup = &test.Requirement{
 		case "none", "":
 			ret = false
 			mess = "cgroup is none"
+		default:
 		}
 		return ret, mess
 	},
@@ -212,6 +213,7 @@ var CGroupV2 = &test.Requirement{
 		case "none", "":
 			ret = false
 			mess = "cgroup is none"
+		default:
 		}
 		if dinf.CgroupVersion != "2" {
 			ret = false

--- a/pkg/testutil/testsyslog/testsyslog.go
+++ b/pkg/testutil/testsyslog/testsyslog.go
@@ -95,12 +95,15 @@ func TestableNetwork(network string) bool {
 			switch runtime.GOARCH {
 			case "arm", "arm64":
 				return false
+			default:
 			}
 		case "windows":
 			return false
+		default:
 		}
 	case "udp", "tcp", "tcp+tls":
 		return !rootlessutil.IsRootless()
+	default:
 	}
 	return true
 }

--- a/pkg/testutil/testsyslog/testsyslog.go
+++ b/pkg/testutil/testsyslog/testsyslog.go
@@ -47,7 +47,8 @@ func StartServer(n, la string, done chan<- string, certs ...*testca.Cert) (addr 
 		os.Remove(la)
 	}
 
-	if n == "udp" || n == "unixgram" {
+	switch n {
+	case "udp", "unixgram":
 		l, e := net.ListenPacket(n, la)
 		if e != nil {
 			log.Fatalf("startServer failed: %v", e)
@@ -55,7 +56,7 @@ func StartServer(n, la string, done chan<- string, certs ...*testca.Cert) (addr 
 		addr = l.LocalAddr().String()
 		sock = l
 		go runPacketSyslog(l, done)
-	} else if n == "tcp+tls" {
+	case "tcp+tls":
 		if len(certs) == 0 {
 			log.Fatalf("certificates required.")
 		}
@@ -75,7 +76,7 @@ func StartServer(n, la string, done chan<- string, certs ...*testca.Cert) (addr 
 		addr = l.Addr().String()
 		sock = l
 		go runStreamSyslog(l, done)
-	} else {
+	default:
 		l, e := net.Listen(n, la)
 		if e != nil {
 			log.Fatalf("startServer failed: %v", e)
@@ -104,6 +105,7 @@ func TestableNetwork(network string) bool {
 	case "udp", "tcp", "tcp+tls":
 		return !rootlessutil.IsRootless()
 	default:
+		// NOP
 	}
 	return true
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -64,6 +64,7 @@ func GetRevision() string {
 				vcsRevision = f.Value
 			case "vcs.modified":
 				vcsModified, _ = strconv.ParseBool(f.Value)
+			default:
 			}
 		}
 		if vcsRevision == "" {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -65,6 +65,7 @@ func GetRevision() string {
 			case "vcs.modified":
 				vcsModified, _ = strconv.ParseBool(f.Value)
 			default:
+				//NOP
 			}
 		}
 		if vcsRevision == "" {


### PR DESCRIPTION
Resolves #4493, in parts.

- enabled `redundant-test-main-exit` & `enforce-switch-style` in golangci file.
- updated code to resolve warnings
  - added errors if relevant
  - moved returns to default
  - blank `default` case otherwise.