### PR TITLE
refactor: enable var-naming revive linter (#4493)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,8 +135,6 @@ linters:
           arguments: [205]
           # 441 occurrences (at default 7). We should try to lower it (involves significant refactoring).
         - name: var-naming
-          # 1 occurrence.
-          disabled: true
 
         ##### P2: nice to have.
         - name: max-public-structs

--- a/mod/tigron/.golangci.yml
+++ b/mod/tigron/.golangci.yml
@@ -100,7 +100,6 @@ linters:
         - name: enforce-switch-style
           disabled: true
         - name: var-naming
-          disabled: true
     depguard:
       rules:
         main:

--- a/pkg/cmd/container/create_userns_opts_linux.go
+++ b/pkg/cmd/container/create_userns_opts_linux.go
@@ -471,7 +471,7 @@ func createSnapshotOpts(
 
 func WithUserNSRemapperLabels(uidmaps, gidmaps []specs.LinuxIDMapping) snapshots.Opt {
 	idMap := ContainerdIDMap{
-		UidMap: uidmaps,
+		UIDMap: uidmaps,
 		GidMap: gidmaps,
 	}
 	uidmapLabel, gidmapLabel := idMap.Marshal()

--- a/pkg/cmd/container/idmap.go
+++ b/pkg/cmd/container/idmap.go
@@ -26,27 +26,23 @@ import (
 
 const invalidID = 1<<32 - 1
 
-var invalidUser = User{Uid: invalidID, Gid: invalidID}
+var invalidUser = User{UID: invalidID, Gid: invalidID}
 
-// User is a Uid and Gid pair of a user
-//
-//nolint:revive
+// User is a UID and Gid pair of a user
 type User struct {
-	Uid uint32
+	UID uint32
 	Gid uint32
 }
 
-// IDMap contains the mappings of Uids and Gids.
-//
-//nolint:revive
+// IDMap contains the mappings of UIDs and Gids.
 type ContainerdIDMap struct {
-	UidMap []specs.LinuxIDMapping `json:"UidMap"`
+	UIDMap []specs.LinuxIDMapping `json:"UIDMap"`
 	GidMap []specs.LinuxIDMapping `json:"GidMap"`
 }
 
 // RootPair returns the ID pair for the root user
 func (i *ContainerdIDMap) RootPair() (User, error) {
-	uid, err := toHost(0, i.UidMap)
+	uid, err := toHost(0, i.UIDMap)
 	if err != nil {
 		return invalidUser, err
 	}
@@ -54,7 +50,7 @@ func (i *ContainerdIDMap) RootPair() (User, error) {
 	if err != nil {
 		return invalidUser, err
 	}
-	return User{Uid: uid, Gid: gid}, nil
+	return User{UID: uid, Gid: gid}, nil
 }
 
 // ToHost returns the host user ID pair for the container ID pair.
@@ -63,7 +59,7 @@ func (i *ContainerdIDMap) ToHost(pair User) (User, error) {
 		target User
 		err    error
 	)
-	target.Uid, err = toHost(pair.Uid, i.UidMap)
+	target.UID, err = toHost(pair.UID, i.UIDMap)
 	if err != nil {
 		return invalidUser, err
 	}
@@ -84,7 +80,7 @@ func (i *ContainerdIDMap) Marshal() (string, string) {
 		}
 		return strings.Join(arr, ",")
 	}
-	return marshal(i.UidMap), marshal(i.GidMap)
+	return marshal(i.UIDMap), marshal(i.GidMap)
 }
 
 // Unmarshal deserialize the passed uidmap and gidmap strings
@@ -104,7 +100,7 @@ func (i *ContainerdIDMap) Unmarshal(uidMap, gidMap string) error {
 		return nil
 	}
 	if err := unmarshal(uidMap, func(m specs.LinuxIDMapping) {
-		i.UidMap = append(i.UidMap, m)
+		i.UIDMap = append(i.UIDMap, m)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR re-enables the `var-naming` revive linter that was temporarily
disabled in #4490 when upgrading golangci-lint to v2.4.0.

Relates to #4493.

Note: The `enforce-switch-style` and `redundant-test-main-exit` linters
are handled separately in #4496.

## Changes

- Renamed `User.Uid` → `User.UID` and `ContainerdIDMap.UidMap` → `ContainerdIDMap.UIDMap` in `pkg/cmd/container/idmap.go`, following Go naming conventions for acronyms (UID is an initialism in the standard Go initialisms list)
- Updated all references to these fields in `pkg/cmd/container/create_userns_opts_linux.go`
- Removed the now-unnecessary `//nolint:revive` comments from the struct definitions
- Removed `disabled: true` from the `var-naming` revive rule in both `.golangci.yml` and `mod/tigron/.golangci.yml`

## Testing

- `go vet ./pkg/cmd/container/...` passes
- `revive` with `var-naming` rule shows no violations

---

*This fix was contributed with AI assistance by SwarmFix (sulphur-swarm).*
