### PR TITLE
fix: image ls with a bare repository name should match all tags

### DIFF
--- a/cmd/nerdctl/image/image_list.go
+++ b/cmd/nerdctl/image/image_list.go
@@ -18,6 +18,7 @@ package image
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/spf13/cobra"
 
@@ -81,7 +82,7 @@ func listOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, er
 		if err != nil {
 			return nil, err
 		}
-		filters = []string{fmt.Sprintf("name==%s", parsedReference)}
+		filters = nameFilterFor(parsedReference)
 	}
 	quiet, err := cmd.Flags().GetBool("quiet")
 	if err != nil {
@@ -123,6 +124,23 @@ func listOptions(cmd *cobra.Command, args []string) (*types.ImageListOptions, er
 		Stdout:           cmd.OutOrStdout(),
 	}, nil
 
+}
+
+// nameFilterFor builds the containerd image-service filter(s) matching the
+// argument to `nerdctl image ls [REPOSITORY[:TAG]]`.
+//
+// If the argument named an explicit tag or digest, it's matched exactly.
+// Otherwise the argument was a bare repository name: referenceutil.Parse
+// normalizes that to an implicit ":latest" tag (matching how most other
+// reference-consuming commands resolve a bare name), but for listing
+// purposes that would incorrectly hide every other tag of the repository -
+// unlike `docker image ls`, which matches all tags of a bare repository
+// name. Match any tag under the repository instead.
+func nameFilterFor(parsedReference *referenceutil.ImageReference) []string {
+	if parsedReference.ExplicitTag != "" || parsedReference.Digest != "" {
+		return []string{fmt.Sprintf("name==%s", parsedReference)}
+	}
+	return []string{fmt.Sprintf("name~=^%s:", regexp.QuoteMeta(parsedReference.Name()))}
 }
 
 func imagesAction(cmd *cobra.Command, args []string) error {

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -38,6 +38,54 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
+// TestNameFilterFor is a regression test for
+// https://github.com/containerd/nerdctl/issues/5113: `nerdctl image ls
+// myapp`, where myapp is a bare repository name, returned nothing unless
+// myapp had a `:latest` tag, because referenceutil.Parse normalizes a bare
+// repository name to an implicit ":latest" tag and the resulting exact-match
+// filter therefore only ever matched that one tag.
+func TestNameFilterFor(t *testing.T) {
+	testCases := []struct {
+		name     string
+		arg      string
+		expected []string
+	}{
+		{
+			name:     "bare repository name matches any tag",
+			arg:      "myapp",
+			expected: []string{`name~=^docker\.io/library/myapp:`},
+		},
+		{
+			name:     "explicit tag matches exactly",
+			arg:      "myapp:v1",
+			expected: []string{"name==docker.io/library/myapp:v1"},
+		},
+		{
+			name:     "explicit latest tag matches exactly",
+			arg:      "myapp:latest",
+			expected: []string{"name==docker.io/library/myapp:latest"},
+		},
+		{
+			name:     "digest matches exactly",
+			arg:      "myapp@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			expected: []string{"name==docker.io/library/myapp@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+		},
+		{
+			name:     "bare repository name with domain and path is escaped for the regex",
+			arg:      "registry.example.com/foo/my.app",
+			expected: []string{`name~=^registry\.example\.com/foo/my\.app:`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsedReference, err := referenceutil.Parse(tc.arg)
+			assert.NilError(t, err)
+			assert.DeepEqual(t, tc.expected, nameFilterFor(parsedReference))
+		})
+	}
+}
+
 func TestImages(t *testing.T) {
 	nerdtest.Setup()
 


### PR DESCRIPTION
## What's the bug

`nerdctl image ls myapp`, where `myapp` is a bare repository name (no tag or digest), returns nothing unless `myapp` happens to have a `:latest` tag. This is different from `docker image ls myapp`, which [lists every tag of the repository](https://docs.docker.com/reference/cli/docker/image/ls/#list-images-by-name-and-tag).

```
$ nerdctl image ls myapp
REPOSITORY    TAG    IMAGE ID    CREATED    PLATFORM    SIZE    BLOB SIZE
```

even though `myapp:9.8-ltsc2022-...` clearly exists.

## Root cause

`referenceutil.Parse` normalizes a bare repository name by unconditionally applying `distribution/reference`'s `TagNameOnly`, which appends an implicit `:latest` tag ([referenceutil.go#L133-L134](https://github.com/containerd/nerdctl/blob/9145d0f1bf1afe97ee6d36b5e350138808468d84/pkg/referenceutil/referenceutil.go#L133-L134)). `listOptions` in `cmd/nerdctl/image/image_list.go` then built an *exact-match* filter straight from that normalized reference:

```go
filters = []string{fmt.Sprintf("name==%s", parsedReference)}
```

which becomes `name==docker.io/library/myapp:latest` - so any image tagged with anything other than `latest` is silently excluded.

## The fix

Extracted the filter-construction logic into a small `nameFilterFor` helper:

- If the argument named an **explicit** tag or digest (`parsedReference.ExplicitTag != "" || parsedReference.Digest != ""`), keep matching it exactly with `name==...`.
- If it was a **bare repository name**, build a `name~=^<repo>:` regex filter instead (escaping the repository name with `regexp.QuoteMeta`), so it matches any tag under that repository.

This mirrors the `~=` regex-filter pattern already used elsewhere in the codebase for similar name/id matching, e.g. [`pkg/idutil/imagewalker/imagewalker.go`](https://github.com/containerd/nerdctl/blob/9145d0f1bf1afe97ee6d36b5e350138808468d84/pkg/idutil/imagewalker/imagewalker.go#L82-L83) and `pkg/idutil/containerwalker/containerwalker.go`, both of which already build `field~=regex` filters with `regexp.QuoteMeta` escaping - so this isn't introducing a new pattern, just applying an existing one to close this gap.

## Testing

- Added `TestNameFilterFor`, a focused unit test on the extracted helper (no daemon required), covering:
  - a bare repository name → now produces a `name~=^docker\.io/library/myapp:` regex filter (matches any tag)
  - an explicit tag (`myapp:v1`) → still an exact `name==...:v1` filter
  - an explicit `:latest` tag → still an exact `name==...:latest` filter
  - a digest reference → still an exact `name==...@sha256:...` filter
  - a bare name with a domain/path that needs regex-escaping (`registry.example.com/foo/my.app`)
- Verified this test fails without the fix, reproducing the exact reported bug: it produces `name==docker.io/library/myapp:latest` instead of a repo-wide match.
- `go build ./...` and `go vet ./...` pass. The rest of the package's tests are `tigron`/E2E tests that shell out to a built `nerdctl` binary against a live containerd daemon, which I don't have available in my sandboxed environment - those fail with `unable to find binary "nerdctl"` regardless of this change (verified against an unmodified checkout).

Fixes #5113
