### PR TITLE
test: refactor container_run_linux_test.go to use Tigron

### DIFF
--- a/cmd/nerdctl/container/container_run_linux_test.go
+++ b/cmd/nerdctl/container/container_run_linux_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -39,7 +40,6 @@ import (
 	"github.com/containerd/nerdctl/mod/tigron/tig"
 
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/helpers"
-	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
@@ -82,234 +82,344 @@ func prepareCustomRootfs(base *testutil.Base, imageName string) string {
 }
 
 func TestRunShmSize(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
 	const shmSize = "32m"
-
-	base.Cmd("run", "--rm", "--shm-size", shmSize, testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts").AssertOutContains("size=32768k")
+	testCase := nerdtest.Setup()
+	testCase.Command = test.Command("run", "--rm", "--shm-size", shmSize, testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts")
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("size=32768k"))
+	testCase.Run(t)
 }
 
 func TestRunShmSizeIPCShareable(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
 	const shmSize = "32m"
-
-	container := testutil.Identifier(t)
-	base.Cmd("run", "--rm", "--name", container, "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts").AssertOutContains("size=32768k")
-	defer base.Cmd("rm", "-f", container)
+	testCase := nerdtest.Setup()
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "--rm", "--name", data.Identifier(), "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("size=32768k"))
+	testCase.Run(t)
 }
 
 func TestRunIPCShareableRemoveMount(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	container := testutil.Identifier(t)
-
-	base.Cmd("run", "--name", container, "--ipc", "shareable", testutil.AlpineImage, "sleep", "0").AssertOK()
-	base.Cmd("rm", container).AssertOK()
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "--name", data.Identifier(), "--ipc", "shareable", testutil.AlpineImage, "sleep", "0")
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("rm", data.Identifier())
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, nil)
+	testCase.Run(t)
 }
 
 func TestRunIPCContainerNotExists(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
-	container := testutil.Identifier(t)
-	result := base.Cmd("run", "--name", container, "--ipc", "container:abcd1234", testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
-	defer base.Cmd("rm", "-f", container)
-	combined := result.Combined()
-	if !strings.Contains(strings.ToLower(combined), "no such container: abcd1234") {
-		t.Fatalf("unexpected output: %s", combined)
+	testCase := nerdtest.Setup()
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
 	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "--name", data.Identifier(), "--ipc", "container:abcd1234", testutil.AlpineImage, "sleep", nerdtest.Infinity)
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeGenericFail, []error{errors.New("no such container: abcd1234")}, nil)
+	testCase.Run(t)
 }
 
 func TestRunShmSizeIPCContainer(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
 	const shmSize = "32m"
-	sharedContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
-	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
-	defer base.Cmd("rm", "-f", baseContainerID).Run()
-
-	base.Cmd("run", "--rm", fmt.Sprintf("--ipc=container:%s", baseContainerID),
-		testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts").AssertOutContains("size=32768k")
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier("shared"), "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier("shared"))
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "--rm", "--ipc=container:"+data.Identifier("shared"), testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("size=32768k"))
+	testCase.Run(t)
 }
 
 func TestRunIPCContainer(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
 	const shmSize = "32m"
-	victimContainerResult := base.Cmd("run", "-d", "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
-	victimContainerID := strings.TrimSpace(victimContainerResult.Stdout())
-	defer base.Cmd("rm", "-f", victimContainerID).Run()
-
-	base.Cmd("run", "--rm", fmt.Sprintf("--ipc=container:%s", victimContainerID),
-		testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts").AssertOutContains("size=32768k")
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier("victim"), "--ipc", "shareable", "--shm-size", shmSize, testutil.AlpineImage, "sleep", nerdtest.Infinity)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier("victim"))
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "--rm", "--ipc=container:"+data.Identifier("victim"), testutil.AlpineImage, "/bin/grep", "shm", "/proc/self/mounts")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("size=32768k"))
+	testCase.Run(t)
 }
 
 func TestRunPidHost(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
 	pid := os.Getpid()
-
-	base.Cmd("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw").AssertOutContains(strconv.Itoa(pid))
+	testCase := nerdtest.Setup()
+	testCase.Command = test.Command("run", "--rm", "--pid=host", testutil.AlpineImage, "ps", "auxw")
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains(strconv.Itoa(pid)))
+	testCase.Run(t)
 }
 
 func TestRunUtsHost(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
 	// Was thinking of os.ReadLink("/proc/1/ns/uts")
 	// but you'd get EPERM for rootless. Just validate the
 	// hostname is the same.
-	hostName, err := os.Hostname()
-	assert.NilError(base.T, err)
-
-	base.Cmd("run", "--rm", "--uts=host", testutil.AlpineImage, "hostname").AssertOutContains(hostName)
-	// Validate we can't provide a hostname with uts=host
-	base.Cmd("run", "--rm", "--uts=host", "--hostname=foobar", testutil.AlpineImage, "hostname").AssertFail()
-	// Validate we can't provide a domainname with uts=host
-	base.Cmd("run", "--rm", "--uts=host", "--domainname=example.com", testutil.AlpineImage, "hostname").AssertFail()
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		hostName, err := os.Hostname()
+		assert.NilError(helpers.T(), err)
+		data.Labels().Set("hostName", hostName)
+	}
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "hostname matches host uts",
+			Command:     test.Command("run", "--rm", "--uts=host", testutil.AlpineImage, "hostname"),
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{ExitCode: expect.ExitCodeSuccess, Output: expect.Contains(data.Labels().Get("hostName"))}
+			},
+		},
+		{
+			Description: "hostname flag rejected with host uts",
+			Command:     test.Command("run", "--rm", "--uts=host", "--hostname=foobar", testutil.AlpineImage, "hostname"),
+			Expected:    test.Expects(expect.ExitCodeGenericFail, nil, nil),
+		},
+		{
+			Description: "domainname flag rejected with host uts",
+			Command:     test.Command("run", "--rm", "--uts=host", "--domainname=example.com", testutil.AlpineImage, "hostname"),
+			Expected:    test.Expects(expect.ExitCodeGenericFail, nil, nil),
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestRunPidContainer(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-
-	sharedContainerResult := base.Cmd("run", "-d", testutil.AlpineImage, "sleep", nerdtest.Infinity).Run()
-	baseContainerID := strings.TrimSpace(sharedContainerResult.Stdout())
-	defer base.Cmd("rm", "-f", baseContainerID).Run()
-
-	base.Cmd("run", "--rm", fmt.Sprintf("--pid=container:%s", baseContainerID),
-		testutil.AlpineImage, "ps", "ax").AssertOutContains("sleep " + nerdtest.Infinity)
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--name", data.Identifier("shared"), testutil.AlpineImage, "sleep", nerdtest.Infinity)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier("shared"))
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "--rm", "--pid=container:"+data.Identifier("shared"), testutil.AlpineImage, "ps", "ax")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("sleep "+nerdtest.Infinity))
+	testCase.Run(t)
 }
 
 func TestRunIpcHost(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
-	testFilePath := filepath.Join("/dev/shm",
-		fmt.Sprintf("%s-%d-%s", testutil.Identifier(t), os.Geteuid(), base.Target))
-	err := os.WriteFile(testFilePath, []byte(""), 0o644)
-	assert.NilError(base.T, err)
-	defer os.Remove(testFilePath)
-
-	base.Cmd("run", "--rm", "--ipc=host", testutil.AlpineImage, "ls", testFilePath).AssertOK()
+	testCase := nerdtest.Setup()
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		testFilePath := filepath.Join("/dev/shm", fmt.Sprintf("%s-%d", data.Identifier(), os.Geteuid()))
+		err := os.WriteFile(testFilePath, []byte(""), 0o644)
+		assert.NilError(helpers.T(), err)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		testFilePath := filepath.Join("/dev/shm", fmt.Sprintf("%s-%d", data.Identifier(), os.Geteuid()))
+		_ = os.Remove(testFilePath)
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		testFilePath := filepath.Join("/dev/shm", fmt.Sprintf("%s-%d", data.Identifier(), os.Geteuid()))
+		return helpers.Command("run", "--rm", "--ipc=host", testutil.AlpineImage, "ls", testFilePath)
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, nil)
+	testCase.Run(t)
 }
 
 func TestRunAddHost(t *testing.T) {
 	// Not parallelizable (https://github.com/containerd/nerdctl/issues/1127)
-	base := testutil.NewBase(t)
-	base.Cmd("run", "--rm", "--add-host", "testing.example.com:10.0.0.1", testutil.AlpineImage, "cat", "/etc/hosts").AssertOutWithFunc(func(stdout string) error {
-		var found bool
-		sc := bufio.NewScanner(bytes.NewBufferString(stdout))
-		for sc.Scan() {
-			// removing spaces and tabs separating items
-			line := strings.ReplaceAll(sc.Text(), " ", "")
-			line = strings.ReplaceAll(line, "\t", "")
-			if strings.Contains(line, "10.0.0.1testing.example.com") {
-				found = true
-			}
-		}
-		if !found {
-			return errors.New("host was not added")
-		}
-		return nil
-	})
-	base.Cmd("run", "--rm", "--add-host", "test:10.0.0.1", "--add-host", "test1:10.0.0.1", testutil.AlpineImage, "cat", "/etc/hosts").AssertOutWithFunc(func(stdout string) error {
-		var found int
-		sc := bufio.NewScanner(bytes.NewBufferString(stdout))
-		for sc.Scan() {
-			// removing spaces and tabs separating items
-			line := strings.ReplaceAll(sc.Text(), " ", "")
-			line = strings.ReplaceAll(line, "\t", "")
-			if strutil.InStringSlice([]string{"10.0.0.1test", "10.0.0.1test1"}, line) {
-				found++
-			}
-		}
-		if found != 2 {
-			return fmt.Errorf("host was not added, found %d", found)
-		}
-		return nil
-	})
-	base.Cmd("run", "--rm", "--add-host", "10.0.0.1:testing.example.com", testutil.AlpineImage, "cat", "/etc/hosts").AssertFail()
-
 	response := "This is the expected response for --add-host special IP test."
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		io.WriteString(w, response)
-	})
 	const hostPort = 8081
