### PR TITLE
tests: fix flaky TestLogs since/until 1s subtests

### DIFF
--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -60,6 +60,11 @@ bar
 	testCase.SubTests = []*test.Case{
 		{
 			Description: "since 1s",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				// Ensure at least 2 seconds have elapsed since the container ran,
+				// so that --since 1s does not include the container's output.
+				time.Sleep(2 * time.Second)
+			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("logs", "--since", "1s", data.Labels().Get("cID"))
 			},
@@ -81,6 +86,11 @@ bar
 		},
 		{
 			Description: "until 1s",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				// Ensure at least 2 seconds have elapsed since the container ran,
+				// so that --until 1s includes the container's output.
+				time.Sleep(2 * time.Second)
+			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
 				return helpers.Command("logs", "--until", "1s", data.Labels().Get("cID"))
 			},


### PR DESCRIPTION
The `since_1s` and `until_1s` subtests raced against wall clock: if the container finished within 1 second before the command ran, both tests produced wrong results.

Add a 2-second Setup sleep so the container logs are always >1s old by the time the timed-filter commands execute.

NOTE: used Claude Code