### PR TITLE
fix: return inspect format errors

### DIFF
--- a/cmd/nerdctl/container/container_inspect.go
+++ b/cmd/nerdctl/container/container_inspect.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/containerd/log"
-
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
@@ -108,13 +106,7 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Display
-	if len(entries) > 0 {
-		if formatErr := formatter.FormatSlice(opt.Format, opt.Stdout, entries); formatErr != nil {
-			log.G(ctx).Error(formatErr)
-		}
-	}
-	return err
+	return formatter.FormatInspectSlice(opt.Format, opt.Stdout, entries)
 }
 
 func containerInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/image/image_inspect.go
+++ b/cmd/nerdctl/image/image_inspect.go
@@ -21,8 +21,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/containerd/log"
-
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
@@ -110,13 +108,7 @@ func imageInspectAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Display
-	if len(entries) > 0 {
-		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, entries); formatErr != nil {
-			log.G(ctx).Error(formatErr)
-		}
-	}
-	return err
+	return formatter.FormatInspectSlice(options.Format, options.Stdout, entries)
 }
 
 func imageInspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/nerdctl/inspect/inspect.go
+++ b/cmd/nerdctl/inspect/inspect.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/containerd/log"
-
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	containercmd "github.com/containerd/nerdctl/v2/cmd/nerdctl/container"
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
@@ -176,11 +174,7 @@ func inspectAction(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("%d errors: %v", len(errs), errs)
 	}
 
-	if formatErr := formatter.FormatSlice(format, cmd.OutOrStdout(), entries); formatErr != nil {
-		log.G(ctx).Error(formatErr)
-	}
-
-	return nil
+	return formatter.FormatInspectSlice(format, cmd.OutOrStdout(), entries)
 }
 
 func inspectShellComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/cmd/network/inspect.go
+++ b/pkg/cmd/network/inspect.go
@@ -98,10 +98,7 @@ func Inspect(ctx context.Context, client *containerd.Client, options types.Netwo
 	}
 
 	if len(result) > 0 {
-		if formatErr := formatter.FormatSlice(options.Format, options.Stdout, result); formatErr != nil {
-			log.G(ctx).Error(formatErr)
-		}
-		err = nil
+		err = formatter.FormatInspectSlice(options.Format, options.Stdout, result)
 	} else {
 		err = errors.New("unable to find any network matching the provided request")
 	}

--- a/pkg/formatter/common.go
+++ b/pkg/formatter/common.go
@@ -78,6 +78,15 @@ func FormatSlice(format string, writer io.Writer, x []interface{}) error {
 	return nil
 }
 
+// FormatInspectSlice formats inspect results and propagates template errors back
+// to the caller so CLI commands can fail with a non-zero exit code.
+func FormatInspectSlice(format string, writer io.Writer, x []interface{}) error {
+	if len(x) == 0 {
+		return nil
+	}
+	return FormatSlice(format, writer, x)
+}
+
 func tryRawFormat(b *bytes.Buffer, f interface{}, tmpl *template.Template) error {
 	m, err := json.MarshalIndent(f, "", "    ")
 	if err != nil {

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -17,6 +17,7 @@
 package formatter
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
@@ -236,4 +237,38 @@ func TestEllipsis(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestFormatInspectSlice(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty slice is ignored", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		err := FormatInspectSlice("{{.ID}}", &buf, nil)
+		assert.NilError(t, err)
+		assert.Equal(t, "", buf.String())
+	})
+
+	t.Run("malformed template returns error", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		err := FormatInspectSlice("{{bad", &buf, []interface{}{
+			map[string]string{"ID": "abc"},
+		})
+		assert.ErrorContains(t, err, "template")
+	})
+
+	t.Run("default format still works", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		err := FormatInspectSlice("", &buf, []interface{}{
+			map[string]string{"ID": "abc"},
+		})
+		assert.NilError(t, err)
+		assert.Assert(t, buf.Len() > 0)
+	})
 }


### PR DESCRIPTION
this makes inspect return a real error when the format string is malformed or unsupported. before this, the command logged the formatter error but still exited 0, which is kinda sneaky in scripts.

repro
1. run `nerdctl image inspect -f '{{bad' alpine`
2. current main prints the template error but exits 0
3. this patch makes it exit non zero

the change only touches the final inspect formatting path. normal json output and valid templates stay the same.
