### PR TITLE
fix: hide internal alias flags from help output

### DIFF
--- a/cmd/nerdctl/compose/compose_help_test.go
+++ b/cmd/nerdctl/compose/compose_help_test.go
@@ -1,0 +1,62 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package compose
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestComposeHelpHidesAliasImplementationFlags(t *testing.T) {
+	cmd := Command()
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := stdout.String()
+	if strings.Contains(out, "-f, --f") {
+		t.Fatalf("help output unexpectedly contains alias implementation flag\n%s", out)
+	}
+	expected := "--file stringArray           Specify an alternate compose file (aliases: -f)"
+	if !strings.Contains(out, expected) {
+		t.Fatalf("help output missing %q\n%s", expected, out)
+	}
+}
+
+func TestComposeHiddenFileAliasStillParses(t *testing.T) {
+	cmd := Command()
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+	cmd.SetArgs([]string{"-f", "compose.yaml", "--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := cmd.Flag("file").Value.String(); got != "[compose.yaml]" {
+		t.Fatalf("file flag = %q, want %q", got, "[compose.yaml]")
+	}
+}

--- a/cmd/nerdctl/helpers/cobra.go
+++ b/cmd/nerdctl/helpers/cobra.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -28,6 +29,28 @@ import (
 
 	"github.com/containerd/log"
 )
+
+func formatAliasLabels(aliasGroups ...[]string) []string {
+	var labels []string
+	for _, aliases := range aliasGroups {
+		for _, alias := range aliases {
+			prefix := "--"
+			if len(alias) == 1 {
+				prefix = "-"
+			}
+			labels = append(labels, prefix+alias)
+		}
+	}
+	return labels
+}
+
+func appendAliasesUsage(usage string, aliasGroups ...[]string) string {
+	labels := formatAliasLabels(aliasGroups...)
+	if len(labels) == 0 {
+		return usage
+	}
+	return fmt.Sprintf("%s (aliases: %s)", usage, strings.Join(labels, ", "))
+}
 
 // UnknownSubcommandAction is needed to let `nerdctl system non-existent-command` fail
 // https://github.com/containerd/nerdctl/issues/487
@@ -74,6 +97,7 @@ func AddStringFlag(cmd *cobra.Command, name string, aliases []string, value stri
 	if envV, ok := os.LookupEnv(env); ok {
 		value = envV
 	}
+	usage = appendAliasesUsage(usage, aliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new(string)
 	flags := cmd.Flags()
@@ -85,6 +109,7 @@ func AddStringFlag(cmd *cobra.Command, name string, aliases []string, value stri
 		} else {
 			flags.StringVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 	}
 }
 
@@ -100,6 +125,7 @@ func AddIntFlag(cmd *cobra.Command, name string, aliases []string, value int, en
 		}
 		value = int(v)
 	}
+	usage = appendAliasesUsage(usage, aliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new(int)
 	flags := cmd.Flags()
@@ -111,6 +137,7 @@ func AddIntFlag(cmd *cobra.Command, name string, aliases []string, value int, en
 		} else {
 			flags.IntVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 	}
 }
 
@@ -126,6 +153,7 @@ func AddDurationFlag(cmd *cobra.Command, name string, aliases []string, value ti
 			log.L.WithError(err).Warnf("Invalid duration value for `%s`", env)
 		}
 	}
+	usage = appendAliasesUsage(usage, aliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new(time.Duration)
 	flags := cmd.Flags()
@@ -137,6 +165,7 @@ func AddDurationFlag(cmd *cobra.Command, name string, aliases []string, value ti
 		} else {
 			flags.DurationVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 	}
 }
 
@@ -176,6 +205,7 @@ func AddPersistentStringArrayFlag(cmd *cobra.Command, name string, aliases, nonP
 	if envV, ok := os.LookupEnv(env); ok {
 		value = []string{envV}
 	}
+	usage = appendAliasesUsage(usage, aliases, nonPersistentAliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new([]string)
 	flags := cmd.Flags()
@@ -186,6 +216,7 @@ func AddPersistentStringArrayFlag(cmd *cobra.Command, name string, aliases, nonP
 		} else {
 			flags.StringArrayVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 	}
 
 	persistentFlags := cmd.PersistentFlags()
@@ -197,6 +228,7 @@ func AddPersistentStringArrayFlag(cmd *cobra.Command, name string, aliases, nonP
 		} else {
 			persistentFlags.StringArrayVar(p, a, value, aliasesUsage)
 		}
+		persistentFlags.MarkHidden(a)
 	}
 }
 
