### PR TITLE
MAINTAINERS: add Hayato Kiwata (haytok) as a REVIEWER

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -23,6 +23,7 @@
 # GitHub ID, Name, Email address, GPG fingerprint
 "jsturtevant","James Sturtevant","jstur@microsoft.com",""
 "Shubhranshu153","Shubharanshu Mahapatra","shubhum@amazon.com",""
+"haytok","Hayato Kiwata","haytok@amazon.co.jp","B485 C5AA 6220 0A06 78FD 294D FA4F 2421 1D65 269F"
 
 # EMERITUS
 # See EMERITUS.md


### PR DESCRIPTION
Hayato Kiwata (@haytok) has been very actively contributing to the project:
https://github.com/containerd/nerdctl/issues?q=is%3Apr+author%3Ahaytok

So I'd like to invite him as a reviewer

Needs explicit LGTM from the candidate and 1/3 of the nerdctl Committers ( $ceil \left( 5 \times \frac{1}{3} \right) = 2$ ), according to
https://github.com/containerd/project/blob/main/GOVERNANCE.md :

> After a candidate has been informally proposed in the maintainers forum, the existing maintainers are given seven days to discuss the candidate, raise objections and show their support. Formal voting takes place on a pull request that adds the contributor to the MAINTAINERS file. Candidates must be approved by 2/3 of the current committers by adding their approval or LGTM to the pull request. The reviewer role has the same process but only requires 1/3 of current committers.
>
> If a candidate is approved, they will be invited to add their own LGTM or approval to the pull request to acknowledge their agreement. A committer will verify the numbers of votes that have been received and the allotted seven days have passed, then merge the pull request and invite the contributor to the organization.
>
> For non-core sub-projects, only committers of the repository that the candidate is proposed for are given votes.

Candidate:
- [x] @haytok

nerdctl Committers:
- [x] @ktock
- [x] @fahedouch 
- [x] @Zheaoli 
- [x] @djdongjin
- [x] @yankay

Core Committers ([*non*-binding](https://github.com/containerd/project/blob/c4720dbfbb436d87fdc9b31eda92a9c562e17ca4/GOVERNANCE.md?plain=1#L73-L74))
- [x] @AkihiroSuda

I'd also like to get a few LGTMs from other Core Committers too. (not necessary)

This PR will remain open for 7 days.