-	s := http.Server{Addr: fmt.Sprintf(":%d", hostPort), Handler: nil, ReadTimeout: 30 * time.Second}
-	go s.ListenAndServe()
-	defer s.Shutdown(context.Background())
-	base.Cmd("run", "--rm", "--add-host", "test:host-gateway", testutil.NginxAlpineImage, "curl", fmt.Sprintf("test:%d", hostPort)).AssertOutExactly(response)
+	var server *http.Server
+	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, response)
+		})
+		server = &http.Server{Addr: fmt.Sprintf(":%d", hostPort), Handler: mux, ReadTimeout: 30 * time.Second}
+		go func() {
+			err := server.ListenAndServe()
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+		}()
+		var err error
+		for i := 0; i < 50; i++ {
+			var resp *http.Response
+			resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:%d", hostPort))
+			if err == nil {
+				_ = resp.Body.Close()
+				return
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+		assert.NilError(helpers.T(), err)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		if server == nil {
+			return
+		}
+		err := server.Shutdown(context.Background())
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			assert.NilError(helpers.T(), err)
+		}
+	}
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "single add-host entry is written",
+			NoParallel:  true,
+			Command:     test.Command("run", "--rm", "--add-host", "testing.example.com:10.0.0.1", testutil.AlpineImage, "cat", "/etc/hosts"),
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+				assert.NilError(t, assertAddHostEntries(stdout, []string{"10.0.0.1testing.example.com"}))
+			}),
+		},
+		{
+			Description: "multiple add-host entries are written",
+			NoParallel:  true,
+			Command:     test.Command("run", "--rm", "--add-host", "test:10.0.0.1", "--add-host", "test1:10.0.0.1", testutil.AlpineImage, "cat", "/etc/hosts"),
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+				assert.NilError(t, assertAddHostEntries(stdout, []string{"10.0.0.1test", "10.0.0.1test1"}))
+			}),
+		},
+		{
+			Description: "invalid add-host input fails",
+			NoParallel:  true,
+			Command:     test.Command("run", "--rm", "--add-host", "10.0.0.1:testing.example.com", testutil.AlpineImage, "cat", "/etc/hosts"),
+			Expected:    test.Expects(expect.ExitCodeGenericFail, nil, nil),
+		},
+		{
+			Description: "host-gateway resolves host service",
+			NoParallel:  true,
+			Command:     test.Command("run", "--rm", "--add-host", "test:host-gateway", testutil.NginxAlpineImage, "curl", fmt.Sprintf("test:%d", hostPort)),
+			Expected:    test.Expects(expect.ExitCodeSuccess, nil, expect.Equals(response)),
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestRunAddHostWithCustomHostGatewayIP(t *testing.T) {
 	// Not parallelizable (https://github.com/containerd/nerdctl/issues/1127)
-	base := testutil.NewBase(t)
-	testutil.DockerIncompatible(t)
-	base.Cmd("run", "--rm", "--host-gateway-ip", "192.168.5.2", "--add-host", "test:host-gateway", testutil.AlpineImage, "cat", "/etc/hosts").AssertOutWithFunc(func(stdout string) error {
-		var found bool
-		sc := bufio.NewScanner(bytes.NewBufferString(stdout))
-		for sc.Scan() {
-			// removing spaces and tabs separating items
-			line := strings.ReplaceAll(sc.Text(), " ", "")
-			line = strings.ReplaceAll(line, "\t", "")
-			if strings.Contains(line, "192.168.5.2test") {
-				found = true
-			}
-		}
-		if !found {
-			return errors.New("host was not added")
-		}
-		return nil
+	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.NoParallel = true
+	testCase.Command = test.Command("run", "--rm", "--host-gateway-ip", "192.168.5.2", "--add-host", "test:host-gateway", testutil.AlpineImage, "cat", "/etc/hosts")
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+		assert.NilError(t, assertAddHostEntries(stdout, []string{"192.168.5.2test"}))
 	})
+	testCase.Run(t)
 }
 
 func TestRunUlimit(t *testing.T) {
-	t.Parallel()
-	base := testutil.NewBase(t)
 	ulimit := "nofile=622:622"
 	ulimit2 := "nofile=622:722"
-
-	base.Cmd("run", "--rm", "--ulimit", ulimit, testutil.AlpineImage, "sh", "-c", "ulimit -Sn").AssertOutExactly("622\n")
-	base.Cmd("run", "--rm", "--ulimit", ulimit, testutil.AlpineImage, "sh", "-c", "ulimit -Hn").AssertOutExactly("622\n")
-
-	base.Cmd("run", "--rm", "--ulimit", ulimit2, testutil.AlpineImage, "sh", "-c", "ulimit -Sn").AssertOutExactly("622\n")
-	base.Cmd("run", "--rm", "--ulimit", ulimit2, testutil.AlpineImage, "sh", "-c", "ulimit -Hn").AssertOutExactly("722\n")
+	testCase := nerdtest.Setup()
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "soft limit matches identical hard limit",
+			Command:     test.Command("run", "--rm", "--ulimit", ulimit, testutil.AlpineImage, "sh", "-c", "ulimit -Sn"),
+			Expected:    test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("622\n")),
+		},
+		{
+			Description: "hard limit matches identical hard limit",
+			Command:     test.Command("run", "--rm", "--ulimit", ulimit, testutil.AlpineImage, "sh", "-c", "ulimit -Hn"),
+			Expected:    test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("622\n")),
+		},
+		{
+			Description: "soft limit uses first value",
+			Command:     test.Command("run", "--rm", "--ulimit", ulimit2, testutil.AlpineImage, "sh", "-c", "ulimit -Sn"),
+			Expected:    test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("622\n")),
+		},
+		{
+			Description: "hard limit uses second value",
+			Command:     test.Command("run", "--rm", "--ulimit", ulimit2, testutil.AlpineImage, "sh", "-c", "ulimit -Hn"),
+			Expected:    test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("722\n")),
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestRunWithInit(t *testing.T) {
-	t.Parallel()
-	testutil.DockerIncompatible(t)
-	testutil.RequireExecutable(t, "tini-custom")
-	base := testutil.NewBase(t)
-
-	container := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", container, testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
-	defer base.Cmd("rm", "-f", container).Run()
-
-	base.Cmd("stop", "--time=3", container).AssertOK()
-	// Unable to handle TERM signal, be killed when timeout
-	assert.Equal(t, base.InspectContainer(container).State.ExitCode, 137)
-
-	// Test with --init-path
-	container1 := container + "-1"
-	base.Cmd("run", "-d", "--name", container1, "--init-binary", "tini-custom",
-		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
-	defer base.Cmd("rm", "-f", container1).Run()
-
-	base.Cmd("stop", "--time=3", container1).AssertOK()
-	assert.Equal(t, base.InspectContainer(container1).State.ExitCode, 143)
-
-	// Test with --init
-	container2 := container + "-2"
-	base.Cmd("run", "-d", "--name", container2, "--init",
-		testutil.AlpineImage, "sleep", nerdtest.Infinity).AssertOK()
-	defer base.Cmd("rm", "-f", container2).Run()
-
-	base.Cmd("stop", "--time=3", container2).AssertOK()
-	assert.Equal(t, base.InspectContainer(container2).State.ExitCode, 143)
+	testCase := nerdtest.Setup()
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		if _, err := exec.LookPath("tini-custom"); err != nil {
+			helpers.T().Skip("required executable doesn't exist in PATH: tini-custom")
+		}
+	}
+	testCase.SubTests = []*test.Case{
+		{
+			// Unable to handle TERM signal, be killed when timeout
+			Description: "without init exits with SIGKILL timeout status",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier("plain"), testutil.AlpineImage, "sleep", nerdtest.Infinity)
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier("plain"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("stop", "--time=3", data.Identifier("plain"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						assert.Equal(t, "137", strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.State.ExitCode}}", data.Identifier("plain"))))
+					},
+				}
+			},
+		},
+		{
+			// Test with --init-binary
+			Description: "custom init binary exits with SIGTERM status",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier("custom"), "--init-binary", "tini-custom", testutil.AlpineImage, "sleep", nerdtest.Infinity)
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier("custom"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("stop", "--time=3", data.Identifier("custom"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						assert.Equal(t, "143", strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.State.ExitCode}}", data.Identifier("custom"))))
+					},
+				}
+			},
+		},
+		{
+			// Test with --init
+			Description: "default init exits with SIGTERM status",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier("default"), "--init", testutil.AlpineImage, "sleep", nerdtest.Infinity)
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("rm", "-f", data.Identifier("default"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("stop", "--time=3", data.Identifier("default"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						assert.Equal(t, "143", strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.State.ExitCode}}", data.Identifier("default"))))
+					},
+				}
+			},
+		},
+	}
+	testCase.Run(t)
 }
 
 func TestRunTTY(t *testing.T) {
@@ -324,7 +434,7 @@ func TestRunTTY(t *testing.T) {
 				helpers.Ensure("rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "-it", data.Identifier(), "stty")
+				cmd := helpers.Command("run", "-it", "--name", data.Identifier(), testutil.CommonImage, "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -336,7 +446,7 @@ func TestRunTTY(t *testing.T) {
 				helpers.Ensure("rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "-t", data.Identifier(), "stty")
+				cmd := helpers.Command("run", "-t", "--name", data.Identifier(), testutil.CommonImage, "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -348,7 +458,7 @@ func TestRunTTY(t *testing.T) {
 				helpers.Ensure("rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "-i", data.Identifier(), "stty")
+				cmd := helpers.Command("run", "-i", "--name", data.Identifier(), testutil.CommonImage, "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -360,7 +470,7 @@ func TestRunTTY(t *testing.T) {
 				helpers.Ensure("rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", data.Identifier(), "stty")
+				cmd := helpers.Command("run", "--name", data.Identifier(), testutil.CommonImage, "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
@@ -372,13 +482,14 @@ func TestRunTTY(t *testing.T) {
 				helpers.Ensure("rm", "-f", data.Identifier())
 			},
 			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
-				cmd := helpers.Command("run", "-td", data.Identifier(), "stty")
+				cmd := helpers.Command("run", "-td", "--name", data.Identifier(), testutil.CommonImage, "stty")
 				cmd.WithPseudoTTY()
 				return cmd
 			},
 			Expected: test.Expects(0, nil, nil),
 		},
 	}
+	testCase.Run(t)
 }
 
 func TestRunSigProxy(t *testing.T) {
@@ -447,72 +558,86 @@ func TestRunSigProxy(t *testing.T) {
 }
 
 func TestRunWithFluentdLogDriver(t *testing.T) {
-	base := testutil.NewBase(t)
-	tempDirectory := t.TempDir()
-	err := os.Chmod(tempDirectory, 0o777)
-	assert.NilError(t, err)
-
-	containerName := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", containerName, "-p", "24224:24224",
-		"-v", fmt.Sprintf("%s:/fluentd/log", tempDirectory), testutil.FluentdImage).AssertOK()
-	defer base.Cmd("rm", "-f", containerName).AssertOK()
-	time.Sleep(3 * time.Second)
-
-	testContainerName := containerName + "test"
-	base.Cmd("run", "-d", "--log-driver", "fluentd", "--name", testContainerName, testutil.CommonImage,
-		"sh", "-c", "echo test").AssertOK()
-	defer base.Cmd("rm", "-f", testContainerName).AssertOK()
-
-	inspectedContainer := base.InspectContainer(testContainerName)
-	matches, err := filepath.Glob(tempDirectory + "/" + "data.*.log")
-	assert.NilError(t, err)
-	assert.Equal(t, 1, len(matches))
-
-	data, err := os.ReadFile(matches[0])
-	assert.NilError(t, err)
-	logData := string(data)
-	assert.Equal(t, true, strings.Contains(logData, "test"))
-	assert.Equal(t, true, strings.Contains(logData, inspectedContainer.ID))
+	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		tempDirectory := data.Temp().Dir("fluentd")
+		err := os.Chmod(tempDirectory, 0o777)
+		assert.NilError(helpers.T(), err)
+		data.Labels().Set("tempDirectory", tempDirectory)
+		helpers.Ensure("run", "-d", "--name", data.Identifier("fluentd"), "-p", "24224:24224", "-v", fmt.Sprintf("%s:/fluentd/log", tempDirectory), testutil.FluentdImage)
+		time.Sleep(3 * time.Second)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier("test"))
+		helpers.Anyhow("rm", "-f", data.Identifier("fluentd"))
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "-d", "--log-driver", "fluentd", "--name", data.Identifier("test"), testutil.CommonImage, "sh", "-c", "echo test")
+	}
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: func(stdout string, t tig.T) {
+				inspectedContainerID := strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.Id}}", data.Identifier("test")))
+				matches, err := filepath.Glob(filepath.Join(data.Labels().Get("tempDirectory"), "data.*.log"))
+				assert.NilError(t, err)
+				assert.Equal(t, 1, len(matches))
+				content, err := os.ReadFile(matches[0])
+				assert.NilError(t, err)
+				logData := string(content)
+				assert.Assert(t, strings.Contains(logData, "test"))
+				assert.Assert(t, strings.Contains(logData, inspectedContainerID))
+			},
+		}
+	}
+	testCase.Run(t)
 }
 
 func TestRunWithFluentdLogDriverWithLogOpt(t *testing.T) {
-	base := testutil.NewBase(t)
-	tempDirectory := t.TempDir()
-	err := os.Chmod(tempDirectory, 0o777)
-	assert.NilError(t, err)
-
-	containerName := testutil.Identifier(t)
-	base.Cmd("run", "-d", "--name", containerName, "-p", "24225:24224",
-		"-v", fmt.Sprintf("%s:/fluentd/log", tempDirectory), testutil.FluentdImage).AssertOK()
-	defer base.Cmd("rm", "-f", containerName).AssertOK()
-	time.Sleep(3 * time.Second)
-
-	testContainerName := containerName + "test"
-	base.Cmd("run", "-d", "--log-driver", "fluentd", "--log-opt", "fluentd-address=127.0.0.1:24225",
-		"--name", testContainerName, testutil.CommonImage, "sh", "-c", "echo test2").AssertOK()
-	defer base.Cmd("rm", "-f", testContainerName).AssertOK()
-
-	inspectedContainer := base.InspectContainer(testContainerName)
-	matches, err := filepath.Glob(tempDirectory + "/" + "data.*.log")
-	assert.NilError(t, err)
-	assert.Equal(t, 1, len(matches))
-
-	data, err := os.ReadFile(matches[0])
-	assert.NilError(t, err)
-	logData := string(data)
-	assert.Equal(t, true, strings.Contains(logData, "test2"))
-	assert.Equal(t, true, strings.Contains(logData, inspectedContainer.ID))
+	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		tempDirectory := data.Temp().Dir("fluentd")
+		err := os.Chmod(tempDirectory, 0o777)
+		assert.NilError(helpers.T(), err)
+		data.Labels().Set("tempDirectory", tempDirectory)
+		helpers.Ensure("run", "-d", "--name", data.Identifier("fluentd"), "-p", "24225:24224", "-v", fmt.Sprintf("%s:/fluentd/log", tempDirectory), testutil.FluentdImage)
+		time.Sleep(3 * time.Second)
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier("test"))
+		helpers.Anyhow("rm", "-f", data.Identifier("fluentd"))
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("run", "-d", "--log-driver", "fluentd", "--log-opt", "fluentd-address=127.0.0.1:24225", "--name", data.Identifier("test"), testutil.CommonImage, "sh", "-c", "echo test2")
+	}
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: func(stdout string, t tig.T) {
+				inspectedContainerID := strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.Id}}", data.Identifier("test")))
+				matches, err := filepath.Glob(filepath.Join(data.Labels().Get("tempDirectory"), "data.*.log"))
+				assert.NilError(t, err)
+				assert.Equal(t, 1, len(matches))
+				content, err := os.ReadFile(matches[0])
+				assert.NilError(t, err)
+				logData := string(content)
+				assert.Assert(t, strings.Contains(logData, "test2"))
+				assert.Assert(t, strings.Contains(logData, inspectedContainerID))
+			},
+		}
+	}
+	testCase.Run(t)
 }
 
 func TestRunWithOOMScoreAdj(t *testing.T) {
-	if rootlessutil.IsRootless() {
-		t.Skip("test skipped for rootless containers.")
-	}
-	t.Parallel()
-	base := testutil.NewBase(t)
 	score := "-42"
-
-	base.Cmd("run", "--rm", "--oom-score-adj", score, testutil.AlpineImage, "cat", "/proc/self/oom_score_adj").AssertOutContains(score)
+	testCase := nerdtest.Setup()
+	testCase.Require = nerdtest.Rootful
+	testCase.Command = test.Command("run", "--rm", "--oom-score-adj", score, testutil.AlpineImage, "cat", "/proc/self/oom_score_adj")
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains(score))
+	testCase.Run(t)
 }
 
 func TestRunWithDetachKeys(t *testing.T) {
@@ -560,24 +685,55 @@ func TestRunWithDetachKeys(t *testing.T) {
 }
 
 func TestRunWithTtyAndDetached(t *testing.T) {
-	base := testutil.NewBase(t)
 	imageName := testutil.CommonImage
-	withoutTtyContainerName := "without-terminal-" + testutil.Identifier(t)
-	withTtyContainerName := "with-terminal-" + testutil.Identifier(t)
-
-	// without -t, fail
-	base.Cmd("run", "-d", "--name", withoutTtyContainerName, imageName, "stty").AssertOK()
-	defer base.Cmd("container", "rm", "-f", withoutTtyContainerName).AssertOK()
-	base.Cmd("logs", withoutTtyContainerName).AssertCombinedOutContains("stty: standard input: Not a tty")
-	withoutTtyContainer := base.InspectContainer(withoutTtyContainerName)
-	assert.Equal(base.T, 1, withoutTtyContainer.State.ExitCode)
-
-	// with -t, success
-	base.Cmd("run", "-d", "-t", "--name", withTtyContainerName, imageName, "stty").AssertOK()
-	defer base.Cmd("container", "rm", "-f", withTtyContainerName).AssertOK()
-	base.Cmd("logs", withTtyContainerName).AssertCombinedOutContains("speed 38400 baud; line = 0;")
-	withTtyContainer := base.InspectContainer(withTtyContainerName)
-	assert.Equal(base.T, 0, withTtyContainer.State.ExitCode)
+	testCase := nerdtest.Setup()
+	testCase.SubTests = []*test.Case{
+		{
+			// without -t, fail
+			Description: "without tty logs not-a-tty error",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "--name", data.Identifier("without-terminal"), imageName, "stty")
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("container", "rm", "-f", data.Identifier("without-terminal"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier("without-terminal"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Errors:   []error{errors.New("stty: standard input: Not a tty")},
+					Output: func(stdout string, t tig.T) {
+						assert.Equal(t, "1", strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.State.ExitCode}}", data.Identifier("without-terminal"))))
+					},
+				}
+			},
+		},
+		{
+			// with -t, success
+			Description: "with tty logs stty output",
+			Setup: func(data test.Data, helpers test.Helpers) {
+				helpers.Ensure("run", "-d", "-t", "--name", data.Identifier("with-terminal"), imageName, "stty")
+			},
+			Cleanup: func(data test.Data, helpers test.Helpers) {
+				helpers.Anyhow("container", "rm", "-f", data.Identifier("with-terminal"))
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("logs", data.Identifier("with-terminal"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						assert.Assert(t, strings.Contains(stdout, "speed 38400 baud; line = 0;"))
+						assert.Equal(t, "0", strings.TrimSpace(helpers.Capture("inspect", "--format", "{{.State.ExitCode}}", data.Identifier("with-terminal"))))
+					},
+				}
+			},
+		},
+	}
+	testCase.Run(t)
 }
 
 // TestIssue3568 tests https://github.com/containerd/nerdctl/issues/3568
