### PR TITLE
Fix foreground run to wait for logging binary before returning

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -506,6 +506,16 @@ func runAction(cmd *cobra.Command, args []string) error {
 		io.Wait()
 		isDetached = true
 	case status := <-statusC:
+		// Wait for IO copy goroutines to finish, ensuring all container
+		// output has been written to both stdout and the logging binary's
+		// pipe. Then close IO to allow the logging binary to receive EOF,
+		// drain remaining data, and write it to the log file.
+		// This matches Docker's behavior where logs are fully written
+		// before the run command returns.
+		if io := task.IO(); io != nil {
+			io.Wait()
+			io.Close()
+		}
 		if createOpt.Rm {
 			if _, taskDeleteErr := task.Delete(ctx); taskDeleteErr != nil {
 				log.L.Error(taskDeleteErr)

--- a/pkg/cioutil/container_io.go
+++ b/pkg/cioutil/container_io.go
@@ -43,6 +43,11 @@ type ncio struct {
 	wg      *sync.WaitGroup
 	closers []io.Closer
 	cancel  context.CancelFunc
+	// logPipeClosers holds the write ends of pipes to the logging binary.
+	// These must be closed before terminating the logging binary so it can
+	// receive EOF and drain any remaining data in the pipe buffer.
+	logPipeClosers []io.Closer
+	closed         bool
 }
 
 var bufPool = sync.Pool{
@@ -63,20 +68,25 @@ func (c *ncio) Wait() {
 }
 
 func (c *ncio) Close() error {
+	if c.closed {
+		return nil
+	}
+	c.closed = true
 
 	var lastErr error
 
-	if c.cmd != nil && c.cmd.Process != nil {
-
-		// Send SIGTERM first, so logger process has a chance to flush and exit properly
-		if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			lastErr = fmt.Errorf("failed to send SIGTERM: %w", err)
-
-			if err := c.cmd.Process.Kill(); err != nil {
-				lastErr = errors.Join(lastErr, fmt.Errorf("failed to kill process after faulty SIGTERM: %w", err))
-			}
-
+	// Close the pipe write ends to the logging binary first, so it receives
+	// EOF and can drain any remaining data before being terminated.
+	for _, closer := range c.logPipeClosers {
+		if closer == nil {
+			continue
 		}
+		if err := closer.Close(); err != nil {
+			lastErr = err
+		}
+	}
+
+	if c.cmd != nil && c.cmd.Process != nil {
 
 		done := make(chan error, 1)
 		go func() {
@@ -86,15 +96,26 @@ func (c *ncio) Close() error {
 		select {
 		case err := <-done:
 			if err != nil {
-				lastErr = fmt.Errorf("faied to run cmd.wait: %w", err)
+				lastErr = fmt.Errorf("failed to run cmd.wait: %w", err)
 			}
 		case <-time.After(binaryIOProcTermTimeout):
-
-			err := c.cmd.Process.Kill()
-			if err != nil {
-				lastErr = fmt.Errorf("failed to kill shim logger process: %w", err)
+			// Logger did not exit after pipe EOF; send SIGTERM
+			if err := c.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+				if err := c.cmd.Process.Kill(); err != nil {
+					lastErr = fmt.Errorf("failed to kill shim logger process: %w", err)
+				}
+			} else {
+				select {
+				case err := <-done:
+					if err != nil {
+						lastErr = fmt.Errorf("failed to run cmd.wait: %w", err)
+					}
+				case <-time.After(binaryIOProcTermTimeout):
+					if err := c.cmd.Process.Kill(); err != nil {
+						lastErr = fmt.Errorf("failed to kill shim logger process: %w", err)
+					}
+				}
 			}
-
 		}
 	}
 
@@ -118,9 +139,10 @@ func (c *ncio) Cancel() {
 func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, stdout, stderr io.Writer) cio.Creator {
 	return func(id string) (_ cio.IO, err error) {
 		var (
-			cmd     *exec.Cmd
-			closers []func() error
-			streams = &cio.Streams{
+			cmd            *exec.Cmd
+			closers        []func() error
+			logPipeClosers []io.Closer
+			streams        = &cio.Streams{
 				Terminal: tty,
 			}
 		)
@@ -196,6 +218,7 @@ func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, 
 
 			stdoutWriters = append(stdoutWriters, stdoutw)
 			stderrWriters = append(stderrWriters, stderrw)
+			logPipeClosers = append(logPipeClosers, stdoutw, stderrw)
 		}
 
 		streams.Stdout = io.MultiWriter(stdoutWriters...)
@@ -218,6 +241,6 @@ func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, 
 		if streams.Stderr == nil {
 			fifos.Stderr = ""
 		}
-		return copyIO(cmd, fifos, streams)
+		return copyIO(cmd, fifos, streams, logPipeClosers)
 	}
 }

--- a/pkg/cioutil/container_io_unix.go
+++ b/pkg/cioutil/container_io_unix.go
@@ -41,7 +41,7 @@ func (p *pipes) closers() []io.Closer {
 }
 
 // copyIO is from https://github.com/containerd/containerd/blob/148d21b1ae0718b75718a09ecb307bb874270f59/cio/io_unix.go#L55
-func copyIO(cmd *exec.Cmd, fifos *cio.FIFOSet, ioset *cio.Streams) (*ncio, error) {
+func copyIO(cmd *exec.Cmd, fifos *cio.FIFOSet, ioset *cio.Streams, logPipeClosers []io.Closer) (*ncio, error) {
 	var ctx, cancel = context.WithCancel(context.Background())
 	pipes, err := openFifos(ctx, fifos)
 	if err != nil {
@@ -85,10 +85,11 @@ func copyIO(cmd *exec.Cmd, fifos *cio.FIFOSet, ioset *cio.Streams) (*ncio, error
 	}
 
 	return &ncio{
-		cmd:     cmd,
-		config:  fifos.Config,
-		wg:      wg,
-		closers: append(pipes.closers(), fifos),
+		cmd:            cmd,
+		config:         fifos.Config,
+		wg:             wg,
+		closers:        append(pipes.closers(), fifos),
+		logPipeClosers: logPipeClosers,
 		cancel: func() {
 			cancel()
 			for _, c := range pipes.closers() {

--- a/pkg/cioutil/container_io_windows.go
+++ b/pkg/cioutil/container_io_windows.go
@@ -28,7 +28,7 @@ import (
 )
 
 // copyIO is from https://github.com/containerd/containerd/blob/148d21b1ae0718b75718a09ecb307bb874270f59/cio/io_windows.go#L44
-func copyIO(_ *exec.Cmd, fifos *cio.FIFOSet, ioset *cio.Streams) (_ *ncio, retErr error) {
+func copyIO(_ *exec.Cmd, fifos *cio.FIFOSet, ioset *cio.Streams, logPipeClosers []io.Closer) (_ *ncio, retErr error) {
 	ncios := &ncio{cmd: nil, config: fifos.Config}
 
 	defer func() {


### PR DESCRIPTION
In the foreground (non-detach) run path, nerdctl was returning immediately after the container exited without waiting for the logging binary to finish writing the JSON log file. This caused flaky TestLogs/since_60s and TestLogs/until_60s failures because subtests would read the log file before it was fully written.

The fix adds io.Wait() + io.Close() after statusC fires, matching Docker's behavior where logs are fully written before the run command returns. The ncio.Close() method is also reworked to close pipe write ends before terminating the logging binary, allowing it to receive EOF and drain remaining data naturally.

NOTE: used Claude Code

Expected to fix https://github.com/containerd/nerdctl/issues/4782