### PR TITLE
feature:support live-restore

### DIFF
--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -53,7 +53,8 @@ func TestRunRestart(t *testing.T) {
 		"--name", testContainerName,
 		"-p", fmt.Sprintf("127.0.0.1:%d:80", hostPort),
 		testutil.NginxAlpineImage).AssertOK()
-
+	inspectedContainer := base.InspectContainer(testContainerName)
+	pid := inspectedContainer.State.Pid
 	check := func(httpGetRetry int) error {
 		resp, err := nettestutil.HTTPGet(fmt.Sprintf("http://127.0.0.1:%d", hostPort), httpGetRetry, false)
 		if err != nil {
@@ -87,6 +88,9 @@ func TestRunRestart(t *testing.T) {
 		}
 		time.Sleep(sleep)
 	}
+	inspectedContainer = base.InspectContainer(testContainerName)
+	assert.Equal(t, inspectedContainer.State.Status, "running")
+	assert.Equal(t, inspectedContainer.State.Pid, pid)
 	base.DumpDaemonLogs(10)
 	t.Fatalf("the container does not seem to be restarted")
 }

--- a/pkg/logging/logging_bsd.go
+++ b/pkg/logging/logging_bsd.go
@@ -1,0 +1,67 @@
+//go:build darwin || freebsd || netbsd || openbsd || dragonfly
+// +build darwin freebsd netbsd openbsd dragonfly
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/muesli/cancelreader"
+	"golang.org/x/sys/unix"
+)
+
+func waitIOClose(reader io.Reader) (chan struct{}, error) {
+	closeIO := make(chan struct{})
+	file, ok := reader.(cancelreader.File)
+	if !ok {
+		return nil, fmt.Errorf("reader is not an cancelreader.File")
+	}
+
+	kq, err := unix.Kqueue()
+	if err != nil {
+		return nil, fmt.Errorf("create kqueue: %w", err)
+	}
+	kev := unix.Kevent_t{
+		Ident:  uint64(file.Fd()),
+		Filter: unix.EVFILT_READ,
+		Flags:  unix.EV_ADD | unix.EV_ENABLE,
+	}
+
+	events := make([]unix.Kevent_t, 1)
+	_, err = unix.Kevent(kq, []unix.Kevent_t{kev}, events, nil)
+	if err != nil {
+		return nil, err
+	}
+	go func() {
+		for {
+			n, err := unix.Kevent(kq, nil, events, nil)
+			if err != nil {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				if events[i].Flags&unix.EV_EOF != 0 {
+					close(closeIO)
+					return
+				}
+			}
+		}
+	}()
+	return closeIO, nil
+}

--- a/pkg/logging/logging_linux.go
+++ b/pkg/logging/logging_linux.go
@@ -1,0 +1,64 @@
+//go:build linux
+// +build linux
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func waitIOClose(reader io.Reader) (chan struct{}, error) {
+	closeIO := make(chan struct{})
+	epfd, err := unix.EpollCreate1(0)
+	if err != nil {
+		return nil, err
+	}
+	file, ok := reader.(*os.File)
+	if !ok {
+		return nil, fmt.Errorf("reader is not an cancelreader.File")
+	}
+	fd := file.Fd()
+	event := unix.EpollEvent{
+		Events: unix.EPOLLHUP,
+		Fd:     int32(fd),
+	}
+	if err := unix.EpollCtl(epfd, unix.EPOLL_CTL_ADD, int(fd), &event); err != nil {
+		return nil, err
+	}
+	events := make([]unix.EpollEvent, 1)
+	go func() {
+		for {
+			n, err := unix.EpollWait(epfd, events, -1)
+			if err != nil {
+				continue
+			}
+			for i := 0; i < n; i++ {
+				if events[i].Events&unix.EPOLLHUP != 0 {
+					close(closeIO)
+					return
+				}
+			}
+		}
+	}()
+	return closeIO, nil
+}

--- a/pkg/logging/logging_windows.go
+++ b/pkg/logging/logging_windows.go
@@ -1,0 +1,24 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import "io"
+
+// TODO: support windows
+func waitIOClose(reader io.Reader) (chan struct{}, error) {
+	return nil, nil
+}


### PR DESCRIPTION
I find containerd will not close pipes until call delete it will cause some ci failed.

```
func (p *Init) delete(ctx context.Context) error {
	waitTimeout(ctx, &p.wg, 2*time.Second)
	err := p.runtime.Delete(ctx, p.id, nil)
	// ignore errors if a runtime has already deleted the process
	// but we still hold metadata and pipes
	//
	// this is common during a checkpoint, runc will delete the container state
	// after a checkpoint and the container will no longer exist within runc
	if err != nil {
		if strings.Contains(err.Error(), "does not exist") {
			err = nil
		} else {
			err = p.runtimeError(err, "failed to delete task")
		}
	}
	if p.io != nil {
		for _, c := range p.closers {
			c.Close()
		}
		p.io.Close()
	}
	if err2 := mount.UnmountRecursive(p.Rootfs, 0); err2 != nil {
		log.G(ctx).WithError(err2).Warn("failed to cleanup rootfs mount")
		if err == nil {
			err = fmt.Errorf("failed rootfs umount: %w", err2)
		}
	}
	return err
}
```
failed ci 

```
func TestLogsFollowNoExtraneousLineFeed(t *testing.T) {
	testCase := nerdtest.Setup()
	// This test verifies that `nerdctl logs -f` does not add extraneous line feeds
	testCase.Require = require.Not(require.Windows)

	testCase.Setup = func(data test.Data, helpers test.Helpers) {
		// Create a container that outputs a message without a trailing newline
		helpers.Ensure("run", "--name", data.Identifier(), testutil.CommonImage,
			"sh", "-c", "printf 'Hello without newline'")
	}
```
