### PR TITLE
fix: shared IPC ns when setting shareable

### DIFF
--- a/pkg/ipcutil/ipcutil.go
+++ b/pkg/ipcutil/ipcutil.go
@@ -207,6 +207,11 @@ func GenerateIPCOpts(ctx context.Context, ipc IPC, client *containerd.Client) ([
 		}
 
 		opts = append(opts, withBindMountHostOtherSourceIPC(*targetConIPC.HostShmPath))
+		ns := specs.LinuxNamespace{
+			Type: specs.IPCNamespace,
+			Path: fmt.Sprintf("/proc/%d/ns/ipc", task.Pid()),
+		}
+		opts = append(opts, oci.WithLinuxNamespace(ns))
 	}
 
 	return opts, nil


### PR DESCRIPTION
Currently, the IPC namespace is not actually shared when using the --ipc=shareable and --ipc=container:<id>.

**Steps to reproduce**

```bash
nerdctl run -d --name ipc_master --ipc=shareable alpine:latest sleep 3600
nerdctl run -d --name ipc_slave --ipc=container:ipc_master alpine:latest sleep 3600
pid_master=$(nerdctl inspect ipc_master --format '{{.State.Pid}}')
pid_slave=$(nerdctl inspect ipc_slave --format '{{.State.Pid}}')
readlink /proc/$pid_master/ns/ipc
readlink /proc/$pid_slave/ns/ipc
```

This commit explicitly set the IPC namespace path to the target container’s namespace in container IPC mode. 
Add assertions in the shared IPC tests to compare ipc between container1 and container2, including after restart.

Ref: #4702