### PR TITLE
fix: TestRunWithSystemdTrueEnabled flakiness

### DIFF
--- a/cmd/nerdctl/container/container_run_systemd_linux_test.go
+++ b/cmd/nerdctl/container/container_run_systemd_linux_test.go
@@ -74,6 +74,7 @@ func TestRunWithSystemdTrueEnabled(t *testing.T) {
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), "--systemd=true", "--entrypoint=/sbin/init", testutil.SystemdImage)
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {


### PR DESCRIPTION
### Problem

The test Setup starts a systemd container in detached mode (`-d`) but immediately proceeds to run `nerdctl exec` without waiting for the container to reach a stable running state.

### Fixes
https://github.com/containerd/nerdctl/issues/4746