### PR TITLE
feat: add missing HostConfig fields to dockercompat inspect response

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -391,10 +391,16 @@ func TestContainerInspectHostConfig(t *testing.T) {
 			"--add-host", "host2:10.0.0.2",
 			"--ipc", "host",
 			"--memory", "512m",
+			"--memory-reservation", "200m",
+			"--memory-swappiness", "60",
+			"--pids-limit", "100",
+			"--ulimit", "nofile=1024:65536",
 			"--read-only",
 			"--shm-size", "256m",
 			"--uts", "host",
+			"--restart", "on-failure:3",
 			"--runtime", "io.containerd.runc.v2",
+			"--annotation", "com.example.key=test-val",
 			testutil.AlpineImage, "sleep", nerdtest.Infinity)
 		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
 	}
@@ -430,6 +436,21 @@ func TestContainerInspectHostConfig(t *testing.T) {
 		assert.Equal(tt, true, inspect.HostConfig.ReadonlyRootfs)
 		assert.Equal(tt, "host", inspect.HostConfig.UTSMode)
 		assert.Equal(tt, int64(268435456), inspect.HostConfig.ShmSize)
+		assert.Equal(tt, int64(209715200), inspect.HostConfig.MemoryReservation)
+		assert.Equal(tt, int64(100), inspect.HostConfig.PidsLimit)
+		assert.Equal(tt, 1, len(inspect.HostConfig.Ulimits))
+		assert.Equal(tt, "nofile", inspect.HostConfig.Ulimits[0].Name)
+		assert.Equal(tt, int64(65536), inspect.HostConfig.Ulimits[0].Hard)
+		assert.Equal(tt, int64(1024), inspect.HostConfig.Ulimits[0].Soft)
+		assert.Equal(tt, "on-failure", inspect.HostConfig.RestartPolicy.Name)
+		assert.Equal(tt, 3, inspect.HostConfig.RestartPolicy.MaximumRetryCount)
+		if !nerdtest.IsDocker() {
+			// The docker CI runner warns "Your kernel does not support memory
+			// swappiness capabilities or the cgroup is not mounted" and returns null.
+			assert.Assert(tt, inspect.HostConfig.MemorySwappiness != nil)
+			assert.Equal(tt, int64(60), *inspect.HostConfig.MemorySwappiness)
+		}
+		assert.Equal(tt, "test-val", inspect.HostConfig.Annotations["com.example.key"])
 	})
 
 	testCase.Run(t)
@@ -509,6 +530,14 @@ func TestContainerInspectHostConfigDefaults(t *testing.T) {
 				assert.Equal(tt, hc.ShmSize, inspect.HostConfig.ShmSize)
 				assert.Equal(tt, hc.Runtime, inspect.HostConfig.Runtime)
 				assert.Equal(tt, 0, len(inspect.HostConfig.Devices))
+				assert.Equal(tt, false, inspect.HostConfig.Privileged)
+				assert.Equal(tt, false, inspect.HostConfig.AutoRemove)
+				assert.Equal(tt, int64(0), inspect.HostConfig.MemoryReservation)
+				assert.Equal(tt, int64(0), inspect.HostConfig.PidsLimit)
+				assert.Equal(tt, 0, len(inspect.HostConfig.CapAdd))
+				assert.Equal(tt, 0, len(inspect.HostConfig.CapDrop))
+				assert.Equal(tt, 0, len(inspect.HostConfig.Ulimits))
+				assert.Assert(tt, inspect.HostConfig.MemorySwappiness == nil)
 
 				// Sysctls can be empty or contain "net.ipv4.ip_unprivileged_port_start" depending on the environment.
 				got := len(inspect.HostConfig.Sysctls)
@@ -880,4 +909,72 @@ type hostConfigValues struct {
 	PidMode      string
 	GroupAddSize int
 	Runtime      string
+}
+
+func TestContainerInspectHostConfigPrivileged(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier(),
+			"--privileged",
+			testutil.AlpineImage, "sleep", nerdtest.Infinity)
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("inspect", data.Identifier())
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, tt tig.T) {
+		var dc []dockercompat.Container
+
+		err := json.Unmarshal([]byte(stdout), &dc)
+		assert.NilError(tt, err)
+		assert.Equal(tt, 1, len(dc))
+
+		inspect := dc[0]
+		assert.Equal(tt, true, inspect.HostConfig.Privileged)
+	})
+
+	testCase.Run(t)
+}
+
+func TestContainerInspectHostConfigCapabilities(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier(),
+			"--cap-add", "NET_ADMIN",
+			"--cap-drop", "CHOWN",
+			testutil.AlpineImage, "sleep", nerdtest.Infinity)
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("inspect", data.Identifier())
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, tt tig.T) {
+		var dc []dockercompat.Container
+
+		err := json.Unmarshal([]byte(stdout), &dc)
+		assert.NilError(tt, err)
+		assert.Equal(tt, 1, len(dc))
+
+		inspect := dc[0]
+		assert.Assert(tt, slices.Contains(inspect.HostConfig.CapAdd, "CAP_NET_ADMIN"),
+			"Expected CAP_NET_ADMIN in CapAdd")
+		assert.Assert(tt, slices.Contains(inspect.HostConfig.CapDrop, "CAP_CHOWN"),
+			"Expected CAP_CHOWN in CapDrop")
+	})
+
+	testCase.Run(t)
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -395,6 +395,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	internalLabels.extraHosts = extraHosts
 
 	internalLabels.rm = containerutil.EncodeContainerRmOptLabel(options.Rm)
