### PR TITLE
fix(container): chunk mounts metadata to prevent max label size crash

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -266,7 +266,7 @@ func TestContainerInspectContainsInternalLabel(t *testing.T) {
 		lbs := inspect.Config.Labels
 
 		// TODO: add more internal labels testcases
-		labelMount := lbs[labels.Mounts]
+		labelMount := labels.GetMount(lbs)
 		expectedLabelMount := "[{\"Type\":\"bind\",\"Source\":\"/tmp\",\"Destination\":\"/app\",\"Mode\":\"rprivate,rbind\",\"RW\":true,\"Propagation\":\"rprivate\"}]"
 		assert.Equal(tt, expectedLabelMount, labelMount)
 	})

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -825,11 +825,13 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 
 	if len(internalLabels.mountPoints) > 0 {
 		mounts := dockercompatMounts(internalLabels.mountPoints)
-		mountPointsJSON, err := json.Marshal(mounts)
+		jsonMountBytes, err := json.Marshal(mounts)
 		if err != nil {
+			return nil, fmt.Errorf("failed to marshal mounts: %w", err)
+		}
+		if err := labels.SetMount(m, jsonMountBytes); err != nil {
 			return nil, err
 		}
-		m[labels.Mounts] = string(mountPointsJSON)
 	}
 
 	if internalLabels.macAddress != "" {

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -335,8 +335,10 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 					return nil, nil, nil, err
 				}
 			}
