### PR TITLE
fix: split else-if to avoid identical-branches lint error

### DIFF
--- a/pkg/cmd/container/create_userns_opts_linux.go
+++ b/pkg/cmd/container/create_userns_opts_linux.go
@@ -324,7 +324,8 @@ func getUserAndGroup(spec string) (user.User, user.Group, error) {
 	parts := strings.Split(spec, ":")
 	if len(parts) > 2 {
 		return user.User{}, user.Group{}, fmt.Errorf("invalid identity mapping format: %s", spec)
-	} else if len(parts) == 2 && (parts[0] == "" || parts[1] == "") {
+	}
+	if len(parts) == 2 && (parts[0] == "" || parts[1] == "") {
 		return user.User{}, user.Group{}, fmt.Errorf("invalid identity mapping format: %s", spec)
 	}
 


### PR DESCRIPTION


## Greetings

This is my first contribution to the project. Thank you for maintaining such a high-quality codebase and for the opportunity to participate. I hope to continue contributing to other areas of the project going forward.

## Summary

While running make fix, I encountered a lint issue reported by revive regarding duplicated conditional branches in getUserAndGroup. To address this, I refactored the conditional logic to eliminate the duplicated else if branch without changing the function's behavior.

## What was changed

Split the duplicated else if into an independent if statement.

No functional change; only improves readability and resolves the lint warning.

### Thank you

Thank you in advance for reviewing this change, and please let me know if any adjustments are needed.