### PR TITLE
feat(network): add --ipv4 to allow IPv6-only networks

### DIFF
--- a/cmd/nerdctl/network/network_create.go
+++ b/cmd/nerdctl/network/network_create.go
@@ -50,6 +50,7 @@ func createCommand() *cobra.Command {
 	cmd.Flags().StringArray("gateway", nil, "IPv4 or IPv6 Gateway for the master subnet")
 	cmd.Flags().StringArray("ip-range", nil, `Allocate container ip from a sub-range`)
 	cmd.Flags().StringArray("label", nil, "Set metadata for a network")
+	cmd.Flags().Bool("ipv4", true, "Enable IPv4 networking (set to false together with --ipv6 for an IPv6-only network)")
 	cmd.Flags().Bool("ipv6", false, "Enable IPv6 networking")
 	cmd.Flags().Bool("internal", false, "Restrict external access to the network")
 	return cmd
@@ -97,6 +98,10 @@ func createAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	labels = strutil.DedupeStrSlice(labels)
+	ipv4, err := cmd.Flags().GetBool("ipv4")
+	if err != nil {
+		return err
+	}
 	ipv6, err := cmd.Flags().GetBool("ipv6")
 	if err != nil {
 		return err
@@ -118,6 +123,7 @@ func createAction(cmd *cobra.Command, args []string) error {
 		IPRange:     ipRanges,
 		Labels:      labels,
 		IPv6:        ipv6,
+		IPv4:        &ipv4,
 		Internal:    internal,
 	}, cmd.OutOrStdout())
 }

