### PR TITLE
fix(image): pin the image a container runs to its digest

### DIFF
--- a/cmd/nerdctl/container/container_inspect_linux_test.go
+++ b/cmd/nerdctl/container/container_inspect_linux_test.go
@@ -278,7 +278,7 @@ func TestContainerInspectConfigImage(t *testing.T) {
 	nerdtest.Setup()
 
 	testCase := &test.Case{
-		Description: "Container inspect contains Config.Image field",
+		Description: "Container inspect names the image by digest, and by reference in Config.Image",
 		Setup: func(data test.Data, helpers test.Helpers) {
 			helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.AlpineImage, "sleep", nerdtest.Infinity)
 		},
@@ -297,6 +297,12 @@ func TestContainerInspectConfigImage(t *testing.T) {
 			container := containers[0]
 			assert.Assert(tt, container.Config != nil, "container Config should not be nil")
 			assert.Assert(tt, container.Config.Image != "", "Config.Image should not be empty")
+			// Docker identifies the image a container runs by digest, pinned at creation, and
+			// keeps the reference the user asked for in Config.Image.
+			assert.Assert(tt, strings.HasPrefix(container.Image, "sha256:"),
+				"Image should be a digest, got %q", container.Image)
+			assert.Assert(tt, !strings.HasPrefix(container.Config.Image, "sha256:"),
+				"Config.Image should be a reference, got %q", container.Config.Image)
 		}),
 	}
 

--- a/cmd/nerdctl/image/image_list_test.go
+++ b/cmd/nerdctl/image/image_list_test.go
@@ -38,6 +38,17 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/testutil/nerdtest"
 )
 
+// padRow widens a row of a table back to the width of its header, so that its last column can be
+// read. tabutil indexes the columns by byte offset and slices without checking the bounds, and a
+// row can be shorter than the header in two ways: the trailing column is empty, and the padding of
+// the very last line is gone once the output has been trimmed.
+func padRow(header, row string) string {
+	if pad := len(header) - len(row); pad > 0 {
+		return row + strings.Repeat(" ", pad)
+	}
+	return row
+}
+
 // TestNameFilterFor is a regression test for
 // https://github.com/containerd/nerdctl/issues/5113: `nerdctl image ls
 // myapp`, where myapp is a bare repository name, returned nothing unless
@@ -203,6 +214,57 @@ func TestImages(t *testing.T) {
 								found++
 							}
 							assert.Assert(t, found > 0, "we should have found the in-use image\n")
+						},
+					}
+				},
+			},
+			{
+				Description: "In use survives a retag",
+				Setup: func(data test.Data, helpers test.Helpers) {
+					// Run a container off a private tag, then move that tag onto another image.
+					// The container still runs the original image, so that is the one that must
+					// stay marked as in use.
+					helpers.Ensure("tag", commonImage.String(), data.Identifier()+":moving")
+					helpers.Ensure("run", "-d", "--quiet", "--name", data.Identifier(),
+						data.Identifier()+":moving", "sleep", nerdtest.Infinity)
+					helpers.Ensure("tag", testutil.NginxAlpineImage, data.Identifier()+":moving")
+
+					nginx, _ := referenceutil.Parse(testutil.NginxAlpineImage)
+					data.Labels().Set("retaggedTo", nginx.FamiliarName()+":"+nginx.Tag)
+				},
+				Cleanup: func(data test.Data, helpers test.Helpers) {
+					helpers.Anyhow("rm", "-f", data.Identifier())
+					helpers.Anyhow("rmi", "-f", data.Identifier()+":moving")
+				},
+				Command: test.Command("images"),
+				Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+					return &test.Expected{
+						Output: func(stdout string, t tig.T) {
+							lines := strings.Split(strings.TrimSpace(stdout), "\n")
+							assert.Assert(t, len(lines) >= 2, "there should be at least two lines\n")
+							tab := tabutil.NewReader("IMAGE\tID\tDISK USAGE\tCONTENT SIZE\tEXTRA")
+							err := tab.ParseHeader(lines[0])
+							assert.NilError(t, err, "ParseHeader should not fail\n")
+
+							original := commonImage.FamiliarName() + ":" + commonImage.Tag
+							retagged := data.Labels().Get("retaggedTo")
+							seen := 0
+							for _, line := range lines[1:] {
+								line = padRow(lines[0], line)
+								image, _ := tab.ReadRow(line, "IMAGE")
+								extra, _ := tab.ReadRow(line, "EXTRA")
+								switch image {
+								case original:
+									assert.Equal(t, extra, "U",
+										"the image the container runs must stay in use: "+image)
+									seen++
+								case retagged:
+									assert.Equal(t, extra, "",
+										"the image the tag now points at is not in use: "+image)
+									seen++
+								}
+							}
+							assert.Equal(t, seen, 2, "both images should be listed\n")
 						},
 					}
 				},

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -215,6 +215,12 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 		internalLabels.user = ensuredImage.ImageConfig.User
 	}
 
