### PR TITLE
test: fix TestLogs timing race for since/until filters

### DIFF
--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -55,6 +55,8 @@ bar
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "--quiet", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar;")
 		data.Labels().Set("cID", data.Identifier())
+		// Sleep to ensure enough time passes for since/until time-based filtering tests
+		time.Sleep(2 * time.Second)
 	}
 
 	testCase.SubTests = []*test.Case{


### PR DESCRIPTION
Add 2-second sleep in TestLogs setup to fix race condition in time-based log filtering tests. Without this delay, "since 1s" and "until 1s" subtests may fail because logs are too recent.

This is similar to the approach used in the previous test implementation before the test rewrite in commit
https://github.com/containerd/nerdctl/commit/8bd7a7dc998c2dcc5960baf7b58be1fcdce9f663.

failed ci: https://github.com/containerd/nerdctl/actions/runs/19279701563/job/55128358083?pr=4600