### PR TITLE
Update cosign to v3.0.5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -332,7 +332,7 @@ WORKDIR /go/src/github.com/containerd/nerdctl
 VOLUME /tmp
 ENV CGO_ENABLED=0
 # copy cosign binary for integration test
-COPY --from=ghcr.io/sigstore/cosign/cosign:v2.2.3@sha256:8fc9cad121611e8479f65f79f2e5bea58949e8a87ffac2a42cb99cf0ff079ba7 /ko-app/cosign /usr/local/bin/cosign
+COPY --from=ghcr.io/sigstore/cosign/cosign:v3.0.5@sha256:be924970ba7438c22e18067dec5637946d6566eac711f5bedd1584e7137008fb /ko-app/cosign /usr/local/bin/cosign
 # installing soci for integration test
 ARG SOCI_SNAPSHOTTER_VERSION
 RUN fname="soci-snapshotter-${SOCI_SNAPSHOTTER_VERSION}-${TARGETOS:-linux}-${TARGETARCH:-amd64}.tar.gz" && \

--- a/cmd/nerdctl/image/image_pull_linux_test.go
+++ b/cmd/nerdctl/image/image_pull_linux_test.go
@@ -102,7 +102,7 @@ CMD ["echo", "nerdctl-build-test-string"]
 					_, pub := nerdtest.GenerateCosignKeyPair(data, helpers, "2")
 					return helpers.Command("pull", "--quiet", "--verify=cosign", "--cosign-key="+pub, data.Labels().Get("image_ref")+":two")
 				},
-				Expected: test.Expects(12, nil, nil),
+				Expected: test.Expects(1, nil, nil),
 			},
 		},
 	}


### PR DESCRIPTION
This PR updates cosign to v3.0.5 in the Dockerfile from v2.2.3.