### PR TITLE
test: fix flaky TestImageConvert/soci test

### DIFF
--- a/cmd/nerdctl/image/image_convert_linux_test.go
+++ b/cmd/nerdctl/image/image_convert_linux_test.go
@@ -97,6 +97,12 @@ func TestImageConvert(t *testing.T) {
 					nerdtest.Soci,
 					nerdtest.SociVersion("0.10.0"),
 				),
+				Setup: func(data test.Data, helpers test.Helpers) {
+					// Clean up any existing SOCI indices to avoid stale ztoc data
+					helpers.Anyhow("rmi", "-f", testutil.CommonImage)
+					helpers.Anyhow("system", "prune", "--force")
+					helpers.Ensure("pull", "--quiet", "--all-platforms", testutil.CommonImage)
+				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rmi", "-f", data.Identifier("converted-image"))
 				},
@@ -115,6 +121,12 @@ func TestImageConvert(t *testing.T) {
 					nerdtest.Soci,
 					nerdtest.SociVersion("0.10.0"),
 				),
+				Setup: func(data test.Data, helpers test.Helpers) {
+					// Clean up any existing SOCI indices to avoid stale ztoc data
+					helpers.Anyhow("rmi", "-f", testutil.CommonImage)
+					helpers.Anyhow("system", "prune", "--force")
+					helpers.Ensure("pull", "--quiet", "--all-platforms", testutil.CommonImage)
+				},
 				Cleanup: func(data test.Data, helpers test.Helpers) {
 					helpers.Anyhow("rmi", "-f", data.Identifier("converted-image"))
 				},
@@ -130,7 +142,6 @@ func TestImageConvert(t *testing.T) {
 	}
 
 	testCase.Run(t)
-
 }
 
 func TestImageConvertNydusVerify(t *testing.T) {


### PR DESCRIPTION
The TestImageConvert/soci sub-test was failing intermittently due to an inconsistent content store state. The SOCI converter detected existing zTOC indices (stale cache from previous runs) and skipped generation, but subsequently failed because the referenced source image blobs were missing.

The failure looks like:
```
=== RUN TestImageConvert/soci

image_convert_linux_test.go:132:


+------------------------------------------------------------------------------------------------------------+

| ➡️ | ⚙️ /usr/local/bin/nerdctl image convert --soci --soci-span-size 2097152 --soci-min-layer-size 0 |

| | ghcr.io/stargz-containers/alpine:3.13-org testimageconvert-soci-converted-image-aceae1d3 |

+------------------------------------------------------------------------------------------------------------+

| | 🚫 command returned a non-zero exit code |

+------------------------------------------------------------------------------------------------------------+

| | ⚠️ 1 |

+------------------------------------------------------------------------------------------------------------+

| | 🟠 time="2026-01-24T06:15:20Z" level=info msg="Converting image from ghcr.io/stargz-containers/a |

| | lpine:3.13-org to docker.io/library/testimageconvert-soci-converted-image-aceae1d3:latest using |

| | SOCI format" |

| | time="2026-01-24T06:15:20Z" level=info msg="soci: layer sha256:ca3cd42a7c9525f6ce3d64c1a70982613 |

| | a8235f0cc057ec9244052921853ef15 -> ztoc sha256:3305435c3cfb133dcf92a6166b6df165dc99f67dee959f5b6 |

| | 48e2f441538dc85 (already exists)" |

| | time="2026-01-24T06:15:20Z" level=info msg="soci: soci: content digest sha256:f75ffcb8f551d79abd |

| | c359aea2a99b4093e1d3655b1908aa29fe00382d129b43: not found" |

| | time="2026-01-24T06:15:20Z" level=fatal msg="failed to convert image to SOCI format: exit status |

| | 1" |

+------------------------------------------------------------------------------------------------------------+

| 🌱 | HOME=/root |

| | PATH=/usr/local/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin |

| | :/bin |

| | DOCKER_CONFIG=/tmp/TestImageConvertsoci1452295190/003 |

| | NERDCTL_TOML=/tmp/TestImageConvertsoci1452295190/003/nerdctl.toml |

+------------------------------------------------------------------------------------------------------------+

| ⏰ | <1s (limit: 3m0s) |

+------------------------------------------------------------------------------------------------------------+

| 📁 | /tmp/TestImageConvertsoci1452295190/002 |

+------------------------------------------------------------------------------------------------------------+


image_convert_linux_test.go:132:


<<<<<<<<<<<<<<<<<<<<

🖊️ Command should succeed

👀 testing: `command returned a non-zero exit code`

❌ FAILED! is `<nil>`

>>>>>>>>>>>>>>>>>>>>


image_convert_linux_test.go:132:


+============================================================================================================+

| 🧽 | "TestImageConvert/soci": post-cleanup |

+============================================================================================================+


image_convert_linux_test.go:101:


+------------------------------------------------------------------------------------------------------------+

| ➡️ | ⚙️ /usr/local/bin/nerdctl rmi -f testimageconvert-soci-converted-image-aceae1d3 |

+------------------------------------------------------------------------------------------------------------+

| | 🟠 time="2026-01-24T06:15:20Z" level=error msg="1 errors:\nno such image: testimageconvert-soci- |

| | converted-image-aceae1d3" |

+------------------------------------------------------------------------------------------------------------+

| 🌱 | HOME=/root |

| | PATH=/usr/local/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin |

| | :/bin |

| | DOCKER_CONFIG=/tmp/TestImageConvertsoci1452295190/003 |

| | NERDCTL_TOML=/tmp/TestImageConvertsoci1452295190/003/nerdctl.toml |

+------------------------------------------------------------------------------------------------------------+

| ⏰ | <1s (limit: 3m0s) |

+------------------------------------------------------------------------------------------------------------+

| 📁 | /tmp/TestImageConvertsoci1452295190/002 |

+------------------------------------------------------------------------------------------------------------+


--- FAIL: TestImageConvert/soci (0.75s)
```

This commit adds a Setup step to the soci sub-test that:
1. Executes `system prune --all --force` to clear stale zTOC artifacts and dangling blobs.
2. Explicitly pulls the source image to ensure all necessary content is present before conversion.