### PR TITLE
docs: fix sig-proxy flag spelling

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -155,7 +155,7 @@ Basic flags:
 - :whale: `-i, --interactive`: Keep STDIN open even if not attached"
 - :whale: `-t, --tty`: Allocate a pseudo-TTY
   - :warning: WIP: currently `-t` conflicts with `-d`
-- :whale: `-sig-proxy`: Proxy received signals to the process (default true)
+- :whale: `--sig-proxy`: Proxy received signals to the process (default true)
 - :whale: `-d, --detach`: Run container in background and print container ID
 - :whale: `--restart=(no|always|on-failure|unless-stopped)`: Restart policy to apply when a container exits
   - Default: "no"


### PR DESCRIPTION
## Summary
- fix the run command reference to document `--sig-proxy` with the correct long flag spelling

## Testing
- git diff --check