### PR TITLE
feat(network): add support for static IPv6 assignment

### DIFF
--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -156,6 +156,130 @@ func TestNetworkCreate(t *testing.T) {
 				}
 			},
 		},
+		{
+			Description: "with static IPv4 address",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				networkName := data.Identifier()
+				staticIP := "172.19.0.100"
+				data.Labels().Set("networkName", networkName)
+				data.Labels().Set("staticIP", staticIP)
+				helpers.Ensure("network", "create", networkName, "--driver", "bridge", "--subnet", "172.19.0.0/24")
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("network", "rm", data.Labels().Get("networkName"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("run", "--rm", "--net", data.Labels().Get("networkName"), "--ip", data.Labels().Get("staticIP"), testutil.CommonImage, "ip", "addr", "show", "eth0")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, fmt.Sprintf("inet %s/24", data.Labels().Get("staticIP"))))
+					},
+				}
+			},
+		},
+		{
+			Description: "with static IPv6 address",
+			Require:     nerdtest.OnlyIPv6,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				networkName := data.Identifier()
+				staticIPv6 := "2001:db8:1::100"
+				data.Labels().Set("networkName", networkName)
+				data.Labels().Set("staticIPv6", staticIPv6)
+				helpers.Ensure("network", "create", networkName, "--driver", "bridge", "--ipv6", "--subnet", "2001:db8:1::/64")
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("network", "rm", data.Labels().Get("networkName"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("run", "--rm", "--net", data.Labels().Get("networkName"), "--ip6", data.Labels().Get("staticIPv6"), testutil.CommonImage, "ip", "addr", "show", "eth0")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, fmt.Sprintf("inet6 %s/64", data.Labels().Get("staticIPv6"))))
+					},
+				}
+			},
+		},
+		{
+			Description: "with dual-stack static IP addresses",
+			Require:     nerdtest.OnlyIPv6,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				networkName := data.Identifier()
+				staticIPv4 := "172.20.0.100"
+				staticIPv6 := "2001:db8:2::100"
+				data.Labels().Set("networkName", networkName)
+				data.Labels().Set("staticIPv4", staticIPv4)
+				data.Labels().Set("staticIPv6", staticIPv6)
+				helpers.Ensure("network", "create", networkName, "--driver", "bridge", "--subnet", "172.20.0.0/24", "--ipv6", "--subnet", "2001:db8:2::/64")
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("network", "rm", data.Labels().Get("networkName"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("run", "--rm", "--net", data.Labels().Get("networkName"), "--ip", data.Labels().Get("staticIPv4"), "--ip6", data.Labels().Get("staticIPv6"), testutil.CommonImage, "ip", "addr", "show", "eth0")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, fmt.Sprintf("inet %s/24", data.Labels().Get("staticIPv4"))))
+						assert.Assert(t, strings.Contains(stdout, fmt.Sprintf("inet6 %s/64", data.Labels().Get("staticIPv6"))))
+					},
+				}
+			},
+		},
+		{
+			Description: "with static IPv6 address on macvlan",
+			Require:     nerdtest.OnlyIPv6,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				id := data.Identifier()
+				if len(id) > 15 {
+					id = strings.TrimRight(id[:15], "-")
+				}
+				dummyLinkName := id
+				networkName := data.Identifier()
+				staticIPv6 := "2001:db8:3::100"
+				subnet := "2001:db8:3::/64"
+
+				data.Labels().Set("dummyLinkName", dummyLinkName)
+				data.Labels().Set("networkName", networkName)
+				data.Labels().Set("staticIPv6", staticIPv6)
+
+				// Create a dummy interface to be the parent of the macvlan network
+				helpers.Custom("ip", "link", "add", dummyLinkName, "type", "dummy").Run(&test.Expected{ExitCode: 0})
+				helpers.Custom("ip", "link", "set", dummyLinkName, "up").Run(&test.Expected{ExitCode: 0})
+
+				// Create the macvlan network
+				helpers.Ensure("network", "create", networkName,
+					"--driver", "macvlan",
+					"--parent", dummyLinkName,
+					"--ipv6",
+					"--subnet", subnet)
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("network", "rm", data.Labels().Get("networkName"))
+				helpers.Custom("ip", "link", "del", data.Labels().Get("dummyLinkName")).Run(nil)
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("run", "--rm",
+					"--net", data.Labels().Get("networkName"),
+					"--ip6", data.Labels().Get("staticIPv6"),
+					testutil.CommonImage, "ip", "addr", "show", "eth0")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, fmt.Sprintf("inet6 %s/64", data.Labels().Get("staticIPv6"))))
+					},
+				}
+			},
+		},
 	}
 
 	testCase.Run(t)

