### PR TITLE
fix(healthcheck): release exec process resources after probe

### DIFF
--- a/cmd/nerdctl/container/container_health_check_linux_test.go
+++ b/cmd/nerdctl/container/container_health_check_linux_test.go
@@ -20,6 +20,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1208,4 +1211,90 @@ func TestStartHealthcheckedContainerAfterExited(t *testing.T) {
 	}
 
 	testCase.Run(t)
+}
+
+// TestHealthCheckDoesNotLeakShimPipeFDs ensures that running a health check does not leak anonymous pipe files in the containerd shim.
+func TestHealthCheckDoesNotLeakShimPipeFDs(t *testing.T) {
+	testCase := nerdtest.Setup()
+	testCase.Require = require.All(
+		require.Not(nerdtest.Rootless),
+		// Docker CLI does not provide a standalone healthcheck command.
+		require.Not(nerdtest.Docker),
+	)
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier(),
+			"--health-cmd", "true", "--health-interval", "1h",
+			testutil.CommonImage, "sleep", nerdtest.Infinity,
+		)
+		nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+
+		inspect := nerdtest.InspectContainer(helpers, data.Identifier())
+		shimPID, err := parentPID(inspect.State.Pid)
+		assert.NilError(helpers.T(), err)
+
+		oldPipes, err := countShimPipeFDs(shimPID)
+		assert.NilError(helpers.T(), err)
+
+		data.Labels().Set("shimPID", strconv.Itoa(shimPID))
+		data.Labels().Set("oldPipes", strconv.Itoa(oldPipes))
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("container", "healthcheck", data.Identifier())
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: func(stdout string, t tig.T) {
+				shimPID, _ := strconv.Atoi(data.Labels().Get("shimPID"))
+				oldPipes, _ := strconv.Atoi(data.Labels().Get("oldPipes"))
+
+				newPipes, err := countShimPipeFDs(shimPID)
+				assert.NilError(t, err)
+				assert.Equal(t, oldPipes, newPipes,
+					"pipes leaked after health check: was %d, now %d",
+					oldPipes, newPipes)
+			},
+		}
+	}
+
+	testCase.Run(t)
+}
+
+func parentPID(pid int) (int, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if v, ok := strings.CutPrefix(line, "PPid:"); ok {
+			return strconv.Atoi(strings.TrimSpace(v))
+		}
+	}
+	return 0, fmt.Errorf("PPid not found in /proc/%d/status", pid)
+}
+
+func countShimPipeFDs(shimPID int) (int, error) {
+	fdDir := fmt.Sprintf("/proc/%d/fd", shimPID)
+	entries, err := os.ReadDir(fdDir)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		target, err := os.Readlink(filepath.Join(fdDir, e.Name()))
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(target, "pipe:") {
+			count++
+		}
+	}
+	return count, nil
 }

--- a/pkg/healthcheck/executor.go
+++ b/pkg/healthcheck/executor.go
@@ -75,6 +75,11 @@ func probeHealthCheck(ctx context.Context, task containerd.Task, hc *Healthcheck
 		log.G(ctx).Debugf("failed to exec health check: %v", err)
 		return nil, fmt.Errorf("exec error: %w", err)
 	}
+	defer func() {
+		if _, err := process.Delete(ctx); err != nil {
+			log.G(ctx).WithError(err).Debug("failed to delete exec process")
+		}
+	}()
 
 	if err := process.Start(ctx); err != nil {
 		log.G(ctx).Debugf("failed to start health check: %v", err)


### PR DESCRIPTION
Each invocation of a health check runs the user-defined command inside the container via containerd's `task.Exec()` API.

We can verify this in the `probeHealthCheck` section of the healthcheck package as follows:

```golang
func probeHealthCheck(ctx context.Context, task containerd.Task, hc *Healthcheck, processSpec *specs.Process) (*HealthcheckResult, error) {

...

	process, err := task.Exec(ctx, execID, processSpec, cio.NewCreator(
		cio.WithStreams(nil, outputBuf, outputBuf),
	))

...

	if err := process.Start(ctx); err != nil {
		log.G(ctx).Debugf("failed to start health check: %v", err)
		return nil, fmt.Errorf("start error: %w", err)
	}

	exitStatusC, err := process.Wait(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to wait for health check: %w", err)
	}
```

However, the current implementation does not release the resources allocated during the health check once the check is complete.

As a result, for example, pipes that should normally be deleted are not removed and continue to accumulate over time.

We can verify this behavior using the following command:

```bash
$ sudo nerdctl run -d --name=health --health-cmd="curl -f http://localhost" --health-interval=1s --health-timeout=1m0s --health-retries=3 --health-start-period=2s nginx:alpine
f2fdd8346a546bc6ef446980efdce1132a436fa63bd64a8ce6756c6197e7ec3f

$ TASK_PID=$(sudo nerdctl inspect health --format '{{.State.Pid}}')

$ SHIM_PID=$(ps -o ppid= -p $TASK_PID | tr -d ' ')

$ sudo ls -la /proc/$SHIM_PID/fd | grep pipe | head -3
lr-x------ 1 root root  64 May 17 20:51 100 -> pipe:[1093131]
lr-x------ 1 root root  64 May 17 20:52 101 -> pipe:[1092248]
lr-x------ 1 root root  64 May 17 20:52 102 -> pipe:[1092228]

$ sudo ls -la /proc/$SHIM_PID/fd | grep pipe | wc -l
16

$ sleep 10

$ sudo ls -la /proc/$SHIM_PID/fd | grep pipe | wc -l
26
```

So, this change adds a deferred `process.Delete()` after `task.Exec()` so that the allocated resources are released when the exec process completes.