### PR TITLE
chore: improve the visibility of orphaned containers in logs

### DIFF
--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -65,7 +65,7 @@ func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
 				return fmt.Errorf("error removeing orphaned containers: %w", err)
 			}
 		} else {
-			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), containerShortIDs(orphans))
 		}
 	}
 

--- a/pkg/composer/orphans.go
+++ b/pkg/composer/orphans.go
@@ -55,3 +55,11 @@ func (c *Composer) getOrphanContainers(ctx context.Context, parsedServices []*se
 
 	return orphanContainers, nil
 }
+
+func containerShortIDs(containers []containerd.Container) []string {
+	names := make([]string, 0, len(containers))
+	for _, c := range containers {
+		names = append(names, c.ID()[:12])
+	}
+	return names
+}

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -201,7 +201,7 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 				return fmt.Errorf("error removing orphaned containers: %w", err)
 			}
 		} else {
-			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), containerShortIDs(orphans))
 		}
 	}
 

--- a/pkg/composer/up.go
+++ b/pkg/composer/up.go
@@ -116,7 +116,7 @@ func (c *Composer) Up(ctx context.Context, uo UpOptions, services []string) erro
 				return fmt.Errorf("error removing orphaned containers: %w", err)
 			}
 		} else {
-			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), orphans)
+			log.G(ctx).Warnf("found %d orphaned containers: %v, you can run this command with the --remove-orphans flag to clean it up", len(orphans), containerShortIDs(orphans))
 		}
 	}
 


### PR DESCRIPTION
When executing the command on compose files like the one below, orphaned containers are displayed, but the current implementation does not show the IDs of these orphaned containers, making them difficult to identify.

```
$ cat compose-full.yaml
services:
  test:
    image: docker.io/library/busybox:latest
    command: ["sleep", "infinity"]
  orphan:
    image: docker.io/library/busybox:latest
    command: ["sleep", "infinity"]

$ cat compose-orphan.yaml
services:
  test:
    image: docker.io/library/busybox:latest
    command: ["sleep", "infinity"]

$ sudo nerdctl compose -f compose-full.yaml up -d
...

$ sudo nerdctl compose -f compose-orphan.yaml down -v
...
WARN[0010] found 1 orphaned containers: [0x4000340000], you can run this command with the --remove-orphans flag to clean it up
...
```

Therefore, this commit modifies to display the IDs of orphaned containers.

Additionally, since there was other logic that performed similar displays, this commit also modifies it in the same manner.