### PR TITLE
Compose down to accept a list of services

### DIFF
--- a/cmd/nerdctl/compose/compose_down.go
+++ b/cmd/nerdctl/compose/compose_down.go
@@ -27,9 +27,8 @@ import (
 
 func downCommand() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:           "down",
+		Use:           "down [flags] [SERVICE...]",
 		Short:         "Remove containers and associated resources",
-		Args:          cobra.NoArgs,
 		RunE:          downAction,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -39,7 +38,7 @@ func downCommand() *cobra.Command {
 	return cmd
 }
 
-func downAction(cmd *cobra.Command, args []string) error {
+func downAction(cmd *cobra.Command, services []string) error {
 	globalOptions, err := helpers.ProcessRootCmdFlags(cmd)
 	if err != nil {
 		return err
@@ -62,6 +61,8 @@ func downAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	options.Services = services
+
 	c, err := compose.New(client, globalOptions, options, cmd.OutOrStdout(), cmd.ErrOrStderr())
 	if err != nil {
 		return err
@@ -71,5 +72,5 @@ func downAction(cmd *cobra.Command, args []string) error {
 		RemoveVolumes: volumes,
 		RemoveOrphans: removeOrphans,
 	}
-	return c.Down(ctx, downOpts)
+	return c.Down(ctx, downOpts, services)
 }

--- a/cmd/nerdctl/compose/compose_down_linux_test.go
+++ b/cmd/nerdctl/compose/compose_down_linux_test.go
@@ -152,3 +152,67 @@ services:
 
 	testCase.Run(t)
 }
+
+func TestComposeDownRemoveSpecifiedService(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		dockerComposeYAML := fmt.Sprintf(`
+services:
+  test1:
+    image: %s
+    command: "sleep infinity"
+  test2:
+    image: %s
+    command: "sleep infinity"
+`, testutil.CommonImage, testutil.CommonImage)
+		composePath := data.Temp().Save(dockerComposeYAML, "compose.yaml")
+
+		projectName := data.Identifier("project")
+		t.Logf("projectName=%q", projectName)
+
+		testContainer1 := serviceparser.DefaultContainerName(projectName, "test1", "1")
+		testContainer2 := serviceparser.DefaultContainerName(projectName, "test2", "1")
+
+		data.Labels().Set("composePath", composePath)
+		data.Labels().Set("projectName", projectName)
+		data.Labels().Set("testContainer1", testContainer1)
+		data.Labels().Set("testContainer2", testContainer2)
+
+		helpers.Ensure("compose", "-p", projectName, "-f", composePath, "up", "-d")
+		nerdtest.EnsureContainerStarted(helpers, testContainer1)
+		nerdtest.EnsureContainerStarted(helpers, testContainer2)
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("compose", "-p", data.Labels().Get("projectName"), "-f", data.Labels().Get("composePath"), "down", "test1")
+	}
+
+	testCase.Expected = test.Expects(0, nil, nil)
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "only specified service is removed",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("compose", "-p", data.Labels().Get("projectName"), "-f", data.Labels().Get("composePath"), "ps", "-a")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: 0,
+					Output: expect.All(
+						expect.DoesNotContain(data.Labels().Get("testContainer1")),
+						expect.Contains(data.Labels().Get("testContainer2")),
+					),
+				}
+			},
+		},
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		if composePath := data.Labels().Get("composePath"); composePath != "" {
+			helpers.Anyhow("compose", "-p", data.Labels().Get("projectName"), "-f", composePath, "down", "-v")
+		}
+	}
+
+	testCase.Run(t)
+}

--- a/pkg/composer/down.go
+++ b/pkg/composer/down.go
@@ -28,10 +28,11 @@ import (
 type DownOptions struct {
 	RemoveVolumes bool
 	RemoveOrphans bool
+	Services      []string
 }
 
-func (c *Composer) Down(ctx context.Context, downOptions DownOptions) error {
-	serviceNames, err := c.ServiceNames()
+func (c *Composer) Down(ctx context.Context, downOptions DownOptions, services []string) error {
+	serviceNames, err := c.ServiceNames(services...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
runing `compose down <service-name>` with a list of service names fails with an error `unknown command <service-name> for down`.

However, this work with docker-compose without an issue, and also work for `compose up`.

This PR address the issue by passing on args to downAction and if present, only specified services will be stoped and removed. 