### PR TITLE
test: extend EnsureContainerExited deadline to fix flaky restart tests

### DIFF
--- a/pkg/testutil/nerdtest/utilities.go
+++ b/pkg/testutil/nerdtest/utilities.go
@@ -117,6 +117,14 @@ func InspectImage(helpers test.Helpers, name string) dockercompat.Image {
 const (
 	maxRetry = 20
 	sleep    = time.Second
+	// exitedDeadline is the maximum duration EnsureContainerExited waits for a
+	// container to reach the "exited" (or "dead") state.
+	// Note that this must accommodate containers using a restart policy
+	// (eg: `--restart=on-failure:2`): such containers are reported as
+	// "restarting" (not "exited") until the restart monitor exhausts the retry
+	// count, and the monitor only reconciles every 10 seconds by default
+	// (see https://github.com/containerd/nerdctl/issues/5030).
+	exitedDeadline = 60 * time.Second
 )
 
 func EnsureContainerStarted(helpers test.Helpers, con string) {
@@ -154,7 +162,8 @@ func EnsureContainerStarted(helpers test.Helpers, con string) {
 func EnsureContainerExited(helpers test.Helpers, con string, exitCode int) {
 	helpers.T().Helper()
 	exited := false
-	for i := 0; i < maxRetry && !exited; i++ {
+	deadline := time.Now().Add(exitedDeadline)
+	for time.Now().Before(deadline) && !exited {
 		helpers.Command("container", "inspect", con).
 			Run(&test.Expected{
 				ExitCode: expect.ExitCodeNoCheck,
@@ -189,7 +198,7 @@ func EnsureContainerExited(helpers test.Helpers, con string, exitCode int) {
 		helpers.T().Log(ins)
 		helpers.T().Log(lgs)
 		helpers.T().Log(ps)
-		helpers.T().Log(fmt.Sprintf("container %s still not exited after %d retries", con, maxRetry))
+		helpers.T().Log(fmt.Sprintf("container %s still not exited after %s", con, exitedDeadline))
 		helpers.T().FailNow()
 	}
 }


### PR DESCRIPTION
TestRunRestartWithOnFailure runs a container with --restart=on-failure:2 and then uses nerdtest.EnsureContainerExited to wait for the container to reach the "exited" state.

However, a stopped container whose restart labels still satisfy restart.Reconcile() is reported by nerdctl as "restarting", not "exited" (see dockercompat.statusFromNative). For on-failure:2, this means the container only shows "exited" after the containerd restart monitor has performed both restarts and bumped the restart count label to 2. Since the monitor only reconciles every 10 seconds by default, convergence takes ~20+ seconds in the worst case - right at (or beyond) the ~20 seconds budget of EnsureContainerExited (20 retries x 1s sleep), especially on slow CI runners. This is the source of the observed "container ... still not exited after 20 retries" flake.

Replace the retry counter with a 60-second deadline (keeping the 1-second poll interval), matching the wait budget already used by TestRunRestartWithUnlessStopped. This also covers TestUpdateRestartPolicy, which calls the same helper with an on-failure:2 policy. Passing runs are not slowed down, as the loop still exits on the first observation of the exited state.

Fixes #5030

Assisted-by: Claude Fable 5 <noreply@anthropic.com>