### PR TITLE
rootlessutil: remove dead -r/ from nsenter args

### DIFF
--- a/pkg/rootlessutil/parent_linux.go
+++ b/pkg/rootlessutil/parent_linux.go
@@ -91,10 +91,13 @@ func ParentMain(hostGatewayIP string) error {
 	if err != nil {
 		return err
 	}
-	// args are compatible with both util-linux nsenter and busybox nsenter
-	args := []string{
-		"-r/", // root dir (busybox nsenter wants this to be explicitly specified),
-	}
+	// -r/ (root dir) is intentionally omitted. nsenter would open the host
+	// root fd before setns, then chroot to it after entering the mount
+	// namespace, anchoring the process to host paths. In rootless mode,
+	// host dirs owned by real uid 0 (e.g. /var/lib/containerd) are
+	// inaccessible inside the user namespace and overlay mounts would
+	// fail with EACCES.
+	args := []string{arg0}
 
 	// Only append wd if we do have a working dir
 	// - https://github.com/rootless-containers/usernetes/pull/327


### PR DESCRIPTION
## Summary

The `-r/` flag in `ParentMain`'s nsenter args has been a no-op since it was added. It was placed at `args[0]`, which becomes `argv[0]` (the program name) when passed to `syscall.Exec(arg0, args, env)`. nsenter consumes it as its own name and never parses it as a flag.

This is harmless today, but if someone corrects the argv ordering (e.g. prepending `arg0` to the slice), `-r/` would start working and break rootless container creation:

1. nsenter opens the root fd (`/`) **before** `setns`
2. After entering the mount namespace, `fchdir(root_fd)` + `chroot(\".\")` anchors the process to the **host** root
3. In rootless mode, the host's `/var/lib/containerd` is owned by real root (uid 0), which is unmapped in the user namespace (appears as `nobody`/65534)
4. Overlay mount lowerdir resolution fails with `EACCES` because the process cannot traverse the 0700 host directory

This also fixes `argv[0]` to be `arg0` (the nsenter binary path), matching the standard convention.

## Verification

Strace comparison before and after, running `nerdctl create` in rootless mode:

**Before** (current code, `-r/` accidentally in argv[0]):
```
execve("/usr/bin/nsenter", ["-r/", "-w/home/user", "--preserve-credentials", "-m", "-U", ...], ...)
setns(CLONE_NEWUSER) = 0
setns(CLONE_NEWNS) = 0
fchdir(3) = 0          # -r/ consumed as argv[0], no chroot
execve("nerdctl", ...)
mount("overlay", ...) = 0   # works because no chroot happened
```

**If -r/ were at argv[1]** (the latent bug):

```
setns(CLONE_NEWUSER) = 0
setns(CLONE_NEWNS) = 0
fchdir(3) = 0
chroot(".") = 0       # anchors to host root
fchdir(4) = 0
execve("nerdctl", ...)
mount("overlay", ...) = -1 EACCES   # host /var/lib/containerd inaccessible
```

**After** (this PR, `-r/` removed, `arg0` as argv[0]):

```
execve("/usr/bin/nsenter", ["/usr/bin/nsenter", "-w/home/user", "--preserve-credentials", "-m", "-U", ...], ...)
setns(CLONE_NEWUSER) = 0
setns(CLONE_NEWNS) = 0
execve("nerdctl", ...)
mount("overlay", ...) = 0   # paths resolve through mount namespace
``` debugger eval code:1:9
