### PR TITLE
fix: sort results of `nerdctl ps` and `nerdctl compose ps` alphabetic…

### DIFF
--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -163,6 +163,8 @@ func FormatPorts(ports []cni.PortMapping) string {
 		)
 	}
 
+	sort.Strings(displayPorts)
+
 	return strings.Join(displayPorts, ", ")
 }
 


### PR DESCRIPTION
…ally

The current implementation can cause the unit test for `FormatPorts` in `pkg/formatter` to fail intermittently, as shown below:

```bash
$ go test -run TestFormatPorts -count 10
--- FAIL: TestFormatPorts (0.00s)
	--- FAIL: TestFormatPorts/mixed_tcp_and_udp_with_consecutive_ports_on_anyhost (0.00s)
		formatter_test.go:191: assertion failed: 0.0.0.0:3000-3001->8080-8081/tcp, 0.0.0.0:3002-3003->8082-8083/udp (tt.expected string) != 0.0.0.0:3002-3003->8082-8083/udp, 0.0.0.0:3000-3001->8080-8081/tcp (result string)
--- FAIL: TestFormatPorts (0.00s)
	--- FAIL: TestFormatPorts/mixed_tcp_and_udp_with_consecutive_ports_on_anyhost (0.00s)
		formatter_test.go:191: assertion failed: 0.0.0.0:3000-3001->8080-8081/tcp, 0.0.0.0:3002-3003->8082-8083/udp (tt.expected string) != 0.0.0.0:3002-3003->8082-8083/udp, 0.0.0.0:3000-3001->8080-8081/tcp (result string)
--- FAIL: TestFormatPorts (0.00s)
	--- FAIL: TestFormatPorts/mixed_tcp_and_udp_with_consecutive_ports_on_anyhost (0.00s)
		formatter_test.go:191: assertion failed: 0.0.0.0:3000-3001->8080-8081/tcp, 0.0.0.0:3002-3003->8082-8083/udp (tt.expected string) != 0.0.0.0:3002-3003->8082-8083/udp, 0.0.0.0:3000-3001->8080-8081/tcp (result string)
FAIL
exit status 1
FAIL	github.com/containerd/nerdctl/v2/pkg/formatter	0.005s
```

This occurs because the `FormatPorts` function iterates over a map, whose iteration order is non-deterministic.
As a result, the output string may vary between test runs.

This behavior has been reported in issue/#4626.

To address this, this commit ensures that the string returned by `FormatPorts` is sorted alphabetically, resulting in stable and predictable output.