### PR TITLE
Revert "Fix SOCI image convertion regression for 0.12.0 release"

### DIFF
--- a/pkg/snapshotterutil/sociutil.go
+++ b/pkg/snapshotterutil/sociutil.go
@@ -117,13 +117,6 @@ func ConvertSociIndexV2(ctx context.Context, client *client.Client, srcRef strin
 
 	sociCmd.Args = append(sociCmd.Args, "convert")
 
-	// The following option temporarily fix the image conversion regression in SOCI v0.12.0
-	// https://github.com/awslabs/soci-snapshotter/issues/1789
-	// TODO: remove after the bug is fixed in SOCI
-	if err := CheckSociVersion("0.12.0"); err == nil {
-		sociCmd.Args = append(sociCmd.Args, "--force")
-	}
-
 	if sOpts.AllPlatforms {
 		sociCmd.Args = append(sociCmd.Args, "--all-platforms")
 	} else if len(sOpts.Platforms) > 0 {


### PR DESCRIPTION
This reverts commit accc2f38793f5f1bfb53c9f5b3b96e2a047ccdc4.
Related: https://github.com/awslabs/soci-snapshotter/issues/1789