### PR TITLE
fix container can't be started when task status is created

### DIFF
--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -258,8 +258,25 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 	}
 
 	if oldTask, err := container.Task(ctx, nil); err == nil {
+		if status, err := oldTask.Status(ctx); err == nil {
+			if status.Status == containerd.Created {
+				sig, err := signal.ParseSignal("SIGKILL")
+				if err != nil {
+					return err
+				}
+				err = oldTask.Kill(ctx, sig)
+				if err != nil {
+					return err
+				}
+				statusC, err := oldTask.Wait(ctx)
+				if err != nil {
+					return err
+				}
+				<-statusC
+			}
+		}
 		if _, err := oldTask.Delete(ctx); err != nil {
-			log.G(ctx).WithError(err).Debug("failed to delete old task")
+			log.G(ctx).WithError(err).Error("failed to delete old task")
 		}
 	}
 	detachC := make(chan struct{})


### PR DESCRIPTION
nerdctl start container failed if  get staus timeout 

<img width="1008" height="40" alt="image" src="https://github.com/user-attachments/assets/82d7e747-7b13-4850-929e-e2013f730620" />

nerdctl can't start this container anymore.

reproduce 
1. nerdctl  run -d busybox sleep 10
c1a3a060f42feabdd2fd7440c05c5905a918ec1cad2ebf9e34e8ca1fa9921a80

2. wait container exited
and  add some sleep here

````
func Start(ctx context.Context, container containerd.Container, isAttach bool, isInteractive bool, client *containerd.Client, detachKeys string, checkpointDir string, cfg *config.Config, nerdctlCmd string, nerdctlArgs []string) (err error) {
...
	task, err := taskutil.NewTask(ctx, client, container, taskutil.TaskOptions{
		AttachStreamOpt: attachStreamOpt,
		IsInteractive:   isInteractive,
		IsTerminal:      isTerminal,
		IsDetach:        true,
		Con:             con,
		LogURI:          logURI,
		DetachKeys:      detachKeys,
		Namespace:       namespace,
		DetachC:         detachC,
		CheckpointDir:   checkpointDir,
	})
	if err != nil {
		return err
	}
	time.Sleep(time.Second*1000)
	statusC, err := task.Wait(ctx)
	if err != nil {
		return err
	}
````


 3 ./nerdctl  start c1a and then kill  "nerdctl start" (will find runc init is running)

4. delete sleep and rebuild nerdctl
5. ./nerdctl  start c1a
FATA[0000] 1 errors:
task c1a3a060f42feabdd2fd7440c05c5905a918ec1cad2ebf9e34e8ca1fa9921a80: already exists

@AkihiroSuda 