### PR TITLE
feat(image): adopt Docker v29 output for images list

### DIFF
--- a/cmd/nerdctl/builder/builder_build_test.go
+++ b/cmd/nerdctl/builder/builder_build_test.go
@@ -671,12 +671,8 @@ CMD ["echo", "nerdctl-build-test-string"]
 		},
 		Command: test.Command("images", "--all"),
 		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-			// TODO: follow Docker v29 behavior (change <none> to <untagged>) https://github.com/containerd/nerdctl/issues/5027
-			noTag := "<none>"
-			if nerdtest.IsDocker() {
-				noTag = "<untagged>"
-			}
-			return test.Expects(expect.ExitCodeSuccess, nil, expect.Contains(noTag))(data, helpers)
+			// The Docker v29 default view renders untagged images as <untagged>.
+			return test.Expects(expect.ExitCodeSuccess, nil, expect.Contains("<untagged>"))(data, helpers)
 		},
 	}
 

--- a/cmd/nerdctl/image/image_list.go
+++ b/cmd/nerdctl/image/image_list.go
@@ -33,11 +33,18 @@ func ImagesCommand() *cobra.Command {
 	shortHelp := "List images"
 	longHelp := shortHelp + `
 
-Properties:
+By default (Docker v29 compatible view) the following columns are shown:
+- IMAGE:        Image reference ("repository:tag", "repository@digest", or "<untagged>")
+- ID:           OCI digest of the image target (index/manifest), shared for multi-platform images. Matches Docker's ID with the containerd image store (differs from the legacy graphdriver image ID).
+- DISK USAGE:   Total on-disk size: content store blobs plus the unpacked snapshots
+- CONTENT SIZE: Size of the blobs (such as layer tarballs) in the content store
+- EXTRA:        Flags for the image; "U" means the image is in use by a container
+
+Passing --format, --quiet, --no-trunc, --digests or --names falls back to the legacy table:
 - REPOSITORY: Repository
 - TAG:        Tag
 - NAME:       Name of the image, --names for skip parsing as repository and tag.
-- IMAGE ID:   OCI Digest. Usually different from Docker image ID. Shared for multi-platform images.
+- IMAGE ID:   OCI digest of the image target (index/manifest), shared for multi-platform images. Matches Docker's ID with the containerd image store (differs from the legacy graphdriver image ID).
 - CREATED:    Created time
 - PLATFORM:   Platform
 - SIZE:       Size of the unpacked snapshots

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -44,7 +44,6 @@ func TestImages(t *testing.T) {
 	commonImage, _ := referenceutil.Parse(testutil.CommonImage)
 
 	testCase := &test.Case{
-		Require: require.Not(nerdtest.Docker),
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("pull", "--quiet", commonImage.String())
 			helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
@@ -58,18 +57,13 @@ func TestImages(t *testing.T) {
 						Output: func(stdout string, t tig.T) {
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
 							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
-							header := "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE"
-							if nerdtest.IsDocker() {
-								header = "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tSIZE"
-							}
-							tab := tabutil.NewReader(header)
+							tab := tabutil.NewReader("IMAGE\tID\tDISK USAGE\tCONTENT SIZE\tEXTRA")
 							err := tab.ParseHeader(lines[0])
 							assert.NilError(t, err, "ParseHeader should not fail\n")
 							found := false
 							for _, line := range lines[1:] {
-								repo, _ := tab.ReadRow(line, "REPOSITORY")
-								tag, _ := tab.ReadRow(line, "TAG")
-								if repo+":"+tag == commonImage.FamiliarName()+":"+commonImage.Tag {
+								image, _ := tab.ReadRow(line, "IMAGE")
+								if image == commonImage.FamiliarName()+":"+commonImage.Tag {
 									found = true
 									break
 								}
@@ -81,7 +75,9 @@ func TestImages(t *testing.T) {
 			},
 			{
 				Description: "With names",
-				Command:     test.Command("images", "--names", commonImage.String()),
+				// --names is a nerdctl-specific flag; Docker does not support it.
+				Require: require.Not(nerdtest.Docker),
+				Command: test.Command("images", "--names", commonImage.String()),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
 						Output: expect.All(
@@ -122,14 +118,52 @@ func TestImages(t *testing.T) {
 					}
 				},
 			},
+			{
+				Description: "In use",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					// Tag the image under a second name: in-use is resolved by target digest, so
+					// every reference to that target must be flagged, not just the one the
+					// container was created from.
+					helpers.Ensure("tag", commonImage.String(), data.Identifier()+":alias")
+					helpers.Ensure("run", "-d", "--quiet", "--name", data.Identifier(), commonImage.String(), "sleep", nerdtest.Infinity)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("rmi", "-f", data.Identifier()+":alias")
+				},
+				Command: test.Command("images"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, t tig.T) {
+							lines := strings.Split(strings.TrimSpace(stdout), "\n")
+							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
+							tab := tabutil.NewReader("IMAGE\tID\tDISK USAGE\tCONTENT SIZE\tEXTRA")
+							err := tab.ParseHeader(lines[0])
+							assert.NilError(t, err, "ParseHeader should not fail\n")
+							// Docker collapses all the names of an image into a single row, while
+							// nerdctl has one row per image record, so just require that every row
+							// referring to that target is marked.
+							found := 0
+							for _, line := range lines[1:] {
+								image, _ := tab.ReadRow(line, "IMAGE")
+								if image != commonImage.FamiliarName()+":"+commonImage.Tag &&
+									image != data.Identifier()+":alias" {
+									continue
+								}
+								extra, _ := tab.ReadRow(line, "EXTRA")
+								assert.Equal(t, extra, "U", "the in-use image should be marked with U: "+image)
+								found++
+							}
+							assert.Assert(t, found > 0, "we should have found the in-use image\n")
+						},
+					}
+				},
+			},
 		},
 	}
 
 	if runtime.GOOS == "windows" {
-		testCase.Require = require.All(
-			testCase.Require,
-			nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3524"),
-		)
+		testCase.Require = nerdtest.IsFlaky("https://github.com/containerd/nerdctl/issues/3524")
 	}
 
 	testCase.Run(t)
@@ -316,18 +350,14 @@ CMD ["echo", "nerdctl-build-notag-string"]
 				Description: "dangling",
 				Command:     test.Command("images", "--filter", "dangling=true"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
-					// TODO: follow Docker v29 behavior (change <none> to <untagged>) https://github.com/containerd/nerdctl/issues/5027
-					dangling := "<none>"
-					if nerdtest.IsDocker() {
-						dangling = "<untagged>"
-					}
-					return test.Expects(0, nil, expect.Contains(dangling))(data, helpers)
+					// The Docker v29 default view (used here, no --format) renders dangling images as <untagged>.
+					return test.Expects(0, nil, expect.Contains("<untagged>"))(data, helpers)
 				},
 			},
 			{
 				Description: "not dangling",
 				Command:     test.Command("images", "--filter", "dangling=false"),
-				Expected:    test.Expects(0, nil, expect.DoesNotContain("<none>")),
+				Expected:    test.Expects(0, nil, expect.DoesNotContain("<untagged>", "<none>")),
 			},
 		},
 	}
@@ -355,20 +385,15 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 							var imageID string
 							var skipLine int
 							lines := strings.Split(strings.TrimSpace(stdout), "\n")
-							header := "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE"
-							if nerdtest.IsDocker() {
-								header = "REPOSITORY\tTAG\tIMAGE ID\tCREATED\tSIZE"
-							}
-							tab := tabutil.NewReader(header)
+							tab := tabutil.NewReader("IMAGE\tID\tDISK USAGE\tCONTENT SIZE\tEXTRA")
 							err := tab.ParseHeader(lines[0])
 							assert.NilError(t, err, "ParseHeader should not fail\n")
 							found := true
 							for i, line := range lines[1:] {
-								repo, _ := tab.ReadRow(line, "REPOSITORY")
-								tag, _ := tab.ReadRow(line, "TAG")
-								if repo+":"+tag == testutil.BusyboxImage {
+								image, _ := tab.ReadRow(line, "IMAGE")
+								if image == testutil.BusyboxImage {
 									skipLine = i
-									imageID, _ = tab.ReadRow(line, "IMAGE ID")
+									imageID, _ = tab.ReadRow(line, "ID")
 									break
 								}
 							}
@@ -376,7 +401,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 								if i == skipLine {
 									continue
 								}
-								id, _ := tab.ReadRow(line, "IMAGE ID")
+								id, _ := tab.ReadRow(line, "ID")
 								if id == imageID {
 									found = false
 									break
@@ -392,7 +417,7 @@ func TestImagesKubeWithKubeHideDupe(t *testing.T) {
 				Command:     test.Command("images"),
 				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
 					return &test.Expected{
-						Output: expect.Contains("<none>"),
+						Output: expect.Contains("<untagged>"),
 					}
 				},
 			},

--- a/cmd/nerdctl/image/image_prune_test.go
+++ b/cmd/nerdctl/image/image_prune_test.go
@@ -77,7 +77,7 @@ func TestImagePrune(t *testing.T) {
 				// Swapping order does not change anything.
 				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
-				assert.Assert(t, strings.Contains(imgList, "<none>"), "Missing <none>")
+				assert.Assert(t, strings.Contains(imgList, "<untagged>"), "Missing <untagged>")
 				assert.Assert(t, strings.Contains(imgList, identifier), "Missing "+identifier)
 			},
 			Command: test.Command("image", "prune", "--force"),
@@ -90,7 +90,7 @@ func TestImagePrune(t *testing.T) {
 						},
 						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
-							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
+							assert.Assert(t, !strings.Contains(imgList, "<untagged>"), imgList)
 							assert.Assert(t, strings.Contains(imgList, identifier))
 						},
 					),
@@ -122,7 +122,7 @@ func TestImagePrune(t *testing.T) {
 				helpers.Ensure("build", buildCtx)
 				helpers.Ensure("build", "-t", identifier, buildCtx)
 				imgList := helpers.Capture("images")
-				assert.Assert(t, strings.Contains(imgList, "<none>"), "Missing <none>")
+				assert.Assert(t, strings.Contains(imgList, "<untagged>"), "Missing <untagged>")
 				assert.Assert(t, strings.Contains(imgList, identifier), "Missing "+identifier)
 				helpers.Ensure("run", "--name", identifier, identifier)
 			},
@@ -136,7 +136,7 @@ func TestImagePrune(t *testing.T) {
 						func(stdout string, t tig.T) {
 							imgList := helpers.Capture("images")
 							assert.Assert(t, strings.Contains(imgList, data.Identifier()))
-							assert.Assert(t, !strings.Contains(imgList, "<none>"), imgList)
+							assert.Assert(t, !strings.Contains(imgList, "<untagged>"), imgList)
 							helpers.Ensure("rm", "-f", data.Identifier())
 							removed := helpers.Capture("image", "prune", "--force", "--all")
 							assert.Assert(t, strings.Contains(removed, data.Identifier()))

--- a/cmd/nerdctl/image/image_remove_test.go
+++ b/cmd/nerdctl/image/image_remove_test.go
@@ -143,7 +143,7 @@ func TestRemove(t *testing.T) {
 					Errors:   []error{},
 					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
-							Output: expect.Contains("<none>"),
+							Output: expect.Contains("<untagged>"),
 						})
 					},
 				}
@@ -249,7 +249,7 @@ func TestRemove(t *testing.T) {
 					Errors:   []error{},
 					Output: func(stdout string, t tig.T) {
 						helpers.Command("images").Run(&test.Expected{
-							Output: expect.Contains("<none>"),
+							Output: expect.Contains("<untagged>"),
 						})
 					},
 				}
@@ -374,7 +374,7 @@ func TestRemoveKubeWithKubeHideDupe(t *testing.T) {
 	)
 	testCase.SubTests = []*test.Case{
 		{
-			Description: "After removing the tag without kube-hide-dupe, repodigest is shown as <none>",
+			Description: "After removing the tag without kube-hide-dupe, repodigest is shown as <untagged>",
 			NoParallel:  true,
 			Setup: func(data test.Data, helpers test.Helpers) {
 				helpers.Ensure("pull", "--quiet", testutil.BusyboxImage)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -833,7 +833,12 @@ support zstdchunked convert
 
 List images
 
-:warning: The image ID is usually different from Docker image ID.
+:warning: The image ID is the OCI digest of the image target (index/manifest). It matches Docker's ID with the containerd image store, but differs from the legacy graphdriver image ID (config digest).
+
+By default (Docker v29 compatible view) the columns are `IMAGE`, `ID`, `DISK USAGE`,
+`CONTENT SIZE` and `EXTRA` (where `U` means the image is in use by a container).
+Passing `--format`, `--quiet`, `--no-trunc`, `--digests` or `--names` falls back to the
+legacy table (`REPOSITORY`, `TAG`, `IMAGE ID`, `CREATED`, `PLATFORM`, `SIZE`, `BLOB SIZE`).
 
 Usage: `nerdctl images [OPTIONS] [REPOSITORY[:TAG]]`
 
@@ -843,7 +848,7 @@ Flags:
 - :whale: `-q, --quiet`: Only show numeric IDs
 - :whale: `--no-trunc`: Don't truncate output
 - :whale: `--format`: Format the output using the given Go template
-  - :whale: `--format=table` (default): Table
+  - :whale: `--format=table`: Legacy table (default is the Docker v29 compatible view)
   - :whale: `--format='{{json .}}'`: JSON
   - :nerd_face: `--format=wide`: Wide table
   - :nerd_face: `--format=json`: Alias of `--format='{{json .}}'`

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -23,16 +23,19 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"text/tabwriter"
 	"text/template"
 	"time"
+	"unicode/utf8"
 
 	"github.com/docker/go-units"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/identity"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/term"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/content"
@@ -174,9 +177,19 @@ func printImages(ctx context.Context, client *containerd.Client, imageList []ima
 	if options.Format == "wide" {
 		digestsFlag = true
 	}
+	// newView selects the Docker v29 default output (IMAGE, ID, DISK USAGE, CONTENT SIZE, EXTRA).
+	// Any "old-view" signal (--format, --quiet, --no-trunc, --digests, --names) falls back to the
+	// legacy table, mirroring Docker's tree-view fallback.
+	newView := options.Format == "" && !options.Quiet && !options.NoTrunc && !options.Digests && !options.Names
 	var tmpl *template.Template
-	switch options.Format {
-	case "", "table", "wide":
+	switch {
+	case newView:
+		// The legend is written to the underlying writer before it is wrapped in the tabwriter,
+		// so it is not aligned to the columns below. Like Docker, it is only shown on a terminal.
+		printImagesLegend(w)
+		w = tabwriter.NewWriter(w, 4, 8, 4, ' ', 0)
+		fmt.Fprintln(w, "IMAGE\tID\tDISK USAGE\tCONTENT SIZE\tEXTRA")
+	case options.Format == "", options.Format == "table", options.Format == "wide":
 		w = tabwriter.NewWriter(w, 4, 8, 4, ' ', 0)
 		if !options.Quiet {
 			printHeader := ""
@@ -191,7 +204,7 @@ func printImages(ctx context.Context, client *containerd.Client, imageList []ima
 			printHeader += "IMAGE ID\tCREATED\tPLATFORM\tSIZE\tBLOB SIZE"
 			fmt.Fprintln(w, printHeader)
 		}
-	case "raw":
+	case options.Format == "raw":
 		return errors.New("unsupported format: \"raw\"")
 	default:
 		if options.Quiet {
@@ -204,12 +217,22 @@ func printImages(ctx context.Context, client *containerd.Client, imageList []ima
 		}
 	}
 
+	// In-use detection requires a container scan, so only pay for it in the new view where the
+	// EXTRA column is rendered.
+	var inUse map[digest.Digest]bool
+	if newView {
+		inUse = imagesInUse(ctx, client)
+		sortByImageRef(finalImageList)
+	}
+
 	printer := &imagePrinter{
 		w:           w,
 		quiet:       options.Quiet,
 		noTrunc:     options.NoTrunc,
 		digestsFlag: digestsFlag,
 		namesFlag:   options.Names,
+		newView:     newView,
+		inUse:       inUse,
 		tmpl:        tmpl,
 		client:      client,
 		provider:    containerdutil.NewProvider(client),
@@ -228,12 +251,13 @@ func printImages(ctx context.Context, client *containerd.Client, imageList []ima
 }
 
 type imagePrinter struct {
-	w                                      io.Writer
-	quiet, noTrunc, digestsFlag, namesFlag bool
-	tmpl                                   *template.Template
-	client                                 *containerd.Client
-	provider                               content.Provider
-	snapshotter                            snapshots.Snapshotter
+	w                                               io.Writer
+	quiet, noTrunc, digestsFlag, namesFlag, newView bool
+	inUse                                           map[digest.Digest]bool // image target -> referenced by at least one container
+	tmpl                                            *template.Template
+	client                                          *containerd.Client
+	provider                                        content.Provider
+	snapshotter                                     snapshots.Snapshotter
 }
 
 type image struct {
@@ -347,6 +371,10 @@ func (x *imagePrinter) printImage(ctx context.Context, img images.Image) error {
 		return err
 	}
 
+	if x.newView {
+		return x.printImageCollapsed(img, candidateImages)
+	}
+
 	for platform, desc := range candidateImages {
 		if err := x.printImageSinglePlatform(*desc.config, img, desc.blobSize, desc.size, desc.platform); err != nil {
 			log.G(ctx).WithError(err).Debugf("failed to get platform %q of image %q", platform, img.Name)
@@ -422,6 +450,138 @@ func (x *imagePrinter) printImageSinglePlatform(desc ocispec.Descriptor, img ima
 		}
 	}
 	return nil
+}
+
+// printImageCollapsed renders a single row in the Docker v29 default view (IMAGE, ID, DISK USAGE,
+// CONTENT SIZE, EXTRA), aggregating disk and content size across the platforms present in the
+// content store.
+func (x *imagePrinter) printImageCollapsed(img images.Image, candidateImages map[string]*image) error {
+	var totalSnapshotSize, totalContentSize int64
+	for _, candidate := range candidateImages {
+		totalSnapshotSize += candidate.size
+		totalContentSize += candidate.blobSize
+	}
+
+	// Match Docker's tree view semantics (api/types/image.ManifestSummary.Size):
+	// CONTENT SIZE is the content-store blobs, and DISK USAGE ("Total") is the content plus the
+	// unpacked snapshots. Docker formats both with 3-significant-digit precision.
+	diskUsage := units.HumanSizeWithPrecision(float64(totalContentSize+totalSnapshotSize), 3)
+	contentSize := units.HumanSizeWithPrecision(float64(totalContentSize), 3)
+
+	// The new view always truncates the ID (it never coexists with --no-trunc).
+	id := img.Target.Digest.String()
+	if _, hex, ok := strings.Cut(id, ":"); ok && len(hex) >= 12 {
+		id = hex[:12]
+	}
+
+	extra := ""
+	if x.inUse[img.Target.Digest] {
+		extra = "U"
+	}
+
+	_, err := fmt.Fprintf(x.w, "%s\t%s\t%s\t%s\t%s\n",
+		newViewImageRef(img.Name),
+		id,
+		diskUsage,
+		contentSize,
+		extra,
+	)
+	return err
+}
+
+// printImagesLegend writes the right-aligned "In Use" legend for the Docker v29 default view.
+// Matching Docker, it is only emitted when the output is a terminal with a known width, so it
+// never pollutes piped or redirected output.
+func printImagesLegend(w io.Writer) {
+	f, ok := w.(*os.File)
+	if !ok {
+		return
+	}
+	width, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || width <= 0 {
+		return
+	}
+	legend := "i Info →   U  In Use"
+	if pad := width - utf8.RuneCountInString(legend); pad > 0 {
+		legend = strings.Repeat(" ", pad) + legend
+	}
+	fmt.Fprintln(w, legend)
+}
+
+// untaggedImageRef is what the Docker v29 view shows in the IMAGE column for dangling images.
+const untaggedImageRef = "<untagged>"
+
+// sortByImageRef orders the images the way Docker v29 orders its collapsed view: lexicographically
+// by the rendered IMAGE column, with untagged images last. The legacy table keeps its own
+// creation-time ordering, so this is only applied to the new view.
+func sortByImageRef(imageList []images.Image) {
+	refs := make(map[string]string, len(imageList))
+	for _, img := range imageList {
+		refs[img.Name] = newViewImageRef(img.Name)
+	}
+	sort.SliceStable(imageList, func(i, j int) bool {
+		a, b := refs[imageList[i].Name], refs[imageList[j].Name]
+		if (a == untaggedImageRef) != (b == untaggedImageRef) {
+			return b == untaggedImageRef
+		}
+		return a < b
+	})
+}
+
+// newViewImageRef builds the IMAGE column for the Docker v29 default view: "repo:tag" for tagged
+// images, "repo@digest" for images pulled by digest, or "<untagged>" for dangling images.
+func newViewImageRef(name string) string {
+	parsed, err := referenceutil.Parse(name)
+	if err != nil {
+		return untaggedImageRef
+	}
+	familiar := parsed.FamiliarName()
+	if familiar == "" {
+		return untaggedImageRef
+	}
+	if parsed.Tag != "" {
+		return familiar + ":" + parsed.Tag
+	}
+	// A tag-less reference is shown as "repo@digest" only when it carries an explicit registry
+	// domain (a real pulled-by-digest image). Dangling build artifacts have a synthetic,
+	// domain-less name (e.g. "<none>@sha256:..." or "<snapshotter>@sha256:..." depending on the
+	// builder) and are rendered as "<untagged>", matching Docker.
+	if parsed.Digest != "" && referenceHasDomain(name) {
+		return familiar + "@" + parsed.Digest.String()
+	}
+	return untaggedImageRef
+}
+
+// referenceHasDomain reports whether the raw image reference includes an explicit registry
+// domain, using the same heuristic as distribution/reference: the component before the first
+// "/" is a domain when it is "localhost" or contains a "." or ":".
+func referenceHasDomain(name string) bool {
+	host, _, ok := strings.Cut(name, "/")
+	if !ok {
+		return false
+	}
+	return host == "localhost" || strings.ContainsAny(host, ".:")
+}
+
+// imagesInUse returns the set of image target digests that are referenced by at least one
+// container (in any state), used to render the Docker v29 "In Use" (U) indicator. Docker matches
+// containers to images by digest, so every name pointing at the same target is flagged, not just
+// the one the container was created from.
+func imagesInUse(ctx context.Context, client *containerd.Client) map[digest.Digest]bool {
+	inUse := map[digest.Digest]bool{}
+	containerList, err := client.Containers(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to list containers for image in-use detection")
+		return inUse
+	}
+	for _, container := range containerList {
+		image, err := container.Image(ctx)
+		if err != nil {
+			continue
+		}
+		inUse[image.Target().Digest] = true
+	}
+	return inUse
 }
 
 func isAttestationManifestDescriptor(desc ocispec.Descriptor) bool {

--- a/pkg/cmd/image/list_test.go
+++ b/pkg/cmd/image/list_test.go
@@ -1,0 +1,77 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package image
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/containerd/v2/core/images"
+)
+
+func TestNewViewImageRef(t *testing.T) {
+	const digest = "sha256:09538a1f51d3ec5af0449a1640937dfdf79b0e9b8c4da5b8a883086d5c1492ef"
+	testCases := []struct {
+		name     string
+		expected string
+	}{
+		{"docker.io/library/hello-world:latest", "hello-world:latest"},
+		{"docker.io/moby/buildkit:buildx-stable-1", "moby/buildkit:buildx-stable-1"},
+		{"ghcr.io/stargz-containers/alpine:3.13", "ghcr.io/stargz-containers/alpine:3.13"},
+		// pulled by digest (has an explicit registry domain, no tag) -> repo@digest
+		{"docker.io/library/hello-world@" + digest, "hello-world@" + digest},
+		{"ghcr.io/stargz-containers/alpine@" + digest, "ghcr.io/stargz-containers/alpine@" + digest},
+		// dangling build artifacts: domain-less name with a digest -> untagged
+		{"<none>@" + digest, "<untagged>"},
+		{"overlayfs@" + digest, "<untagged>"},
+		// bare config digest as name (created by the CRI plugin) -> untagged
+		{digest, "<untagged>"},
+		// unparsable / empty name -> untagged
+		{"", "<untagged>"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, newViewImageRef(tc.name), tc.expected)
+		})
+	}
+}
+
+func TestSortByImageRef(t *testing.T) {
+	const digest = "sha256:09538a1f51d3ec5af0449a1640937dfdf79b0e9b8c4da5b8a883086d5c1492ef"
+	imageList := []images.Image{
+		{Name: "<none>@" + digest},
+		{Name: "docker.io/library/nginx:alpine"},
+		{Name: "ghcr.io/stargz-containers/alpine:3.13"},
+		{Name: "overlayfs@" + digest},
+		{Name: "docker.io/library/alpine:latest"},
+	}
+	sortByImageRef(imageList)
+	// Ordering is on the rendered IMAGE column (the familiar name), like Docker, so
+	// "docker.io/library/nginx:alpine" sorts as "nginx:alpine".
+	expected := []string{
+		"docker.io/library/alpine:latest",
+		"ghcr.io/stargz-containers/alpine:3.13",
+		"docker.io/library/nginx:alpine",
+		// untagged images come last, in their original order
+		"<none>@" + digest,
+		"overlayfs@" + digest,
+	}
+	for i, img := range imageList {
+		assert.Equal(t, img.Name, expected[i])
+	}
+}


### PR DESCRIPTION
  Make the default `nerdctl images` output match Docker v29: a collapsed view with
  `IMAGE`, `ID`, `DISK USAGE`, `CONTENT SIZE` and `EXTRA` columns, an "In Use" (`U`)
  indicator, and `<untagged>` for dangling images. Multi-platform images are collapsed
  into a single row with aggregated disk and content size.

  Details that follow Docker's behavior:
  - `DISK USAGE` is the content store blobs plus the unpacked snapshots (Docker's
    `Total`), `CONTENT SIZE` is the blobs alone. Both are formatted with 3 significant
    digits, like Docker.
  - In use is resolved by image target digest, the way Docker matches containers to
    images, so every reference to a used target is flagged, not only the one the
    container was created from.
  - The "In Use" legend is only printed when the output is a terminal, so piped and
    redirected output stays clean.
  - Rows are ordered by image reference with untagged images last, rather than by
    creation time.
  - The `ID` column is the OCI digest of the image target, which matches Docker's ID
    with the containerd image store (it differs only from the legacy graphdriver
    image ID). The help text and docs are updated accordingly.

  The new view is used only for the bare command. Passing `--format`, `--quiet`,
  `--no-trunc`, `--digests` or `--names` falls back to the legacy table (`REPOSITORY`,
  `TAG`, `IMAGE ID`, `CREATED`, `PLATFORM`, `SIZE`, `BLOB SIZE`), so existing scripts and
  templates keep working, including their creation-time ordering. This mirrors Docker's
  own `shouldUseTree` fallback.

  Since the default output now matches Docker, the images tests also run against the
  Docker target; only the nerdctl-specific `--names` subtest stays gated. Tests that
  assert on the default `images` output for untagged images (image prune/remove and
  build-without-tag) are updated to expect `<untagged>`.

  The expanded per-platform `--tree` view is left for a follow-up.

  Closes #5027