### PR TITLE
CI: skip flaky tests on EL8 and ARM64

### DIFF
--- a/.github/workflows/job-test-in-container.yml
+++ b/.github/workflows/job-test-in-container.yml
@@ -35,6 +35,10 @@ on:
         required: false
         default: false
         type: boolean
+      skip-flaky:
+        required: false
+        default: false
+        type: boolean
 
 env:
   GOTOOLCHAIN: local
@@ -171,6 +175,7 @@ jobs:
           fi
       # FIXME: this NEEDS to go away
       - name: "Run: integration tests (flaky)"
+        if: ${{ !fromJSON(inputs.skip-flaky) }}
         run: |
           . ./hack/github/action-helpers.sh
           github::md::h2 "flaky" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/job-test-in-lima.yml
+++ b/.github/workflows/job-test-in-lima.yml
@@ -16,6 +16,10 @@ on:
       guest:
         required: true
         type: string
+      skip-flaky:
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   test:
@@ -114,6 +118,7 @@ jobs:
             docker run -t -v /dev:/dev --rm --privileged test-integration ./hack/test-integration.sh -test.only-flaky=false
           fi
       - name: "Run: integration tests (flaky)"
+        if: ${{ !fromJSON(inputs.skip-flaky) }}
         run: |
           set -eux
           if [ "$TARGET" = "rootless" ]; then

--- a/.github/workflows/workflow-flaky.yml
+++ b/.github/workflows/workflow-flaky.yml
@@ -29,6 +29,7 @@ jobs:
       runner: ubuntu-24.04
       guest: ${{ matrix.guest }}
       target: ${{ matrix.target }}
+      skip-flaky: true  # skip the most flaky ones for now
 
   test-integration-freebsd:
     name: "FreeBSD"

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -69,9 +69,11 @@ jobs:
           # arm64
           - runner: ubuntu-24.04-arm
             target: rootless
+            skip-flaky: true
           # port-slirp4netns
           - runner: ubuntu-24.04
             target: rootless-port-slirp4netns
+            skip-flaky: true
           # old containerd + old ubuntu + old rootlesskit
           - runner: ubuntu-22.04
             target: rootless
@@ -88,6 +90,7 @@ jobs:
           # arm64
           - runner: ubuntu-24.04-arm
             target: rootful
+            skip-flaky: true
           # old containerd + old ubuntu
           - runner: ubuntu-22.04
             target: rootful
@@ -96,6 +99,7 @@ jobs:
           - runner: ubuntu-24.04
             target: rootful
             ipv6: true
+            skip-flaky: true
           # all canary
           - runner: ubuntu-24.04
             target: rootful
@@ -110,6 +114,7 @@ jobs:
       rootlesskit-version: ${{ matrix.rootlesskit-version }}
       ipv6: ${{ matrix.ipv6 && true || false }}
       canary: ${{ matrix.canary && true || false }}
+      skip-flaky: ${{ matrix.skip-flaky && true || false }}
 
   test-integration-host:
     name: "in-host${{ inputs.hack }}"


### PR DESCRIPTION
Those tests should be enabled again once the flakiness is improved.