### PR TITLE
fix: return error for invalid --pull option in nerdctl compose create

### DIFF
--- a/pkg/composer/serviceparser/serviceparser.go
+++ b/pkg/composer/serviceparser/serviceparser.go
@@ -458,7 +458,7 @@ func Parse(project *types.Project, svc types.ServiceConfig) (*Service, error) {
 		parsed.Build.Force = true
 		parsed.PullMode = "never"
 	default:
-		log.L.Warnf("Ignoring: service %s: pull_policy: %q", svc.Name, svc.PullPolicy)
+		return nil, fmt.Errorf("invalid --pull option %q", svc.PullPolicy)
 	}
 
 	for i := 0; i < replicas; i++ {


### PR DESCRIPTION
In the current implementation, specifying an invalid string for the --pull option of the nerdctl compose create command causes it to fall back to missing, allowing the image to be pulled as shown below.

```
$ sudo nerdctl compose create --pull foo
WARN[0000] Ignoring: service svc0: pull_policy: "foo"
INFO[0000] Ensuring image alpine
...
INFO[0004] Creating container fix-compose-pull-policy-with-invalid-option-svc0-1
```

On the other hand, docker compose returns the following error in a similar situation.

```
$ docker compose create --pull foo
invalid --pull option "foo"
```

This commit fixes it to be compatible with docker compose.