### PR TITLE
fix: Add delay for systemd to startup before running exec

### DIFF
--- a/cmd/nerdctl/container/container_run_systemd_linux_test.go
+++ b/cmd/nerdctl/container/container_run_systemd_linux_test.go
@@ -18,7 +18,9 @@ package container
 
 import (
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/containerd/nerdctl/mod/tigron/expect"
 	"github.com/containerd/nerdctl/mod/tigron/require"
@@ -89,18 +91,24 @@ func TestRunWithSystemdTrueEnabled(t *testing.T) {
 				Output:   expect.Contains("SIGRTMIN+3"),
 			})
 
-		// waits for systemd to become ready and lists systemd jobs
-		return helpers.Command("exec", data.Identifier(), "sh", "-c", "--", `tries=0
-until systemctl is-system-running >/dev/null 2>&1; do
-	>&2 printf "Waiting for systemd to come up...\n"
-	sleep 1s
-	tries=$(( tries + 1))
-	[ $tries -lt 10 ] || {
-		>&2 printf "systemd failed to come up in a reasonable amount of time\n"
-		exit 1
-	}
-done
-systemctl list-jobs`)
+		// Poll for systemd to become ready
+		maxRetries := 30
+		systemdReady := false
+		for i := 0; i < maxRetries && !systemdReady; i++ {
+			output := helpers.Capture("exec", data.Identifier(), "sh", "-c", "--", "systemctl is-system-running 2>&1 || true")
+			if strings.Contains(output, "running") || strings.Contains(output, "degraded") {
+				systemdReady = true
+			}
+			if !systemdReady {
+				time.Sleep(time.Second)
+			}
+		}
+		if !systemdReady {
+			helpers.T().Log("systemd did not become ready after 30 seconds")
+			helpers.T().FailNow()
+		}
+
+		return helpers.Command("exec", data.Identifier(), "sh", "-c", "--", "systemctl list-jobs")
 	}
 
 	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("jobs"))


### PR DESCRIPTION
Attempting to fix: https://github.com/containerd/nerdctl/issues/4746

TestRunWithSystemdTrueEnabled seems to pass now after a few runs. 
