### PR TITLE
fix: remove duplicated defaults from help output

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -89,7 +89,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("help", false, "show help")
 
 	cmd.Flags().BoolP("tty", "t", false, "Allocate a pseudo-TTY")
-	cmd.Flags().Bool("sig-proxy", true, "Proxy received signals to the process (default true)")
+	cmd.Flags().Bool("sig-proxy", true, "Proxy received signals to the process")
 	cmd.Flags().BoolP("interactive", "i", false, "Keep STDIN open even if not attached")
 	cmd.Flags().String("restart", "no", `Restart policy to apply when a container exits (implemented values: "no"|"always|on-failure:n|unless-stopped")`)
 	cmd.RegisterFlagCompletionFunc("restart", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -159,7 +159,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("memory", "m", "", "Memory limit")
 	cmd.Flags().String("memory-reservation", "", "Memory soft limit")
 	cmd.Flags().String("memory-swap", "", "Swap limit equal to memory plus swap: '-1' to enable unlimited swap")
-	cmd.Flags().Int64("memory-swappiness", -1, "Tune container memory swappiness (0 to 100) (default -1)")
+	cmd.Flags().Int64("memory-swappiness", -1, "Tune container memory swappiness (0 to 100)")
 	cmd.Flags().String("kernel-memory", "", "Kernel memory limit (deprecated)")
 	cmd.Flags().Bool("oom-kill-disable", false, "Disable OOM Killer")
 	cmd.Flags().Int("oom-score-adj", 0, "Tune container’s OOM preferences (-1000 to 1000, rootless: 100 to 1000)")
@@ -219,7 +219,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("cap-drop", []string{}, "Drop Linux capabilities")
 	cmd.RegisterFlagCompletionFunc("cap-drop", capShellComplete)
 	cmd.Flags().Bool("privileged", false, "Give extended privileges to this container")
-	cmd.Flags().String("systemd", "false", "Allow running systemd in this container (default: false)")
+	cmd.Flags().String("systemd", "false", "Allow running systemd in this container")
 	// #endregion
 
 	// #region runtime flags

--- a/cmd/nerdctl/container/container_run_help_test.go
+++ b/cmd/nerdctl/container/container_run_help_test.go
@@ -1,0 +1,44 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestRunHelpDoesNotDuplicateDefaults(t *testing.T) {
+	cmd := RunCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	help := stdout.String()
+	assert.Assert(t, strings.Contains(help, "Proxy received signals to the process (default true)"))
+	assert.Assert(t, !strings.Contains(help, "Proxy received signals to the process (default true) (default true)"))
+	assert.Assert(t, strings.Contains(help, "Tune container memory swappiness (0 to 100) (default -1)"))
+	assert.Assert(t, !strings.Contains(help, "Tune container memory swappiness (0 to 100) (default -1) (default -1)"))
+	assert.Assert(t, strings.Contains(help, "Allow running systemd in this container (default \"false\")"))
+	assert.Assert(t, !strings.Contains(help, "Allow running systemd in this container (default: false) (default \"false\")"))
+}

--- a/cmd/nerdctl/image/image_history.go
+++ b/cmd/nerdctl/image/image_history.go
@@ -63,7 +63,7 @@ func addHistoryFlags(cmd *cobra.Command) {
 		return []string{"json"}, cobra.ShellCompDirectiveNoFileComp
 	})
 	cmd.Flags().BoolP("quiet", "q", false, "Only show numeric IDs")
-	cmd.Flags().BoolP("human", "H", true, "Print sizes and dates in human readable format (default true)")
+	cmd.Flags().BoolP("human", "H", true, "Print sizes and dates in human readable format")
 	cmd.Flags().Bool("no-trunc", false, "Don't truncate output")
 }
 

--- a/cmd/nerdctl/image/image_history_help_test.go
+++ b/cmd/nerdctl/image/image_history_help_test.go
@@ -1,0 +1,40 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestHistoryHelpDoesNotDuplicateDefaults(t *testing.T) {
+	cmd := HistoryCommand()
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+	assert.NilError(t, err)
+
+	help := stdout.String()
+	assert.Assert(t, strings.Contains(help, "Print sizes and dates in human readable format (default true)"))
+	assert.Assert(t, !strings.Contains(help, "Print sizes and dates in human readable format (default true) (default true)"))
+}


### PR DESCRIPTION
A few help entries print the default value twice right now, which looks a bit goofy.

Before:
`go run ./cmd/nerdctl run --help | rg 'memory-swappiness|sig-proxy|systemd'`
`go run ./cmd/nerdctl image history --help | rg 'human|default'`

You can see lines like:
`--memory-swappiness ... (default -1) (default -1)`
`--sig-proxy ... (default true) (default true)`
`--systemd ... (default: false) (default "false")`
`--human ... (default true) (default true)`

This just drops the hardcoded default text where Cobra already prints it for us, and adds small tests so it does not drift back.

Checks:
`go test ./cmd/nerdctl/container -run TestRunHelpDoesNotDuplicateDefaults -count=1`
`go test ./cmd/nerdctl/image -run TestHistoryHelpDoesNotDuplicateDefaults -count=1`