### PR TITLE
docs: update list of unimplemented Docker features

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -343,7 +343,6 @@ Health check flags:
 - :whale: `--health-timeout`: Time to wait before considering the check failed (e.g., 5s)
 - :whale: `--health-retries`: Number of failures before container is considered unhealthy
 - :whale: `--health-start-period`: Start period for the container to initialize before starting health-retries countdown
-- :whale: `--health-start-interval`: Interval between checks during the start period
 - :whale: `--no-healthcheck`: Disable any health checks defined by image or CLI
 
 Logging flags:
@@ -454,7 +453,8 @@ IPFS flags:
 
 Unimplemented `docker run` flags:
     `--device-cgroup-rule`, `--disable-content-trust`, `--expose`,
-    `--link*`, `--publish-all`, `--storage-opt`, `--volume-driver`
+    `--health-start-interval`, `--link*`, `--publish-all`, `--storage-opt`,
+    `--volume-driver`
 
 ### :whale: nerdctl exec
 
@@ -1809,7 +1809,7 @@ Push service images
 
 Usage: `nerdctl compose push [OPTIONS] [SERVICE...]`
 
-Unimplemented `docker-compose pull` (V1) flags: `--ignore-push-failures`
+Unimplemented `docker-compose push` (V1) flags: `--ignore-push-failures`
 
 ### :whale: nerdctl compose pause
 
@@ -1994,7 +1994,13 @@ Network management:
 
 Compose:
 
-- `docker-compose events|scale`
+- `docker compose attach`
+- `docker compose events`
+- `docker compose ls`
+- `docker compose scale`
+- `docker compose stats`
+- `docker compose wait`
+- `docker compose watch`
 
 Builder:
 


### PR DESCRIPTION
Took a pass at updating the unimplemented Docker features list in `docs/command-reference.md`.

Changes:
- `--health-start-interval` was marked with :whale: but the flag doesn't actually exist in the codebase. `docs/healthchecks.md` already says it's unsupported, so added an `(unimplemented)` note to match.
- Fixed a typo under `nerdctl compose push` — it said `docker-compose pull` instead of `push`.
- Expanded the unimplemented compose commands section. It only listed `events|scale` but nerdctl is also missing `attach`, `ls`, `stats`, `wait`, and `watch`. Switched to `docker compose` (V2) syntax since V1 is EOL.

Grepped through the source to double-check everything — all the "unimplemented" claims check out.

Partial fix for #3867