### PR TITLE
tigron: hide env from logs by default

### DIFF
--- a/mod/tigron/test/command.go
+++ b/mod/tigron/test/command.go
@@ -214,8 +214,16 @@ func (gc *GenericCommand) Run(expect *Expected) {
 			duration = "<1s"
 		}
 
+		// The environment may contain secrets (e.g. tokens inherited from the CI
+		// environment), and test logs may end-up in publicly accessible places.
+		// Do not display it unless TIGRON_DEBUG_ENV is set.
+		environ := "(hidden: set TIGRON_DEBUG_ENV=1 to display)"
+		if debugEnv, _ := strconv.ParseBool(os.Getenv("TIGRON_DEBUG_ENV")); debugEnv {
+			environ = strings.Join(result.Environ, "\n")
+		}
+
 		debug = append(debug,
-			[]any{envDecorator, strings.Join(result.Environ, "\n")},
+			[]any{envDecorator, environ},
 			[]any{timeoutDecorator, duration + " (limit: " + gc.cmd.Timeout.String() + ")"},
 			[]any{cwdDecorator, gc.cmd.WorkingDir},
 		)


### PR DESCRIPTION
Lots of env vars were shown since commit f21b32b (PR #5035) `CI: run test-integration[-rootless] directly on hosts and Lima guests`.

GITHUB_TOKEN and ACTIONS_RUNTIME_TOKEN did not seem leaked so far, though.