### PR TITLE
fix: cannot start container when IPv6 is disabled

### DIFF
--- a/pkg/portutil/port_allocate_linux.go
+++ b/pkg/portutil/port_allocate_linux.go
@@ -17,8 +17,10 @@
 package portutil
 
 import (
+	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/containerd/nerdctl/v2/pkg/portutil/iptable"
 	"github.com/containerd/nerdctl/v2/pkg/portutil/procnet"
@@ -87,14 +89,14 @@ func getUsedPorts(ip string, protocol string) (map[uint64]bool, error) {
 	// So we need some trick to process this situation.
 	if protocol == "tcp" {
 		tempTCPV6Data, err := procnet.ReadStatsFileData("tcp6")
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
 		netprocItems = append(netprocItems, procnet.Parse(tempTCPV6Data)...)
 	}
 	if protocol == "udp" {
 		tempUDPV6Data, err := procnet.ReadStatsFileData("udp6")
-		if err != nil {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return nil, err
 		}
 		netprocItems = append(netprocItems, procnet.Parse(tempUDPV6Data)...)


### PR DESCRIPTION
 ## Problem

 On systems where IPv6 is disabled (e.g. kernel boot parameter `ipv6.disable=1`), running a container with port mapping fails with the following error:

```
$ cat /proc/cmdline | tr ' ' '\n'  | grep ipv6
ipv6.disable=1
$ sudo nerdctl run -p 8080:8080 alpine:latest echo 'OK'
FATA[0000] failed to load networking flags: open /proc/net/tcp6: no such file or directory
$ sudo nerdctl run alpine:latest echo 'OK'
OK
$
```

## Root Cause

When allocating host ports, nerdctl unconditionally reads `/proc/net/tcp6` and `/proc/net/udp6` to check for ports already in use. On IPv6-disabled systems, the kernel does not create these files, causing the port allocation to fail entirely.

## Fix

Treat `ErrNotExist` for `/proc/net/tcp6` and `/proc/net/udp6` as a non-error, returning `nil` (no IPv6 ports in use) instead of propagating the error.

## Result

After this fix, containers with port mapping (`-p`) start successfully on IPv6-disabled systems.

## Testing

No unit test is added at this time, as `netTCP6Stats` and `netUDP6Stats` are defined as `const`, making it difficult to inject alternative paths. If the maintainers prefer, these could be changed to `var` to allow unit testing with a mock path.