### PR TITLE
CI: drop ppa:criu/ppa

### DIFF
--- a/.github/workflows/job-test-in-host.yml
+++ b/.github/workflows/job-test-in-host.yml
@@ -192,7 +192,6 @@ jobs:
 
           # FIXME: remove expect when we are done removing unbuffer from tests
           echo "::group:: installing test dependencies"
-          sudo add-apt-repository ppa:criu/ppa -y
           sudo apt-get install -qq expect criu
           echo "::endgroup::"
 

--- a/.github/workflows/job-test-unit.yml
+++ b/.github/workflows/job-test-unit.yml
@@ -78,7 +78,6 @@ jobs:
           elif [ "$RUNNER_OS" == "Linux" ]; then
             ./hack/provisioning/linux/cni.sh install "${INPUTS_LINUX_CNI_VERSION}" "amd64" "${INPUTS_LINUX_CNI_SHA}"
             sudo apt-get update -qq
-            sudo add-apt-repository ppa:criu/ppa -y
             sudo apt-get install -qq criu
           fi
         env:

--- a/hack/provisioning/linux/test-integration-env.sh
+++ b/hack/provisioning/linux/test-integration-env.sh
@@ -44,7 +44,8 @@ host::packages(){
     # `expect` package contains `unbuffer(1)`, which is used for emulating TTY for testing
     # `jq` is required to generate test summaries
     apt-get update -qq >/dev/null
-    add-apt-repository -y ppa:criu/ppa >/dev/null
+    # Ubuntu 22.04 needs PPA version of CRIU
+    grep -q UBUNTU_CODENAME=jammy /etc/os-release && add-apt-repository -y ppa:criu/ppa >/dev/null
     apt-get install -qq --no-install-recommends \
       apparmor \
       criu \


### PR DESCRIPTION
Apparently CRIU no longer needs to be installed from PPA.

Fix #5111