### PR TITLE
fix: honor --workdir in compose run

### DIFF
--- a/cmd/nerdctl/compose/compose_run_linux_test.go
+++ b/cmd/nerdctl/compose/compose_run_linux_test.go
@@ -326,6 +326,51 @@ services:
 	testCase.Run(t)
 }
 
+func TestComposeRunWithWorkdir(t *testing.T) {
+	const expectedOutput = "/tmp"
+
+	dockerComposeYAML := fmt.Sprintf(`
+services:
+  alpine:
+    image: %s
+    entrypoint:
+      - pwd
+`, testutil.CommonImage)
+
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		composePath := data.Temp().Save(dockerComposeYAML, "compose.yaml")
+		projectName := filepath.Base(filepath.Dir(composePath))
+		t.Logf("projectName=%q", projectName)
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		cmd := helpers.Command(
+			"compose",
+			"-f",
+			data.Temp().Path("compose.yaml"),
+			"run",
+			"--workdir",
+			"/tmp",
+			"--name",
+			data.Identifier(),
+			"alpine",
+		)
+		cmd.WithPseudoTTY()
+		return cmd
+	}
+
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains(expectedOutput))
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", "-v", data.Identifier())
+		helpers.Anyhow("compose", "-f", data.Temp().Path("compose.yaml"), "down", "-v")
+	}
+
+	testCase.Run(t)
+}
+
 func TestComposeRunWithLabel(t *testing.T) {
 	dockerComposeYAML := fmt.Sprintf(`
 services:

--- a/pkg/composer/run.go
+++ b/pkg/composer/run.go
@@ -155,7 +155,7 @@ func (c *Composer) Run(ctx context.Context, ro RunOptions) error {
 		}
 	}
 	if ro.WorkDir != "" {
-		c.project.WorkingDir = ro.WorkDir
+		targetSvc.WorkingDir = ro.WorkDir
 	}
 
 	// `compose run` command does not create any of the ports specified in the service configuration.


### PR DESCRIPTION
Fix `nerdctl compose run --workdir` so it actually sets the container cwd.

Right now `compose run --workdir /tmp` writes `/tmp` into the project working dir, not the service working dir. So `pwd` still does not run from `/tmp`, and relative host paths can get a bit weird too.

Repro
1. Create a compose file with:
```yaml
services:
  app:
    image: alpine
    entrypoint:
      - pwd
```
2. Run `nerdctl compose run --workdir /tmp app`
3. Before this patch, it does not print `/tmp`

This patch writes `ro.WorkDir` to `targetSvc.WorkingDir`, which is what `serviceparser` turns into `-w=...`. Added a regression test too, pretty small and to the point.
