### PR TITLE
fix: show Pid as `0` for stopped containers in `nerdctl container ins…

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -336,6 +336,7 @@ func TestContainerInspectState(t *testing.T) {
 				}
 				assert.Assert(tt, strings.Contains(inspect.State.Error, "executable file not found in $PATH"), fmt.Sprintf("expected: %s, actual: %s", "executable file not found in $PATH", inspect.State.Error))
 				assert.Equal(tt, expectedErrStatus, inspect.State.Status)
+				assert.Equal(tt, 0, inspect.State.Pid)
 			}),
 		},
 		{
@@ -361,6 +362,7 @@ func TestContainerInspectState(t *testing.T) {
 				inspect := dc[0]
 				assert.Assert(tt, strings.Contains(inspect.State.Error, ""), fmt.Sprintf("expected: %s, actual: %s", "", inspect.State.Error))
 				assert.Equal(tt, "exited", inspect.State.Status)
+				assert.Equal(tt, 0, inspect.State.Pid)
 			}),
 		},
 	}

--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -57,6 +57,9 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 		log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect Status")
 		return n, nil
 	}
+	if st.Status == containerd.Stopped {
+		n.Process.Pid = 0
+	}
 	n.Process.Status = st
 	netNS, err := InspectNetNS(ctx, n.Process.Pid)
 	if err != nil {


### PR DESCRIPTION
…pect`

In Docker, running `docker container inspect` on a stopped container shows the Pid as `0`.

```bash
> docker ps -a --filter=name=nginx
CONTAINER ID   IMAGE     COMMAND                  CREATED          STATUS                     PORTS     NAMES
c8dcc84e427f   nginx     "/docker-entrypoint.…"   14 seconds ago   Exited (0) 8 seconds ago             nginx

> docker container inspect nginx | grep 'Pid"'
            "Pid": 0,
```

However, running `nerdctl container inspect` on a stopped container still shows a stale Pid from the already-exited process.

```bash
> sudo nerdctl ps -a --filter=name=nginx
CONTAINER ID    IMAGE                             COMMAND                   CREATED           STATUS                      PORTS    NAMES
4ce4cb9b1ed1    docker.io/library/nginx:latest    "/docker-entrypoint.…"    16 seconds ago    Exited (0) 4 seconds ago             nginx

> sn container inspect nginx | grep 'Pid"'
            "Pid": 1531853,
```

The docker daemon subscribes to containerd's events and when it detects a task exit event, it deletes the task and updates the state of the container it manages, setting Pid to `0`. Therefore, in Docker the Pid becomes `0` after the container stops.

- https://github.com/moby/moby/blob/docker-v29.5.3/daemon/monitor.go#L34

On the other hand, nerdctl has no long-running daemon like the docker daemon, so it does not subscribe to containerd's events. As a result, the task is not deleted even after the container stops, and `nerdctl container inspect` still shows the stale Pid of the already-exited process returned by `task.Pid()`.

Therefore, this commit changes the behavior so that `nerdctl container inspect` on a stopped container shows the Pid as `0`, for compatibility with Docker.