### PR TITLE
fix: free reserved ports in rootful mode

### DIFF
--- a/pkg/cmd/container/stop.go
+++ b/pkg/cmd/container/stop.go
@@ -27,6 +27,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
+	"github.com/containerd/nerdctl/v2/pkg/ocihook"
 )
 
 // Stop stops a list of containers specified by `reqs`.
@@ -49,6 +50,9 @@ func Stop(ctx context.Context, client *containerd.Client, reqs []string, opt typ
 					return nil
 				}
 				return err
+			}
+			if err := ocihook.CleanupPortReserverProcess(opt.GOptions.Namespace, found.Container.ID()); err != nil {
+				return fmt.Errorf("unable to cleanup port reserver process for container: %s: %w", found.Req, err)
 			}
 			_, err := fmt.Fprintln(opt.Stdout, found.Req)
 			return err

--- a/pkg/ocihook/ocihook.go
+++ b/pkg/ocihook/ocihook.go
@@ -456,8 +456,24 @@ func reserveSocket(protocol, hostAddr string) (*os.File, error) {
 }
 
 // portReserverPidFilePath returns /run/nerdctl/<namespace>/<id>/port-reserver.pid
-func portReserverPidFilePath(opts *handlerOpts) string {
-	return filepath.Join("/run/nerdctl/", opts.state.Annotations[labels.Namespace], opts.state.ID, "port-reserver.pid")
+func portReserverPidFilePath(namespace, id string) string {
+	return filepath.Join("/run/nerdctl/", namespace, id, "port-reserver.pid")
+}
+
+func CleanupPortReserverProcess(namespace, id string) error {
+	// In rootless mode, port-reserver is handled by Rootlesskit, so no cleanup is needed.
+	if rootlessutil.IsRootlessChild() {
+		return nil
+	}
+
+	pidFile := portReserverPidFilePath(namespace, id)
+	if err := killProcessByPidFile(pidFile); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(filepath.Dir(pidFile)); err != nil {
+		log.L.WithError(err).Errorf("failed to remove the port-reserver directory %s", filepath.Dir(pidFile))
+	}
+	return nil
 }
 
 func applyNetworkSettings(opts *handlerOpts) (err error) {
@@ -503,10 +519,10 @@ func applyNetworkSettings(opts *handlerOpts) (err error) {
 			if err != nil {
 				log.L.Debugf("killing the port reserver process (pid=%d)", reserverCmdPid)
 				_ = reserverCmd.Process.Kill()
-				_ = os.RemoveAll(filepath.Dir(portReserverPidFilePath(opts)))
+				_ = os.RemoveAll(filepath.Dir(portReserverPidFilePath(opts.state.Annotations[labels.Namespace], opts.state.ID)))
 			}
 		}()
-		if err := writePidFile(portReserverPidFilePath(opts), reserverCmdPid); err != nil {
+		if err := writePidFile(portReserverPidFilePath(opts.state.Annotations[labels.Namespace], opts.state.ID), reserverCmdPid); err != nil {
 			return fmt.Errorf("cannot write the pid file of the port reserver process: %w", err)
 		}
 	}
@@ -745,12 +761,8 @@ func onPostStop(opts *handlerOpts) error {
 		return fmt.Errorf("failed to release container name %s: %w", name, err)
 	}
 	// Kill port-reserver process if any
-	portReserverPidFile := portReserverPidFilePath(opts)
-	if err = killProcessByPidFile(portReserverPidFile); err != nil {
+	if err = CleanupPortReserverProcess(ns, opts.state.ID); err != nil {
 		log.L.WithError(err).Errorf("failed to kill the port-reserver process")
-	}
-	if err := os.RemoveAll(filepath.Dir(portReserverPidFile)); err != nil {
-		log.L.WithError(err).Errorf("failed to remove the port-reserver directory %s", filepath.Dir(portReserverPidFile))
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #4843

This PR reuses the existing clean-up logic in `pkg/ocihook/ocihook.go` on `nerdctl stop` to free up reserved ports in rootful mode.