@@ -670,10 +826,6 @@ func TestPortBindingWithCustomHost(t *testing.T) {
 }
 
 func TestRunDeviceCDI(t *testing.T) {
-	t.Parallel()
-	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
-	testutil.DockerIncompatible(t)
-	cdiSpecDir := filepath.Join(t.TempDir(), "cdi")
 	const testCDIVendor1 = `
 cdiVersion: "0.3.0"
 kind: "vendor1.com/device"
@@ -683,21 +835,22 @@ devices:
     env:
     - FOO=injected
 `
-	writeTestCDISpec(t, testCDIVendor1, "vendor1.yaml", cdiSpecDir)
-
-	base := testutil.NewBase(t)
-	base.Cmd("--cdi-spec-dirs", cdiSpecDir, "run",
-		"--rm",
-		"--device", "vendor1.com/device=foo",
-		testutil.AlpineImage, "env",
-	).AssertOutContains("FOO=injected")
+	testCase := nerdtest.Setup()
+	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cdiSpecDir := data.Temp().Dir("cdi")
+		writeTestCDISpecTigron(helpers.T(), testCDIVendor1, "vendor1.yaml", cdiSpecDir)
+		data.Labels().Set("cdiSpecDir", cdiSpecDir)
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("--cdi-spec-dirs", data.Labels().Get("cdiSpecDir"), "run", "--rm", "--device", "vendor1.com/device=foo", testutil.AlpineImage, "env")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("FOO=injected"))
+	testCase.Run(t)
 }
 
 func TestRunDeviceCDIWithNerdctlConfig(t *testing.T) {
-	t.Parallel()
-	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
-	testutil.DockerIncompatible(t)
-	cdiSpecDir := filepath.Join(t.TempDir(), "cdi")
 	const testCDIVendor1 = `
 cdiVersion: "0.3.0"
 kind: "vendor1.com/device"
@@ -707,28 +860,28 @@ devices:
     env:
     - FOO=injected
 `
-	writeTestCDISpec(t, testCDIVendor1, "vendor1.yaml", cdiSpecDir)
-
-	tomlPath := filepath.Join(t.TempDir(), "nerdctl.toml")
-	err := os.WriteFile(tomlPath, []byte(fmt.Sprintf(`
-cdi_spec_dirs = ["%s"]
-`, cdiSpecDir)), 0o400)
-	assert.NilError(t, err)
-
-	base := testutil.NewBase(t)
-	base.Env = append(base.Env, "NERDCTL_TOML="+tomlPath)
-	base.Cmd("run",
-		"--rm",
-		"--device", "vendor1.com/device=foo",
-		testutil.AlpineImage, "env",
-	).AssertOutContains("FOO=injected")
+	testCase := nerdtest.Setup()
+	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cdiSpecDir := data.Temp().Dir("cdi")
+		writeTestCDISpecTigron(helpers.T(), testCDIVendor1, "vendor1.yaml", cdiSpecDir)
+		tomlPath := filepath.Join(data.Temp().Path(), "nerdctl.toml")
+		err := os.WriteFile(tomlPath, []byte(fmt.Sprintf("\ncdi_spec_dirs = [\"%s\"]\n", cdiSpecDir)), 0o400)
+		assert.NilError(helpers.T(), err)
+		data.Labels().Set("tomlPath", tomlPath)
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		cmd := helpers.Command("run", "--rm", "--device", "vendor1.com/device=foo", testutil.AlpineImage, "env")
+		cmd.Setenv("NERDCTL_TOML", data.Labels().Get("tomlPath"))
+		return cmd
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("FOO=injected"))
+	testCase.Run(t)
 }
 
 // TestRunGPU tests GPU injection using the --gpus flag.
 func TestRunGPU(t *testing.T) {
-	t.Parallel()
-	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
-	testutil.DockerIncompatible(t)
 	const nvidiaSpec = `
 cdiVersion: "0.5.0"
 kind: "nvidia.com/gpu"
@@ -765,13 +918,7 @@ devices:
     - UNKNOWN_GPU_0=injected
 `
 
-	testCases := []struct {
-		name         string
-		specs        map[string]string
-		gpuFlags     []string
-		expectedEnvs []string
-		expectFail   bool
-	}{
+	testCases := []runGPUTestCase{
 		{
 			name:         "nvidia device injection",
 			specs:        map[string]string{"nvidia.yaml": nvidiaSpec},
@@ -797,41 +944,15 @@ devices:
 			expectFail: true,
 		},
 	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			tmpDir := t.TempDir()
-			for fileName, spec := range tc.specs {
-				writeTestCDISpec(t, spec, fileName, tmpDir)
-			}
-
-			base := testutil.NewBase(t)
-			args := []string{"--cdi-spec-dirs", tmpDir, "run", "--rm"}
-			args = append(args, tc.gpuFlags...)
-			args = append(args, testutil.AlpineImage, "env")
-
-			if tc.expectFail {
-				base.Cmd(args...).AssertFail()
-			} else {
-				base.Cmd(args...).AssertOutWithFunc(func(stdout string) error {
-					for _, expectedEnv := range tc.expectedEnvs {
-						if !strings.Contains(stdout, expectedEnv) {
-							return fmt.Errorf("%s not found", expectedEnv)
-						}
-					}
-					return nil
-				})
-			}
-		})
-	}
+	testCase := nerdtest.Setup()
+	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.SubTests = runGPUCases(testCases)
+	testCase.Run(t)
 }
 
 // TestRunGPUWithOtherCDIDevices tests GPU CDI injection along with other CDI devices.
 func TestRunGPUWithOtherCDIDevices(t *testing.T) {
-	t.Parallel()
-	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
-	testutil.DockerIncompatible(t)
 	const amdSpec = `
 cdiVersion: "0.5.0"
 kind: "amd.com/gpu"
@@ -854,31 +975,90 @@ devices:
     env:
     - FOO=injected
 `
-
-	tmpDir := t.TempDir()
-	writeTestCDISpec(t, amdSpec, "amd.yaml", tmpDir)
-	writeTestCDISpec(t, vendor1Spec, "vendor1.yaml", tmpDir)
-
-	base := testutil.NewBase(t)
-	base.Cmd("--cdi-spec-dirs", tmpDir, "run", "--rm",
-		"--gpus", "2",
-		"--device", "vendor1.com/device=foo",
-		testutil.AlpineImage, "env",
-	).AssertOutWithFunc(func(stdout string) error {
-		if !strings.Contains(stdout, "AMD_GPU_0=injected") {
-			return errors.New("AMD_GPU_0=injected not found")
-		}
-		if !strings.Contains(stdout, "AMD_GPU_1=injected") {
-			return errors.New("AMD_GPU_1=injected not found")
-		}
-		if !strings.Contains(stdout, "FOO=injected") {
-			return errors.New("FOO=injected not found")
-		}
-		return nil
+	testCase := nerdtest.Setup()
+	// Although CDI injection is supported by Docker, specifying the --cdi-spec-dirs on the command line is not.
+	testCase.Require = require.Not(nerdtest.Docker)
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cdiSpecDir := data.Temp().Dir("cdi")
+		writeTestCDISpecTigron(helpers.T(), amdSpec, "amd.yaml", cdiSpecDir)
+		writeTestCDISpecTigron(helpers.T(), vendor1Spec, "vendor1.yaml", cdiSpecDir)
+		data.Labels().Set("cdiSpecDir", cdiSpecDir)
+	}
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("--cdi-spec-dirs", data.Labels().Get("cdiSpecDir"), "run", "--rm", "--gpus", "2", "--device", "vendor1.com/device=foo", testutil.AlpineImage, "env")
+	}
+	testCase.Expected = test.Expects(expect.ExitCodeSuccess, nil, func(stdout string, t tig.T) {
+		assert.Assert(t, strings.Contains(stdout, "AMD_GPU_0=injected"))
+		assert.Assert(t, strings.Contains(stdout, "AMD_GPU_1=injected"))
+		assert.Assert(t, strings.Contains(stdout, "FOO=injected"))
 	})
+	testCase.Run(t)
 }
 