@@ -209,6 +241,7 @@ func AddPersistentStringFlag(cmd *cobra.Command, name string, aliases, localAlia
 	if envV, ok := os.LookupEnv(env); ok {
 		value = envV
 	}
+	usage = appendAliasesUsage(usage, aliases, localAliases, persistentAliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new(string)
 
@@ -222,6 +255,7 @@ func AddPersistentStringFlag(cmd *cobra.Command, name string, aliases, localAlia
 		} else {
 			flags.StringVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 		// non-persistent flags are not added to the InheritedFlags, so we should add them manually
 		f := flags.Lookup(a)
 		aliasToBeInherited.AddFlag(f)
@@ -236,6 +270,7 @@ func AddPersistentStringFlag(cmd *cobra.Command, name string, aliases, localAlia
 		} else {
 			localFlags.StringVar(p, a, value, aliasesUsage)
 		}
+		localFlags.MarkHidden(a)
 	}
 
 	// persistentFlags cannot redefine alias already used in subcommands
@@ -248,6 +283,7 @@ func AddPersistentStringFlag(cmd *cobra.Command, name string, aliases, localAlia
 		} else {
 			persistentFlags.StringVar(p, a, value, aliasesUsage)
 		}
+		persistentFlags.MarkHidden(a)
 	}
 }
 
@@ -264,6 +300,7 @@ func AddPersistentBoolFlag(cmd *cobra.Command, name string, aliases, nonPersiste
 			log.L.WithError(err).Warnf("Invalid boolean value for `%s`", env)
 		}
 	}
+	usage = appendAliasesUsage(usage, aliases, nonPersistentAliases)
 	aliasesUsage := fmt.Sprintf("Alias of --%s", name)
 	p := new(bool)
 	flags := cmd.Flags()
@@ -274,6 +311,7 @@ func AddPersistentBoolFlag(cmd *cobra.Command, name string, aliases, nonPersiste
 		} else {
 			flags.BoolVar(p, a, value, aliasesUsage)
 		}
+		flags.MarkHidden(a)
 	}
 
 	persistentFlags := cmd.PersistentFlags()
@@ -285,6 +323,7 @@ func AddPersistentBoolFlag(cmd *cobra.Command, name string, aliases, nonPersiste
 		} else {
 			persistentFlags.BoolVar(p, a, value, aliasesUsage)
 		}
+		persistentFlags.MarkHidden(a)
 	}
 }
 

--- a/cmd/nerdctl/main_test.go
+++ b/cmd/nerdctl/main_test.go
@@ -17,7 +17,9 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/containerd/containerd/v2/defaults"
@@ -129,4 +131,72 @@ version = 2`),
 	}
 
 	testCase.Run(t)
+}
+
+func TestRootHelpHidesAliasImplementationFlags(t *testing.T) {
+	app, err := newApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app.SetOut(&stdout)
+	app.SetErr(&stdout)
+	app.SetArgs([]string{"--help"})
+
+	if err := app.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	out := stdout.String()
+	for _, unexpected := range []string{
+		"-a, --a",
+		"-H, --H",
+		"-n, --n",
+	} {
+		if strings.Contains(out, unexpected) {
+			t.Fatalf("help output unexpectedly contains %q\n%s", unexpected, out)
+		}
+	}
+	for _, expected := range []string{
+		"--address string           containerd address, optionally with \"unix://\" prefix [$CONTAINERD_ADDRESS] (aliases: -a, -H, --host)",
+		"--namespace string         containerd namespace, such as \"moby\" for Docker, \"k8s.io\" for Kubernetes [$CONTAINERD_NAMESPACE] (aliases: -n)",
+	} {
+		if !strings.Contains(out, expected) {
+			t.Fatalf("help output missing %q\n%s", expected, out)
+		}
+	}
+}
+
+func TestRootHiddenAliasesStillParse(t *testing.T) {
+	app, err := newApp()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	app.SetOut(&stdout)
+	app.SetErr(&stdout)
+	app.SetArgs([]string{
+		"-a", "unix:///tmp/a.sock",
+		"-H", "unix:///tmp/h.sock",
+		"--host", "unix:///tmp/host.sock",
+		"-n", "testns",
+		"--storage-driver", "native",
+		"--help",
+	})
+
+	if err := app.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := app.Flag("address").Value.String(); got != "unix:///tmp/host.sock" {
+		t.Fatalf("address flag = %q, want %q", got, "unix:///tmp/host.sock")
+	}
+	if got := app.Flag("namespace").Value.String(); got != "testns" {
+		t.Fatalf("namespace flag = %q, want %q", got, "testns")
+	}
+	if got := app.Flag("snapshotter").Value.String(); got != "native" {
+		t.Fatalf("snapshotter flag = %q, want %q", got, "native")
+	}
 }


### PR DESCRIPTION
small help output papercut.

right now `nerdctl --help` shows internal alias shim flags like `-a, --a`, `-H, --H`, `-n, --n`. same thing in `nerdctl compose --help` with `-f, --f`. looks a bit weird, and not really what users should see.

this hides those shim flags from help, and shows aliases on the real flag line instead. alias parsing still works, so no behavior change there.

repro
```bash
go build ./cmd/nerdctl
./nerdctl --help
./nerdctl compose --help
```

before
```text
-a, --a string
-H, --H string
-n, --n string
-f, --f stringArray
```

after
```text
--address string ... (aliases: -a, -H, --host)
--namespace string ... (aliases: -n)
--file stringArray ... (aliases: -f)
```

checks
```bash
go test ./cmd/nerdctl -run 'TestRootHelpHidesAliasImplementationFlags|TestRootHiddenAliasesStillParse'
go test ./cmd/nerdctl/compose -run 'TestComposeHelpHidesAliasImplementationFlags|TestComposeHiddenFileAliasStillParses'
```
