### PR TITLE
feature: support to print snapshot info for image

### DIFF
--- a/pkg/imageinspector/imageinspector.go
+++ b/pkg/imageinspector/imageinspector.go
@@ -19,6 +19,8 @@ package imageinspector
 import (
 	"context"
 
+	"github.com/opencontainers/image-spec/identity"
+
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/images"
 	"github.com/containerd/containerd/v2/core/snapshots"
@@ -56,6 +58,17 @@ func Inspect(ctx context.Context, client *containerd.Client, image images.Image,
 	} else {
 		n.ImageConfigDesc = imageConfigDesc
 		n.ImageConfig = imageConfig
+		chainIDs := identity.ChainIDs(imageConfig.RootFS.DiffIDs)
+		snapshots := make([]snapshots.Info, len(chainIDs))
+		for i, id := range chainIDs {
+			snapInfo, err := snapshotter.Stat(ctx, id.String())
+			if err == nil {
+				snapshots[i] = snapInfo
+			} else {
+				log.G(ctx).WithError(err).WithField("id", image.Name).Warnf("failed to get snapshot %s info", id.String())
+			}
+		}
+		n.Snapshots = snapshots
 	}
 	n.Size, err = imgutil.UnpackedImageSize(ctx, snapshotter, img)
 	if err != nil {

--- a/pkg/inspecttypes/native/image.go
+++ b/pkg/inspecttypes/native/image.go
@@ -20,6 +20,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/snapshots"
 )
 
 // Image corresponds to a containerd-native image object.
@@ -34,4 +35,5 @@ type Image struct {
 	ImageConfigDesc ocispec.Descriptor `json:"ImageConfigDesc"`
 	ImageConfig     ocispec.Image      `json:"ImageConfig"`
 	Size            int64              `json:"size"`
+	Snapshots       []snapshots.Info   `json:"Snapshots,omitempty"`
 }


### PR DESCRIPTION
nerdctl  -n k8s.io inspect busybox --mode=native

containerd config 
```
  [plugins."io.containerd.snapshotter.v1.overlayfs"]
    upperdir_label = true
```

will show snapshot info we can find busybox image use  dir /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs
```
        "Snapshots": [
            {
                "Kind": "Committed",
                "Name": "sha256:134949ec8800e56aef84679127eb2da7e1d2db5c0c905268e1ba5b12f58ee06c",
                "Labels": {
                    "containerd.io/snapshot/overlay.upperdir": "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/3/fs"
                },
                "Created": "2026-08-01T09:29:08.733458432Z",
                "Updated": "2026-08-01T09:29:08.733458432Z"
            }
        ]
    }

```
todo add snapshot info for container  rw layer.
@AkihiroSuda 

fix https://github.com/containerd/containerd/discussions/10053