### PR TITLE
formatter: make ellipsis unicode safe

### DIFF
--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -97,18 +97,19 @@ func Ellipsis(str string, maxDisplayWidth int) string {
 		return ""
 	}
 
-	lenStr := len(str)
+	runes := []rune(str)
+	lenStr := len(runes)
 	if maxDisplayWidth == 1 {
 		if lenStr <= maxDisplayWidth {
 			return str
 		}
-		return string(str[0])
+		return string(runes[0])
 	}
 
 	if lenStr <= maxDisplayWidth {
 		return str
 	}
-	return str[:maxDisplayWidth-1] + "…"
+	return string(runes[:maxDisplayWidth-1]) + "…"
 }
 
 func formatRange(startHost, endHost, startContainer, endContainer int32) string {

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -19,6 +19,7 @@ package formatter
 import (
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"gotest.tools/v3/assert"
 
@@ -188,6 +189,52 @@ func TestFormatPorts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := FormatPorts(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEllipsis(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		input           string
+		maxDisplayWidth int
+		expected        string
+	}{
+		{
+			name:            "ascii under limit",
+			input:           "hello",
+			maxDisplayWidth: 5,
+			expected:        "hello",
+		},
+		{
+			name:            "ascii truncated",
+			input:           "hello",
+			maxDisplayWidth: 4,
+			expected:        "hel…",
+		},
+		{
+			name:            "unicode truncated",
+			input:           "éclair",
+			maxDisplayWidth: 4,
+			expected:        "écl…",
+		},
+		{
+			name:            "unicode truncated to single rune",
+			input:           "éclair",
+			maxDisplayWidth: 1,
+			expected:        "é",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := Ellipsis(tt.input, tt.maxDisplayWidth)
+			assert.Assert(t, utf8.ValidString(result), "expected valid UTF-8, got %q", result)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -19,7 +19,6 @@ package formatter
 import (
 	"testing"
 	"time"
-	"unicode/utf8"
 
 	"gotest.tools/v3/assert"
 
@@ -234,7 +233,6 @@ func TestEllipsis(t *testing.T) {
 			t.Parallel()
 
 			result := Ellipsis(tt.input, tt.maxDisplayWidth)
-			assert.Assert(t, utf8.ValidString(result), "expected valid UTF-8, got %q", result)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
Fixes `formatter.Ellipsis` so it truncates by rune, not byte. Tiny one, but real: unicode text can show up in commands and registry descriptions.

Repro before this patch:

```console
$ go test ./pkg/formatter -run TestEllipsis -count=1
--- FAIL: TestEllipsis/unicode_truncated_to_single_rune
    formatter_test.go:238: assertion failed: é != Ã
```

Tested:

```console
go test ./pkg/formatter ./pkg/cmd/search -count=1
```

No related issue found with gh search, so no closes line here.