### PR TITLE
save: add --quiet/-q to suppress progress output

### DIFF
--- a/cmd/nerdctl/image/image_save.go
+++ b/cmd/nerdctl/image/image_save.go
@@ -45,6 +45,7 @@ func SaveCommand() *cobra.Command {
 		SilenceErrors:     true,
 	}
 	cmd.Flags().StringP("output", "o", "", "Write to a file, instead of STDOUT")
+	cmd.Flags().BoolP("quiet", "q", false, "Suppress the progress output")
 
 	// #region platform flags
 	// platform is defined as StringSlice, not StringArray, to allow specifying "--platform=amd64,arm64"
@@ -70,11 +71,16 @@ func saveOptions(cmd *cobra.Command) (types.ImageSaveOptions, error) {
 	if err != nil {
 		return types.ImageSaveOptions{}, err
 	}
+	quiet, err := cmd.Flags().GetBool("quiet")
+	if err != nil {
+		return types.ImageSaveOptions{}, err
+	}
 
 	return types.ImageSaveOptions{
 		GOptions:     globalOptions,
 		AllPlatforms: allPlatforms,
 		Platform:     platform,
+		Quiet:        quiet,
 	}, err
 }
 

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -66,6 +66,37 @@ func TestSaveContent(t *testing.T) {
 	testCase.Run(t)
 }
 
+func TestSaveQuiet(t *testing.T) {
+	nerdtest.Setup()
+
+	testCase := &test.Case{
+		// --quiet is a nerdctl-specific flag, so this is skipped under the Docker compatibility mode.
+		Require: require.All(require.Not(require.Windows), require.Not(nerdtest.Docker)),
+		Setup: func(_ test.Data, helpers test.Helpers) {
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("save", "--quiet", "-o", filepath.Join(data.Temp().Path(), "out.tar"), testutil.CommonImage)
+		},
+		Expected: func(data test.Data, _ test.Helpers) *test.Expected {
+			return &test.Expected{
+				ExitCode: expect.ExitCodeSuccess,
+				Output: func(_ string, t tig.T) {
+					// The archive is still written correctly with --quiet.
+					rootfsPath := filepath.Join(data.Temp().Path(), "rootfs")
+					err := testhelpers.ExtractDockerArchive(filepath.Join(data.Temp().Path(), "out.tar"), rootfsPath)
+					assert.NilError(t, err)
+					etcOSReleaseBytes, err := os.ReadFile(filepath.Join(rootfsPath, "/etc/os-release"))
+					assert.NilError(t, err)
+					assert.Assert(t, strings.Contains(string(etcOSReleaseBytes), "Alpine"))
+				},
+			}
+		},
+	}
+
+	testCase.Run(t)
+}
+
 func TestSave(t *testing.T) {
 	testCase := nerdtest.Setup()
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -928,6 +928,7 @@ Usage: `nerdctl save [OPTIONS] IMAGE [IMAGE...]`
 Flags:
 
 - :whale: `-o, --output`: Write to a file, instead of STDOUT
+- :nerd_face: `-q, --quiet`: Suppress the progress output
 - :nerd_face: `--platform=(amd64|arm64|...)`: Export content for a specific platform
 - :nerd_face: `--all-platforms`: Export content for all platforms
 

--- a/pkg/api/types/image_types.go
+++ b/pkg/api/types/image_types.go
@@ -279,6 +279,8 @@ type ImageSaveOptions struct {
 	AllPlatforms bool
 	// Export content for a specific platform
 	Platform []string
+	// Quiet suppresses the progress output.
+	Quiet bool
 }
 
 // ImageSignOptions contains options for signing an image. It contains options from

--- a/pkg/cmd/image/save.go
+++ b/pkg/cmd/image/save.go
@@ -103,7 +103,11 @@ func Save(ctx context.Context, client *containerd.Client, images []string, optio
 
 	w := nopWriteCloser{options.Stdout}
 
-	pf, done := transferutil.ProgressHandler(ctx, os.Stderr)
+	progressOutput := io.Writer(os.Stderr)
+	if options.Quiet {
+		progressOutput = io.Discard
+	}
+	pf, done := transferutil.ProgressHandler(ctx, progressOutput)
 	defer done()
 
 	return client.Transfer(ctx,


### PR DESCRIPTION
Fixes #4958.

> Re-opening [#5054](https://github.com/containerd/nerdctl/pull/5054), which I accidentally closed with a force-push. This is the same single squashed commit (`expect.ExitCodeSuccess` review suggestion from @sathiraumesh already applied). Thanks @AkihiroSuda.

`nerdctl save` always writes a progress bar to stderr, which clutters logs when it is used in scripts and CI. This adds a `--quiet`/`-q` flag that suppresses the progress output.

The implementation mirrors the existing `--quiet` flag on `nerdctl load`: the flag is threaded into `ImageSaveOptions.Quiet`, and when set, the transfer progress handler writes to `io.Discard` instead of `os.Stderr`. The archive itself is written exactly as before; only the progress output is suppressed.

- `cmd/nerdctl/image/image_save.go`: register `-q, --quiet` and pass it into the options
- `pkg/api/types/image_types.go`: add `Quiet` to `ImageSaveOptions`
- `pkg/cmd/image/save.go`: route progress to `io.Discard` when quiet
- `docs/command-reference.md`: document the flag
- `cmd/nerdctl/image/image_save_test.go`: add `TestSaveQuiet` verifying the archive is still produced correctly with `--quiet`

Manual check: `nerdctl save --help` now lists `-q, --quiet   Suppress the progress output`.
