### PR TITLE
Refactor `container_kill_linux_test.go` to use Tigron

### DIFF
--- a/cmd/nerdctl/container/container_kill_linux_test.go
+++ b/cmd/nerdctl/container/container_kill_linux_test.go
@@ -18,63 +18,127 @@ package container
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/coreos/go-iptables/iptables"
 	"gotest.tools/v3/assert"
 
-	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
+	"github.com/containerd/nerdctl/mod/tigron/expect"
+	"github.com/containerd/nerdctl/mod/tigron/test"
+	"github.com/containerd/nerdctl/mod/tigron/tig"
+
 	"github.com/containerd/nerdctl/v2/pkg/testutil"
 	iptablesutil "github.com/containerd/nerdctl/v2/pkg/testutil/iptables"
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
+	"github.com/containerd/nerdctl/v2/pkg/testutil/portlock"
 )
 
-// TestKillCleanupForwards runs a container that exposes a port and then kill it.
-// The test checks that the kill command effectively clean up
-// the iptables forwards creted from the run.
+// TestKillCleanupForwards runs a container that exposes a port and then kills it.
+// The test checks that the kill command effectively cleans up
+// the iptables forwards created from the run.
 func TestKillCleanupForwards(t *testing.T) {
-	const (
-		hostPort          = 9999
-		testContainerName = "ngx"
-	)
-	base := testutil.NewBase(t)
-	defer func() {
-		base.Cmd("rm", "-f", testContainerName).Run()
-	}()
+	testCase := nerdtest.Setup()
+	testCase.Require = nerdtest.Rootful // pkg/testutil/iptables does not support rootless
 
-	// skip if rootless
-	if rootlessutil.IsRootless() {
-		t.Skip("pkg/testutil/iptables does not support rootless")
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		port, err := portlock.Acquire(0)
+		assert.NilError(helpers.T(), err)
+		data.Labels().Set("hostPort", strconv.Itoa(port))
+
+		containerID := helpers.Capture("run", "-d",
+			"--restart=no",
+			"--name", data.Identifier(),
+			"-p", fmt.Sprintf("127.0.0.1:%d:80", port),
+			testutil.NginxAlpineImage)
+		containerID = strings.TrimSuffix(containerID, "\n")
+
+		containerIP := helpers.Capture("inspect",
+			"-f",
+			"'{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'",
+			data.Identifier())
+		containerIP = strings.ReplaceAll(containerIP, "'", "")
+		containerIP = strings.TrimSuffix(containerIP, "\n")
+
+		// define iptables chain name depending on the target (docker/nerdctl)
+		ipt, err := iptables.New()
+		assert.NilError(helpers.T(), err)
+
+		var chain string
+		if nerdtest.IsDocker() {
+			chain = "DOCKER"
+		} else {
+			redirectChain := "CNI-HOSTPORT-DNAT"
+			chain = iptablesutil.GetRedirectedChain(t, ipt, redirectChain, testutil.Namespace, containerID)
+		}
+
+		data.Labels().Set("chain", chain)
+		data.Labels().Set("containerIP", containerIP)
+		data.Labels().Set("containerName", data.Identifier())
 	}
 
-	ipt, err := iptables.New()
-	assert.NilError(t, err)
-
-	containerID := base.Cmd("run", "-d",
-		"--restart=no",
-		"--name", testContainerName,
-		"-p", fmt.Sprintf("127.0.0.1:%d:80", hostPort),
-		testutil.NginxAlpineImage).Run().Stdout()
-	containerID = strings.TrimSuffix(containerID, "\n")
-
-	containerIP := base.Cmd("inspect",
-		"-f",
-		"'{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}'",
-		testContainerName).Run().Stdout()
-	containerIP = strings.ReplaceAll(containerIP, "'", "")
-	containerIP = strings.TrimSuffix(containerIP, "\n")
-
-	// define iptables chain name depending on the target (docker/nerdctl)
-	var chain string
-	if nerdtest.IsDocker() {
-		chain = "DOCKER"
-	} else {
-		redirectChain := "CNI-HOSTPORT-DNAT"
-		chain = iptablesutil.GetRedirectedChain(t, ipt, redirectChain, testutil.Namespace, containerID)
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Labels().Get("containerName"))
+		if portStr := data.Labels().Get("hostPort"); portStr != "" {
+			port, err := strconv.Atoi(portStr)
+			if err == nil {
+				_ = portlock.Release(port)
+			}
+		}
 	}
