### PR TITLE
fix: suppress spurious hostsstore NotFound warning on container removal

### DIFF
--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -258,8 +258,11 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		hs, err := hostsstore.New(dataStore, containerNamespace)
 		if err != nil {
 			log.G(ctx).WithError(err).Warnf("failed to instantiate hostsstore for %q", containerNamespace)
-		} else if err = hs.Delete(id); err != nil {
+		} else if err = hs.Delete(id); err != nil && !errors.Is(err, store.ErrNotFound) {
 			// De-allocate hosts file - soft failure
+			// Some platforms and network modes never allocate a hosts file for the container in the first
+			// place (e.g. Windows containers), so ignore NotFound errors here, similarly to the
+			// nameStore.Release call above.
 			log.G(ctx).WithError(err).Warnf("failed to remove hosts file for container %q", id)
 		}
 


### PR DESCRIPTION
Motivation:
On Windows, `nerdctl run --rm ...` (and `nerdctl rm`) logs a confusing
warning after every container removal:

  level=warning msg="failed to remove hosts file for container \"<id>\""
  error="hosts-store error\nnot found\nGetFileAttributesEx
  ...\\etchosts\\default\\<id>: The system cannot find the file specified."

Fixes #4678

Approach:
pkg/containerutil/container_network_manager_windows.go never calls
hostsstore.Acquire/AllocHostsFile (unlike the Linux and generic network
manager code paths), so no hosts-store directory is ever created for a
Windows container. As a result, hostsstore.Delete(id) in
RemoveContainer (pkg/cmd/container/remove.go) always fails with
store.ErrNotFound on Windows, and that failure was unconditionally
logged as a warning.

This is purely a noisy/confusing log message, not a functional bug:
hostsstore.Delete's error was already only logged (soft failure), so
container removal succeeds identically before and after this change.

The fix mirrors the existing nameStore.Release handling a few lines
above in the same function (which already ignores store.ErrNotFound
to tolerate double-release with --rm): hostsstore.Delete's NotFound
error is now ignored for the same reason - the hosts-store entry may
simply never have been allocated for this container/platform/network
mode.

Validation:
- go build ./... passes.
- go test ./pkg/... passes (all packages ok, including
  pkg/dnsutil/hostsstore and pkg/store).
- gofmt -l pkg/cmd/container/remove.go reports no issues.
- pkg/cmd/container has no unit tests for RemoveContainer (it requires
  a live containerd.Container); this matches the existing test
  coverage pattern for that function (integration-only, via
  cmd/nerdctl/container/container_remove_test.go).

Signed-off-by: Pujitha Paladugu <venkat@dema.shop>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
