### PR TITLE
ci: fix test logs on linux

### DIFF
--- a/cmd/nerdctl/container/container_logs_test.go
+++ b/cmd/nerdctl/container/container_logs_test.go
@@ -37,97 +37,144 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
-func TestLogs(t *testing.T) {
-	const expected = `foo
+const expected = `foo
 bar
 `
+const ExitSuccess = 0
 
+func newLogTestCase(name string) *test.Case {
 	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", name)
+	}
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "--quiet", "--name", name, testutil.CommonImage,
+			"sh", "-euxc", "echo foo; echo bar;")
+	}
+	return testCase
+}
 
-	testCase.Require = nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/4782")
+func TestLogs_Since1s(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
 	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
 		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
 	}
+	testCase.SubTests = []*test.Case{{
+		Description: "since 1s",
+		Setup: func(data test.Data, helpers test.Helpers) {
+			// Ensure at least 2 seconds have elapsed since the container ran,
+			// so that --since 1s does not include the container's output.
+			time.Sleep(2 * time.Second)
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "--since", "1s", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.DoesNotContain(expected)),
+	}}
+	testCase.Run(t)
+}
 
-	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
-		helpers.Anyhow("rm", "-f", data.Identifier())
+func TestLogs_Since60s(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
 	}
+	testCase.SubTests = []*test.Case{{
+		Description: "since 60s",
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "--since", "60s", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.Equals(expected)),
+	}}
+	testCase.Run(t)
+}
 
-	testCase.Setup = func(data test.Data, helpers test.Helpers) {
-		helpers.Ensure("run", "--quiet", "--name", data.Identifier(), testutil.CommonImage, "sh", "-euxc", "echo foo; echo bar;")
-		data.Labels().Set("cID", data.Identifier())
+func TestLogs_Until60s(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
 	}
+	testCase.SubTests = []*test.Case{{
+		Description: "until 60s",
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "--until", "60s", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.DoesNotContain(expected)),
+	}}
+	testCase.Run(t)
+}
 
-	testCase.SubTests = []*test.Case{
-		{
-			Description: "since 1s",
-			Setup: func(data test.Data, helpers test.Helpers) {
-				// Ensure at least 2 seconds have elapsed since the container ran,
-				// so that --since 1s does not include the container's output.
-				time.Sleep(2 * time.Second)
-			},
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "--since", "1s", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.DoesNotContain(expected)),
-		},
-		{
-			Description: "since 60s",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "--since", "60s", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.Equals(expected)),
-		},
-		{
-			Description: "until 60s",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "--until", "60s", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.DoesNotContain(expected)),
-		},
-		{
-			Description: "until 1s",
-			Setup: func(data test.Data, helpers test.Helpers) {
-				// Ensure at least 2 seconds have elapsed since the container ran,
-				// so that --until 1s includes the container's output.
-				time.Sleep(2 * time.Second)
-			},
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "--until", "1s", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.Equals(expected)),
-		},
-		{
-			Description: "follow",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "-f", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.Equals(expected)),
-		},
-		{
-			Description: "timestamp",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "-t", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.Contains(time.Now().UTC().Format("2006-01-02"))),
-		},
-		{
-			Description: "tail flag",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "-n", "all", data.Labels().Get("cID"))
-			},
-			Expected: test.Expects(0, nil, expect.Equals(expected)),
-		},
-		{
-			Description: "tail flag",
-			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				return helpers.Command("logs", "-n", "1", data.Labels().Get("cID"))
-			},
-			// FIXME: why?
-			Expected: test.Expects(0, nil, expect.Match(regexp.MustCompile("^(?:bar\n|)$"))),
-		},
+func TestLogs_Until1s(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
 	}
+	testCase.SubTests = []*test.Case{{
+		Description: "until 1s",
+		// Ensure at least 2 seconds have elapsed since the container ran,
+		// so that --until 1s includes the container's output.
+		Setup: func(data test.Data, helpers test.Helpers) {
+			time.Sleep(2 * time.Second)
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "--until", "1s", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.Equals(expected)),
+	}}
+	testCase.Run(t)
+}
 
+func TestLogs_Follow(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
+	}
+	testCase.SubTests = []*test.Case{{
+		Description: "follow",
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "-f", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.Equals(expected)),
+	}}
+	testCase.Run(t)
+}
+
+func TestLogs_Timestamp(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
+	}
+	testCase.SubTests = []*test.Case{{
+		Description: "timestamp",
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "-t", t.Name())
+		},
+		Expected: test.Expects(ExitSuccess, nil, expect.Contains(time.Now().UTC().Format("2006-01-02"))),
+	}}
+	testCase.Run(t)
+}
+
+func TestLogs_Tail1(t *testing.T) {
+	testCase := newLogTestCase(t.Name())
+	if runtime.GOOS == "windows" {
+		// Logging seems broken on windows.
+		testCase.Require = nerdtest.NerdctlNeedsFixing("https://github.com/containerd/nerdctl/issues/4237")
+	}
+	testCase.SubTests = []*test.Case{{
+		Description: "tail flag",
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("logs", "-n", "1", t.Name())
+		},
+		// FIXME: why?
+		Expected: test.Expects(ExitSuccess, nil, expect.Match(regexp.MustCompile("^(?:bar\n|)$"))),
+	}}
 	testCase.Run(t)
 }
 


### PR DESCRIPTION
call "nerdctl  logs --untils " time is 16:03:19
```
2026-05-11T16:09:34.1135624Z 2026/05/11 16:03:19  binary is /usr/local/bin/nerdctl arg is [logs --until 60s testlogs001] 
```
but  json logs time is 16:01:40.459948268Z
```
logs --until 60s testlogs001]*******content is:{"log":"+ echo foo\n","stream":"stderr","time":"2026-05-11T16:01:40.459948277Z"}
2026-05-11T16:09:34.1137555Z {"log":"+ echo bar\n","stream":"stderr","time":"2026-05-11T16:01:40.461456573Z"}
2026-05-11T16:09:34.1137691Z {"log":"foo\n","stream":"stdout","time":"2026-05-11T16:01:40.459948268Z"}
```
the root reason should be the number exceeds the maximum concurrent test case limit, and some test cases will be queued .
The default concurrency of t.Parallel() is the number of CPU cores.
so we can't run many  testcase at a same time in test logs because it is Time-critical testcase.
fix https://github.com/containerd/nerdctl/issues/4889
@AkihiroSuda 