-	assert.Equal(t, iptablesutil.ForwardExists(t, ipt, chain, containerIP, hostPort), true)
 
-	base.Cmd("kill", testContainerName).AssertOK()
-	assert.Equal(t, iptablesutil.ForwardExists(t, ipt, chain, containerIP, hostPort), false)
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "iptables forwarding rule should exist before container is killed",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Custom("iptables", "-t", "nat", "-S", data.Labels().Get("chain"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeSuccess,
+					Output: func(stdout string, t tig.T) {
+						rules := strings.Split(stdout, "\n")
+						port, _ := strconv.Atoi(data.Labels().Get("hostPort"))
+						found, err := iptablesutil.ForwardExistsFromRules(rules, data.Labels().Get("containerIP"), port)
+						assert.NilError(t, err)
+						assert.Assert(t, found, "iptables forwarding rule should exist before kill")
+					},
+				}
+			},
+		},
+		{
+			Description: "kill container",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Command("kill", data.Labels().Get("containerName"))
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
+		{
+			Description: "iptables forwarding rule should be removed after container is killed",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				return helpers.Custom("iptables", "-t", "nat", "-S", data.Labels().Get("chain"))
+			},
+			Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+				return &test.Expected{
+					ExitCode: expect.ExitCodeNoCheck,
+					Output: func(stdout string, t tig.T) {
+						rules := strings.Split(stdout, "\n")
+						port, _ := strconv.Atoi(data.Labels().Get("hostPort"))
+						found, err := iptablesutil.ForwardExistsFromRules(rules, data.Labels().Get("containerIP"), port)
+						if err != nil {
+							// chain may have been removed entirely after kill — that's fine
+							return
+						}
+						assert.Assert(t, !found, "iptables forwarding rule should be removed after kill")
+					},
+				}
+			},
+		},
+	}
+
+	testCase.Run(t)
 }

--- a/pkg/testutil/iptables/iptables_linux.go
+++ b/pkg/testutil/iptables/iptables_linux.go
@@ -55,6 +55,32 @@ func ForwardExists(t *testing.T, ipt *iptables.IPTables, chain, containerIP stri
 	return found
 }
 
+// ForwardExistsFromRules checks whether an iptables forwarding rule exists
+// in the provided list of rule strings. Unlike ForwardExists, this function
+// does not query iptables directly, making it suitable for use with
+// pre-captured command output (e.g., from helpers.Custom("iptables", ...)).
+func ForwardExistsFromRules(rules []string, containerIP string, port int) (bool, error) {
+	if len(rules) < 1 {
+		return false, fmt.Errorf("not enough rules: %d", len(rules))
+	}
+
+	found := false
+	matchRule := `--dport ` + fmt.Sprintf("%d", port) + ` .+ --to-destination ` + containerIP
+
+	for _, rule := range rules {
+		foundInRule, err := regexp.MatchString(matchRule, rule)
+		if err != nil {
+			return false, fmt.Errorf("error in match string: %q", err)
+		}
+
+		if foundInRule {
+			found = foundInRule
+		}
+	}
+
+	return found, nil
+}
+
 // GetRedirectedChain returns the chain where the traffic is being redirected.
 // This is how libcni manage its port maps.
 // Suppose you have the following rule:


### PR DESCRIPTION
Updates tests to use nerdtest.Setup and the Tigron testing framework as per issue https://github.com/containerd/nerdctl/issues/4613 cmd/nerdctl/container/container_kill_linux_test.go