### PR TITLE
feat(version): print RootlessKit version in `nerdctl version`

### DIFF
--- a/pkg/infoutil/infoutil.go
+++ b/pkg/infoutil/infoutil.go
@@ -122,6 +122,7 @@ func ClientVersion() dockercompat.ClientVersion {
 		Arch:      runtime.GOARCH,
 		Components: []dockercompat.ComponentVersion{
 			buildctlVersion(),
+			rootlesskitVersion(),
 		},
 	}
 }
@@ -231,6 +232,52 @@ func parseRuncVersion(runcVersionStdout []byte) (*dockercompat.ComponentVersion,
 		Details: details,
 	}, nil
 }
+
+func rootlesskitVersion() dockercompat.ComponentVersion {
+	stdout, err := exec.Command("rootlesskit", "--version").Output()
+	if err != nil {
+		log.L.WithError(err).Warnf("unable to determine rootlesskit version")
+		return dockercompat.ComponentVersion{Name: "rootlesskit"}
+	}
+	v, err := parseRootlesskitVersion(stdout)
+	if err != nil {
+		log.L.Warn(err)
+		return dockercompat.ComponentVersion{Name: "rootlesskit"}
+	}
+	return *v
+}
+
+func parseRootlesskitVersion(rootlesskitVersionStdout []byte) (*dockercompat.ComponentVersion, error) {
+	var versionList = strings.Split(strings.TrimSpace(string(rootlesskitVersionStdout)), "\n")
+	if len(versionList) == 0 {
+		return nil, fmt.Errorf("unable to determine rootlesskit version, got: %s", string(rootlesskitVersionStdout))
+	}
+	firstLine := strings.Fields(versionList[0])
+	if len(firstLine) != 3 || firstLine[0] != "rootlesskit" {
+		return nil, fmt.Errorf("unable to determine rootlesskit version, got: %s", string(rootlesskitVersionStdout))
+	}
+	version := firstLine[2]
+
+	details := map[string]string{}
+	for _, detailsLine := range versionList[1:] {
+		detail := strings.SplitN(detailsLine, ":", 2)
+		if len(detail) != 2 {
+			log.L.Warnf("unable to determine one of rootlesskit details, got: %s, %d", detail, len(detail))
+			continue
+		}
+		switch strings.TrimSpace(detail[0]) {
+		case "commit":
+			details["GitCommit"] = strings.TrimSpace(detail[1])
+		}
+	}
+
+	return &dockercompat.ComponentVersion{
+		Name:    "rootlesskit",
+		Version: version,
+		Details: details,
+	}, nil
+}
+
 
 // getMobySysInfo returns the moby system info for the given cgroup manager
 func getMobySysInfo(cgroupManager string) *sysinfo.SysInfo {

--- a/pkg/infoutil/infoutil_test.go
+++ b/pkg/infoutil/infoutil_test.go
@@ -83,3 +83,31 @@ libseccomp: 2.5.1`: {
 		}
 	}
 }
+
+func TestParseRootlesskitVersion(t *testing.T) {
+	testCases := map[string]*dockercompat.ComponentVersion{
+		`rootlesskit version 2.0.2
+commit: 8d573c0b4b4b6e2e1c8e9044c4f8b4f3e2c1a0b1`: {
+			Name:    "rootlesskit",
+			Version: "2.0.2",
+			Details: map[string]string{
+				"GitCommit": "8d573c0b4b4b6e2e1c8e9044c4f8b4f3e2c1a0b1",
+			},
+		},
+		`rootlesskit version 1.1.1`: {
+			Name:    "rootlesskit",
+			Version: "1.1.1",
+		},
+		"foo bar baz": nil,
+	}
+
+	for s, expected := range testCases {
+		got, err := parseRootlesskitVersion([]byte(s))
+		if expected != nil {
+			assert.NilError(t, err)
+			assert.DeepEqual(t, expected, got)
+		} else {
+			assert.Assert(t, err != nil)
+		}
+	}
+}


### PR DESCRIPTION
## What

`nerdctl version` now prints the RootlessKit version in the same format that `docker version` uses for its auxiliary components (buildctl, runc).

## Why

Closes #4936.

Users running rootless containers have no quick way to see which RootlessKit version they're on from nerdctl itself. They currently have to shell out to \`rootlesskit --version\` separately. Docker shows runtime tooling versions in its version output; nerdctl already follows this pattern for \`buildctl\` and \`runc\` but was missing RootlessKit.

## How

Adds \`rootlesskitVersion()\` alongside the existing \`buildctlVersion()\` and \`runcVersion()\` in \`pkg/infoutil\`. It shells out to \`rootlesskit --version\`, parses the output with \`parseRootlesskitVersion()\`, and returns a \`dockercompat.ComponentVersion\`.

When RootlessKit is not installed, the output gracefully degrades to a bare \`rootlesskit\` entry with no version — identical to how \`buildctlVersion()\` behaves when buildctl is missing.

Sample output:
\`\`\`
Client:
 Version:	1.0.0
 OS/Arch:	linux/amd64
 Git commit:	...
 buildctl:
  Version:	v0.20.2
  GitCommit:	...
 rootlesskit:
  Version:	2.0.2
  GitCommit:	...
\`\`\`