### PR TITLE
Refactor container_list_test.go to use Tigron

### DIFF
--- a/cmd/nerdctl/container/container_list_test.go
+++ b/cmd/nerdctl/container/container_list_test.go
@@ -20,43 +20,67 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
 // https://github.com/containerd/nerdctl/issues/2598
 func TestContainerListWithFormatLabel(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	tID := testutil.Identifier(t)
-	cID := tID
-	labelK := "label-key-" + tID
-	labelV := "label-value-" + tID
-
-	base.Cmd("run", "-d",
-		"--name", cID,
-		"--label", labelK+"="+labelV,
-		testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
-	defer base.Cmd("rm", "-f", cID).AssertOK()
-	base.Cmd("ps", "-a",
-		"--filter", "label="+labelK,
-		"--format", fmt.Sprintf("{{.Label %q}}", labelK)).AssertOutExactly(labelV + "\n")
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Setup: func(data test.Data, helpers test.Helpers) {
+			labelK := "label-key-" + data.Identifier()
+			labelV := "label-value-" + data.Identifier()
+			helpers.Ensure("run", "-d",
+				"--name", data.Identifier(),
+				"--label", labelK+"="+labelV,
+				testutil.CommonImage, "sleep", nerdtest.Infinity)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			labelK := "label-key-" + data.Identifier()
+			return helpers.Command("ps", "-a",
+				"--filter", "label="+labelK,
+				"--format", fmt.Sprintf("{{.Label %q}}", labelK)) //nolint:dupামিটার
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			labelV := "label-value-" + data.Identifier()
+			return test.Expects(0, nil, expect.Equals(labelV+"\n"))(data, helpers)
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestContainerListWithJsonFormatLabel(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	tID := testutil.Identifier(t)
-	cID := tID
-	labelK := "label-key-" + tID
-	labelV := "label-value-" + tID
-
-	base.Cmd("run", "-d",
-		"--name", cID,
-		"--label", labelK+"="+labelV,
-		testutil.CommonImage, "sleep", nerdtest.Infinity).AssertOK()
-	defer base.Cmd("rm", "-f", cID).AssertOK()
-	base.Cmd("ps", "-a",
-		"--filter", "label="+labelK,
-		"--format", "json").AssertOutContains(fmt.Sprintf("%s=%s", labelK, labelV))
+	nerdtest.Setup()
+	testCase := &test.Case{
+		Setup: func(data test.Data, helpers test.Helpers) {
+			labelK := "label-key-" + data.Identifier()
+			labelV := "label-value-" + data.Identifier()
+			helpers.Ensure("run", "-d",
+				"--name", data.Identifier(),
+				"--label", labelK+"="+labelV,
+				testutil.CommonImage, "sleep", nerdtest.Infinity)
+		},
+		Cleanup: func(data test.Data, helpers test.Helpers) {
+			helpers.Anyhow("rm", "-f", data.Identifier())
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			labelK := "label-key-" + data.Identifier()
+			return helpers.Command("ps", "-a",
+				"--filter", "label="+labelK,
+				"--format", "json")
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			labelK := "label-key-" + data.Identifier()
+			labelV := "label-value-" + data.Identifier()
+			return test.Expects(0, nil, expect.Contains(fmt.Sprintf("%s=%s", labelK, labelV)))(data, helpers)
+		},
+	}
+	testCase.Run(t)
 }


### PR DESCRIPTION
Updates tests to use nerdtest.Setup and the Tigron testing framework as per issue #4613.



- - -

Used Gemini, with the following prompt
```
Work on https://github.com/containerd/nerdctl/issues/4613 for @cmd/nerdctl/container/container_list_test.go .

- Try to preserve the original test structure as much as possible.
- In Tigron, `t.Parallel()` does not need to be explicitly set. Refer to @docs/testing/tools.md for further information about Tigron.
- To run a test, use `go test -exec sudo -run <TESTNAME> <PACKAGE>`.
```
