### PR TITLE
fix: update status label should call after task is started

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/containerd/console"
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
@@ -464,6 +465,18 @@ func runAction(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := task.Start(ctx); err != nil {
+		return err
+	}
+
+	// Set status label running should call after task is started.
+	_, restartPolicyExist := lab[restart.PolicyLabel]
+	if restartPolicyExist {
+		if err := containerutil.UpdateStatusLabel(ctx, c, containerd.Running); err != nil {
+			return err
+		}
+	}
+
+	if err := containerutil.UpdateExplicitlyStoppedLabel(ctx, c, false); err != nil {
 		return err
 	}
 

--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -27,6 +27,8 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/poll"
 
+	"github.com/containerd/containerd/v2/core/runtime/restart"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
@@ -182,4 +184,19 @@ func TestAddRestartPolicy(t *testing.T) {
 	poll.WaitOn(t, check, poll.WithDelay(100*time.Microsecond), poll.WithTimeout(60*time.Second))
 	inspect = base.InspectContainer(tID)
 	assert.Equal(t, inspect.RestartCount, 1)
+}
+
+func TestRunRestartStatusLabel(t *testing.T) {
+	base := testutil.NewBase(t)
+	if !nerdtest.IsDocker() {
+		testutil.RequireContainerdPlugin(base, "io.containerd.internal.v1", "restart", []string{"always"})
+	}
+	tID := testutil.Identifier(t)
+	defer base.Cmd("rm", "-f", tID).Run()
+	base.Cmd("create", "--restart=always", "--name", tID, testutil.CommonImage, "sleep", "infinity").AssertOK()
+
+	inspect := base.InspectContainer(tID)
+	label := inspect.Config.Labels
+	statusLabel := label[restart.StatusLabel]
+	assert.Assert(t, statusLabel == "")
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -280,7 +280,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		internalLabels.logConfig.Driver = "json-file"
 	}
 
-	restartOpts, err := generateRestartOpts(ctx, client, options.Restart, logConfig.LogURI, options.InRun)
+	restartOpts, err := generateRestartOpts(ctx, client, options.Restart, logConfig.LogURI)
 	if err != nil {
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
 	}

--- a/pkg/cmd/container/run_restart.go
+++ b/pkg/cmd/container/run_restart.go
@@ -51,7 +51,7 @@ func checkRestartCapabilities(ctx context.Context, client *containerd.Client, re
 	return true, nil
 }
 
-func generateRestartOpts(ctx context.Context, client *containerd.Client, restartFlag, logURI string, inRun bool) ([]containerd.NewContainerOpts, error) {
+func generateRestartOpts(ctx context.Context, client *containerd.Client, restartFlag, logURI string) ([]containerd.NewContainerOpts, error) {
 	if restartFlag == "" || restartFlag == "no" {
 		return nil, nil
 	}
@@ -63,11 +63,7 @@ func generateRestartOpts(ctx context.Context, client *containerd.Client, restart
 	if err != nil {
 		return nil, err
 	}
-	desireStatus := containerd.Created
-	if inRun {
-		desireStatus = containerd.Running
-	}
-	opts := []containerd.NewContainerOpts{restart.WithPolicy(policy), restart.WithStatus(desireStatus)}
+	opts := []containerd.NewContainerOpts{restart.WithPolicy(policy)}
 	if logURI != "" {
 		opts = append(opts, restart.WithLogURIString(logURI))
 	}

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -257,16 +257,6 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		return nil
 	}
 
-	_, restartPolicyExist := lab[restart.PolicyLabel]
-	if restartPolicyExist {
-		if err := UpdateStatusLabel(ctx, container, containerd.Running); err != nil {
-			return err
-		}
-	}
-
-	if err := UpdateExplicitlyStoppedLabel(ctx, container, false); err != nil {
-		return err
-	}
 	if oldTask, err := container.Task(ctx, nil); err == nil {
 		if _, err := oldTask.Delete(ctx); err != nil {
 			log.G(ctx).WithError(err).Debug("failed to delete old task")
@@ -299,6 +289,17 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		return err
 	}
 	if err := task.Start(ctx); err != nil {
+		return err
+	}
+
+	// Set status label running should call after task is started.
+	_, restartPolicyExist := lab[restart.PolicyLabel]
+	if restartPolicyExist {
+		if err := UpdateStatusLabel(ctx, container, containerd.Running); err != nil {
+			return err
+		}
+	}
+	if err := UpdateExplicitlyStoppedLabel(ctx, container, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
fix: https://github.com/containerd/containerd/pull/13350
how it happened
nerdctl run -d --restart=always busybox sleep 10000
step 1
```
	task, err := taskutil.NewTask(ctx, client, c, taskutil.TaskOptions{
		AttachStreamOpt: createOpt.Attach,
		IsInteractive:   createOpt.Interactive,
		IsTerminal:      createOpt.TTY,
		IsDetach:        createOpt.Detach,
		Con:             con,
		LogURI:          logURI,
		DetachKeys:      createOpt.DetachKeys,
		Namespace:       createOpt.GOptions.Namespace,
		DetachC:         detachC,
		CheckpointDir:   "",
	})
```
after  taskutil.NewTask task is created

setp 2
containerd find desiredStatus is running but task != running (task status is created)
```
	desiredStatus := containerd.ProcessStatus(labels[restart.StatusLabel])
		if task, err = c.Task(ctx, nil); err == nil {
			if status, err = task.Status(ctx); err == nil {
				if desiredStatus == status.Status {
					continue
				}
			}
```

step 3.   nerdctl start the task sucessfully 
step 4   containerd will kill and delete task   (containerd find task is not running but actually is running  )
step5 : nerdctl exec failed 
step6:  containerd recreate the task  
@AkihiroSuda  @ChengyuZhu6  can you take a look ?