### PR TITLE
fix: suppress warning message on a stopped container in nerdctl conta…

### DIFF
--- a/pkg/containerinspector/containerinspector.go
+++ b/pkg/containerinspector/containerinspector.go
@@ -58,11 +58,13 @@ func Inspect(ctx context.Context, container containerd.Container) (*native.Conta
 		return n, nil
 	}
 	n.Process.Status = st
-	netNS, err := InspectNetNS(ctx, n.Process.Pid)
-	if err != nil {
-		log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect NetNS")
-		return n, nil
+	if st.Status == containerd.Running || st.Status == containerd.Paused {
+		netNS, err := InspectNetNS(ctx, n.Process.Pid)
+		if err != nil {
+			log.G(ctx).WithError(err).WithField("id", id).Warnf("failed to inspect NetNS")
+			return n, nil
+		}
+		n.Process.NetNS = netNS
 	}
-	n.Process.NetNS = netNS
 	return n, nil
 }


### PR DESCRIPTION
…iner inspect

Currently, when running `nerdctl container inspect` on a stopped container, the following warning message is shown:

```bash
> sudo nerdctl ps -a --filter=name=nginx
CONTAINER ID    IMAGE                             COMMAND                   CREATED         STATUS                      PORTS    NAMES
4ce4cb9b1ed1    docker.io/library/nginx:latest    "/docker-entrypoint.…"    14 hours ago    Exited (0) 8 seconds ago             nginx

> sudo nerdctl container inspect nginx
WARN[0000] failed to inspect NetNS                       error="failed to Statfs \"/proc/1548927/ns/net\": no such file or directory" id=4ce4cb9b1ed12f65b02e0f4af8a753d0e9ad1d42d5b77dac206c396021d90ab0
...
```

This warning occurs because `/proc/<PID>/ns/net` is referenced using a stale PID, but the process for a stopped container has already been released.

`/proc/<PID>/ns/net` should not be referenced when the container is stopped.

Therefore, this commit suppresses the warning message above when running `nerdctl container inspect` on a stopped container.