### PR TITLE
fix(convertor): add overlaybd vsize option

### DIFF
--- a/cmd/nerdctl/image/image_convert.go
+++ b/cmd/nerdctl/image/image_convert.go
@@ -88,6 +88,7 @@ func convertCommand() *cobra.Command {
 	cmd.Flags().Bool("overlaybd", false, "Convert tar.gz layers to overlaybd layers")
 	cmd.Flags().String("overlaybd-fs-type", "ext4", "Filesystem type for overlaybd")
 	cmd.Flags().String("overlaybd-dbstr", "", "Database config string for overlaybd")
+	cmd.Flags().Int("overlaybd-vsize", 64, "Virtual block device size in GB for overlaybd")
 	// #endregion
 
 	// #region soci flags
@@ -226,6 +227,10 @@ func convertOptions(cmd *cobra.Command) (types.ImageConvertOptions, error) {
 	if err != nil {
 		return types.ImageConvertOptions{}, err
 	}
+	overlaybdVsize, err := cmd.Flags().GetInt("overlaybd-vsize")
+	if err != nil {
+		return types.ImageConvertOptions{}, err
+	}
 	// #endregion
 
 	// #region soci flags
@@ -307,6 +312,7 @@ func convertOptions(cmd *cobra.Command) (types.ImageConvertOptions, error) {
 			Overlaybd:      overlaybd,
 			OverlayFsType:  overlaybdFsType,
 			OverlaydbDBStr: overlaybdDbstr,
+			OverlaybdVsize: overlaybdVsize,
 		},
 		SociConvertOptions: types.SociConvertOptions{
 			Soci: soci,

--- a/cmd/nerdctl/image/image_convert_test.go
+++ b/cmd/nerdctl/image/image_convert_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"gotest.tools/v3/assert"
+)
+
+func TestConvertOptionsOverlaybdVsize(t *testing.T) {
+	testCases := []struct {
+		name  string
+		flags map[string]string
+		want  int
+	}{
+		{
+			name: "default",
+			want: 64,
+		},
+		{
+			name: "explicit value",
+			flags: map[string]string{
+				"overlaybd-vsize": "128",
+			},
+			want: 128,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := convertCommand()
+			addRootFlagsForConvertOptionsTest(t, cmd)
+			assert.NilError(t, cmd.Flags().Set("overlaybd", "true"))
+			for name, value := range tc.flags {
+				assert.NilError(t, cmd.Flags().Set(name, value))
+			}
+
+			got, err := convertOptions(cmd)
+			assert.NilError(t, err)
+			assert.Equal(t, got.OverlaybdVsize, tc.want)
+		})
+	}
+}
+
+func addRootFlagsForConvertOptionsTest(t *testing.T, cmd *cobra.Command) {
+	t.Helper()
+
+	flags := cmd.Flags()
+	flags.Bool("debug", false, "")
+	flags.Bool("debug-full", false, "")
+	flags.String("address", "", "")
+	flags.String("namespace", "default", "")
+	flags.String("snapshotter", "", "")
+	flags.String("cni-path", "", "")
+	flags.String("cni-netconfpath", "", "")
+	flags.String("data-root", t.TempDir(), "")
+	flags.String("cgroup-manager", "", "")
+	flags.Bool("insecure-registry", false, "")
+	flags.StringSlice("hosts-dir", nil, "")
+	flags.Bool("experimental", false, "")
+	flags.String("host-gateway-ip", "", "")
+	flags.String("bridge-ip", "", "")
+	flags.Bool("kube-hide-dupe", false, "")
+	flags.StringSlice("cdi-spec-dirs", nil, "")
+	flags.StringSlice("global-dns", nil, "")
+	flags.StringSlice("global-dns-opts", nil, "")
+	flags.StringSlice("global-dns-search", nil, "")
+	flags.Bool("selinux-enabled", false, "")
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1012,6 +1012,10 @@ Flags:
 - `--zstdchunked-record-in=<FILE>` : read `ctr-remote optimize --record-out=<FILE>` record file. :warning: This flag is experimental and subject to change.
 - `--zstdchunked-compression-level=<LEVEL>`: zstd:chunked compression level (default: 3)
 - `--zstdchunked-chunk-size=<SIZE>`: zstd:chunked chunk size
+- `--overlaybd`                        : convert tar.gz layers to overlaybd layers. Should be used in conjunction with '--oci'
+- `--overlaybd-fs-type=<TYPE>`         : filesystem type for overlaybd (default: `ext4`)
+- `--overlaybd-dbstr=<STRING>`         : database config string for overlaybd
+- `--overlaybd-vsize=<SIZE>`           : virtual block device size in GB for overlaybd (default: 64)
 - `--uncompress`                       : convert tar.gz layers to uncompressed tar layers
 - `--oci`                              : convert Docker media types to OCI media types
 - `--platform=<PLATFORM>`              : convert content for a specific platform

--- a/docs/overlaybd.md
+++ b/docs/overlaybd.md
@@ -38,3 +38,5 @@ For more details about how to build overlaybd image, please refer to [accelerate
 Nerdctl supports to convert an OCI image or docker format v2 image to OverlayBD image by using the `nerdctl image convert` command.
 
 Before the conversion, you should have the `overlaybd-snapshotter` binary installed, which build from [accelerated-container-image](https://github.com/containerd/accelerated-container-image). You can run the command like `nerdctl image convert --overlaybd --oci <source_image> <target_image>` to convert the `<source_image>` to a OverlayBD image whose tag is `<target_image>`.
+
+By default, `nerdctl image convert --overlaybd` uses a 64 GB virtual block device size. You can customize it with `--overlaybd-vsize`.

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -139,6 +139,8 @@ type OverlaybdOptions struct {
 	OverlayFsType string
 	// OverlaydbDBStr database config string for overlaybd
 	OverlaydbDBStr string
+	// OverlaybdVsize virtual block device size in GB for overlaybd
+	OverlaybdVsize int
 	// #endregion
 }
 

--- a/pkg/cmd/image/convert.go
+++ b/pkg/cmd/image/convert.go
@@ -394,6 +394,7 @@ func getOBDConvertOpts(options types.ImageConvertOptions) ([]overlaybdconvert.Op
 	obdOpts := []overlaybdconvert.Option{
 		overlaybdconvert.WithFsType(options.OverlayFsType),
 		overlaybdconvert.WithDbstr(options.OverlaydbDBStr),
+		overlaybdconvert.WithVsize(options.OverlaybdVsize),
 	}
 	return obdOpts, nil
 }


### PR DESCRIPTION
### What this PR does

Adds an `--overlaybd-vsize`  option to `nerdctl image convert --overlaybd`.

The option defaults to 64, matching the standalone overlaybd convertor default, and is passed through types.OverlaybdOptions to overlaybdconvert.WithVsize(...).

This also updates the command reference and OverlayBD documentation.

### Why this is needed
`nerdctl image convert --overlaybd` can not work fine now.

```
time="2026-06-08T08:34:38Z" level=fatal msg="failed to preprare snapshot \"overlaybd-conv-917563811-qune\": failed to attach and mount for snapshot 26: failed to mkfs for dev /dev/sdd: mke2fs 1.47.0 (5-Feb-2023)
mkfs.ext4: Device size reported to be zero.  Invalid partition specified, or partition table wasn't reread after running fdisk, due to a modified partition being busy and in use.  You may need to reboot to re-read your partition table.
: exit status 1: unknown"
```

### Related context
containerd/accelerated-container-image#245
containerd/accelerated-container-image#256