### PR TITLE
CI: ipv6: consistently use Ubuntu 26.04

### DIFF
--- a/.github/workflows/workflow-test.yml
+++ b/.github/workflows/workflow-test.yml
@@ -88,7 +88,7 @@ jobs:
             target: rootless
             binary: "nerdctl.gomodjail"
           # ipv6
-          - runner: ubuntu-24.04
+          - runner: ubuntu-26.04
             target: rootless
             ipv6: true
             skip-flaky: true


### PR DESCRIPTION
The rootless variant was using Ubuntu 24.04