### PR TITLE
feat: label-based filtering added to `nerdctl events`

### DIFF
--- a/cmd/nerdctl/system/system_events_linux_test.go
+++ b/cmd/nerdctl/system/system_events_linux_test.go
@@ -51,6 +51,27 @@ func testEventFilterExecutor(data test.Data, helpers test.Helpers) test.Testable
 	return cmd
 }
 
+func testEventLabelFilterExecutor(data test.Data, helpers test.Helpers) test.TestableCommand {
+	helpers.Ensure("pull", testutil.CommonImage)
+
+	cmd := helpers.Command("events", "--filter", data.Labels().Get("filter"), "--format", "json")
+	cmd.WithTimeout(10 * time.Second)
+	cmd.Background()
+
+	helpers.Ensure(
+		"run",
+		"-d",
+		"--name", data.Identifier(),
+		"--label", data.Labels().Get("containerLabel"),
+		testutil.CommonImage,
+		"tail", "-f", "/dev/null",
+	)
+	time.Sleep(1 * time.Second)
+	helpers.Ensure("rm", "-f", data.Identifier())
+
+	return cmd
+}
+
 func TestEventFilters(t *testing.T) {
 	testCase := nerdtest.Setup()
 
@@ -126,6 +147,36 @@ func TestEventFilters(t *testing.T) {
 			Data: test.WithLabels(map[string]string{
 				"filter": "status=unknown",
 				"output": "\"Status\":\"unknown\"",
+			}),
+		},
+		{
+			Description: "LabelFilter",
+			Command:     testEventLabelFilterExecutor,
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeTimeout,
+					Output:   expect.Contains(data.Labels().Get("output")),
+				}
+			},
+			Data: test.WithLabels(map[string]string{
+				"filter":         "label=com.example.app=myapp",
+				"containerLabel": "com.example.app=myapp",
+				"output":         startEventOutput(),
+			}),
+		},
+		{
+			Description: "LabelKeyOnlyFilter",
+			Command:     testEventLabelFilterExecutor,
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeTimeout,
+					Output:   expect.Contains(data.Labels().Get("output")),
+				}
+			},
+			Data: test.WithLabels(map[string]string{
+				"filter":         "label=com.example.app",
+				"containerLabel": "com.example.app=myapp",
+				"output":         startEventOutput(),
 			}),
 		},
 	}

--- a/pkg/cmd/system/events.go
+++ b/pkg/cmd/system/events.go
@@ -44,6 +44,7 @@ type EventOut struct {
 	Topic     string
 	Status    Status
 	Event     string
+	Labels    map[string]string
 }
 
 type Status string
@@ -89,6 +90,31 @@ func generateEventFilter(filter, filterValue string) (func(e *EventOut) bool, er
 			}
 
 			return strings.EqualFold(string(e.Status), filterValue)
+		}, nil
+	case "LABEL":
+		parts := strings.SplitN(filterValue, "=", 2)
+		key := parts[0]
+		if key == "" {
+			return nil, fmt.Errorf("%s is an invalid label filter", filterValue)
+		}
+		wantValue := len(parts) == 2
+		var value string
+		if wantValue {
+			value = parts[1]
+		}
+		return func(e *EventOut) bool {
+			if len(e.Labels) == 0 {
+				return false
+			}
+			got, ok := e.Labels[key]
+			if !ok {
+				return false
+			}
+
+			if !wantValue {
+				return true
+			}
+			return got == value
 		}, nil
 	}
 
@@ -161,6 +187,13 @@ func Events(ctx context.Context, client *containerd.Client, options types.System
 			return err
 		}
 	}
+	labelFilterEnabled := false
+	for _, f := range options.Filters {
+		if strings.HasPrefix(strings.ToLower(f), "label=") {
+			labelFilterEnabled = true
+			break
+		}
+	}
 	filterMap, err := generateEventFilters(options.Filters)
 	if err != nil {
 		return err
@@ -175,6 +208,7 @@ func Events(ctx context.Context, client *containerd.Client, options types.System
 		if e != nil {
 			var out []byte
 			var id string
+			labels := map[string]string{}
 			if e.Event != nil {
 				v, err := typeurl.UnmarshalAny(e.Event)
 				if err != nil {
@@ -194,11 +228,19 @@ func Events(ctx context.Context, client *containerd.Client, options types.System
 			} else {
 				_, ok := data["container_id"]
 				if ok {
-					id = data["container_id"].(string)
+					if containerID, ok := data["container_id"].(string); ok {
+						id = containerID
+					}
 				}
 			}
-
-			eOut := EventOut{e.Timestamp, id, e.Namespace, e.Topic, TopicToStatus(e.Topic), string(out)}
+			if labelFilterEnabled && id != "" {
+				if container, err := client.ContainerService().Get(ctx, id); err != nil {
+					log.G(ctx).WithError(err).WithField("containerID", id).Debug("failed to retrieve container labels")
+				} else {
+					labels = container.Labels
+				}
+			}
+			eOut := EventOut{e.Timestamp, id, e.Namespace, e.Topic, TopicToStatus(e.Topic), string(out), labels}
 			match := applyFilters(&eOut, filterMap)
 			if match {
 				if tmpl != nil {


### PR DESCRIPTION
## Description
This PR adds support for label-based filtering in nerdctl events. Users can now filter the event stream using container labels, for example:
```
nerdctl events --filter label=com.example.app=myapp
```

Fixes: #4690 

The implementation resolves container metadata from incoming events and matches the configured label filter before displaying the event. This helps users focus on events related to a specific workload in environments with so many running containers.

- [x] I have tested this out in my local machine before pushing it.