### PR TITLE
Fix TestImageConvert/soci* tests for v0.12.0 release

### DIFF
--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -117,6 +117,13 @@ func ConvertSociIndexV2(ctx context.Context, client *client.Client, srcRef strin
 
 	sociCmd.Args = append(sociCmd.Args, "convert")
 
+	// The following option temporarily fix the image conversion regression in SOCI v0.12.0
+	// https://github.com/awslabs/soci-snapshotter/issues/1789
+	// TODO: remove after the bug is fixed in SOCI
+	if err := CheckSociVersion("0.12.0"); err == nil {
+		sociCmd.Args = append(sociCmd.Args, "--force")
+	}
+
 	if sOpts.AllPlatforms {
 		sociCmd.Args = append(sociCmd.Args, "--all-platforms")
 	} else if len(sOpts.Platforms) > 0 {


### PR DESCRIPTION
Fixes: https://github.com/containerd/nerdctl/issues/4622

Temporarily fix the soci image conversion regression introduced in soci v0.12.0 release.

It looks like proper fix would require a soci code change.

This patch simply fix the nerdctl canary.