### PR TITLE
test: remove a new line from containerID for correct test execution

### DIFF
--- a/cmd/nerdctl/container/container_remove_linux_test.go
+++ b/cmd/nerdctl/container/container_remove_linux_test.go
@@ -19,6 +19,7 @@ package container
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -93,7 +94,7 @@ func TestContainerRmIptables(t *testing.T) {
 
 				// Create a container with port mapping to ensure iptables rules are created
 				containerID := helpers.Capture("run", "-d", "--name", data.Identifier(), "-p", fmt.Sprintf("%d:80", port), testutil.NginxAlpineImage)
-				data.Labels().Set("containerID", containerID)
+				data.Labels().Set("containerID", strings.TrimSpace(containerID))
 				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 			},
 			Cleanup: func(data test.Data, helpers test.Helpers) {


### PR DESCRIPTION
When running `TestContainerRmIptables` with verbose output, the following error can be observed:

```
$ sudo go test -run TestContainerRmIptables -v

...

=== CONT  TestContainerRmIptables/Test_iptables_rules_are_cleared_after_container_deletion
    container_remove_linux_test.go:135:

...

    container_remove_linux_test.go:49:

        +------------------------------------------------------------------------------------------------------------+
        | ➡️      | ⚙️ /usr/local/bin/nerdctl rm -f fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504 |
        |         |                                                                                                  |
        +------------------------------------------------------------------------------------------------------------+
        |         | 🟠 time="2026-03-23T00:00:53+09:00" level=error msg="1 errors:\nfilters: parse error: [labels.\" |
        |         | nerdctl/name\"==fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504 >|\n|< ]: unexp |
        |         | ected input: \n: invalid argument: invalid argument"                                             |

...

    container_remove_linux_test.go:135:

        <<<<<<<<<<<<<<<<<<<<
                🖊️ Inspecting output (does not contain)
                👀 testing:             `-P PREROUTING ACCEPT
        -P INPUT ACCEPT

...

        -A POSTROUTING -s 10.4.0.148/32 -m comment --comment "name: \"bridge\" id: \"nerdctl-test-fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504\"" -j CNI-d4bd64738075587aa8d84afc

...

        -A CNI-HOSTPORT-DNAT -p tcp -m comment --comment "dnat name: \"bridge\" id: \"nerdctl-test-fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504\"" -m multiport --dports 5000 -j CNI-DN-d4bd64738075587aa8d84
...
        -A CNI-d4bd64738075587aa8d84afc -d 10.4.0.0/24 -m comment --comment "name: \"bridge\" id: \"nerdctl-test-fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504\"" -j ACCEPT
        -A CNI-d4bd64738075587aa8d84afc ! -d 224.0.0.0/4 -m comment --comment "name: \"bridge\" id: \"nerdctl-test-fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504\"" -j MASQUERADE

...

        -P POSTROUTING ACCEPT
        `
                ✅️ does verify:         ! ~= `fd4fc99e04476d7f673133a06338933aadc547d4eef883f469464d7d31467504
        `
        >>>>>>>>>>>>>>>>>>>>

...

=== NAME  TestContainerRmIptables
    container_remove_linux_test.go:135:

        +============================================================================================================+
        | 🧽      | "TestContainerRmIptables": post-cleanup                                                          |
        +============================================================================================================+

--- PASS: TestContainerRmIptables (0.00s)
    --- PASS: TestContainerRmIptables/Test_iptables_rules_are_cleared_after_container_deletion (2.93s)
PASS
ok      github.com/containerd/nerdctl/v2/cmd/nerdctl/container  2.936s
```

The error `unexpected input: \n: invalid argument: invalid argument` indicates that the container is not being removed correctly.

Additionally, since the container ID remains in the iptables output, it is clear that `expect.DoesNotContain(containerID)` passes for the wrong reason, and the test is not properly validating the iptables cleanup behavior after container removal.

This commit removes the new line from the container ID using `strings.TrimSpace`.