### PR TITLE
nerdctl image prune -f means --force, not --filter

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -978,7 +978,7 @@ Usage: `nerdctl image prune [OPTIONS]`
 Flags:
 
 - :whale: `-a, --all`: Remove all unused images, not just dangling ones
-- :whale: `-f, --filter`: Filter the images.
+- :whale: `--filter`: Filter the images.
   - :whale: `--filter=until=<timestamp>`: Images created before given date formatted timestamps or Go duration strings. Currently does not support Unix timestamps.
   - :whale: `--filter=label<key>=<value>`: Matches images based on the presence of a label alone or a label and a value
 - :whale: `-f, --force`: Do not prompt for confirmation


### PR DESCRIPTION
Fix ambiguous flag in command reference for `nerdctl image prune`: `-f` was given as the short flag for both `--filter` and `--force`, but checking the source this should be `--force` only.