### PR TITLE
fix: clarify healthcheck help defaults

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -250,9 +250,9 @@ func setCreateFlags(cmd *cobra.Command) {
 
 	// Health check flags
 	cmd.Flags().String("health-cmd", "", "Command to run to check health")
-	cmd.Flags().Duration("health-interval", 0, "Time between running the check (default: 30s)")
-	cmd.Flags().Duration("health-timeout", 0, "Maximum time to allow one check to run (default: 30s)")
-	cmd.Flags().Int("health-retries", 0, "Consecutive failures needed to report unhealthy (default: 3)")
+	cmd.Flags().Duration("health-interval", 0, "Time between running the check; 0 uses the image value or 30s when unset there too")
+	cmd.Flags().Duration("health-timeout", 0, "Maximum time to allow one check to run; 0 uses the image value or 30s when unset there too")
+	cmd.Flags().Int("health-retries", 0, "Consecutive failures needed to report unhealthy; 0 uses the image value or 3 when unset there too")
 	cmd.Flags().Duration("health-start-period", 0, "Start period for the container to initialize before starting health-retries countdown")
 	cmd.Flags().Bool("no-healthcheck", false, "Disable any container-specified HEALTHCHECK")
 

--- a/cmd/nerdctl/container/container_run_help_test.go
+++ b/cmd/nerdctl/container/container_run_help_test.go
@@ -41,4 +41,7 @@ func TestRunHelpDoesNotDuplicateDefaults(t *testing.T) {
 	assert.Assert(t, !strings.Contains(help, "Tune container memory swappiness (0 to 100) (default -1) (default -1)"))
 	assert.Assert(t, strings.Contains(help, "Allow running systemd in this container (default \"false\")"))
 	assert.Assert(t, !strings.Contains(help, "Allow running systemd in this container (default: false) (default \"false\")"))
+	assert.Assert(t, strings.Contains(help, "Time between running the check; 0 uses the image value or 30s when unset there too"))
+	assert.Assert(t, strings.Contains(help, "Maximum time to allow one check to run; 0 uses the image value or 30s when unset there too"))
+	assert.Assert(t, strings.Contains(help, "Consecutive failures needed to report unhealthy; 0 uses the image value or 3 when unset there too"))
 }


### PR DESCRIPTION
small help text bug.

`nerdctl run --help` says `--health-interval`, `--health-timeout`, and `--health-retries` default to `30s` or `3`.
That is a bit off, tbh. `0` there means not set, then nerdctl uses the image value, or falls back later.

repro:
1. `GOOS=linux make binaries`
2. `./_output/nerdctl run --help | rg "health-(interval|timeout|retries)"`

before this patch, the help text claims fixed defaults.
after this patch, it says what `0` really means. small thing, but less confusing and more honest.
