### PR TITLE
Fix: namestore directory regression - restore 'names' subdirectory in path

### DIFF
--- a/pkg/namestore/namestore.go
+++ b/pkg/namestore/namestore.go
@@ -40,7 +40,7 @@ func New(stateDir, namespace string) (NameStore, error) {
 		return nil, errors.Join(ErrNameStore, store.ErrInvalidArgument)
 	}
 
-	st, err := store.New(filepath.Join(stateDir, namespace), 0, 0)
+	st, err := store.New(filepath.Join(stateDir, "names", namespace), 0, 0)
 	if err != nil {
 		return nil, errors.Join(ErrNameStore, err)
 	}

--- a/pkg/namestore/namestore_test.go
+++ b/pkg/namestore/namestore_test.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package namestore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/store"
+)
+
+func TestNamestoreNew(t *testing.T) {
+	tempDir := t.TempDir()
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   bool
+		errChecks []error
+	}{
+		{
+			name:      "empty namespace",
+			namespace: "",
+			wantErr:   true,
+			errChecks: []error{ErrNameStore, store.ErrInvalidArgument},
+		},
+		{
+			name:      "valid namespace",
+			namespace: "testnamespace",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ns, err := New(tempDir, tt.namespace)
+			if tt.wantErr {
+				assert.Assert(t, err != nil, "New should return an error for %s", tt.name)
+				for _, errCheck := range tt.errChecks {
+					assert.ErrorIs(t, err, errCheck, "Error should contain %v for %s", errCheck, tt.name)
+				}
+			} else {
+				assert.NilError(t, err, "New should succeed for %s", tt.name)
+				assert.Assert(t, ns != nil, "New should return a non-nil NameStore for %s", tt.name)
+
+				// Check that the directory is created in the correct path
+				expectedDir := filepath.Join(tempDir, "names", tt.namespace)
+				_, err = os.Stat(expectedDir)
+				assert.NilError(t, err, "Directory should be created at the correct path for %s", tt.name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

fix: #4525

This PR addresses a critical regression in the namestore directory creation logic, ensuring that container names are stored in the correct subdirectory structure.

### Problem

Starting with v2.0, the namestore directory has been incorrectly created as `<DATAROOT>/<ADDRHASH>/<NAMESPACE>` (e.g., `/var/lib/nerdctl/1935db59/default/foo`) instead of the intended `<DATAROOT>/<ADDRHASH>/names/<NAMESPACE>`. This was caused by [commit bf89c08](https://github.com/containerd/nerdctl/commit/bf89c08#diff-7e8241ea95018a415ccbb4d0697f2842179f62d2a4b968671d4ebdb962f2e11aL32), where the "names" subdirectory was inadvertently omitted from the path.

### Breaking Change Warning

This fix introduces a **breaking change** because existing containers will no longer be recognized in the corrected path. Affected users must:
- Migrate existing name data to the new path

Due to the breaking fix, this may not be included in a patch release.
