### PR TITLE
fix: correct usage display to show [command] instead of [flags]

### DIFF
--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -64,7 +64,9 @@ var (
 // usage was derived from https://github.com/spf13/cobra/blob/v1.2.1/command.go#L491-L514
 func usage(c *cobra.Command) error {
 	s := "Usage: "
-	if c.Runnable() {
+	if c.HasSubCommands() {
+		s += c.CommandPath() + " [command]\n"
+	} else if c.Runnable() {
 		s += c.UseLine() + "\n"
 	} else {
 		s += c.CommandPath() + " [command]\n"


### PR DESCRIPTION
## Summary

Fix the usage display when running `nerdctl` without any command.

Fixes #3185

## Problem

When running `nerdctl` without any arguments, the usage text showed:
```
Usage: nerdctl [flags]
```

But it should show:
```
Usage: nerdctl [command]
```

## Root Cause

The `usage()` function used `c.Runnable()` to decide whether to show `[flags]` or `[command]`. However, the root command has `RunE` set to `helpers.UnknownSubcommandAction` (for handling unknown subcommands), which makes it "runnable" from cobra's perspective.

## Solution

Changed the logic to prioritize checking `HasSubCommands()` first. Commands with subcommands should always show `[command]` in their usage, regardless of whether they have a Run function.

```go
// Before
if c.Runnable() {
    s += c.UseLine() + "\n"
} else {
    s += c.CommandPath() + " [command]\n"
}

// After
if c.HasSubCommands() {
    s += c.CommandPath() + " [command]\n"
} else if c.Runnable() {
    s += c.UseLine() + "\n"
} else {
    s += c.CommandPath() + " [command]\n"
}
```

## Testing

- Code compiles successfully
- Logic is straightforward and follows the expected behavior