+	internalLabels.privileged = options.Privileged
 
 	// TODO: abolish internal labels and only use annotations
 	ilOpt, err := withInternalLabels(internalLabels)
@@ -765,6 +766,8 @@ type internalLabels struct {
 	user string
 
 	healthcheck string
+
+	privileged bool
 }
 
 // WithInternalLabels sets the internal labels for a container.
@@ -843,6 +846,10 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 
 	if internalLabels.rm != "" {
 		m[labels.ContainerAutoRemove] = internalLabels.rm
+	}
+
+	if internalLabels.privileged {
+		m[labels.Privileged] = "true"
 	}
 
 	if internalLabels.cidFile != "" {

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -142,26 +142,27 @@ type HostConfig struct {
 	// Binds           []string      // List of volume bindings for this container
 	ContainerIDFile string          // File (path) where the containerId is written
 	LogConfig       loggerLogConfig // Configuration of the logs for this container
-	// NetworkMode     NetworkMode   // Network mode to use for the container
-	PortBindings nat.PortMap // Port mapping between the exposed port (container) and the host
-	// RestartPolicy   RestartPolicy // Restart policy to be used for the container
-	// AutoRemove      bool          // Automatically remove container when it exits
+	NetworkMode     string          // Network mode to use for the container
+	PortBindings    nat.PortMap     // Port mapping between the exposed port (container) and the host
+	RestartPolicy   RestartPolicy   // Restart policy to be used for the container
+	AutoRemove      bool            // Automatically remove container when it exits
 	// VolumeDriver    string        // Name of the volume driver used to mount volumes
 	// VolumesFrom     []string      // List of volumes to take from other container
-	// CapAdd          strslice.StrSlice // List of kernel capabilities to add to the container
-	// CapDrop         strslice.StrSlice // List of kernel capabilities to remove from the container
+	CapAdd  []string // List of kernel capabilities to add to the container
+	CapDrop []string // List of kernel capabilities to remove from the container
 
-	CgroupnsMode string   // Cgroup namespace mode to use for the container
-	DNS          []string `json:"Dns"`        // List of DNS server to lookup
-	DNSOptions   []string `json:"DnsOptions"` // List of DNSOption to look for
-	DNSSearch    []string `json:"DnsSearch"`  // List of DNSSearch to look for
-	ExtraHosts   []string // List of extra hosts
-	GroupAdd     []string // GroupAdd specifies additional groups to join
-	IpcMode      string   `json:"IpcMode"` // IPC namespace to use for the container
+	CgroupnsMode string            // Cgroup namespace mode to use for the container
+	DNS          []string          `json:"Dns"`        // List of DNS server to lookup
+	DNSOptions   []string          `json:"DnsOptions"` // List of DNSOption to look for
+	DNSSearch    []string          `json:"DnsSearch"`  // List of DNSSearch to look for
+	ExtraHosts   []string          // List of extra hosts
+	GroupAdd     []string          // GroupAdd specifies additional groups to join
+	IpcMode      string            `json:"IpcMode"`    // IPC namespace to use for the container
+	Annotations  map[string]string `json:",omitempty"` // Arbitrary non-identifying metadata attached to container and provided to the runtime
 	// Cgroup          CgroupSpec        // Cgroup to use for the container
 	OomScoreAdj int    // specifies the tune container’s OOM preferences (-1000 to 1000, rootless: 100 to 1000)
 	PidMode     string // PID namespace to use for the container
-	// Privileged      bool              // Is the container in privileged mode
+	Privileged  bool   // Is the container in privileged mode
 	// PublishAllPorts bool              // Should docker publish all exposed port for the container
 	ReadonlyRootfs bool // Is the container root filesystem in read-only
 	// SecurityOpt     []string          // List of string values to customize labels for MLS systems, such as SELinux.
@@ -180,6 +181,10 @@ type HostConfig struct {
 	CPURealtimeRuntime int64             `json:"CpuRealtimeRuntime"` // Limits the CPU real-time runtime in microseconds
 	Memory             int64             // Memory limit (in bytes)
 	MemorySwap         int64             // Total memory usage (memory + swap); set `-1` to enable unlimited swap
+	MemoryReservation  int64             // Memory soft limit (in bytes)
+	MemorySwappiness   *int64            // Tuning container memory swappiness (0 to 100); nil means not set
+	PidsLimit          int64             // Setting PIDs limit for a container; 0 or -1 for unlimited
+	Ulimits            []*units.Ulimit   // List of ulimits to be set in the container
 	OomKillDisable     bool              // specifies whether to disable OOM Killer
 	Devices            []DeviceMapping   // List of devices to map inside the container
 	BlkioSettings
@@ -268,6 +273,12 @@ type DeviceMapping struct {
 	CgroupPermissions string
 }
 
+// RestartPolicy represents the restart policies of the container.
+type RestartPolicy struct {
+	Name              string
+	MaximumRetryCount int
+}
+
 type CPUSettings struct {
 	CPUSetCpus         string
 	CPUSetMems         string
@@ -307,6 +318,26 @@ type NetworkEndpointSettings struct {
 	GlobalIPv6PrefixLen int
 	MacAddress          string
 	// TODO DriverOpts          map[string]string
+}
+
+// defaultCaps mirrors containerd's defaultUnixCaps() — the 14 capabilities
+// granted to non-privileged containers by default. Used as the baseline for
+// reconstructing CapAdd/CapDrop from the OCI spec's bounding set.
+var defaultCaps = map[string]struct{}{
+	"CAP_CHOWN":            {},
+	"CAP_DAC_OVERRIDE":     {},
+	"CAP_FSETID":           {},
+	"CAP_FOWNER":           {},
+	"CAP_MKNOD":            {},
+	"CAP_NET_RAW":          {},
+	"CAP_SETGID":           {},
+	"CAP_SETUID":           {},
+	"CAP_SETFCAP":          {},
+	"CAP_SETPCAP":          {},
+	"CAP_NET_BIND_SERVICE": {},
+	"CAP_SYS_CHROOT":       {},
+	"CAP_KILL":             {},
+	"CAP_AUDIT_WRITE":      {},
 }
 
 // ContainerFromNative instantiates a Docker-compatible Container from containerd-native Container.
@@ -500,6 +531,11 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 	c.HostConfig.OomKillDisable = memorySettings.DisableOOMKiller
 	c.HostConfig.Memory = memorySettings.Limit
 	c.HostConfig.MemorySwap = memorySettings.Swap
+	c.HostConfig.MemoryReservation = memorySettings.Reservation
+	if memorySettings.Swappiness != nil {
+		swappiness := int64(*memorySettings.Swappiness)
+		c.HostConfig.MemorySwappiness = &swappiness
+	}
 
 	dnsSettings, err := getDNSFromNative(n.Labels)
 	if err != nil {
@@ -572,6 +608,63 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 	if n.Labels[labels.User] != "" {
 		c.Config.User = n.Labels[labels.User]
 	}
+
+	capAdd, capDrop, err := getCapabilitiesFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get capabilities: %w", err)
+	}
+	c.HostConfig.CapAdd = capAdd
+	c.HostConfig.CapDrop = capDrop
+
+	ulimits, err := getUlimitsFromNative(n.Spec.(*specs.Spec))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ulimits: %w", err)
+	}
+	c.HostConfig.Ulimits = ulimits
+
+	if policyStr := n.Labels[restart.PolicyLabel]; policyStr != "" {
+		rp, err := restart.NewPolicy(policyStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse restart policy: %w", err)
+		}
+		c.HostConfig.RestartPolicy = RestartPolicy{
+			Name:              rp.Name(),
+			MaximumRetryCount: rp.MaximumRetryCount(),
+		}
+	}
+
+	if len(containerAnnotations) > 0 {
+		userAnnotations := make(map[string]string)
+		for k, v := range containerAnnotations {
+			if !strings.HasPrefix(k, labels.Prefix) {
+				userAnnotations[k] = v
+			}
+		}
+		if len(userAnnotations) > 0 {
+			c.HostConfig.Annotations = userAnnotations
+		}
+	}
+
+	if sp, ok := n.Spec.(*specs.Spec); ok {
+		if sp.Linux != nil && sp.Linux.Resources != nil &&
+			sp.Linux.Resources.Pids != nil && sp.Linux.Resources.Pids.Limit != nil {
+			c.HostConfig.PidsLimit = *sp.Linux.Resources.Pids.Limit
+		}
+	}
+
+	if networksJSON := n.Labels[labels.Networks]; networksJSON != "" {
+		var networks []string
+		if err := json.Unmarshal([]byte(networksJSON), &networks); err != nil {
+			return nil, fmt.Errorf("failed to parse networks label: %v", err)
+		}
+		if len(networks) > 0 {
+			c.HostConfig.NetworkMode = networks[0]
+		}
+	}
+
+	c.HostConfig.Privileged = n.Labels[labels.Privileged] == "true"
+
+	c.HostConfig.AutoRemove = n.Labels[labels.ContainerAutoRemove] == "true"
 
 	// Add health check config if present in labels
 	if hConfig, ok := n.Labels[labels.HealthCheck]; ok && hConfig != "" {
@@ -850,6 +943,15 @@ func getMemorySettingsFromNative(sp *specs.Spec) (*MemorySetting, error) {
 		if sp.Linux.Resources.Memory.Swap != nil {
 			res.Swap = *sp.Linux.Resources.Memory.Swap
 		}
+
+		if sp.Linux.Resources.Memory.Reservation != nil {
+			res.Reservation = *sp.Linux.Resources.Memory.Reservation
+		}
+
+		if sp.Linux.Resources.Memory.Swappiness != nil {
+			v := *sp.Linux.Resources.Memory.Swappiness
+			res.Swappiness = &v
+		}
 	}
 	return res, nil
 }
@@ -904,6 +1006,43 @@ func getSysctlFromNative(sp *specs.Spec) (map[string]string, error) {
 	return res, nil
 }
 
+func getCapabilitiesFromNative(sp *specs.Spec) (capAdd, capDrop []string, err error) {
+	if sp.Process == nil || sp.Process.Capabilities == nil {
+		return nil, nil, nil
+	}
+	capAdd = []string{}
+	capDrop = []string{}
+	boundingSet := make(map[string]struct{}, len(sp.Process.Capabilities.Bounding))
+	for _, cap := range sp.Process.Capabilities.Bounding {
+		boundingSet[cap] = struct{}{}
+		if _, isDefault := defaultCaps[cap]; !isDefault {
+			capAdd = append(capAdd, cap)
+		}
+	}
+	for cap := range defaultCaps {
+		if _, present := boundingSet[cap]; !present {
+			capDrop = append(capDrop, cap)
+		}
+	}
+	return capAdd, capDrop, nil
+}
+
+func getUlimitsFromNative(sp *specs.Spec) ([]*units.Ulimit, error) {
+	if sp.Process == nil || len(sp.Process.Rlimits) == 0 {
+		return nil, nil
+	}
+	ulimits := make([]*units.Ulimit, 0, len(sp.Process.Rlimits))
+	for _, rl := range sp.Process.Rlimits {
+		name := strings.ToLower(strings.TrimPrefix(rl.Type, "RLIMIT_"))
+		ulimits = append(ulimits, &units.Ulimit{
+			Name: name,
+			Hard: int64(rl.Hard),
+			Soft: int64(rl.Soft),
+		})
+	}
+	return ulimits, nil
+}
+
 type IPAMConfig struct {
 	Subnet  string `json:"Subnet,omitempty"`
 	Gateway string `json:"Gateway,omitempty"`
@@ -944,9 +1083,11 @@ type structuredCNI struct {
 }
 
 type MemorySetting struct {
-	Limit            int64 `json:"limit"`
-	Swap             int64 `json:"swap"`
-	DisableOOMKiller bool  `json:"disableOOMKiller"`
+	Limit            int64   `json:"limit"`
+	Swap             int64   `json:"swap"`
+	Reservation      int64   `json:"reservation"`
+	Swappiness       *uint64 `json:"swappiness"`
+	DisableOOMKiller bool    `json:"disableOOMKiller"`
 }
 
 // parseNetworkSubnets extracts and parses subnet configurations from IPAM config

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/docker/go-units"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -70,15 +71,46 @@ func TestContainerFromNative(t *testing.T) {
 			n: &native.Container{
 				Container: containers.Container{
 					Labels: map[string]string{
-						"nerdctl/mounts":    "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
-						"nerdctl/state-dir": tempStateDir,
-						"nerdctl/hostname":  "host1",
-						"nerdctl/user":      "test-user",
+						"nerdctl/mounts":               "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
+						"nerdctl/state-dir":            tempStateDir,
+						"nerdctl/hostname":             "host1",
+						"nerdctl/user":                 "test-user",
+						"nerdctl/networks":             `["my-net"]`,
+						"nerdctl/privileged":           "true",
+						"nerdctl/auto-remove":          "true",
+						"containerd.io/restart.policy": "on-failure:3",
 					},
 				},
 				Spec: &specs.Spec{
 					Process: &specs.Process{
 						Env: []string{"/some/path"},
+						Capabilities: &specs.LinuxCapabilities{
+							Bounding: []string{
+								"CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER",
+								"CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID",
+								"CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE",
+								"CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE",
+								"CAP_NET_ADMIN",
+							},
+						},
+						Rlimits: []specs.POSIXRlimit{
+							{Type: "RLIMIT_NOFILE", Hard: 65536, Soft: 1024},
+						},
+					},
+					Linux: &specs.Linux{
+						Resources: &specs.LinuxResources{
+							Memory: &specs.LinuxMemory{
+								Reservation: func() *int64 { v := int64(209715200); return &v }(),
+								Swappiness:  func() *uint64 { v := uint64(60); return &v }(),
+							},
+							Pids: &specs.LinuxPids{
+								Limit: func() *int64 { v := int64(100); return &v }(),
+							},
+						},
+					},
+					Annotations: map[string]string{
+						"nerdctl/state-dir": tempStateDir,
+						"com.example.key":   "user-val",
 					},
 				},
 				Process: &native.Process{
@@ -105,9 +137,20 @@ func TestContainerFromNative(t *testing.T) {
 						Driver: "json-file",
 						Opts:   map[string]string{},
 					},
-					UTSMode:       "host",
-					Tmpfs:         map[string]string{},
-					BlkioSettings: getDefaultBlkioSettings(),
+					UTSMode:           "host",
+					Tmpfs:             map[string]string{},
+					BlkioSettings:     getDefaultBlkioSettings(),
+					NetworkMode:       "my-net",
+					Privileged:        true,
+					AutoRemove:        true,
+					RestartPolicy:     RestartPolicy{Name: "on-failure", MaximumRetryCount: 3},
+					CapAdd:            []string{"CAP_NET_ADMIN"},
+					CapDrop:           []string{},
+					Ulimits:           []*units.Ulimit{{Name: "nofile", Hard: 65536, Soft: 1024}},
+					MemoryReservation: 209715200,
+					MemorySwappiness:  func() *int64 { v := int64(60); return &v }(),
+					PidsLimit:         100,
+					Annotations:       map[string]string{"com.example.key": "user-val"},
 				},
 				Mounts: []MountPoint{
 					{
@@ -121,10 +164,14 @@ func TestContainerFromNative(t *testing.T) {
 				},
 				Config: &Config{
 					Labels: map[string]string{
-						"nerdctl/mounts":    "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
-						"nerdctl/state-dir": tempStateDir,
-						"nerdctl/hostname":  "host1",
-						"nerdctl/user":      "test-user",
+						"nerdctl/mounts":               "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
+						"nerdctl/state-dir":            tempStateDir,
+						"nerdctl/hostname":             "host1",
+						"nerdctl/user":                 "test-user",
+						"nerdctl/networks":             `["my-net"]`,
+						"nerdctl/privileged":           "true",
+						"nerdctl/auto-remove":          "true",
+						"containerd.io/restart.policy": "on-failure:3",
 					},
 					Hostname: "host1",
 					Env:      []string{"/some/path"},
@@ -367,6 +414,193 @@ func TestContainerFromNative(t *testing.T) {
 		t.Run(tc.name, func(tt *testing.T) {
 			d, _ := ContainerFromNative(tc.n)
 			assert.DeepEqual(tt, d, tc.expected)
+		})
+	}
+}
+
+func TestGetCapabilitiesFromNative(t *testing.T) {
+	// Build the full default bounding set for test fixtures.
+	allDefaults := []string{
+		"CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER",
+		"CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID",
+		"CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE",
+		"CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE",
+	}
+
+	testcases := []struct {
+		name            string
+		spec            *specs.Spec
+		expectedCapAdd  []string
+		expectedCapDrop []string
+	}{
+		{
+			name: "default container",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Capabilities: &specs.LinuxCapabilities{
+						Bounding: allDefaults,
+					},
+				},
+			},
+			expectedCapAdd:  []string{},
+			expectedCapDrop: []string{},
+		},
+		{
+			name: "cap added",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Capabilities: &specs.LinuxCapabilities{
+						Bounding: append(allDefaults, "CAP_NET_ADMIN"),
+					},
+				},
+			},
+			expectedCapAdd:  []string{"CAP_NET_ADMIN"},
+			expectedCapDrop: []string{},
+		},
+		{
+			name: "cap dropped",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Capabilities: &specs.LinuxCapabilities{
+						Bounding: func() []string {
+							var caps []string
+							for _, c := range allDefaults {
+								if c != "CAP_CHOWN" {
+									caps = append(caps, c)
+								}
+							}
+							return caps
+						}(),
+					},
+				},
+			},
+			expectedCapAdd:  []string{},
+			expectedCapDrop: []string{"CAP_CHOWN"},
+		},
+		{
+			name: "cap added and dropped",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Capabilities: &specs.LinuxCapabilities{
+						Bounding: func() []string {
+							var caps []string
+							for _, c := range allDefaults {
+								if c != "CAP_CHOWN" {
+									caps = append(caps, c)
+								}
+							}
+							return append(caps, "CAP_NET_ADMIN")
+						}(),
+					},
+				},
+			},
+			expectedCapAdd:  []string{"CAP_NET_ADMIN"},
+			expectedCapDrop: []string{"CAP_CHOWN"},
+		},
+		{
+			name: "empty bounding set",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Capabilities: &specs.LinuxCapabilities{
+						Bounding: []string{},
+					},
+				},
+			},
+			expectedCapAdd:  []string{},
+			expectedCapDrop: allDefaults,
+		},
+		{
+			name:            "nil process",
+			spec:            &specs.Spec{},
+			expectedCapAdd:  nil,
+			expectedCapDrop: nil,
+		},
+		{
+			name: "nil capabilities",
+			spec: &specs.Spec{
+				Process: &specs.Process{},
+			},
+			expectedCapAdd:  nil,
+			expectedCapDrop: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(tt *testing.T) {
+			capAdd, capDrop, err := getCapabilitiesFromNative(tc.spec)
+			assert.NilError(tt, err)
+			assert.DeepEqual(tt, capAdd, tc.expectedCapAdd)
+			// CapDrop order is non-deterministic (map iteration), so check length and contents
+			if tc.expectedCapDrop == nil {
+				assert.Assert(tt, capDrop == nil)
+			} else {
+				assert.Equal(tt, len(capDrop), len(tc.expectedCapDrop))
+				dropSet := make(map[string]struct{}, len(capDrop))
+				for _, c := range capDrop {
+					dropSet[c] = struct{}{}
+				}
+				for _, c := range tc.expectedCapDrop {
+					_, ok := dropSet[c]
+					assert.Assert(tt, ok, "expected %s in CapDrop", c)
+				}
+			}
+		})
+	}
+}
+
+func TestGetUlimitsFromNative(t *testing.T) {
+	testcases := []struct {
+		name     string
+		spec     *specs.Spec
+		expected []*units.Ulimit
+	}{
+		{
+			name: "single rlimit",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Rlimits: []specs.POSIXRlimit{
+						{Type: "RLIMIT_NOFILE", Hard: 65536, Soft: 1024},
+					},
+				},
+			},
+			expected: []*units.Ulimit{
+				{Name: "nofile", Hard: 65536, Soft: 1024},
+			},
+		},
+		{
+			name: "multiple rlimits",
+			spec: &specs.Spec{
+				Process: &specs.Process{
+					Rlimits: []specs.POSIXRlimit{
+						{Type: "RLIMIT_NOFILE", Hard: 65536, Soft: 1024},
+						{Type: "RLIMIT_NPROC", Hard: 4096, Soft: 2048},
+					},
+				},
+			},
+			expected: []*units.Ulimit{
+				{Name: "nofile", Hard: 65536, Soft: 1024},
+				{Name: "nproc", Hard: 4096, Soft: 2048},
+			},
+		},
+		{
+			name: "no rlimits",
+			spec: &specs.Spec{
+				Process: &specs.Process{},
+			},
+			expected: nil,
+		},
+		{
+			name:     "nil process",
+			spec:     &specs.Spec{},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(tt *testing.T) {
+			result, err := getUlimitsFromNative(tc.spec)
+			assert.NilError(tt, err)
+			assert.DeepEqual(tt, result, tc.expected)
 		})
 	}
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -128,4 +128,7 @@ const (
 
 	// HealthState stores the current health state (status and failing streak).
 	HealthState = Prefix + "healthstate"
+
+	// Privileged indicates whether the container was created with --privileged.
+	Privileged = Prefix + "privileged"
 )


