### PR TITLE
feat: add support for container cp with tarballs

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -494,6 +494,8 @@ Usage:
 - `nerdctl cp [OPTIONS] CONTAINER:SRC_PATH DEST_PATH|-`
 - `nerdctl cp [OPTIONS] SRC_PATH|- CONTAINER:DEST_PATH`
 
+Using `-` as the `SRC_PATH` streams the contents of `STDIN` as a tar archive. The command extracts the content of the tar to the `DEST_PATH` in container's filesystem. In this case, `DEST_PATH` must specify a directory. Using `-` as the `DEST_PATH` streams the contents of the resource as a tar archive to `STDOUT`.
+
 :warning: `nerdctl cp` is designed only for use with trusted, cooperating containers.
 Using `nerdctl cp` with untrusted or malicious containers is unsupported and may not provide protection against unexpected behavior.
 

--- a/pkg/api/types/container_types.go
+++ b/pkg/api/types/container_types.go
@@ -541,6 +541,10 @@ type ContainerCpOptions struct {
 	SrcPath string
 	// Follow symbolic links in SRC_PATH
 	FollowSymLink bool
+	// true if copying to container from tarball in stdin
+	FromStdin bool
+	// true if copying from container to stdout in tarball format
+	ToStdout bool
 }
 
 // ContainerStatsOptions specifies options for `nerdctl stats`.

--- a/pkg/containerutil/cp_resolve_linux.go
+++ b/pkg/containerutil/cp_resolve_linux.go
@@ -48,13 +48,16 @@ var (
 // besides exposing relevant properties (endsWithSeparator, etc), it also provides a fully resolved *host* path to
 // access the resource
 type pathSpecifier struct {
-	originalPath         string
+	originalPath string
+	resolvedPath string
+
 	endsWithSeparator    bool
 	endsWithSeparatorDot bool
 	exists               bool
 	isADir               bool
 	readOnly             bool
-	resolvedPath         string
+	fromStdin            bool
+	toStdout             bool
 }
 
 // getPathSpecFromHost builds a pathSpecifier from a host location
@@ -132,7 +135,7 @@ func getPathSpecFromHost(originalPath string) (*pathSpecifier, error) {
 	return pathSpec, nil
 }
 
-// getPathSpecFromHost builds a pathSpecifier from a container location
+// getPathSpecFromContainer builds a pathSpecifier from a container location
 func getPathSpecFromContainer(originalPath string, conSpec *oci.Spec, containerHostRoot string) (*pathSpecifier, error) {
 	pathSpec := &pathSpecifier{
 		originalPath:         originalPath,


### PR DESCRIPTION
Closes #4691 

This PR should allow support for the following in `container cp`:
- Specifying `-` in src to allow streaming the contents of a tarball into a container.
- Specifying `-` in dst to allow streaming the contents of a container into a tarball that is written to stdout
