### PR TITLE
feature: support to print snapshot info for container

### DIFF
--- a/pkg/cmd/container/inspect.go
+++ b/pkg/cmd/container/inspect.go
@@ -23,6 +23,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/snapshots"
+	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
@@ -94,6 +95,14 @@ func (x *containerInspector) Handler(ctx context.Context, found containerwalker.
 
 	switch x.mode {
 	case "native":
+		if n.SnapshotKey != "" {
+			info, err := x.snapshotter.Stat(ctx, n.SnapshotKey)
+			if err != nil {
+				log.G(ctx).WithError(err).Warnf("failed to get snapshot %s info", n.SnapshotKey)
+			} else {
+				n.SnapshotInfo = &info
+			}
+		}
 		x.entries = append(x.entries, n)
 	case "dockercompat":
 		d, err := dockercompat.ContainerFromNative(n)

--- a/pkg/inspecttypes/native/container.go
+++ b/pkg/inspecttypes/native/container.go
@@ -21,6 +21,7 @@ import (
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/containers"
+	"github.com/containerd/containerd/v2/core/snapshots"
 	"github.com/containerd/go-cni"
 )
 
@@ -28,8 +29,9 @@ import (
 // Not compatible with `docker container inspect`.
 type Container struct {
 	containers.Container
-	Spec    interface{} `json:"Spec,omitempty"`
-	Process *Process    `json:"Process,omitempty"`
+	Spec         interface{}     `json:"Spec,omitempty"`
+	Process      *Process        `json:"Process,omitempty"`
+	SnapshotInfo *snapshots.Info `json:"SnapshotInfo,omitempty"`
 }
 
 type Process struct {


### PR DESCRIPTION

containerd config
```
  [plugins."io.containerd.snapshotter.v1.overlayfs"]
    upperdir_label = true
```
nerdctl  -n k8s.io container inspect 6fca  --mode=native
 we can find container's rwlayer dir is  /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/439/fs

```
        "SnapshotInfo": {
            "Kind": "Active",
            "Name": "6fca9b85372791a91e6931a0fc8895aa1f362453cbca9d0ddf7e4c19d257875d",
            "Parent": "sha256:e215fa422c604a8ea57ffcf6abc11e686d50a89f861c9b90adbb76033a956c66",
            "Labels": {
                "containerd.io/snapshot/overlay.upperdir": "/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/439/fs"
            },
            "Created": "2026-08-02T00:43:41.55270773Z",
            "Updated": "2026-08-02T00:43:41.55270773Z"
        }
```

fix https://github.com/containerd/containerd/discussions/10053