### PR TITLE
feat(run): add support for `--expose` and `--publish-all`

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -133,6 +133,8 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSlice("dns-option", nil, "Set DNS options")
 	// publish is defined as StringSlice, not StringArray, to allow specifying "--publish=80:80,443:443" (compatible with Podman)
 	cmd.Flags().StringSliceP("publish", "p", nil, "Publish a container's port(s) to the host")
+	cmd.Flags().StringSlice("expose", nil, "Expose a port or a range of ports")
+	cmd.Flags().BoolP("publish-all", "P", false, "Publish all exposed ports to random ports")
 	cmd.Flags().String("ip", "", "IPv4 address to assign to the container")
 	cmd.Flags().String("ip6", "", "IPv6 address to assign to the container")
 	cmd.Flags().StringP("hostname", "h", "", "Container host name")

--- a/cmd/nerdctl/container/container_run_network.go
+++ b/cmd/nerdctl/container/container_run_network.go
@@ -187,6 +187,19 @@ func loadNetworkFlags(cmd *cobra.Command, globalOpts types.GlobalCommandOptions)
 		return netOpts, err
 	}
 	portSlice = strutil.DedupeStrSlice(portSlice)
+
+	expose, err := cmd.Flags().GetStringSlice("expose")
+	if err != nil {
+		return netOpts, err
+	}
+	netOpts.ExposedPorts = strutil.DedupeStrSlice(expose)
+
+	publishAll, err := cmd.Flags().GetBool("publish-all")
+	if err != nil {
+		return netOpts, err
+	}
+	netOpts.PublishAll = publishAll
+
 	portMappings := []cni.PortMapping{}
 	for _, p := range portSlice {
 		pm, err := portutil.ParseFlagP(p)

--- a/cmd/nerdctl/container/container_run_network_linux_test.go
+++ b/cmd/nerdctl/container/container_run_network_linux_test.go
@@ -1198,3 +1198,80 @@ func TestReservePorts(t *testing.T) {
 	}
 	testCase.Run(t)
 }
