### PR TITLE
fix: support human-readable sizes for fluentd-buffer-limit log option

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -365,7 +365,7 @@ Logging flags:
     - The `fluentd` logging driver supports the following logging options:
       - :whale: `--log-opt=fluentd-address=<ADDRESS>`: The address of the `fluentd` daemon, tcp(default) and unix sockets are supported..
       - :whale: `--log-opt=fluentd-async=<true|false>`: Enable async mode for fluentd. The default value is false.
-      - :whale: `--log-opt=fluentd-buffer-limit=<LIMIT>`: The buffer limit for fluentd. If the buffer is full, the call to record logs will fail. The default is 8192. (<https://github.com/fluent/fluent-logger-golang/tree/master#bufferlimit>)
+      - :whale: `--log-opt=fluentd-buffer-limit=<LIMIT>`: The buffer limit for fluentd. If the buffer is full, the call to record logs will fail. The default is 1MiB. Accepts human-readable sizes (e.g., `1KiB`, `1MiB`, `1GiB`) or raw byte values. (<https://github.com/fluent/fluent-logger-golang/tree/master#bufferlimit>)
       - :whale: `--log-opt=fluentd-retry-wait=<1s|1ms>`: The time to wait before retrying to send logs to fluentd. The default value is 1s.
       - :whale: `--log-opt=fluentd-max-retries=<1>`: The maximum number of retries to send logs to fluentd. The default value is MaxInt32.
       - :whale: `--log-opt=fluentd-sub-second-precision=<true|false>`: Enable sub-second precision for fluentd. The default value is false.

--- a/pkg/logging/fluentd_logger.go
+++ b/pkg/logging/fluentd_logger.go
@@ -27,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	units "github.com/docker/go-units"
 	"github.com/fluent/fluent-logger-golang/fluent"
 
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
@@ -223,10 +224,14 @@ func parseFluentdConfig(config map[string]string) (fluent.Config, error) {
 	}
 	bufferLimit := defaultBufferLimit
 	if config[fluentdBufferLimit] != "" {
-		bufferLimit, err = strconv.Atoi(config[fluentdBufferLimit])
+		parsedBufferLimit, err := units.RAMInBytes(config[fluentdBufferLimit])
 		if err != nil {
 			return result, fmt.Errorf("error occurs %w,invalid buffer limit (%s)", err, config[fluentdBufferLimit])
 		}
+		if parsedBufferLimit > int64(math.MaxInt) {
+			return result, fmt.Errorf("invalid buffer limit: value %d overflows int", parsedBufferLimit)
+		}
+		bufferLimit = int(parsedBufferLimit)
 	}
 	retryWait := int(defaultRetryWait)
 	if config[fluentdRetryWait] != "" {

--- a/pkg/logging/fluentd_logger_test.go
+++ b/pkg/logging/fluentd_logger_test.go
@@ -229,6 +229,27 @@ func TestParseFluentdConfig(t *testing.T) {
 				AsyncReconnectInterval: 0,
 				SubSecondPrecision:     false,
 				RequestAck:             true}, false},
+		{"HumanReadableBufferLimit", args{
+			config: map[string]string{
+				fluentdBufferLimit: "1M",
+			}},
+			fluent.Config{
+				FluentPort:             defaultPort,
+				FluentHost:             defaultHost,
+				FluentNetwork:          defaultProtocol,
+				FluentSocketPath:       "",
+				BufferLimit:            defaultBufferLimit,
+				RetryWait:              int(defaultRetryWait),
+				MaxRetry:               defaultMaxRetries,
+				Async:                  false,
+				AsyncReconnectInterval: 0,
+				SubSecondPrecision:     false,
+				RequestAck:             false}, false},
+		{"InvalidHumanReadableBufferLimit", args{
+			config: map[string]string{
+				fluentdBufferLimit: "not-a-size",
+			}},
+			fluent.Config{}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

`fluentd-buffer-limit` currently accepts only raw integer values in `nerdctl`.  
In Docker-compatible workflows, users may specify human-readable values such as:

```
... --log-opt fluentd-buffer-limit=16M ...
```

## Fix

Use github.com/docker/go-units to parse fluentd-buffer-limit.  
This allows nerdctl to accept human-readable values such as 16M and 16MiB in addition to raw byte values.