### PR TITLE
CI: disable canary

### DIFF
--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -33,9 +33,10 @@ jobs:
           - runner: ubuntu-24.04
             goos: windows
           # Additionally lint for canary
-          - runner: ubuntu-24.04
-            goos: linux
-            canary: true
+          # FIXME: failing since the release of go1.27rc1
+          # - runner: ubuntu-24.04
+          #   goos: linux
+          #   canary: true
     with:
       timeout: 10
       go-version: "1.26"
@@ -72,8 +73,9 @@ jobs:
         include:
           - go-version: "1.26"
           # Additionally build for canary
-          - go-version: "1.26"
-            canary: true
+          # FIXME: failing since the release of go1.27rc1
+          # - go-version: "1.26"
+          #   canary: true
     with:
       timeout: 10
       go-version: ${{ matrix.go-version }}

--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -26,8 +26,9 @@ jobs:
           - runner: "ubuntu-24.04"
           - runner: "macos-15"
           - runner: "windows-2025"
-          - runner: "ubuntu-24.04"
-            canary: true
+          # FIXME: failing since the release of go1.27rc1
+          # - runner: "ubuntu-24.04"
+          #   canary: true
     with:
       runner: ${{ matrix.runner }}
       canary: ${{ matrix.canary && true || false }}
@@ -104,9 +105,10 @@ jobs:
             ipv6: true
             skip-flaky: true
           # all canary
-          - runner: ubuntu-24.04
-            target: rootful
-            canary: true
+          # FIXME: failing since the release of go1.27rc1
+          # - runner: ubuntu-24.04
+          #   target: rootful
+          #   canary: true
 
     with:
       timeout: 80
@@ -128,8 +130,9 @@ jobs:
         include:
           # Test on windows w/o canary
           - runner: windows-2022
-          - runner: windows-2025
-            canary: true
+          # FIXME: failing since the release of go1.27rc1
+          # - runner: windows-2025
+          #   canary: true
           # Test docker on linux
           - runner: ubuntu-24.04
             binary: docker

--- a/.github/workflows/workflow-tigron.yml
+++ b/.github/workflows/workflow-tigron.yml
@@ -31,8 +31,9 @@ jobs:
           - runner: windows-2022
           - runner: ubuntu-24.04
             goos: freebsd
-          - runner: ubuntu-24.04
-            canary: go-canary
+          # FIXME: failing since the release of go1.27rc1
+          # - runner: ubuntu-24.04
+          #   canary: go-canary
     steps:
       - name: "Checkout project"
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
Failing since the release of go1.27rc1

```
level=warning msg="[runner] Can't run linter goanalysis_metalinter: inspect: failed to load package context: could not load export data: internal error in importing \"context\" (cannot decode \"context\", export data version 4 is greater than maximum supported version 2); please report an issue"
level=error msg="Running error: can't run linter goanalysis_metalinter\ninspect: failed to load package context: could not load export data: internal error in importing \"context\" (cannot decode \"context\", export data version 4 is greater than maximum supported version 2); please report an issue"
make[1]: *** [Makefile:142: lint-go] Error 3
make[1]: Leaving directory '/home/runner/work/nerdctl/nerdctl'
make: *** [Makefile:148: lint-go-all] Error 2
```

Workaround for:
- #4979