### PR TITLE
Support `push --all-tags` to push all tags

### DIFF
--- a/cmd/nerdctl/image/image_push.go
+++ b/cmd/nerdctl/image/image_push.go
@@ -69,6 +69,9 @@ func PushCommand() *cobra.Command {
 
 	cmd.Flags().Bool(allowNonDistFlag, false, "Allow pushing images with non-distributable blobs")
 
+	// support Docker-compatible all-tags flag
+	cmd.Flags().BoolP("all-tags", "a", false, "Push all local tags of the repository")
+
 	return cmd
 }
 
@@ -101,6 +104,10 @@ func pushOptions(cmd *cobra.Command) (types.ImagePushOptions, error) {
 	if err != nil {
 		return types.ImagePushOptions{}, err
 	}
+	allTags, err := cmd.Flags().GetBool("all-tags")
+	if err != nil {
+		return types.ImagePushOptions{}, err
+	}
 	allowNonDist, err := cmd.Flags().GetBool(allowNonDistFlag)
 	if err != nil {
 		return types.ImagePushOptions{}, err
@@ -123,6 +130,7 @@ func pushOptions(cmd *cobra.Command) (types.ImagePushOptions, error) {
 		IpfsEnsureImage:                ipfsEnsureImage,
 		IpfsAddress:                    ipfsAddress,
 		Quiet:                          quiet,
+		AllTags:                        allTags,
 		AllowNondistributableArtifacts: allowNonDist,
 		Stdout:                         cmd.OutOrStdout(),
 	}, nil

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -183,7 +183,11 @@ type ImageInspectOptions struct {
 
 // ImagePushOptions specifies options for `nerdctl (image) push`.
 type ImagePushOptions struct {
-	Stdout      io.Writer
+	Stdout io.Writer
+	Stderr io.Writer
+	// ProgressOutputToStdout directs progress output to stdout instead of stderr
+	ProgressOutputToStdout bool
+
 	GOptions    GlobalCommandOptions
 	SignOptions ImageSignOptions
 	SociOptions SociOptions
@@ -202,6 +206,12 @@ type ImagePushOptions struct {
 	Quiet bool
 	// AllowNondistributableArtifacts allow pushing non-distributable artifacts
 	AllowNondistributableArtifacts bool
+
+	// AllTags if true, push all local tags for the repository when no tag is specified
+	AllTags bool
+
+	// SkipSoci when true, skip creating/pushing SOCI index (used when pushing multiple tags to avoid overwriting)
+	SkipSoci bool
 }
 
 // RemoteSnapshotterFlags are used for pulling with remote snapshotters

--- a/pkg/cmd/image/push.go
+++ b/pkg/cmd/image/push.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -61,7 +62,18 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		return err
 	}
 
+	// Disallow tag (or digest) together with --all-tags
+	if options.AllTags {
+		if parsedReference.Tag != "" || parsedReference.Digest != "" {
+			return fmt.Errorf("tag can't be used with --all-tags/-a")
+		}
+	}
+
 	if parsedReference.Protocol != "" {
+		if options.AllTags {
+			return fmt.Errorf("--all-tags is not supported for %q references", parsedReference.Protocol)
+		}
+
 		if parsedReference.Protocol != referenceutil.IPFSProtocol {
 			return fmt.Errorf("ipfs scheme is only supported but got %q", parsedReference.Protocol)
 		}
@@ -105,10 +117,43 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		return nil
 	}
 
-	parsedReference, err = referenceutil.Parse(rawRef)
-	if err != nil {
-		return err
+	// Handle --all-tags
+	if options.AllTags {
+		repo := ""
+		if parsedReference.Domain != "" {
+			repo = parsedReference.Domain + "/"
+		}
+		repo += parsedReference.Path
+
+		imgList, err := client.ImageService().List(ctx)
+		if err != nil {
+			return err
+		}
+
+		var tagRefs []string
+		for _, img := range imgList {
+			if strings.HasPrefix(img.Name, repo+":") {
+				tagRefs = append(tagRefs, img.Name)
+			}
+		}
+
+		if len(tagRefs) == 0 {
+			return fmt.Errorf("no local tags found for repository %q", repo)
+		}
+
+		for i, tagRef := range tagRefs {
+			tagOpts := options
+			tagOpts.AllTags = false  // avoid infinite recursion
+			tagOpts.SkipSoci = i > 0 // avoid SOCI indexing for the same image
+
+			if err := Push(ctx, client, tagRef, tagOpts); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
+
 	ref := parsedReference.String()
 	refDomain := parsedReference.Domain
 
@@ -209,7 +254,7 @@ func Push(ctx context.Context, client *containerd.Client, rawRef string, options
 		options.SignOptions); err != nil {
 		return err
 	}
-	if options.GOptions.Snapshotter == "soci" {
+	if options.GOptions.Snapshotter == "soci" && !options.SkipSoci {
 		if err = snapshotterutil.CreateSociIndexV1(ref, options.GOptions, options.AllPlatforms, options.Platforms, options.SociOptions); err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR adds Docker-compatible --all-tags support and fixes a SOCI regression when pushing multiple tags of the same image.

Key changes:
- New `--all-tags` flag for `image push`
- SOCI integration fix for multi-tag pushes

Fixes #3751 