### PR TITLE
healthcheck: fix path issues and add default config values

### DIFF
--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -892,6 +892,11 @@ func withHealthcheck(options types.ContainerCreateOptions, ensuredImage *imgutil
 		hc.StartPeriod = options.HealthStartPeriod
 	}
 
+	// Apply defaults for any unset values, but only if we have a healthcheck configured
+	if len(hc.Test) > 0 && hc.Test[0] != "NONE" {
+		hc.ApplyDefaults()
+	}
+
 	// If no healthcheck config is set (via CLI or image), return empty string so we skip adding to container config.
 	if reflect.DeepEqual(hc, &healthcheck.Healthcheck{}) {
 		return "", nil

--- a/pkg/healthcheck/health.go
+++ b/pkg/healthcheck/health.go
@@ -136,3 +136,19 @@ func HealthcheckResultFromJSON(s string) (*HealthcheckResult, error) {
 	}
 	return &r, nil
 }
+
+// ApplyDefaults sets default values for unset healthcheck fields
+func (hc *Healthcheck) ApplyDefaults() {
+	if hc.Interval == 0 {
+		hc.Interval = DefaultProbeInterval
+	}
+	if hc.Timeout == 0 {
+		hc.Timeout = DefaultProbeTimeout
+	}
+	if hc.StartPeriod == 0 {
+		hc.StartPeriod = DefaultStartPeriod
+	}
+	if hc.Retries == 0 {
+		hc.Retries = DefaultProbeRetries
+	}
+}


### PR DESCRIPTION
This fixes a couple of issues we saw with the healthcheck automation
- Fixed PATH resolution errors by providing an explicit path to the nerdctl
binary in systemd service files, eliminating `'nerdctl' not found in PATH` errors
during healthcheck execution.
- Added default values for unspecified healthcheck flags to prevent silent
failures and ensure consistent behavior regardless of user-provided flags