### PR TITLE
fix: filter non-executable files when symlinking buildkit-cni plugins (#4553)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -167,7 +167,7 @@ RUN BUILDKIT_VERSION=${BUILDKIT_VERSION%%@*}; \
   grep "${fname}" "/SHA256SUMS.d/buildkit-${BUILDKIT_VERSION}" | sha256sum -c && \
   tar xzf "${fname}" -C /out && \
   rm -f "${fname}" /out/bin/buildkit-qemu-* /out/bin/buildkit-cni-* /out/bin/buildkit-runc && \
-  for f in /out/libexec/cni/*; do ln -s ../libexec/cni/$(basename $f) /out/bin/buildkit-cni-$(basename $f); done && \
+  for f in /out/libexec/cni/*; do [ -x "$f" ] && [ -f "$f" ] && ln -s ../libexec/cni/$(basename $f) /out/bin/buildkit-cni-$(basename $f); done && \
   echo "- BuildKit: ${BUILDKIT_VERSION}" >> /out/share/doc/nerdctl-full/README.md
 # NOTE: github.com/moby/buildkit/examples/systemd is not included in BuildKit v0.8.x, will be included in v0.9.x
 RUN cd /out/lib/systemd/system && \


### PR DESCRIPTION
Fixes #4553 

The `nerdctl-full` tarball was incorrectly creating symlinks for all files in `libexec/cni/`, including documentation files like `README.md` and `LICENSE`. This resulted in non-executable files appearing in the `bin/` directory as `buildkit-cni-README.md` and `buildkit-cni-LICENSE`.

## Root Cause

The symlink creation loop in the Dockerfile (line 170) processed all files in `/out/libexec/cni/*` without filtering:

```dockerfile
# Before (buggy)
for f in /out/libexec/cni/*; do ln -s ../libexec/cni/$(basename $f) /out/bin/buildkit-cni-$(basename $f); done
```

The CNI plugins tarball includes both executable binaries and documentation files with no execute permissions.

## Solution

Added file type and permission checks to filter out non-executable files:

```dockerfile
# After (fixed)
for f in /out/libexec/cni/*; do [ -x "$f" ] && [ -f "$f" ] && ln -s ../libexec/cni/$(basename $f) /out/bin/buildkit-cni-$(basename $f); done
```

- `[ -f "$f" ]` - ensures it's a regular file
- `[ -x "$f" ]` - ensures it has execute permission

## Testing

Built and compared the full artifact before and after the fix:

**Before:**
- 46 files in `bin/`
- Includes: `buildkit-cni-README.md` and `buildkit-cni-LICENSE`

**After:**
- 44 files in `bin/`
- Documentation symlinks removed
- All 18 CNI plugin executables still correctly symlinked

## Impact

- [x] Removes incorrect symlinks for documentation files
- [x] Preserves all 18 CNI plugin executables (bandwidth through vrf)
- [x] Documentation files remain in `libexec/cni/` where they belong
- [x] No other functionality affected