-func writeTestCDISpec(t *testing.T, spec string, fileName string, cdiSpecDir string) {
+type runGPUTestCase struct {
+	name         string
+	specs        map[string]string
+	gpuFlags     []string
+	expectedEnvs []string
+	expectFail   bool
+}
+
+func runGPUCases(cases []runGPUTestCase) []*test.Case {
+	subTests := make([]*test.Case, len(cases))
+	for i, tc := range cases {
+		i, tc := i, tc
+		subTests[i] = &test.Case{
+			Description: tc.name,
+			Setup: func(data test.Data, helpers test.Helpers) {
+				cdiSpecDir := data.Temp().Dir("cdi")
+				for fileName, spec := range tc.specs {
+					writeTestCDISpecTigron(helpers.T(), spec, fileName, cdiSpecDir)
+				}
+				data.Labels().Set("cdiSpecDir", cdiSpecDir)
+			},
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				args := []string{"--cdi-spec-dirs", data.Labels().Get("cdiSpecDir"), "run", "--rm"}
+				args = append(args, tc.gpuFlags...)
+				args = append(args, testutil.AlpineImage, "env")
+				return helpers.Command(args...)
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				if tc.expectFail {
+					return &test.Expected{ExitCode: expect.ExitCodeGenericFail}
+				}
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						for _, expectedEnv := range tc.expectedEnvs {
+							assert.Assert(t, strings.Contains(stdout, expectedEnv), expectedEnv+" not found")
+						}
+					},
+				}
+			},
+		}
+	}
+	return subTests
+}
+
+// assertAddHostEntries checks that each expected entry appears in stdout
+// after removing spaces and tabs separating items.
+func assertAddHostEntries(stdout string, expected []string) error {
+	var found int
+	sc := bufio.NewScanner(bytes.NewBufferString(stdout))
+	for sc.Scan() {
+		line := strings.ReplaceAll(sc.Text(), " ", "")
+		line = strings.ReplaceAll(line, "\t", "")
+		if strutil.InStringSlice(expected, line) {
+			found++
+		}
+	}
+	if found != len(expected) {
+		return fmt.Errorf("host was not added, found %d", found)
+	}
+	return nil
+}
+
+func writeTestCDISpecTigron(t tig.T, spec string, fileName string, cdiSpecDir string) {
 	err := os.MkdirAll(cdiSpecDir, 0o700)
 	assert.NilError(t, err)
 	cdiSpecPath := filepath.Join(cdiSpecDir, fileName)


### PR DESCRIPTION
Rewrite tests in container_run_linux_test.go from testutil.NewBase to nerdtest.Setup (Tigron framework). Part of #4613.