--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -604,6 +604,9 @@ func newContainer(project *types.Project, parsed *Service, i int) (*Container, e
 			if value != nil && value.Ipv4Address != "" {
 				c.RunArgs = append(c.RunArgs, "--ip="+value.Ipv4Address)
 			}
+			if value != nil && value.Ipv6Address != "" {
+				c.RunArgs = append(c.RunArgs, "--ip6="+value.Ipv6Address)
+			}
 			if value != nil && value.MacAddress != "" {
 				c.RunArgs = append(c.RunArgs, "--mac-address="+value.MacAddress)
 			}

--- a/pkg/composer/serviceparser/serviceparser_test.go
+++ b/pkg/composer/serviceparser/serviceparser_test.go
@@ -519,6 +519,44 @@ services:
 
 }
 
+func TestParseDualStackAddress(t *testing.T) {
+	t.Parallel()
+	const dockerComposeYAML = `
+services:
+  foo:
+    image: nginx:alpine
+    networks:
+      default:
+        ipv4_address: "172.30.0.100"
+        ipv6_address: "2001:db8:abc:123::42"
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.30.0.0/24"
+        - subnet: "2001:db8:abc:123::/64"
+`
+	comp := testutil.NewComposeDir(t, dockerComposeYAML)
+	defer comp.CleanUp()
+
+	project, err := testutil.LoadProject(comp.YAMLFullPath(), comp.ProjectName(), nil)
+	assert.NilError(t, err)
+
+	fooSvc, err := project.GetService("foo")
+	assert.NilError(t, err)
+
+	foo, err := Parse(project, fooSvc)
+	assert.NilError(t, err)
+
+	t.Logf("foo: %+v", foo)
+	for _, c := range foo.Containers {
+		assert.Assert(t, in(c.RunArgs, "--ip=172.30.0.100"))
+		assert.Assert(t, in(c.RunArgs, "--ip6=2001:db8:abc:123::42"))
+	}
+}
+
 func TestParseConfigs(t *testing.T) {
 	t.Parallel()
 	if runtime.GOOS == "windows" {

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -138,6 +138,10 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 		bridge.HairpinMode = true
 		if ipv6 {
 			bridge.Capabilities["ips"] = true
+			// Explicitly declare capabilities that are implicitly lost when
+			// the bridge.Capabilities map becomes non-empty.
+			bridge.Capabilities["dns"] = true
+			bridge.Capabilities["portMappings"] = true
 		}
 
 		// Determine the appropriate firewall ingress policy based on icc setting
@@ -207,6 +211,10 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 		vlan.IPAM = ipam
 		if ipv6 {
 			vlan.Capabilities["ips"] = true
+			// Explicitly declare capabilities that are implicitly lost when
+			// the vlan.Capabilities map becomes non-empty.
+			vlan.Capabilities["dns"] = true
+			vlan.Capabilities["portMappings"] = true
 		}
 		plugins = []CNIPlugin{vlan}
 	default:
@@ -230,7 +238,8 @@ func (e *CNIEnv) generateIPAM(driver string, subnets []string, gatewayStr, ipRan
 			return nil, err
 		}
 		ipamConf.Ranges = append(ipamConf.Ranges, ranges...)
-		if !findIPv4 {
+		// if no subnet is specified, an ipv4 subnet should be added automatically.
+		if !findIPv4 && (len(subnets) == 1 && subnets[0] == "") {
 			ranges, _, _ = e.parseIPAMRanges([]string{""}, gatewayStr, ipRangeStr, ipv6)
 			ipamConf.Ranges = append(ipamConf.Ranges, ranges...)
 		}


### PR DESCRIPTION
This PR introduces end-to-end support for assigning static IPv6 addresses to containers, both via the command line and through `nerdctl compose`.

Key changes:

- A new `--ip6` flag is added to `nerdctl run` to allow direct assignment of a static IPv6 address.

- The CNI bridge configuration for IPv6 networks is now updated to declare the `"ips"` capability. This is required by libcni to process static IP capability arguments.

- To prevent regressions in downstream CNI plugins (like dnsname and firewall), the `"dns"` and `"portMappings"` capabilities are also explicitly declared for IPv6 networks. This avoids issues where implicit capabilities were being dropped.

- The compose parser now recognizes the `ipv6_address` field within a service's network configuration and translates it to the `--ip6` flag during container creation.

- Adds comprehensive integration tests for static IPv4, IPv6, and dual-stack IP assignment, as well as unit tests for compose file parsing, to validate the new functionality and prevent regressions.

fixes #4597