### PR TITLE
CI: temporarily disable release check for PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
     - 'v*'
     - 'test-action-release-*'
-  pull_request:
-    paths-ignore:
-    - '**.md'
 
 env:
   GOTOOLCHAIN: local


### PR DESCRIPTION
Not likely compromised so far, but temporarily disable the check during investigation.