--- a/cmd/nerdctl/network/network_create_linux_test.go
+++ b/cmd/nerdctl/network/network_create_linux_test.go
@@ -180,6 +180,36 @@ func TestNetworkCreate(t *testing.T) {
 			},
 		},
 		{
+			Description: "ipv6-only with --ipv4=false",
+			Require:     nerdtest.OnlyIPv6,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				subnetStr := "2001:db8:9::/64"
+				data.Labels().Set("subnetStr", subnetStr)
+				_, _, err := net.ParseCIDR(subnetStr)
+				assert.Assert(t, err == nil)
+
+				helpers.Ensure("network", "create", data.Identifier(), "--ipv6", "--ipv4=false", "--subnet", subnetStr)
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("network", "rm", data.Identifier())
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("run", "--rm", "--net", data.Identifier(), testutil.CommonImage, "ip", "addr", "show", "dev", "eth0")
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						_, subnet, _ := net.ParseCIDR(data.Labels().Get("subnetStr"))
+						ip := nerdtest.FindIPv6(stdout)
+						assert.Assert(t, subnet.Contains(ip), fmt.Sprintf("subnet %s contains ip %s", subnet, ip))
+						// With IPv4 disabled the interface must not get a v4 address.
+						assert.Assert(t, !strings.Contains(stdout, "inet "), "eth0 should have no IPv4 address")
+					},
+				}
+			},
+		},
+		{
 			Description: "internal enabled",
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("network", "create", "--internal", data.Identifier())

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1280,6 +1280,7 @@ Flags:
 - :whale: `--gateway`: IPv4 or IPv6 Gateway for the master subnet
 - :whale: `--ip-range`: Allocate container ip from a sub-range
 - :whale: `--label`: Set metadata on a network
+- :whale: `--ipv4`: Enable IPv4. Enabled by default; set to false with `--ipv6` and an IPv6 subnet for an IPv6-only network. `--ipv4=false` is not supported on Windows.
 - :whale: `--ipv6`: Enable IPv6. Should be used with a valid subnet.
 - :whale: `--internal`: Restrict external access to the network.
 

--- a/pkg/api/types/network_types.go
+++ b/pkg/api/types/network_types.go
@@ -35,7 +35,11 @@ type NetworkCreateOptions struct {
 	IPRange     []string
 	Labels      []string
 	IPv6        bool
-	Internal    bool
+	// IPv4 enables IPv4 on the network. A nil value defaults to enabled, so a
+	// directly-constructed NetworkCreateOptions keeps IPv4 on; setting it to
+	// false together with IPv6 yields an IPv6-only network.
+	IPv4     *bool
+	Internal bool
 }
 
 // NetworkInspectOptions specifies options for `nerdctl network inspect`.

--- a/pkg/cmd/network/create.go
+++ b/pkg/cmd/network/create.go
@@ -27,6 +27,19 @@ import (
 )
 
 func Create(options types.NetworkCreateOptions, stdout io.Writer) error {
+	// A nil IPv4 defaults to enabled.
+	ipv4 := options.IPv4 == nil || *options.IPv4
+	// At least one address family must be enabled, matching docker which
+	// rejects a network with both IPv4 and IPv6 turned off.
+	if !ipv4 && !options.IPv6 {
+		return fmt.Errorf("IPv4 or IPv6 must be enabled")
+	}
+	if !ipv4 && len(options.Subnets) == 0 {
+		// IPv6-only needs a concrete IPv6 subnet: unlike docker, nerdctl does
+		// not auto-allocate one, and the empty-subnet default below would pick
+		// an IPv4 range, contradicting the disabled IPv4.
+		return fmt.Errorf("IPv6-only network requires an IPv6 subnet, specify --subnet manually")
+	}
 	if len(options.Subnets) == 0 {
 		if len(options.Gateway) > 0 || len(options.IPRange) > 0 {
 			return fmt.Errorf("cannot set gateway or ip-range without subnet, specify --subnet manually")

--- a/pkg/netutil/netutil.go
+++ b/pkg/netutil/netutil.go
@@ -339,7 +339,9 @@ func (e *CNIEnv) CreateNetwork(opts types.NetworkCreateOptions) (*NetworkConfig,
 	if _, ok := netMap[opts.Name]; ok {
 		return nil, errdefs.ErrAlreadyExists
 	}
-	ipam, err := e.generateIPAM(opts.IPAMDriver, opts.Subnets, opts.Gateway, opts.IPRange, opts.IPAMOptions, opts.IPv6, opts.Internal)
+	// A nil IPv4 defaults to enabled.
+	ipv4 := opts.IPv4 == nil || *opts.IPv4
+	ipam, err := e.generateIPAM(opts.IPAMDriver, opts.Subnets, opts.Gateway, opts.IPRange, opts.IPAMOptions, opts.IPv6, ipv4, opts.Internal)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netutil/netutil_unix.go
+++ b/pkg/netutil/netutil_unix.go
@@ -215,24 +215,35 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 	return plugins, nil
 }
 
-func (e *CNIEnv) generateIPAM(driver string, subnets []string, gateways []string, ipRanges []string, opts map[string]string, ipv6 bool, internal bool) (map[string]interface{}, error) {
+func (e *CNIEnv) generateIPAM(driver string, subnets []string, gateways []string, ipRanges []string, opts map[string]string, ipv6, ipv4, internal bool) (map[string]interface{}, error) {
 	var ipamConfig interface{}
 	switch driver {
 	case "default", "host-local":
 		ipamConf := newHostLocalIPAMConfig()
 		if !internal {
+			// An IPv6-only network has no IPv4 gateway, so its default route
+			// must be the IPv6 one; otherwise host-local installs an IPv4
+			// default route with no matching range.
+			defaultRoute := "0.0.0.0/0"
+			if !ipv4 {
+				defaultRoute = "::/0"
+			}
 			ipamConf.Routes = []IPAMRoute{
-				{Dst: "0.0.0.0/0"},
+				{Dst: defaultRoute},
 			}
 		}
 		ranges, findIPv4, err := e.parseIPAMRanges(subnets, gateways, ipRanges, ipv6)
 		if err != nil {
 			return nil, err
 		}
+		if !ipv4 && findIPv4 {
+			return nil, fmt.Errorf("--ipv4=false conflicts with an IPv4 subnet")
+		}
 		ipamConf.Ranges = append(ipamConf.Ranges, ranges...)
-		if !findIPv4 {
+		if ipv4 && !findIPv4 {
 			// The default IPv4 range uses a computed gateway and no ip-range;
 			// any user-supplied gateway or ip-range belongs to an explicit subnet.
+			// Skipped when IPv4 is disabled, leaving the network IPv6-only.
 			ranges, _, _ = e.parseIPAMRanges([]string{""}, nil, nil, ipv6)
 			ipamConf.Ranges = append(ipamConf.Ranges, ranges...)
 		}

--- a/pkg/netutil/netutil_windows.go
+++ b/pkg/netutil/netutil_windows.go
@@ -72,11 +72,15 @@ func (e *CNIEnv) generateCNIPlugins(driver string, name string, ipam map[string]
 	return plugins, nil
 }
 
-func (e *CNIEnv) generateIPAM(driver string, subnets []string, gateways []string, ipRanges []string, opts map[string]string, ipv6 bool, internal bool) (map[string]interface{}, error) {
+func (e *CNIEnv) generateIPAM(driver string, subnets []string, gateways []string, ipRanges []string, opts map[string]string, ipv6, ipv4, internal bool) (map[string]interface{}, error) {
 	switch driver {
 	case "default":
 	default:
 		return nil, fmt.Errorf("unsupported ipam driver %q", driver)
+	}
+	// IPv6-only networks are not supported on Windows.
+	if !ipv4 {
+		return nil, fmt.Errorf("--ipv4=false is not supported on Windows")
 	}
 
 	// Windows is single-subnet, so use at most one gateway and one ip-range.


### PR DESCRIPTION
Part of #5012. Docker's `network create` has `--ipv4` (on by default) so you can pass `--ipv4=false` with `--ipv6` to get an IPv6-only network. nerdctl had no equivalent — `generateIPAM` always appends a default IPv4 range when no v4 subnet is given, so every bridge network ends up with IPv4.

This adds the flag. It's carried through as `DisableIPv4` (the inverse) so the zero value keeps IPv4 enabled and nothing changes for existing callers, including the default bridge network. When IPv4 is disabled the default v4 range is skipped, the host-local default route becomes `::/0` instead of `0.0.0.0/0`, and an IPv4 subnet is rejected. It requires `--ipv6` and an explicit IPv6 subnet, and is rejected on Windows where IPv6-only isn't supported.

One difference from Docker worth calling out: with `--ipv6 --ipv4=false` and no subnet, Docker auto-assigns a ULA /64. nerdctl doesn't allocate IPv6 subnets anywhere today — even a plain `--ipv6` without a subnet only gets the default IPv4 range — so this errors and asks for an explicit `--subnet` instead. Auto-allocating a ULA range is worth doing on its own since it would apply to the dual-stack case too.

Verified against Docker 29.4 locally: same addresses for an IPv6-only network, same rejection without `--ipv6`. Logs in a comment below.
