### PR TITLE
ci: add zizmor workflow linting

### DIFF
--- a/.github/workflows/ghcr-image-build-and-publish.yml
+++ b/.github/workflows/ghcr-image-build-and-publish.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       # FIXME: setup-qemu-action is depended by `gomodjail pack`
       - name: Set up QEMU

--- a/.github/workflows/job-build.yml
+++ b/.github/workflows/job-build.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve GO_VERSION"

--- a/.github/workflows/job-lint-go.yml
+++ b/.github/workflows/job-lint-go.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - if: ${{ inputs.canary }}
         name: "Init (canary): retrieve GO_VERSION"
@@ -74,5 +75,7 @@ jobs:
           if [ "${{ inputs.canary }}" == "true" ]; then
             NO_COLOR=true make lint-go-all
           else
-            NO_COLOR=true GOOS="${{ inputs.goos }}" make lint-go
+            NO_COLOR=true GOOS="${INPUTS_GOOS}" make lint-go
           fi
+        env:
+          INPUTS_GOOS: ${{ inputs.goos }}

--- a/.github/workflows/job-lint-other.yml
+++ b/.github/workflows/job-lint-other.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Run: yaml"
         run: |

--- a/.github/workflows/job-lint-project.yml
+++ b/.github/workflows/job-lint-project.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           fetch-depth: 100
           path: src/github.com/containerd/nerdctl
+          persist-credentials: false
 
       - name: "Init: install go"
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0

--- a/.github/workflows/job-test-dependencies.yml
+++ b/.github/workflows/job-test-dependencies.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Init: expose GitHub Runtime variables for gha"
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487  # v4.0.0
@@ -41,14 +42,15 @@ jobs:
       - name: "Run: build dependencies for the integration test environment image"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_CONTAINERD_VERSION: ${{ inputs.containerd-version }}
         run: |
           # Cache is sharded per-architecture
           arch=${{ env.RUNNER_ARCH == 'ARM64' && 'arm64' || 'amd64' }}
           docker buildx create --name with-gha --use
           # Honor old containerd if requested
           args=()
-          if [ "${{ inputs.containerd-version }}" != "" ]; then
-            args=(--build-arg CONTAINERD_VERSION=${{ inputs.containerd-version }})
+          if [ "${INPUTS_CONTAINERD_VERSION}" != "" ]; then
+            args=(--build-arg CONTAINERD_VERSION=${INPUTS_CONTAINERD_VERSION})
           fi
           docker buildx build \
             --secret id=github_token,env=GITHUB_TOKEN \

--- a/.github/workflows/job-test-in-container.yml
+++ b/.github/workflows/job-test-in-container.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Init: expose GitHub Runtime variables for gha"
         uses: crazy-max/ghaction-github-runtime@04d248b84655b509d8c44dc1d6f990c879747487  # v4.0.0
@@ -98,18 +99,21 @@ jobs:
         name: "Init: prepare test image"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_CONTAINERD_VERSION: ${{ inputs.containerd-version }}
+          INPUTS_TARGET: ${{ inputs.target }}
+          INPUTS_ROOTLESSKIT_VERSION: ${{ inputs.rootlesskit-version }}
         run: |
           buildargs=()
           # If the runner is old, use old ubuntu inside the container as well
           [ "${{ contains(inputs.runner, '22.04') }}" != "true" ] || buildargs=(--build-arg UBUNTU_VERSION=22.04)
           # Honor if we want old containerd
-          [ "${{ inputs.containerd-version }}" == "" ] || buildargs+=(--build-arg CONTAINERD_VERSION=${{ inputs.containerd-version }})
+          [ "${INPUTS_CONTAINERD_VERSION}" == "" ] || buildargs+=(--build-arg CONTAINERD_VERSION=${INPUTS_CONTAINERD_VERSION})
           # Honor custom targets and if we want old rootlesskit
           target=test-integration
