### PR TITLE
test: remove redundant test lock pre-check

### DIFF
--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -18,7 +18,6 @@ package testutil
 
 import (
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -504,14 +503,6 @@ func M(m *testing.M) {
 	}
 
 	os.Exit(func() int {
-		// If there is a lockfile (no err), or if we error-ed stating it (permission), another test run is currently going.
-		// Note that this could be racy. The .lock file COULD get acquired after this and before we hit the lock section.
-		// This is not a big deal then: we will just wait for the lock to free.
-		if _, err := os.Stat(testLockFile); err == nil || !errors.Is(err, os.ErrNotExist) {
-			log.L.Errorf("Another test binary is already running. If you think this is an error, manually remove %s", testLockFile)
-			return 1
-		}
-
 		err := os.MkdirAll(filepath.Dir(testLockFile), 0o777)
 		if err != nil {
 			log.L.WithError(err).Errorf("failed creating testing lock directory %q", filepath.Dir(testLockFile))


### PR DESCRIPTION
This pre-check bails out too early.

`testutil.M` already takes a blocking filesystem lock, but the extra `os.Stat` check can fail filtered package runs before any test even starts. It kinda defeats the lock we already have. Pretty easy to hit in practice because `go test ./cmd/nerdctl/...` runs package test binaries in parallel by default.

Repro:
`go test ./cmd/nerdctl/... -run TestNonExistent -count=0`

Before:
some `cmd/nerdctl/*` packages fail with `Another test binary is already running...`

After:
the same command passes, and concurrent invocations still serialize fine.
