### PR TITLE
Add support for mount manager

### DIFF
--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -173,6 +173,16 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 			return nil, nil, nil, err
 		}
 
+		mm := client.MountManager()
+
+		active, err := mm.Activate(ctx, tempDir, mounts)
+		if err == nil {
+			defer mm.Deactivate(ctx, tempDir)
+			mounts = active.System
+		} else if !errors.Is(err, errdefs.ErrNotImplemented) {
+			return nil, nil, nil, fmt.Errorf("failed to activate mounts: %w", err)
+		}
+
 		// windows has additional steps for mounting see
 		// https://github.com/containerd/containerd/commit/791e175c79930a34cfbb2048fbcaa8493fd2c86b
 		unmounter := func(tempDir string) {


### PR DESCRIPTION
generateMountOpts() needs to be adapted since it duplicates some client code.

tested with erofs snapshotter and runC:
<img width="2998" height="596" alt="image" src="https://github.com/user-attachments/assets/a5f6da6e-f24e-493e-b781-733119c8821b" />
