### PR TITLE
fix: handle long fractional Unix timestamps

### DIFF
--- a/pkg/timestamp/timestamp.go
+++ b/pkg/timestamp/timestamp.go
@@ -25,7 +25,6 @@ package timestamp
 
 import (
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -144,11 +143,16 @@ func parseTimestamp(value string) (seconds int64, nanoseconds int64, _ error) {
 	if !ok {
 		return sec, 0, nil
 	}
+	if len(n) > 9 {
+		n = n[:9]
+	}
 	nsec, err := strconv.ParseInt(n, 10, 64)
 	if err != nil {
 		return sec, nsec, err
 	}
 	// should already be in nanoseconds but just in case convert n to nanoseconds
-	nsec = int64(float64(nsec) * math.Pow(float64(10), float64(9-len(n))))
+	for range 9 - len(n) {
+		nsec *= 10
+	}
 	return sec, nsec, nil
 }

--- a/pkg/timestamp/timestamp_test.go
+++ b/pkg/timestamp/timestamp_test.go
@@ -67,6 +67,7 @@ func TestGetTimestamp(t *testing.T) {
 		// unix timestamps returned as is
 		{"1136073600", "1136073600", false},
 		{"1136073600.000000001", "1136073600.000000001", false},
+		{"1136073600.123456789123456789123", "1136073600.123456789123456789123", false},
 		// Durations
 		{"1m", fmt.Sprintf("%d", now.Add(-1*time.Minute).Unix()), false},
 		{"1.5h", fmt.Sprintf("%d", now.Add(-90*time.Minute).Unix()), false},
@@ -99,6 +100,7 @@ func TestParseTimestamps(t *testing.T) {
 		{"1136073600.0000000010", 0, 1136073600, 1, false},
 		{"1136073600.0000000001", 0, 1136073600, 0, false},
 		{"1136073600.0000000009", 0, 1136073600, 0, false},
+		{"1136073600.123456789123456789123", 0, 1136073600, 123456789, false},
 		{"1136073600.00000001", 0, 1136073600, 10, false},
 		{"foo.bar", 0, 0, 0, true},
 		{"1136073600.bar", 0, 1136073600, 0, true},


### PR DESCRIPTION
Tiny parser fix. Before this, a Unix timestamp with a long fractional part got validated before truncation, so it could overflow int64 and fail. Kinda annoying, but real: logs --since/--until feed user timestamp strings through this path.

Repro before the fix:
```
go test ./pkg/timestamp
```
with `1136073600.123456789123456789123`, it errors with `value out of range` instead of truncating to 9 ns digits.

Now the parser truncates first, then parses. Existing short fractions still work.

Checked:
```
go test ./pkg/timestamp
go test ./pkg/...
git diff --check origin/main..HEAD
```