### PR TITLE
feat(ps): show container health status in STATUS column

### DIFF
--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -26,10 +26,13 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/require"
 	"github.com/containerd/nerdctl/mod/tigron/test"
 	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/tabutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
@@ -692,6 +695,121 @@ func TestContainerListStatusFilter(t *testing.T) {
 					Output: func(stdout string, t tig.T) {
 						assert.Assert(t, strings.Contains(stdout, data.Labels().Get("cID")), "No container found with status created")
 					},
+				}
+			},
+		},
+	}
+
+	testCase.Run(t)
+}
+
+func TestContainerListWithHealthStatus(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Require = require.All(
+		// Docker CLI does not provide a standalone healthcheck command.
+		require.Not(nerdtest.Docker),
+		require.Not(nerdtest.Rootless),
+	)
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "ps shows healthy status after a successful probe",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "true", "--health-interval", "3s",
+					testutil.CommonImage, "sleep", nerdtest.Infinity,
+				)
+				helpers.Ensure("container", "healthcheck", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("ps", "--filter", "name="+data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output:   expect.Contains(fmt.Sprintf("(%s)", healthcheck.Healthy)),
+				}
+			},
+		},
+		{
+			Description: "ps shows starting status",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "exit 1",
+					"--health-interval", "1s",
+					"--health-start-period", "60s",
+					"--health-retries", "2",
+					testutil.CommonImage, "sleep", nerdtest.Infinity)
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+				helpers.Ensure("container", "healthcheck", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("ps", "--filter", "name="+data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output:   expect.Contains(fmt.Sprintf("(health: %s)", healthcheck.Starting)),
+				}
+			},
+		},
+		{
+			Description: "ps shows unhealthy status",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "not-a-real-cmd",
+					"--health-interval", "1s",
+					"--health-retries", "1",
+					testutil.CommonImage, "sleep", nerdtest.Infinity)
+				nerdtest.EnsureContainerStarted(helpers, data.Identifier())
+				helpers.Ensure("container", "healthcheck", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("ps", "--filter", "name="+data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output:   expect.Contains(fmt.Sprintf("(%s)", healthcheck.Unhealthy)),
+				}
+			},
+		},
+		{
+			Description: "ps does not show health suffix for stopped containers",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier(),
+					"--health-cmd", "true",
+					testutil.CommonImage, "sleep", nerdtest.Infinity)
+				helpers.Ensure("container", "healthcheck", data.Identifier())
+				helpers.Ensure("stop", data.Identifier())
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("ps", "-a", "--filter", "name="+data.Identifier())
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: expect.All(
+						expect.Contains("Exited"),
+						expect.DoesNotContain(
+							"(health:",
+							fmt.Sprintf("(%s)", healthcheck.Healthy),
+							fmt.Sprintf("(%s)", healthcheck.Unhealthy),
+						),
+					),
 				}
 			},
 		},

--- a/pkg/cmd/container/list.go
+++ b/pkg/cmd/container/list.go
@@ -36,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
+	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/portutil"
@@ -161,6 +162,19 @@ func prepareContainers(ctx context.Context, client *containerd.Client, container
 		var status string
 		if s, ok := statusPerContainer[c.ID()]; ok {
 			status = s
+			if strings.HasPrefix(status, "Up") && info.Labels[labels.HealthState] != "" {
+				healthState, err := healthcheck.HealthStateFromJSON(info.Labels[labels.HealthState])
+				if err != nil {
+					log.G(ctx).WithError(err).Debugf("failed to parse health state for container %s", c.ID())
+				} else {
+					switch healthState.Status {
+					case healthcheck.Healthy, healthcheck.Unhealthy:
+						status = fmt.Sprintf("%s (%s)", status, healthState.Status)
+					case healthcheck.Starting:
+						status = fmt.Sprintf("%s (health: %s)", status, healthState.Status)
+					}
+				}
+			}
 		} else {
 			return nil, fmt.Errorf("can't get container %s status", c.ID())
 		}


### PR DESCRIPTION
`docker ps` displays the health check results for healthchecked containers in the STATUS column:

```bash
$ docker run -d --name health --health-cmd=true --health-interval=3s alpine sleep inf
ace14dd125355ac04e8cbad9f1cf2eaaa7209d76cb648ccefb81e45b986c58f7

$ docker ps
CONTAINER ID   IMAGE     COMMAND       CREATED          STATUS                    PORTS     NAMES
ace14dd12535   alpine    "sleep inf"   23 seconds ago   Up 22 seconds (healthy)             health
```

However, `nerdctl ps` doesn't show the health status.

Therefore, to ensure compatibility with Docker, this change makes `nerdctl ps` display the health check results in the STATUS column for containers that perform health checks.

After this change, the output looks like:

```bash
$ sudo nerdctl ps
CONTAINER ID    IMAGE                              COMMAND                   CREATED          STATUS                   PORTS    NAMES
02c64243528a    docker.io/library/alpine:latest    "sleep inf"               7 seconds ago    Up (health: starting)             hoge
```

```bash
$ sudo nerdctl ps
CONTAINER ID    IMAGE                              COMMAND                   CREATED         STATUS          PORTS    NAMES
690aa502978c    docker.io/library/alpine:latest    "sleep inf"               1 second ago    Up (healthy)             hoge
```

```bash
$ sudo nerdctl ps
CONTAINER ID    IMAGE                              COMMAND                   CREATED         STATUS            PORTS    NAMES
02c64243528a    docker.io/library/alpine:latest    "sleep inf"               2 hours ago     Up (unhealthy)             hoge
```