### PR TITLE
feat(run): allow -i and -d together when -t is set

### DIFF
--- a/cmd/nerdctl/container/container_run_detach_interactive_linux_test.go
+++ b/cmd/nerdctl/container/container_run_detach_interactive_linux_test.go
@@ -1,0 +1,86 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/require"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
+
+	"github.com/containerd/nerdctl/v2/pkg/testutil"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+)
+
+// TestRunDetachInteractiveWithTTY verifies that `run -t -d -i` is accepted and
+// starts a detached container that keeps running, matching Docker. The TTY's pty
+// is held by the shim, so the combination is valid.
+func TestRunDetachInteractiveWithTTY(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "-t", "-d", "-i", "--name", data.Identifier(),
+			testutil.CommonImage, "sleep", "infinity")
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: func(stdout string, t tig.T) {
+				assert.Assert(t, strings.Contains(
+					helpers.Capture("inspect", "--format", "{{.State.Running}}", data.Identifier()), "true"))
+			},
+		}
+	}
+
+	testCase.Run(t)
+}
+
+// TestRunDetachInteractiveWithoutTTYFails verifies that `run -d -i` without -t is
+// rejected: being daemonless, nerdctl has no process to keep stdin open after
+// detaching. Docker (daemon-backed) supports it, so this is nerdctl-only.
+func TestRunDetachInteractiveWithoutTTYFails(t *testing.T) {
+	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Docker)
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "-d", "-i", "--name", data.Identifier(), testutil.CommonImage, "cat")
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeGenericFail,
+			Errors:   []error{errors.New("can only be specified together with -t")},
+		}
+	}
+
+	testCase.Run(t)
+}

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -253,10 +253,11 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
 	}
 
-	if options.Interactive {
-		if options.Detach {
-			return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), errors.New("currently flag -i and -d cannot be specified together (FIXME)")
-		}
+	// -i with -d requires -t. Without a pty, nerdctl (being daemonless) has no
+	// process to keep the container's stdin open after it detaches, so the
+	// process would read EOF immediately; with -t the shim holds the pty open.
+	if options.Interactive && options.Detach && !options.TTY {
+		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), errors.New("combination of flags -i and -d can only be specified together with -t")
 	}
 
 	if options.TTY {


### PR DESCRIPTION
Fixes #317

`nerdctl run` rejected `-i` together with `-d` via a hardcoded FIXME, so the command in #317 (`nerdctl run -t -d -i ...`) failed.

## What this does
- Allows `-i -d` when `-t` is also set — with a TTY the containerd shim holds the pty open, so the detached container keeps a usable stdin and stays running. Unblocks the issue's exact command.
- Without `-t`, returns a clear error (`flags -i and -d can only be specified together with -t`) instead of the FIXME.

## Why not non-TTY `-d -i`?
nerdctl is daemonless. For a detached container, stdout/stderr use containerd binary logging; the shim's `createIO` picks the IO path solely from the stdout URI scheme, so a `binary://` logger and a stdin FIFO can't coexist. With no daemon to hold a plain stdin pipe open, a non-TTY `-d -i` process reads EOF immediately. Docker supports it only because dockerd holds the FIFOs; doing so in nerdctl would need a persistent per-container IO holder (conmon-style), out of scope here.

## Out of scope
- `run`/`create` only — the same FIXME in `exec`/`compose run` is left alone.
- Attaching to an already-detached TTY container is a separate pre-existing limitation (`TerminalBinaryIO` stores a `binary://` stdout that `attach` can't reopen).

## Tests
New `cmd/nerdctl/container/container_run_detach_interactive_linux_test.go`:
- `TestRunDetachInteractiveWithTTY` — `run -t -d -i` runs detached and stays running.
- `TestRunDetachInteractiveWithoutTTYFails` — `run -d -i` (no -t) fails with the clear error (nerdctl-only; Docker supports it).

Verified locally in a Linux + containerd sandbox: gofmt, go vet, build, and the new + existing `TestAttach*` integration tests pass.

cc @AkihiroSuda 