+	// Pin the image the container is created from. containerd only records the image name, and a
+	// name can later be retagged onto a different image.
+	if ensuredImage != nil && ensuredImage.Image != nil {
+		internalLabels.imageDigest = ensuredImage.Image.Target().Digest.String()
+	}
+
 	// Override it if User is passed
 	if options.User != "" {
 		internalLabels.user = options.User
@@ -811,6 +817,8 @@ type internalLabels struct {
 	domainname string
 	// automatically generated
 	stateDir string
+	// the digest of the image target the container was created from
+	imageDigest string
 	// network
 	networks             []string
 	ipAddress            string
@@ -917,6 +925,10 @@ func withInternalLabels(internalLabels internalLabels) (containerd.NewContainerO
 	m[labels.Platform], err = platformutil.NormalizeString(internalLabels.platform)
 	if err != nil {
 		return nil, err
+	}
+
+	if internalLabels.imageDigest != "" {
+		m[labels.ImageDigest] = internalLabels.imageDigest
 	}
 
 	if len(internalLabels.mountPoints) > 0 {

--- a/pkg/cmd/image/list.go
+++ b/pkg/cmd/image/list.go
@@ -48,6 +48,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
 	"github.com/containerd/nerdctl/v2/pkg/formatter"
 	"github.com/containerd/nerdctl/v2/pkg/imgutil"
+	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/referenceutil"
 )
 
@@ -575,13 +576,48 @@ func imagesInUse(ctx context.Context, client *containerd.Client) map[digest.Dige
 		return inUse
 	}
 	for _, container := range containerList {
-		image, err := container.Image(ctx)
-		if err != nil {
-			continue
+		if dgst, ok := containerImageDigest(ctx, container); ok {
+			inUse[dgst] = true
 		}
-		inUse[image.Target().Digest] = true
 	}
 	return inUse
+}
+
+// containerImageDigest returns the image target a container was created from.
+//
+// The digest is read from the label nerdctl records at creation time. Resolving the image name
+// instead would follow the tag wherever it points now: after `nerdctl tag` moves a tag onto another
+// image, the container would be attributed to an image it never ran. Containers created before this
+// label existed, or outside nerdctl, still have to be resolved by name.
+func containerImageDigest(ctx context.Context, container containerd.Container) (digest.Digest, bool) {
+	// The already-loaded metadata carries the labels, so this costs no extra round trip.
+	if info, err := container.Info(ctx, containerd.WithoutRefreshedMetadata); err == nil {
+		if dgst, ok := pinnedImageDigest(info.Labels); ok {
+			return dgst, true
+		}
+	}
+
+	image, err := container.Image(ctx)
+	if err != nil {
+		return "", false
+	}
+	return image.Target().Digest, true
+}
+
+// pinnedImageDigest returns the image target digest a container pinned at creation time. An
+// unparsable value is treated as absent, so that a hand-edited label degrades to resolving the
+// image by name rather than dropping the container from the in-use set.
+func pinnedImageDigest(containerLabels map[string]string) (digest.Digest, bool) {
+	value := containerLabels[labels.ImageDigest]
+	if value == "" {
+		return "", false
+	}
+	dgst, err := digest.Parse(value)
+	if err != nil {
+		log.L.Debugf("ignoring invalid %s label value %q", labels.ImageDigest, value)
+		return "", false
+	}
+	return dgst, true
 }
 
 func isAttestationManifestDescriptor(desc ocispec.Descriptor) bool {

--- a/pkg/cmd/image/list_test.go
+++ b/pkg/cmd/image/list_test.go
@@ -22,6 +22,8 @@ import (
 	"gotest.tools/v3/assert"
 
 	"github.com/containerd/containerd/v2/core/images"
+
+	"github.com/containerd/nerdctl/v2/pkg/labels"
 )
 
 func TestNewViewImageRef(t *testing.T) {
@@ -73,5 +75,48 @@ func TestSortByImageRef(t *testing.T) {
 	}
 	for i, img := range imageList {
 		assert.Equal(t, img.Name, expected[i])
+	}
+}
+
+func TestPinnedImageDigest(t *testing.T) {
+	t.Parallel()
+
+	const pinned = "sha256:09538a1f51d3ec5af0449a1640937dfdf79b0e9b8c4da5b8a883086d5c1492ef"
+
+	testCases := []struct {
+		name            string
+		containerLabels map[string]string
+		expected        string
+	}{
+		{
+			name:            "pinned at creation",
+			containerLabels: map[string]string{labels.ImageDigest: pinned},
+			expected:        pinned,
+		},
+		{
+			// Containers created before the label existed, or outside nerdctl, have to be resolved
+			// by image name instead.
+			name:            "no label",
+			containerLabels: map[string]string{labels.Platform: "linux/amd64"},
+		},
+		{
+			name:            "empty label",
+			containerLabels: map[string]string{labels.ImageDigest: ""},
+		},
+		{
+			// Falling back to the name is better than dropping the container from the in-use set.
+			name:            "unparsable label",
+			containerLabels: map[string]string{labels.ImageDigest: "not-a-digest"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dgst, ok := pinnedImageDigest(tc.containerLabels)
+			assert.Equal(t, ok, tc.expected != "")
+			assert.Equal(t, string(dgst), tc.expected)
+		})
 	}
 }

--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -340,13 +340,28 @@ var defaultCaps = map[string]struct{}{
 	"CAP_AUDIT_WRITE":      {},
 }
 
+// containerImage is the image the container was created from, the way Docker identifies it: by
+// digest, pinned when the container was created. containerd only records the image name, and a name
+// can later be retagged onto another image, so it is not an answer. The name is still the fallback
+// for the containers created before that digest was recorded, or created outside nerdctl.
+//
+// With the containerd image store, the image ID Docker reports here is the digest of the image
+// target (moby daemon/containerd/image.go, image.ID(img.Target.Digest)), which is what nerdctl
+// pins.
+func containerImage(n *native.Container) string {
+	if dgst := n.Labels[labels.ImageDigest]; dgst != "" {
+		return dgst
+	}
+	return n.Image
+}
+
 // ContainerFromNative instantiates a Docker-compatible Container from containerd-native Container.
 func ContainerFromNative(n *native.Container) (*Container, error) {
 	var hostname string
 	c := &Container{
 		ID:      n.ID,
 		Created: n.CreatedAt.Format(time.RFC3339Nano),
-		Image:   n.Image,
+		Image:   containerImage(n),
 		Name:    n.Labels[labels.Name],
 		Driver:  n.Snapshotter,
 		// XXX is this always right? what if the container OS is NOT the same as the host OS?
@@ -576,7 +591,8 @@ func ContainerFromNative(n *native.Container) (*Container, error) {
 	c.State = cs
 	c.Config = &Config{
 		Labels: n.Labels,
-		Image:  c.Image,
+		// Docker keeps the reference the user asked for here, and the digest in Image above.
+		Image: n.Image,
 	}
 	if exposedPortsJSON := n.Labels[labels.ExposedPorts]; exposedPortsJSON != "" {
 		var exposedPorts nat.PortSet

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -418,6 +418,36 @@ func TestContainerFromNative(t *testing.T) {
 	}
 }
 
+func TestContainerFromNativeImage(t *testing.T) {
+	const (
+		ref    = "example.com/foo:latest"
+		digest = "sha256:0168606be2318a4b6a9ad9e5a6d9dbf1b0a6d7e2c8c4a1b0e5d3f2a1c0b9e8d7"
+	)
+
+	// Docker names the image a container was created from by digest, and keeps the reference the
+	// user asked for in Config.Image.
+	pinned, err := ContainerFromNative(&native.Container{
+		Container: containers.Container{
+			Image:  ref,
+			Labels: map[string]string{labels.ImageDigest: digest},
+		},
+		Spec: &specs.Spec{},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, pinned.Image, digest)
+	assert.Equal(t, pinned.Config.Image, ref)
+
+	// A container created before that digest was recorded, or created outside nerdctl, is left
+	// with the name it has.
+	unpinned, err := ContainerFromNative(&native.Container{
+		Container: containers.Container{Image: ref},
+		Spec:      &specs.Spec{},
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, unpinned.Image, ref)
+	assert.Equal(t, unpinned.Config.Image, ref)
+}
+
 func TestGetCapabilitiesFromNative(t *testing.T) {
 	// Build the full default bounding set for test fixtures.
 	allDefaults := []string{

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -87,6 +87,11 @@ const (
 	// Platform is the normalized platform string like "linux/ppc64le".
 	Platform = Prefix + "platform"
 
+	// ImageDigest is the digest of the image target the container was created from. The image name
+	// stored by containerd can be retagged to point at something else, so it is not enough to tell
+	// which image a container actually uses.
+	ImageDigest = Prefix + "image-digest"
+
 	// Mounts is the mount points for the container.
 	Mounts = Prefix + "mounts"
 


### PR DESCRIPTION
`nerdctl images` marks an image as in use by resolving the image name recorded on the container. A name is a mutable reference: `container.Image(ctx)` looks it up in the image store as it is now, not as it was when the container was created. Once a tag is moved, the `U` indicator lands on the wrong row.

```sh
 $ nerdctl tag alpine:3.13 mytag:latest
 $ nerdctl run -d --name c1 mytag:latest sleep infinity
 $ nerdctl tag nginx:alpine mytag:latest
 $ nerdctl images
 IMAGE           ID              DISK USAGE    CONTENT SIZE    EXTRA
 alpine:3.13     09538a1f51d3    5.9MB         2.7MB
 nginx:alpine    0168606be231    22.4MB        9.1MB           U
```

Both answers are wrong. The container still runs alpine, containerd still holds its snapshot and its layers, so alpine cannot be removed - yet it is shown as free, while nginx is shown as busy although nothing ever ran it. A container whose tag was removed altogether fails to resolve and drops out of the in-use set entirely.

**The fix**

Record the image target digest on the container at creation time, in a new nerdctl/image-digest label, and use it for the in-use lookup. The digest comes from the image nerdctl has already resolved, so nothing extra is fetched, and the label is read from the metadata the listing has already loaded (WithoutRefreshedMetadata), so the lookup costs no additional round trip.

**Compatibility**

Containers created before this label existed, or created outside nerdctl (ctr, kubelet, another client), have no such label. For those the previous behavior is kept as a fallback: they are still resolved by name. No state migration is needed and no existing container changes behavior for the worse.

An unparsable label value falls back the same way rather than dropping the container from the in-use set. Dropping it would be the more harmful failure: the image would look free, and anything built on this lookup would offer to reclaim space that is actually held.

**Why it matters beyond the indicator**

The same lookup backs the ACTIVE and RECLAIMABLE columns of `nerdctl system df` (follow-up, #3942). There a misattributed container is not a single letter in a column: the unique layers of an image that is actually in use get counted as reclaimable space, which is exactly the number a user acts on when deciding what to delete.

**The same digest is what `nerdctl inspect` should report**

Added after review feedback. Docker names the image a container was created from by ID, and with the containerd image store that ID is the digest of the image target, pinned on the container at creation:

```go
// moby daemon/containerd/image.go
imgV1 := dockerOciImageToDockerImagePartial(image.ID(img.Target.Digest), ociImage)
// moby daemon/create.go
imgID = img.ID()
ctr, err = daemon.newContainer(opts.params.Name, platform, ..., imgID, opts.managed)
// moby daemon/inspect.go
Image: ctr.ImageID.String(),
```

That is the value this label records. nerdctl was filling `Container.Image` with the containerd image *name*, which a retag moves just the same as the in-use lookup above, so `ContainerFromNative` now reports the pinned digest there. The reference the user asked for stays in `Config.Image`, as it does in Docker; the containers with no label keep the name.

**Tests**

  - `TestPinnedImageDigest` covers the four label states: pinned, absent, empty, unparsable.
  - `TestImages/In use survives a retag` reproduces the scenario end to end and asserts both sides: the image the container runs keeps `U`, the image the tag now points at does not.
  - `TestContainerFromNativeImage` covers both inspect fields, pinned and not.
  - `TestContainerInspectConfigImage` asserts end to end that `Image` is a digest and `Config.Image` is not.

The in-use lookup was introduced in #5093.