### PR DESCRIPTION
This PR populates missing `HostConfig` fields in the dockercompat inspect response, bringing `nerdctl inspect --mode=dockercompat` closer to what consumers expect from Docker's `GET /containers/{id}/json`.

All data comes from sources already available in `ContainerFromNative()` via the OCI spec and container labels.

**OCI spec fields:** `PidsLimit`, `Ulimits`, `MemoryReservation`, `MemorySwappiness`, and `Annotations`. Ulimits are converted from OCI `RLIMIT_*` format to Docker's lowercase format (inverse of `run_ulimit_linux.go`). Annotations are filtered to exclude `nerdctl/` prefixed internal entries.

**Label-based fields:** `NetworkMode` (from `nerdctl/networks`), `RestartPolicy` (parsed from `containerd.io/restart.policy` via `restart.NewPolicy()`), and `AutoRemove` (from `nerdctl/auto-remove`). These labels already exist — we're just populating the fields.

**Privileged:** The OCI spec doesn't store a "privileged" flag; it just applies all caps and device access. Inferring that from the spec is fragile, so we store a `nerdctl/privileged` label at creation time and read it back at inspect. This required minor additions to `create.go` and `labels.go`.

**CapAdd/CapDrop:** nerdctl doesn't persist the original `--cap-add`/`--cap-drop` flags; only the resulting OCI bounding set survives. We reconstruct by diffing the bounding set against containerd's 14 default capabilities ([containerd source](https://github.com/containerd/containerd/blob/main/pkg/oci/spec.go), [moby source](https://github.com/moby/moby/blob/master/daemon/pkg/oci/caps/defaults.go) — same set). Caps in bounding but not in defaults → CapAdd. Defaults not in bounding → CapDrop. There's a slight difference from Docker when --cap-add ALL is used: Docker stores and returns the literal ["ALL"], while we show the expanded list since we only have the OCI spec. This is functionally equivalent. 

**Testing:**
- Unit: `TestGetCapabilitiesFromNative` (7 cases), `TestGetUlimitsFromNative` (4 cases), extended "container from nerdctl" in `TestContainerFromNative` with all new fields.
- Integration: extended `TestContainerInspectHostConfig` with resource and label flags + assertions, extended `TestContainerInspectHostConfigDefaults` with zero-value checks. Added `TestContainerInspectHostConfigPrivileged` (rootful only) and `TestContainerInspectHostConfigCapabilities` as separate tests since privileged requires root and conflicts with cap flags.