### PR TITLE
fix: handle CNI config stat errors without panic

### DIFF
--- a/pkg/netutil/netutil_test.go
+++ b/pkg/netutil/netutil_test.go
@@ -366,3 +366,16 @@ func TestNetworkWithDefaultNameAlreadyExists(t *testing.T) {
 	assert.Assert(t, len(defaultNamedNetworksFileDefinitions) == 1)
 	assert.Assert(t, defaultNamedNetworksFileDefinitions[0] == testConfFile)
 }
+
+func TestFSExistsPropagatesStatError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cni-conf-root")
+	assert.NilError(t, filesystem.WriteFile(path, nil, 0600))
+
+	cniEnv := CNIEnv{
+		NetconfPath: path,
+	}
+
+	exists, err := fsExists(&cniEnv, DefaultNetworkName)
+	assert.Assert(t, !exists)
+	assert.Assert(t, err != nil)
+}

--- a/pkg/netutil/store.go
+++ b/pkg/netutil/store.go
@@ -53,7 +53,10 @@ func fsRemove(e *CNIEnv, net *NetworkConfig) error {
 
 func fsExists(e *CNIEnv, name string) (bool, error) {
 	fi, err := os.Stat(getConfigPathForNetworkName(e, name))
-	return !os.IsNotExist(err) && !fi.IsDir(), err
+	if err != nil {
+		return false, err
+	}
+	return !fi.IsDir(), nil
 }
 
 func fsWrite(e *CNIEnv, net *NetworkConfig) error {


### PR DESCRIPTION
Small fix for a CNI config path footgun.

If `--cni-netconfpath` / `$NETCONFPATH` points at a regular file, `fsExists` gets a stat error and then derefs a nil `FileInfo`. Boom: panic. This can happen from a bad local path, no weird infra limit needed.

Repro:
1. Add `TestFSExistsPropagatesStatError` from this PR on `main`.
2. Run `go test ./pkg/netutil -run TestFSExistsPropagatesStatError -count=1`.
3. It panics at `pkg/netutil/store.go:56`.

This returns the stat error instead, and keeps missing-file behavior intact.

Tests:
- `go test ./pkg/netutil -run TestFSExistsPropagatesStatError -count=1`
- `go test ./pkg/netutil -count=1`
- `go test ./pkg/...`