### PR TITLE
fix: skip rootless reexec for help-only command paths

### DIFF
--- a/cmd/nerdctl/main_linux.go
+++ b/cmd/nerdctl/main_linux.go
@@ -35,6 +35,9 @@ func appNeedsRootlessParentMain(cmd *cobra.Command, args []string) bool {
 	if !rootlessutil.IsRootlessParent() {
 		return false
 	}
+	if len(args) == 0 && cmd.HasSubCommands() {
+		return false
+	}
 	if len(commands) < 2 {
 		return true
 	}

--- a/cmd/nerdctl/main_linux_test.go
+++ b/cmd/nerdctl/main_linux_test.go
@@ -1,0 +1,69 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+)
+
+func TestAppNeedsRootlessParentMain(t *testing.T) {
+	if !rootlessutil.IsRootlessParent() {
+		t.Skip("test requires a rootless parent context")
+	}
+
+	app, err := newApp()
+	assert.NilError(t, err)
+
+	tests := []struct {
+		name     string
+		path     []string
+		expected bool
+	}{
+		{
+			name:     "root help path does not require reexec",
+			path:     nil,
+			expected: false,
+		},
+		{
+			name:     "management command help path does not require reexec",
+			path:     []string{"system"},
+			expected: false,
+		},
+		{
+			name:     "runtime command still requires reexec",
+			path:     []string{"system", "info"},
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := app
+			args := []string{}
+			if len(tc.path) > 0 {
+				var findErr error
+				cmd, args, findErr = app.Find(tc.path)
+				assert.NilError(t, findErr)
+			}
+			assert.Equal(t, appNeedsRootlessParentMain(cmd, args), tc.expected)
+		})
+	}
+}


### PR DESCRIPTION
rootless help paths can die early right now.

`nerdctl` and parent commands like `nerdctl system` try to reexec into RootlessKit before showing help. if rootless containerd is not running, users get `rootless containerd not running?` instead of usage.

This skips that reexec when the command only needs to show subcommands. real runtime commands still keep the old path, so no funny business.

How to repro

1. On Linux as a non root user, make sure rootless containerd is not running.
2. Run `go build -o /tmp/nerdctl ./cmd/nerdctl`
3. Run `/tmp/nerdctl`
4. Run `/tmp/nerdctl system`

Before, both commands fail with `rootless containerd not running?`.
After, both print help. `system info` still follows the old path.

Kinda adjacent to #3185.
