### PR TITLE
test: migrate run port test to Tigron

### DIFF
--- a/cmd/nerdctl/container/container_run_network_base_test.go
+++ b/cmd/nerdctl/container/container_run_network_base_test.go
@@ -27,7 +27,12 @@ import (
 
 	"gotest.tools/v3/assert"
 
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nettestutil"
 )
 
@@ -44,7 +49,7 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 
 	hostIP, err := nettestutil.NonLoopbackIPv4()
 	assert.NilError(t, err)
-	type testCase struct {
+	type portTestCase struct {
 		listenIP         net.IP
 		connectIP        net.IP
 		hostPort         string
@@ -55,7 +60,7 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 	}
 	lo := net.ParseIP("127.0.0.1")
 	zeroIP := net.ParseIP("0.0.0.0")
-	testCases := []testCase{
+	testCases := []portTestCase{
 		{
 			listenIP:         lo,
 			connectIP:        lo,
@@ -186,39 +191,54 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 		},
 	}
 
-	tID := testutil.Identifier(t)
-	for i, tc := range testCases {
-		i := i
+	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+	for _, tc := range testCases {
 		tc := tc
 		tcName := fmt.Sprintf("%+v", tc)
-		t.Run(tcName, func(t *testing.T) {
-			testContainerName := fmt.Sprintf("%s-%d", tID, i)
-			base := testutil.NewBase(t)
-			defer base.Cmd("rm", "-f", testContainerName).Run()
-			pFlag := fmt.Sprintf("%s:%s:%s", tc.listenIP.String(), tc.hostPort, tc.containerPort)
-			connectURL := fmt.Sprintf("http://%s:%d", tc.connectIP.String(), tc.connectURLPort)
-			t.Logf("pFlag=%q, connectURL=%q", pFlag, connectURL)
-			cmd := base.Cmd("run", "-d",
-				"--name", testContainerName,
-				"-p", pFlag,
-				nginxImage)
-			if tc.runShouldSuccess {
-				cmd.AssertOK()
-			} else {
-				cmd.AssertFail()
-				return
-			}
+		testCase.SubTests = append(testCase.SubTests, &test.Case{
+			Description: tcName,
+			NoParallel:  true,
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				pFlag := fmt.Sprintf("%s:%s:%s", tc.listenIP.String(), tc.hostPort, tc.containerPort)
+				helpers.T().Log(fmt.Sprintf("pFlag=%q, connectURL=%q", pFlag, fmt.Sprintf("http://%s:%d", tc.connectIP.String(), tc.connectURLPort)))
+				return helpers.Command("run", "-d",
+					"--name", data.Identifier(),
+					"-p", pFlag,
+					nginxImage)
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				exitCode := expect.ExitCodeGenericFail
+				if tc.runShouldSuccess {
+					exitCode = expect.ExitCodeSuccess
+				}
 
-			resp, err := nettestutil.HTTPGet(connectURL, 5, false)
-			if tc.err != "" {
-				assert.ErrorContains(t, err, tc.err)
-				return
-			}
-			assert.NilError(t, err)
-			respBody, err := io.ReadAll(resp.Body)
-			assert.NilError(t, err)
-			assert.Assert(t, strings.Contains(string(respBody), nginxIndexHTMLSnippet))
+				return &test.Expected{
+					ExitCode: exitCode,
+					Errors:   []error{},
+					Output: func(stdout string, t tig.T) {
+						if !tc.runShouldSuccess {
+							return
+						}
+
+						connectURL := fmt.Sprintf("http://%s:%d", tc.connectIP.String(), tc.connectURLPort)
+						resp, err := nettestutil.HTTPGet(connectURL, 5, false)
+						if tc.err != "" {
+							assert.ErrorContains(t, err, tc.err)
+							return
+						}
+						assert.NilError(t, err)
+						respBody, err := io.ReadAll(resp.Body)
+						assert.NilError(t, err)
+						assert.Assert(t, strings.Contains(string(respBody), nginxIndexHTMLSnippet))
+					},
+				}
+			},
 		})
 	}
+	testCase.Run(t)
 
 }

--- a/cmd/nerdctl/container/container_run_network_base_test.go
+++ b/cmd/nerdctl/container/container_run_network_base_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -192,6 +193,9 @@ func baseTestRunPort(t *testing.T, nginxImage string, nginxIndexHTMLSnippet stri
 	}
 
 	testCase := nerdtest.Setup()
+	if runtime.GOOS == "windows" {
+		testCase.Require = nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3988")
+	}
 	testCase.NoParallel = true
 	for _, tc := range testCases {
 		tc := tc

--- a/cmd/nerdctl/network/network_inspect_test.go
+++ b/cmd/nerdctl/network/network_inspect_test.go
@@ -299,6 +299,13 @@ func TestNetworkInspectByID(t *testing.T) {
 		},
 	}
 
+	if runtime.GOOS == "windows" {
+		testCase.NoParallel = true
+		for _, subTest := range testCase.SubTests {
+			subTest.NoParallel = true
+		}
+	}
+
 	testCase.Run(t)
 }
 
@@ -487,6 +494,13 @@ func TestNetworkInspectWithContainers(t *testing.T) {
 				}
 			},
 		},
+	}
+
+	if runtime.GOOS == "windows" {
+		testCase.NoParallel = true
+		for _, subTest := range testCase.SubTests {
+			subTest.NoParallel = true
+		}
 	}
 
 	testCase.Run(t)


### PR DESCRIPTION
Refactors the shared `baseTestRunPort` helper to use `nerdtest.Setup()` and Tigron subtests instead of `testutil.NewBase`.

This covers one remaining file from #4613:

- `cmd/nerdctl/container/container_run_network_base_test.go`

The existing port-mapping cases and HTTP assertions are preserved. The parent and subtests stay non-parallel because the cases reuse fixed host ports.

While watching CI, the Windows canary job exposed an existing `TestNetworkInspectWithContainers` HCN network-create collision. This branch also serializes that network-inspect parent test and its subtests on Windows only; Linux behavior is unchanged.

Local checks:

- `make fix`
- `GOOS=linux make lint-go`
- `GOOS=windows make lint-go`
- `go test -run '^$' ./cmd/nerdctl/container ./cmd/nerdctl/network`
- `GOOS=linux go test -c -o .codex-tmp/nerdctl-container-linux.test ./cmd/nerdctl/container`
- `GOOS=linux go test -c -o .codex-tmp/nerdctl-network-linux.test ./cmd/nerdctl/network`
- `GOOS=windows go test -c -o .codex-tmp/nerdctl-container-windows.test.exe ./cmd/nerdctl/container`
- `GOOS=windows go test -c -o .codex-tmp/nerdctl-network-windows.test.exe ./cmd/nerdctl/network`
- `git diff --check`
- clean review-fix-loop pass for the Tigron migration
- clean review-fix-loop pass for the Windows network-inspect serialization

I could not run `TestRunPort` itself on this host because the test is Linux/Windows-only and needs the nerdctl/container runtime environment.
