### PR TITLE
fix: wait for logger to finish before reading logs of stopped containers

### DIFF
--- a/pkg/cmd/container/logs.go
+++ b/pkg/cmd/container/logs.go
@@ -105,6 +105,14 @@ func Logs(ctx context.Context, client *containerd.Client, container string, opti
 				}
 			}
 
+			// When follow was requested but the task has already stopped,
+			// wait for the logger to finish writing before reading the log file.
+			if !follow && options.Follow {
+				if err := logging.WaitForLogger(dataStore, l[labels.Namespace], found.Container.ID()); err != nil {
+					log.G(ctx).WithError(err).Warn("failed to wait for logger shutdown")
+				}
+			}
+
 			var detailPrefix string
 			if options.Details {
 				if logConfigJSON, ok := l["nerdctl/log-config"]; ok {


### PR DESCRIPTION
`TestLogsFollowNoExtraneousLineFeed` sometimes fails on CI.

- https://github.com/containerd/nerdctl/actions/runs/24197307638/job/71240723501?pr=4835
- https://github.com/containerd/nerdctl/actions/runs/24197307638/job/71215370984?pr=4835

```bash
        +------------------------------------------------------------------------------------------------------------+
        | ➡️      | ⚙️ /usr/local/bin/nerdctl.gomodjail run --name testlogsfollownoextraneouslinefeed-f5d64e9b ghcr. |
        |         | io/stargz-containers/alpine:3.13-org sh -c printf 'Hello without newline'                        |
        +------------------------------------------------------------------------------------------------------------+
        |         | 🟢 Hello without newline
...
    container_logs_test.go:562: 	🔗

        <<<<<<<<<<<<<<<<<<<<
        	🖊️ Inspecting output (equals)
        	👀 testing:		``
        	❌ FAILED!		= `Hello without newline`
        >>>>>>>>>>>>>>>>>>>>
```

My Investigation revealed that the flakiness of
`TestLogsFollowNoExtraneousLineFeed` is caused by `nerdctl logs -f` not waiting for the logger to finish writing when the container has already stopped.

Therefore, this commit fixes `nerdctl logs -f` to wait for the logger to finish writing when the container has already stopped.

This commit should fix the flakiness of `TestLogsFollowNoExtraneousLineFeed`.

After applying this fix, running the test **1000 times** showed no flakiness.

```bash
$ sudo go test -count=1000 -run '^TestLogsFollowNoExtraneousLineFeed$'
test target: "nerdctl"
PASS
ok  	github.com/containerd/nerdctl/v2/cmd/nerdctl/container	419.653s
```