### PR TITLE
run, exec: fix `-i` hanging when stdin reaches EOF during task creation

### DIFF
--- a/pkg/cmd/container/exec.go
+++ b/pkg/cmd/container/exec.go
@@ -73,8 +73,21 @@ func execActionWithContainer(ctx context.Context, client *containerd.Client, con
 	var (
 		ioCreator cio.Creator
 		in        io.Reader
-		stdinC    = &taskutil.StdinCloser{
+		// The io copy goroutines are started by the cio.Creator, inside task.Exec
+		// below: on a short enough stdin, they can reach EOF before the process
+		// handle is available. Block until it is: losing the CloseIO would leave
+		// the write end of the stdin FIFO open inside the shim, and the exec'ed
+		// process would never receive EOF on its stdin.
+		processC = make(chan containerd.Process, 1)
+		stdinC   = &taskutil.StdinCloser{
 			Stdin: os.Stdin,
+			Closer: func() {
+				if p, ok := <-processC; ok {
+					if err := p.CloseIO(ctx, containerd.WithStdinCloser); err != nil {
+						log.G(ctx).WithError(err).Warn("failed to close the process stdin")
+					}
+				}
+			},
 		}
 	)
 
@@ -90,11 +103,10 @@ func execActionWithContainer(ctx context.Context, client *containerd.Client, con
 	execID := "exec-" + idgen.GenerateID()
 	process, err := task.Exec(ctx, execID, pspec, ioCreator)
 	if err != nil {
+		close(processC)
 		return err
 	}
-	stdinC.Closer = func() {
-		process.CloseIO(ctx, containerd.WithStdinCloser)
-	}
+	processC <- process
 	// if detach, we should not call this defer
 	if !options.Detach {
 		defer process.Delete(ctx)

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -68,6 +68,7 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 	var (
 		checkpoint *types.Descriptor
 		t          containerd.Task
+		stdinTask  chan containerd.Task
 		err        error
 	)
 
@@ -206,17 +207,24 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			} else if sv.LessThan(semver.MustParse("1.6.0-0")) {
 				log.G(ctx).Warnf("`nerdctl (run|exec) -i` without `-t` expects containerd 1.6 or later, got containerd %v", sv)
 			}
-			var stdinC io.ReadCloser = &StdinCloser{
+			// The io copy goroutines are started by the cio.Creator, inside
+			// container.NewTask below: on a short enough stdin, they can reach EOF
+			// before the task is registered in containerd, so the task cannot be
+			// looked up here through the API. Block until the task handle returned
+			// by container.NewTask is available instead: losing the CloseIO would
+			// leave the write end of the stdin FIFO open inside the shim, and the
+			// container would never receive EOF on its stdin.
+			stdinTask = make(chan containerd.Task, 1)
+			in = &StdinCloser{
 				Stdin: os.Stdin,
 				Closer: func() {
-					if t, err := container.Task(ctx, nil); err != nil {
-						log.G(ctx).WithError(err).Debugf("failed to get task for StdinCloser")
-					} else {
-						t.CloseIO(ctx, containerd.WithStdinCloser)
+					if t, ok := <-stdinTask; ok {
+						if err := t.CloseIO(ctx, containerd.WithStdinCloser); err != nil {
+							log.G(ctx).WithError(err).Warn("failed to close the task stdin")
+						}
 					}
 				},
 			}
-			in = stdinC
 		}
 		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, in, os.Stdout, os.Stderr)
 	}
@@ -230,7 +238,13 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 
 	t, err = container.NewTask(ctx, ioCreator, taskOpts...)
 	if err != nil {
+		if stdinTask != nil {
+			close(stdinTask)
+		}
 		return nil, err
+	}
+	if stdinTask != nil {
+		stdinTask <- t
 	}
 	return t, nil
 }


### PR DESCRIPTION
`nerdctl (run|exec) -i` (without `-t`) propagates the EOF of its own stdin to the container by calling CloseIO: the shim deliberately keeps its own write end of the stdin FIFO open (so that a detached client does not propagate EOF), and only CloseIO makes the shim close it.

The io copy goroutines are started by the cio.Creator, inside container.NewTask (respectively task.Exec), before the task (process) is registered in containerd:
- in taskutil.NewTask, when the stdin was short enough to reach EOF during the creation, the container.Task API lookup in the closer failed with "no such task", and the error was discarded at the debug level;
- in container.Exec, the closer was only installed after task.Exec returned, and a closer firing before that was a silent no-op.

In both cases the CloseIO was lost forever: the container never received EOF on its stdin, and eg: `nerdctl run --rm -i IMAGE cat` hung until killed.

Make the closer block on a channel that receives the task (process) handle when the creation returns, so that the CloseIO is always delivered.

The race is easily reproducible under load; in the CI it is the cause of the TestRunStdin flakiness, which became a consistent failure on the slow almalinux-8 guests after the tests moved out of Docker.

Fix #5029

Assisted-by: Claude Fable 5 <noreply@anthropic.com>