-          if [ "${{ inputs.target }}" != "rootful" ]; then
-            target+=-${{ inputs.target }}
-            if [ "${{ inputs.rootlesskit-version }}" != "" ]; then
-              buildargs+=(--build-arg ROOTLESSKIT_VERSION=${{ inputs.rootlesskit-version }})
+          if [ "${INPUTS_TARGET}" != "rootful" ]; then
+            target+=-${INPUTS_TARGET}
+            if [ "${INPUTS_ROOTLESSKIT_VERSION}" != "" ]; then
+              buildargs+=(--build-arg ROOTLESSKIT_VERSION=${INPUTS_ROOTLESSKIT_VERSION})
             fi
           fi
           # Cache is sharded per-architecture
@@ -175,14 +179,17 @@ jobs:
           # On the other side, using the host network is easier at configuration.
           # Besides, each job is running on a different instance, which means using host network here
           # is safe and has no side effects on others.
-          [ "${{ inputs.target }}" == "rootful" ] \
+          [ "${INPUTS_TARGET}" == "rootful" ] \
             && args=(test-integration ./hack/test-integration.sh -test.allow-modify-users=true) \
-            || args=(test-integration-${{ inputs.target }} /test-integration-rootless.sh ./hack/test-integration.sh)
+            || args=(test-integration-${INPUTS_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh)
           if [ "${{ inputs.ipv6 }}" == true ]; then
-            docker run --network host -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=false -test.only-ipv6 -test.target=${{ inputs.binary }}
+            docker run --network host -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=false -test.only-ipv6 -test.target=${INPUTS_BINARY}
           else
-            docker run -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=false -test.target=${{ inputs.binary }}
+            docker run -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=false -test.target=${INPUTS_BINARY}
           fi
+        env:
+          INPUTS_TARGET: ${{ inputs.target }}
+          INPUTS_BINARY: ${{ inputs.binary }}
       # FIXME: this NEEDS to go away
       - name: "Run: integration tests (flaky)"
         if: ${{ !fromJSON(inputs.skip-flaky) }}
@@ -190,11 +197,14 @@ jobs:
           . ./hack/github/action-helpers.sh
           github::md::h2 "flaky" >> "$GITHUB_STEP_SUMMARY"
 
-          [ "${{ inputs.target }}" == "rootful" ] \
+          [ "${INPUTS_TARGET}" == "rootful" ] \
             && args=(test-integration ./hack/test-integration.sh) \
-            || args=(test-integration-${{ inputs.target }} /test-integration-rootless.sh ./hack/test-integration.sh)
+            || args=(test-integration-${INPUTS_TARGET} /test-integration-rootless.sh ./hack/test-integration.sh)
           if [ "${{ inputs.ipv6 }}" == true ]; then
-            docker run --network host -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=true -test.only-ipv6 -test.target=${{ inputs.binary }}
+            docker run --network host -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=true -test.only-ipv6 -test.target=${INPUTS_BINARY}
           else
-            docker run -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=true -test.target=${{ inputs.binary }}
+            docker run -t --rm --privileged -e GITHUB_STEP_SUMMARY="$GITHUB_STEP_SUMMARY" -v "$GITHUB_STEP_SUMMARY":"$GITHUB_STEP_SUMMARY" -e WORKAROUND_ISSUE_622=${WORKAROUND_ISSUE_622:-} "${args[@]}" -test.only-flaky=true -test.target=${INPUTS_BINARY}
           fi
+        env:
+          INPUTS_TARGET: ${{ inputs.target }}
+          INPUTS_BINARY: ${{ inputs.binary }}

--- a/.github/workflows/job-test-in-host.yml
+++ b/.github/workflows/job-test-in-host.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - if: ${{ inputs.no-hyperv }}
         name: "Init (no-hyperv): Disable Hyper-V"
@@ -96,6 +97,7 @@ jobs:
         name: "Init (canary): retrieve latest go and containerd"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_RUNNER: ${{ inputs.runner }}
         run: |
           latest_go="$(. ./hack/provisioning/version/fetch.sh; go::canary::for::go-setup)"
           latest_containerd="$(. ./hack/provisioning/version/fetch.sh; github::project::latest "containerd/containerd")"
@@ -103,13 +105,13 @@ jobs:
           [ "$latest_go" == "" ] || \
             printf "GO_VERSION=%s\n" "$latest_go" >> "$GITHUB_ENV"
 
-          if [[ "${{ inputs.runner }}" == *windows* ]]; then
+          if [[ "${INPUTS_RUNNER}" == *windows* ]]; then
             containerd_version="$WINDOWS_CONTAINERD_VERSION"
           else
             containerd_version="$LINUX_CONTAINERD_VERSION"
           fi
           [ "${latest_containerd:1}" == "$containerd_version" ] || {
-            if [[ "${{ inputs.runner }}" == *windows* ]]; then
+            if [[ "${INPUTS_RUNNER}" == *windows* ]]; then
               printf "WINDOWS_CONTAINERD_VERSION=%s\n" "${latest_containerd:1}" >> "$GITHUB_ENV"
               printf "WINDOWS_CONTAINERD_SHA=canary is volatile and I accept the risk\n" >> "$GITHUB_ENV"
             else
@@ -139,7 +141,7 @@ jobs:
             sudo mkdir -p /etc/docker
             sudo jq -n '.features.cdi = true | .experimental = true' | sudo tee /etc/docker/daemon.json
             echo "::endgroup::"
-            echo "::group:: downgrade docker to the specific version we want to test (${{ inputs.docker-version }})"
+            echo "::group:: downgrade docker to the specific version we want to test (${INPUTS_DOCKER_VERSION})"
             sudo apt-get update -qq
             sudo apt-get install -qq ca-certificates curl
             sudo install -m 0755 -d /etc/apt/keyrings
@@ -149,16 +151,16 @@ jobs:
               $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" \
               | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
             sudo apt-get update -qq
-            sudo apt-get install -qq --allow-downgrades docker-ce=${{ inputs.docker-version }} docker-ce-cli=${{ inputs.docker-version }}
+            sudo apt-get install -qq --allow-downgrades docker-ce=${INPUTS_DOCKER_VERSION} docker-ce-cli=${INPUTS_DOCKER_VERSION}
             sudo systemctl restart docker
             echo "::endgroup::"
           else
             # FIXME: this is missing runc (see top level workflow note about the state of this)
             echo "::group:: install dependencies"
             sudo ./hack/provisioning/linux/containerd.sh uninstall
-            ./hack/provisioning/linux/containerd.sh rootful "$LINUX_CONTAINERD_VERSION" "amd64" "$LINUX_CONTAINERD_SHA" "${{ inputs.linux-containerd-service-sha }}"
+            ./hack/provisioning/linux/containerd.sh rootful "$LINUX_CONTAINERD_VERSION" "amd64" "$LINUX_CONTAINERD_SHA" "${INPUTS_LINUX_CONTAINERD_SERVICE_SHA}"
             sudo ./hack/provisioning/linux/cni.sh uninstall
-            ./hack/provisioning/linux/cni.sh install "${{ inputs.linux-cni-version }}" "amd64" "${{ inputs.linux-cni-sha }}"
+            ./hack/provisioning/linux/cni.sh install "${INPUTS_LINUX_CNI_VERSION}" "amd64" "${INPUTS_LINUX_CNI_SHA}"
             echo "::endgroup::"
 
             echo "::group:: build nerctl"
@@ -188,16 +190,22 @@ jobs:
 
           # This ensures that bridged traffic goes through netfilter
           sudo modprobe br-netfilter
+        env:
+          INPUTS_DOCKER_VERSION: ${{ inputs.docker-version }}
+          INPUTS_LINUX_CONTAINERD_SERVICE_SHA: ${{ inputs.linux-containerd-service-sha }}
+          INPUTS_LINUX_CNI_VERSION: ${{ inputs.linux-cni-version }}
+          INPUTS_LINUX_CNI_SHA: ${{ inputs.linux-cni-sha }}
 
       - if: ${{ contains(inputs.runner, 'windows') && env.SHOULD_RUN == 'yes' }}
         name: "Init (windows): prepare host"
         env:
           ctrdVersion: ${{ env.WINDOWS_CONTAINERD_VERSION }}
           ctrdSha: ${{ env.WINDOWS_CONTAINERD_SHA }}
+          INPUTS_WINDOWS_CNI_VERSION: ${{ inputs.windows-cni-version }}
         run: |
           # Install WinCNI
           echo "::group:: install wincni"
-          GOPATH=$(go env GOPATH) WINCNI_VERSION=${{ inputs.windows-cni-version }} ./hack/provisioning/windows/cni.sh
+          GOPATH=$(go env GOPATH) WINCNI_VERSION=${INPUTS_WINDOWS_CNI_VERSION} ./hack/provisioning/windows/cni.sh
           echo "::endgroup::"
 
           # Install containerd
@@ -226,7 +234,9 @@ jobs:
           . ./hack/github/action-helpers.sh
           github::md::h2 "ipv6" >> "$GITHUB_STEP_SUMMARY"
 
-          ./hack/test-integration.sh -test.target=${{ inputs.binary }} -test.only-ipv6
+          ./hack/test-integration.sh -test.target=${INPUTS_BINARY} -test.only-ipv6
+        env:
+          INPUTS_BINARY: ${{ inputs.binary }}
 
       - if: ${{ env.SHOULD_RUN == 'yes' }}
         name: "Run: integration tests"
@@ -234,7 +244,9 @@ jobs:
           . ./hack/github/action-helpers.sh
           github::md::h2 "non-flaky" >> "$GITHUB_STEP_SUMMARY"
 
-          ./hack/test-integration.sh -test.target=${{ inputs.binary }} -test.only-flaky=false
+          ./hack/test-integration.sh -test.target=${INPUTS_BINARY} -test.only-flaky=false
+        env:
+          INPUTS_BINARY: ${{ inputs.binary }}
 
       # FIXME: this must go
       - if: ${{ env.SHOULD_RUN == 'yes' }}
@@ -243,4 +255,6 @@ jobs:
           . ./hack/github/action-helpers.sh
           github::md::h2 "flaky" >> "$GITHUB_STEP_SUMMARY"
 
-          ./hack/test-integration.sh -test.target=${{ inputs.binary }} -test.only-flaky=true
+          ./hack/test-integration.sh -test.target=${INPUTS_BINARY} -test.only-flaky=true
+        env:
+          INPUTS_BINARY: ${{ inputs.binary }}

--- a/.github/workflows/job-test-in-lima.yml
+++ b/.github/workflows/job-test-in-lima.yml
@@ -28,11 +28,13 @@ jobs:
     runs-on: "${{ inputs.runner }}"
     env:
       TARGET: ${{ inputs.target }}
+      GUEST: ${{ inputs.guest }}
     steps:
       - name: "Init: checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Init: lima"
         uses: lima-vm/lima-actions/setup@55627e31b78637bf254a8b2a14da8ea7d12564e5  # v1.1.0
@@ -54,7 +56,7 @@ jobs:
             --memory=12 \
             --containerd=none \
             --set '.mounts=null | .portForwards=[{"guestSocket":"/var/run/docker.sock","hostSocket":"{{.Dir}}/sock/docker.sock"}]' \
-            template://${{ inputs.guest }}
+            template://${GUEST}
 
       # FIXME: the tests should be directly executed in the VM without nesting Docker inside it
       # https://github.com/containerd/nerdctl/issues/3858

--- a/.github/workflows/job-test-in-vagrant.yml
+++ b/.github/workflows/job-test-in-vagrant.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: "Init: setup cache"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/.github/workflows/job-test-unit.yml
+++ b/.github/workflows/job-test-unit.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       # If canary is requested, check for the latest unstable release
       - if: ${{ inputs.canary }}
@@ -73,13 +74,17 @@ jobs:
         name: "Init: set up CNI and CRIU"
         run: |
           if [ "$RUNNER_OS" == "Windows" ]; then
-            GOPATH=$(go env GOPATH) WINCNI_VERSION=${{ inputs.windows-cni-version }} ./hack/provisioning/windows/cni.sh
+            GOPATH=$(go env GOPATH) WINCNI_VERSION=${INPUTS_WINDOWS_CNI_VERSION} ./hack/provisioning/windows/cni.sh
           elif [ "$RUNNER_OS" == "Linux" ]; then
-            ./hack/provisioning/linux/cni.sh install "${{ inputs.linux-cni-version }}" "amd64" "${{ inputs.linux-cni-sha }}"
+            ./hack/provisioning/linux/cni.sh install "${INPUTS_LINUX_CNI_VERSION}" "amd64" "${INPUTS_LINUX_CNI_SHA}"
             sudo apt-get update -qq
             sudo add-apt-repository ppa:criu/ppa -y
             sudo apt-get install -qq criu
           fi
+        env:
+          INPUTS_WINDOWS_CNI_VERSION: ${{ inputs.windows-cni-version }}
+          INPUTS_LINUX_CNI_VERSION: ${{ inputs.linux-cni-version }}
+          INPUTS_LINUX_CNI_SHA: ${{ inputs.linux-cni-sha }}
 
       - if: ${{ env.GO_VERSION != '' }}
         name: "Run"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       attestations: write  # for provenances
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      with:
+        persist-credentials: false
     # FIXME: setup-qemu-action is depended by `gomodjail pack`
     - name: "Set up QEMU"
       uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a  # v4.0.0
@@ -32,6 +34,7 @@ jobs:
       with:
         go-version: "1.26"
         check-latest: true
+        cache: false
     - name: "Compile binaries"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/workflow-flaky.yml
+++ b/.github/workflows/workflow-flaky.yml
@@ -10,6 +10,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   test-integration-el:
     name: "EL${{ inputs.hack }}"
@@ -49,6 +52,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: "Run"
         run: |
           # FIXME: this should be a bit more elegant to use.

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -7,6 +7,9 @@ on:
       - 'release/**'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # Runs golangci to ensure that:
   # 1. the tooling is working on the target platform
@@ -76,3 +79,20 @@ jobs:
       go-version: ${{ matrix.go-version }}
       runner: ubuntu-24.04
       canary: ${{ matrix.canary && true || false }}
+
+  zizmor:
+    name: "zizmor"
+    runs-on: ubuntu-24.04
+    steps:
+      - name: "Init: checkout"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      - name: "Run: zizmor"
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          inputs: .github/workflows
+          # Do not send workflow diagnostics to GitHub Advanced Security code scanning in this project right now.
+          # Keep this as a local CI check.
+          advanced-security: false

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -9,6 +9,9 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     # Note: inputs.hack is undefined - its purpose is to prevent GitHub Actions from displaying all matrix variants as part of the name.

--- a/.github/workflows/workflow-tigron.yml
+++ b/.github/workflows/workflow-tigron.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths: 'mod/tigron/**'
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: "1.26"
   GOTOOLCHAIN: local
@@ -35,6 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 100
+          persist-credentials: false
       - if: ${{ matrix.canary }}
         name: "Init (canary): retrieve GO_VERSION"
         env:
@@ -50,6 +54,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           check-latest: true
+          cache: false
       - if: ${{ env.GO_VERSION != '' }}
         name: "Install tools"
         run: |


### PR DESCRIPTION
Summary:
- Add zizmor to the workflow lint CI.
- Fix the workflow findings reported by zizmor, including token persistence, excessive permissions, setup-go caching, and template-injection warnings.

Verification:
- `uvx zizmor .github/workflows`
- `C:\Users\omrib\go\bin\actionlint.exe -ignore 'not assignable' -ignore 'property "hack" is not defined'`
- `git diff --check`

Note: raw `actionlint` reports the same existing baseline findings on clean `origin/main` and this branch. With those baseline findings ignored, this branch does not add new actionlint findings.

This was implemented with Codex assistance, with the final diff reviewed before posting.