+
+func TestRunExposeOnly(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Labels().Set("containerName", data.Identifier())
+		helpers.Ensure("run", "-d", "--name", data.Labels().Get("containerName"), "--expose", "8089", testutil.NginxAlpineImage)
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Labels().Get("containerName"))
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "exposed ports are shown in inspect",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("inspect", data.Labels().Get("containerName"), "--format", "{{json .Config.ExposedPorts}}")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+				assert.Assert(t, strings.Contains(stdout, `"80/tcp":{}`), stdout)
+				assert.Assert(t, strings.Contains(stdout, `"8089/tcp":{}`), stdout)
+			}),
+		},
+		{
+			Description: "expose does not publish ports",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("port", data.Labels().Get("containerName"))
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.DoesNotContain("8089/tcp ->")),
+		},
+	}
+
+	testCase.Run(t)
+}
+
+func TestRunExposePublishAll(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Require = require.All(
+		require.Not(nerdtest.Rootless), // Automatic port allocation is only supported in rootful mode.
+	)
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		data.Labels().Set("containerName", data.Identifier())
+		helpers.Ensure("run", "-d", "--name", data.Labels().Get("containerName"), "--expose", "8089", "-P", testutil.NginxAlpineImage)
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Labels().Get("containerName"))
+	}
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "exposed ports are shown in inspect",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("inspect", data.Labels().Get("containerName"), "--format", "{{json .Config.ExposedPorts}}")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+				assert.Assert(t, strings.Contains(stdout, `"80/tcp":{}`), stdout)
+				assert.Assert(t, strings.Contains(stdout, `"8089/tcp":{}`), stdout)
+			}),
+		},
+		{
+			Description: "publish-all publishes image and CLI exposed ports",
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("port", data.Labels().Get("containerName"))
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+				assert.Assert(t, strings.Contains(stdout, "80/tcp ->"), stdout)
+				assert.Assert(t, strings.Contains(stdout, "8089/tcp ->"), stdout)
+			}),
+		},
+	}
+
+	testCase.Run(t)
+}

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -466,8 +466,8 @@ IPFS flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker run` flags:
-    `--device-cgroup-rule`, `--disable-content-trust`, `--expose`,
-    `--health-start-interval`, `--link*`, `--publish-all`, `--storage-opt`,
+    `--device-cgroup-rule`, `--disable-content-trust`,
+    `--health-start-interval`, `--link*`, `--storage-opt`,
     `--volume-driver`
 
 ### :whale: nerdctl exec

--- a/pkg/api/types/container_network_types.go
+++ b/pkg/api/types/container_network_types.go
@@ -46,4 +46,8 @@ type NetworkOptions struct {
 	UTSNamespace string
 	// PortMappings specifies a list of ports to publish from the container to the host
 	PortMappings []cni.PortMapping
+	// Additional ports exposed via --expose. Used to generate PortMappings when PublishAll is enabled.
+	ExposedPorts []string
+	// Automatically publish all exposed ports by generating PortMappings.
+	PublishAll bool
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -38,6 +38,7 @@ import (
 	"github.com/containerd/containerd/v2/core/containers"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
@@ -293,6 +294,31 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	}
 	cOpts = append(cOpts, restartOpts...)
 
+	var imageExposedPorts map[string]struct{}
+
+	if ensuredImage != nil {
+		imageExposedPorts = ensuredImage.ImageConfig.ExposedPorts
+	}
+
+	exposedPorts := mergeExposedPorts(imageExposedPorts, netManager.NetworkOptions().ExposedPorts)
+
+	internalLabels.exposedPorts = exposedPorts
+
+	if netManager.NetworkOptions().PublishAll {
+		publishAllPortMappings, err := generatePublishAllPortMappings(exposedPorts)
+		if err != nil {
+			return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
+		}
+
+		netOpts := netManager.NetworkOptions()
+		netOpts.PortMappings = append(netOpts.PortMappings, publishAllPortMappings...)
+
+		netManager, err = containerutil.NewNetworkingOptionsManager(options.GOptions, netOpts, client)
+		if err != nil {
+			return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
+		}
+	}
+
 	if err = netManager.VerifyNetworkOptions(ctx); err != nil {
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), fmt.Errorf("failed to verify networking settings: %w", err)
 	}
@@ -445,6 +471,40 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	}
 
 	return c, nil, nil
+}
+
+func mergeExposedPorts(imageExposedPorts map[string]struct{}, cliExposedPorts []string) map[string]struct{} {
+	exposedPorts := map[string]struct{}{}
+
+	for port := range imageExposedPorts {
+		exposedPorts[port] = struct{}{}
+	}
+
+	for _, port := range cliExposedPorts {
+		if port == "" {
+			continue
+		}
+		if !strings.Contains(port, "/") {
+			port += "/tcp"
+		}
+		exposedPorts[port] = struct{}{}
+	}
+
+	return exposedPorts
+}
+
+func generatePublishAllPortMappings(exposedPorts map[string]struct{}) ([]cni.PortMapping, error) {
+	var portMappings []cni.PortMapping
+
+	for port := range exposedPorts {
+		pm, err := portutil.ParseFlagP(port)
+		if err != nil {
+			return nil, err
+		}
+		portMappings = append(portMappings, pm...)
+	}
+
+	return portMappings, nil
 }
 
 func generateRootfsOpts(args []string, id string, ensured *imgutil.EnsuredImage, options types.ContainerCreateOptions) (opts []oci.SpecOpts, cOpts []containerd.NewContainerOpts, err error) {
@@ -769,6 +829,8 @@ type internalLabels struct {
 	healthcheck string
 
 	privileged bool
+
+	exposedPorts map[string]struct{}
 }
 
 // WithInternalLabels sets the internal labels for a container.
@@ -833,6 +895,14 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 		if err := labels.SetMount(m, jsonMountBytes); err != nil {
 			return nil, err
 		}
+	}
+
+	if len(internalLabels.exposedPorts) > 0 {
+		exposedPortsJSON, err := json.Marshal(internalLabels.exposedPorts)
+		if err != nil {
+			return nil, err
+		}
+		m[labels.ExposedPorts] = string(exposedPortsJSON)
 	}
 
 	if internalLabels.macAddress != "" {

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -578,6 +578,14 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 		Labels: n.Labels,
 		Image:  c.Image,
 	}
+	if exposedPortsJSON := n.Labels[labels.ExposedPorts]; exposedPortsJSON != "" {
+		var exposedPorts nat.PortSet
+		if err := json.Unmarshal([]byte(exposedPortsJSON), &exposedPorts); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal exposed ports: %w", err)
+		}
+		c.Config.ExposedPorts = exposedPorts
+	}
+
 	if n.Labels[labels.Hostname] != "" {
 		hostname = n.Labels[labels.Hostname]
 	}

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -134,4 +134,6 @@ const (
 
 	// Privileged indicates whether the container was created with --privileged.
 	Privileged = Prefix + "privileged"
+	// ExposedPorts is a JSON-marshalled string of nat.PortSet.
+	ExposedPorts = Prefix + "exposed-ports"
 )


### PR DESCRIPTION
## Description
This PR adds support for the Docker compatible `--expose` and `--publish-all` (-P) flags to `nerdctl run` and `nerdctl create`.

 Previously, nerdctl supported explicit port publishing through `--publish` (-p), but did not support declaring additional exposed ports with `--expose` or automatically publishing all exposed ports using `-P`. With this change, users can expose additional container ports via the CLI, and `-P` will publish both image defined (`EXPOSE`) and cli defined (`--expose`) ports to automatically allocated host ports by reusing the existing port mapping implementation. This improves Docker CLI compatibility while preserving the existing behaviors.

Fixes: #4689