### PR TITLE
CI: lint: increase timeout

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -34,7 +34,7 @@ jobs:
             goos: linux
             canary: true
     with:
-      timeout: 5
+      timeout: 10
       go-version: "1.25"
       runner: ubuntu-24.04
       # Note: in GitHub yaml world, if `matrix.canary` is undefined, and is passed to `inputs.canary`, the job


### PR DESCRIPTION
`lint / go / linux (go canary)` was often timing out