### PR TITLE
test: de-parallelize TestRunQuiet so it stops GC'ing the shared image

### DIFF
--- a/cmd/nerdctl/container/container_run_test.go
+++ b/cmd/nerdctl/container/container_run_test.go
@@ -798,6 +798,11 @@ func TestRunAttachFlag(t *testing.T) {
 func TestRunQuiet(t *testing.T) {
 	testCase := nerdtest.Setup()
 
+	// This test removes the shared image to force a fresh pull, so it must not
+	// run alongside other tests that use it: the content store is global across
+	// namespaces, so the rmi would GC layers out from under a parallel run.
+	testCase.NoParallel = true
+
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("rmi", "-f", testutil.CommonImage)
 	}


### PR DESCRIPTION
TestRunUmask was failing on the almalinux-8 rootless lane with:

```
nerdctl run --rm --umask 0200 ghcr.io/stargz-containers/alpine:3.13-org sh -c umask
level=fatal msg="content digest sha256:ec14c7992a97fc11425907e908340c6c3d6ff602f5f13d899e6b7027c9b4133a: not found"
--- FAIL: TestRunUmask (0.17s)
```

The cause is TestRunQuiet: it `rmi -f`s the shared CommonImage (== AlpineImage) in both setup and cleanup to exercise a fresh pull, but it runs in parallel. containerd's content store is global across namespaces, so that removal GCs the Alpine layer blobs out from under another test that is mid-`run` with `--pull missing` — the manifest is still present so it skips the fetch, then cannot find the blob.

Rather than pull the image in every consumer's setup, this marks TestRunQuiet NoParallel so it no longer races. That fixes it at the source for all tests sharing the image.