### PR TITLE
docs: fix missing list prefix for --security-opt label entry

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -255,7 +255,7 @@ Security flags:
 
 - :whale: `--security-opt seccomp=<PROFILE_JSON_FILE>`: specify custom seccomp profile
 - :whale: `--security-opt apparmor=<PROFILE>`: specify custom AppArmor profile
-  :whale: `--security-opt label=<selinuxlabel>`: specify custom selinux label
+- :whale: `--security-opt label=<selinuxlabel>`: specify custom selinux label
 - :whale: `--security-opt no-new-privileges`: disallow privilege escalation, e.g., setuid and file capabilities
 - :whale: `--security-opt systempaths=unconfined`: Turn off confinement for system paths (masked paths, read-only paths) for the container
 - :whale: `--security-opt writable-cgroups`: making the cgroups writeable


### PR DESCRIPTION
The `--security-opt label=<selinuxlabel>` entry was added in #4639 but
was indented with two spaces as a continuation of the line above rather
than as its own Markdown list item. This causes it to render as
sub-content of the `--security-opt apparmor` bullet instead of a
sibling entry.

Change the leading `  ` to `- ` to match all other entries in the
Security flags list.

Partial fix for #3867.