### PR TITLE
Revert "CI: temporarily disable release check for PRs"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - 'v*'
     - 'test-action-release-*'
+  pull_request:
+    paths-ignore:
+    - '**.md'
 
 env:
   GOTOOLCHAIN: local


### PR DESCRIPTION
Revert:
- #4762

I was overreacting to https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation .
We were not vulnerable because we had no workflows that permitted triggers from `pull_request_target`, `issue_comment`, or anything similar events.