-			if m, found := ls[labels.Mounts]; found {
-				err = json.Unmarshal([]byte(m), &vfMountPoints)
+
+			nerdctlMounts := labels.GetMount(ls)
+			if nerdctlMounts != "" {
+				err = json.Unmarshal([]byte(nerdctlMounts), &vfMountPoints)
 				if err != nil {
 					return nil, nil, nil, err
 				}

--- a/pkg/cmd/volume/rm.go
+++ b/pkg/cmd/volume/rm.go
@@ -92,8 +92,9 @@ func usedVolumes(ctx context.Context, containers []containerd.Container) (map[st
 			}
 			return nil, err
 		}
-		mountsJSON, ok := l[labels.Mounts]
-		if !ok {
+
+		mountsJSON := labels.GetMount(l)
+		if mountsJSON == "" {
 			continue
 		}
 

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -584,8 +584,15 @@ func GetContainerVolumes(containerLabels map[string]string) []*ContainerVolume {
 	var vols []*ContainerVolume
 	volLabels := []string{labels.AnonymousVolumes, labels.Mounts}
 	for _, volLabel := range volLabels {
-		names, ok := containerLabels[volLabel]
-		if !ok {
+		var names string
+
+		if volLabel == labels.Mounts {
+			names = labels.GetMount(containerLabels)
+		} else {
+			names = containerLabels[volLabel]
+		}
+
+		if names == "" {
 			continue
 		}
 		var (

--- a/pkg/containerutil/containerutil_test.go
+++ b/pkg/containerutil/containerutil_test.go
@@ -19,6 +19,8 @@ package containerutil
 import (
 	"reflect"
 	"testing"
+
+	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
 func TestParseExtraHosts(t *testing.T) {
@@ -79,5 +81,42 @@ func TestParseExtraHosts(t *testing.T) {
 				t.Fatalf("expected %v, actual %v", test.expected, extraHosts)
 			}
 		})
+	}
+}
+
+func TestGetContainerVolumes_Indexed(t *testing.T) {
+	m0 := `{"Type":"volume","Name":"vol-0","Source":"/var/lib/vol-0","Destination":"/mnt/vol-0"}`
+	m1 := `{"Type":"volume","Name":"vol-1","Source":"/var/lib/vol-1","Destination":"/mnt/vol-1"}`
+	m2 := `{"Type":"volume","Name":"vol-2","Source":"/var/lib/vol-2","Destination":"/mnt/vol-2"}`
+
+	rawJSON := "[" + m0 + "," + m1 + "," + m2 + "]"
+
+	indexedLabels := map[string]string{
+		"nerdctl/mounts.0": m0,
+		"nerdctl/mounts.1": m1,
+		"nerdctl/mounts.2": m2,
+	}
+
+	legacyLabels := map[string]string{
+		labels.Mounts: rawJSON,
+	}
+
+	indexedResult := GetContainerVolumes(indexedLabels)
+	legacyResult := GetContainerVolumes(legacyLabels)
+
+	if len(indexedResult) == 0 {
+		t.Fatal("Expected to extract volumes from indexed labels, but got 0 results")
+	}
+
+	if len(indexedResult) != len(legacyResult) {
+		t.Errorf("Mismatched output! Indexed found %d volumes, Legacy found %d volumes.",
+			len(indexedResult), len(legacyResult))
+	}
+
+	if indexedResult[0].Name != "vol-0" {
+		t.Errorf("Expected first volume to be named 'vol-0', got '%s'", indexedResult[0].Name)
+	}
+	if len(indexedResult) > 2 && indexedResult[2].Name != "vol-2" {
+		t.Errorf("Expected third volume to be named 'vol-2', got '%s'", indexedResult[2].Name)
 	}
 }

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -400,7 +400,7 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 	}
 
 	c.HostConfig.Tmpfs = make(map[string]string)
-	if nerdctlMounts := n.Labels[labels.Mounts]; nerdctlMounts != "" {
+	if nerdctlMounts := labels.GetMount(n.Labels); nerdctlMounts != "" {
 		mounts, err := parseMounts(nerdctlMounts)
 		if err != nil {
 			return nil, err

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -71,7 +71,7 @@ func TestContainerFromNative(t *testing.T) {
 			n: &native.Container{
 				Container: containers.Container{
 					Labels: map[string]string{
-						"nerdctl/mounts":               "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
+						"nerdctl/mounts.0":             "{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}",
 						"nerdctl/state-dir":            tempStateDir,
 						"nerdctl/hostname":             "host1",
 						"nerdctl/user":                 "test-user",
@@ -164,7 +164,7 @@ func TestContainerFromNative(t *testing.T) {
 				},
 				Config: &Config{
 					Labels: map[string]string{
-						"nerdctl/mounts":               "[{\"Type\":\"bind\",\"Source\":\"/mnt/foo\",\"Destination\":\"/mnt/foo\",\"Mode\":\"rshared,rw\",\"RW\":true,\"Propagation\":\"rshared\"}]",
+						"nerdctl/mounts.0":             `{"Type":"bind","Source":"/mnt/foo","Destination":"/mnt/foo","Mode":"rshared,rw","RW":true,"Propagation":"rshared"}`,
 						"nerdctl/state-dir":            tempStateDir,
 						"nerdctl/hostname":             "host1",
 						"nerdctl/user":                 "test-user",

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -86,6 +86,9 @@ const (
 	// Mounts is the mount points for the container.
 	Mounts = Prefix + "mounts"
 
+	// MountsKeyFormat is used to dynamically store individual mounts
+	MountsKeyFormat = Prefix + "mounts.%d"
+
 	// StopTimeout is seconds to wait for stop a container.
 	StopTimeout = Prefix + "stop-timeout"
 

--- a/pkg/labels/mount.go
+++ b/pkg/labels/mount.go
@@ -1,0 +1,70 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package labels
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// SetMount parses a JSON array of mounts and stores each individual mount object as an indexed label.
+func SetMount(m map[string]string, jsonMountBytes []byte) error {
+	if len(jsonMountBytes) == 0 || string(jsonMountBytes) == "null" || string(jsonMountBytes) == "[]" {
+		return nil
+	}
+
+	var rawMounts []json.RawMessage
+	if err := json.Unmarshal(jsonMountBytes, &rawMounts); err != nil {
+		// Fallback: If it's somehow not a slice, write the whole thing to the legacy key
+		m[Mounts] = string(jsonMountBytes)
+		return nil
+	}
+
+	for i, rawMount := range rawMounts {
+		key := fmt.Sprintf(MountsKeyFormat, i)
+		m[key] = string(rawMount)
+	}
+
+	return nil
+}
+
+// GetMount extracts and reassembles indexed mount metadata back into a single JSON array string
+func GetMount(containerLabels map[string]string) string {
+	// Try legacy label first for backward compatibility
+	if legacyMount, ok := containerLabels[Mounts]; ok && legacyMount != "" {
+		return legacyMount
+	}
+
+	var rawMounts []string
+
+	for i := 0; i < len(containerLabels); i++ {
+		key := fmt.Sprintf(MountsKeyFormat, i)
+		chunk, found := containerLabels[key]
+
+		if !found || chunk == "" {
+			break
+		}
+		rawMounts = append(rawMounts, chunk)
+	}
+
+	if len(rawMounts) > 0 {
+		return "[" + strings.Join(rawMounts, ",") + "]"
+	}
+
+	return ""
+}


### PR DESCRIPTION
When a container has too many volume mounts, the marshaled JSON string exceeds the 4096-byte protocol buffer limit enforced by containerd, causing creation to fail. 

This patch fixes the issue by breaking the mounts metadata string into smaller 4000-byte pieces (using 'nerdctl/mounts/chunk-%d' labels). The container volume extraction path has been updated to stitch these chunks back together dynamically before parsing. 

Unit tests have been added to verify that chunked reassembly works exactly like the legacy payload behavior.

FIXES : #4914 