### PR TITLE
fix(login): accept equivalent registry hosts in auth creds callback

### DIFF
--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 
@@ -117,19 +118,7 @@ func loginClientSide(ctx context.Context, globalOptions types.GlobalCommandOptio
 	}
 	dOpts = append(dOpts, dockerconfigresolver.WithHostsDirs(globalOptions.HostsDir))
 
-	authCreds := func(acArg string) (string, string, error) {
-		if acArg == host {
-			if credentials.RegistryToken != "" {
-				// Even containerd/CRI does not support RegistryToken as of v1.4.3,
-				// so, nobody is actually using RegistryToken?
-				log.G(ctx).Warnf("RegistryToken (for %q) is not supported yet (FIXME)", host)
-			}
-			return credentials.Username, credentials.Password, nil
-		}
-		return "", "", fmt.Errorf("expected acArg to be %q, got %q", host, acArg)
-	}
-
-	dOpts = append(dOpts, dockerconfigresolver.WithAuthCreds(authCreds))
+	dOpts = append(dOpts, dockerconfigresolver.WithAuthCreds(loginAuthCreds(ctx, host, registryURL, credentials)))
 	ho, err := dockerconfigresolver.NewHostOptions(ctx, host, dOpts...)
 	if err != nil {
 		return "", err
@@ -211,4 +200,54 @@ func tryLoginWithRegHost(ctx context.Context, rh docker.RegistryHost) error {
 	}
 
 	return errors.New("too many 401 (probably)")
+}
+
+// loginAuthCreds returns the credentials callback handed to the containerd
+// authorizer during login.
+func loginAuthCreds(ctx context.Context, host string, registryURL *dockerconfigresolver.RegistryURL, credentials *dockerconfigresolver.Credentials) func(string) (string, string, error) {
+	return func(acArg string) (string, string, error) {
+		if acArg == host || isEquivalentRegistryHost(acArg, registryURL) {
+			if credentials.RegistryToken != "" {
+				// Even containerd/CRI does not support RegistryToken as of v1.4.3,
+				// so, nobody is actually using RegistryToken?
+				log.G(ctx).Warnf("RegistryToken (for %q) is not supported yet (FIXME)", host)
+			}
+			return credentials.Username, credentials.Password, nil
+		}
+		return "", "", fmt.Errorf("expected acArg to be %q, got %q", host, acArg)
+	}
+}
+
+// isEquivalentRegistryHost reports whether acArg, the host value the
+// containerd authorizer passes to the credentials callback, refers to the
+// same registry as registryURL, the address the user asked to log in to.
+//
+// Parse always appends the standard HTTPS port to registryURL when the user
+// did not specify one, while the authorizer may call back with a host that
+// omits the default port, or with a Docker Hub alias, in which case strict
+// equality fails spuriously.
+// See https://github.com/containerd/nerdctl/issues/3992 and
+// https://github.com/containerd/nerdctl/issues/3245.
+func isEquivalentRegistryHost(acArg string, registryURL *dockerconfigresolver.RegistryURL) bool {
+	acHost, acPort, err := net.SplitHostPort(acArg)
+	if err != nil {
+		// acArg carries no port
+		acHost, acPort = acArg, ""
+	}
+	// A callback host carrying an explicit non-standard port can only be
+	// equivalent by exact equality, which the caller already checked.
+	if acPort != "" && acPort != dockerconfigresolver.StandardHTTPSPort {
+		return false
+	}
+	// The user did not pass an explicit non-default port, so a callback
+	// host that merely omits the standard HTTPS port is equivalent.
+	if registryURL.Port() == dockerconfigresolver.StandardHTTPSPort && acHost == registryURL.Hostname() {
+		return true
+	}
+	// Docker Hub aliases: "docker.io" logins resolve to index.docker.io,
+	// while the actual registry endpoint is registry-1.docker.io.
+	if registryURL.Hostname() == "index.docker.io" && acHost == "registry-1.docker.io" {
+		return true
+	}
+	return false
 }

--- a/pkg/cmd/login/login.go
+++ b/pkg/cmd/login/login.go
@@ -231,8 +231,9 @@ func loginAuthCreds(ctx context.Context, host string, registryURL *dockerconfigr
 func isEquivalentRegistryHost(acArg string, registryURL *dockerconfigresolver.RegistryURL) bool {
 	acHost, acPort, err := net.SplitHostPort(acArg)
 	if err != nil {
-		// acArg carries no port
-		acHost, acPort = acArg, ""
+		// acArg carries no port; Hostname strips the brackets of IPv6
+		// literals so that "[::1]" can match registryURL.Hostname()
+		acHost, acPort = (&url.URL{Host: acArg}).Hostname(), ""
 	}
 	// A callback host carrying an explicit non-standard port can only be
 	// equivalent by exact equality, which the caller already checked.
@@ -245,8 +246,12 @@ func isEquivalentRegistryHost(acArg string, registryURL *dockerconfigresolver.Re
 		return true
 	}
 	// Docker Hub aliases: "docker.io" logins resolve to index.docker.io,
-	// while the actual registry endpoint is registry-1.docker.io.
-	if registryURL.Hostname() == "index.docker.io" && acHost == "registry-1.docker.io" {
+	// while the actual registry endpoint is registry-1.docker.io. Only
+	// honor the alias when logging in over the standard HTTPS port, so a
+	// login to index.docker.io on a non-default port does not leak
+	// credentials to registry-1.docker.io.
+	if registryURL.Port() == dockerconfigresolver.StandardHTTPSPort &&
+		registryURL.Hostname() == "index.docker.io" && acHost == "registry-1.docker.io" {
 		return true
 	}
 	return false

--- a/pkg/cmd/login/login_test.go
+++ b/pkg/cmd/login/login_test.go
@@ -55,6 +55,16 @@ func TestLoginAuthCredsAcceptsEquivalentHosts(t *testing.T) {
 			acArg:   "registry-1.docker.io:443",
 		},
 		{
+			name:    "bracketed ipv6 without port",
+			address: "[::1]",
+			acArg:   "[::1]",
+		},
+		{
+			name:    "ipv6 with standard port",
+			address: "[::1]",
+			acArg:   "[::1]:443",
+		},
+		{
 			name:    "mismatched host",
 			address: "harbor.example.io",
 			acArg:   "evil.example.io",
@@ -70,6 +80,18 @@ func TestLoginAuthCredsAcceptsEquivalentHosts(t *testing.T) {
 			name:    "different explicit port",
 			address: "harbor.example.io",
 			acArg:   "harbor.example.io:8443",
+			wantErr: true,
+		},
+		{
+			name:    "docker.io alias rejected on non-standard login port",
+			address: "index.docker.io:8443",
+			acArg:   "registry-1.docker.io",
+			wantErr: true,
+		},
+		{
+			name:    "docker.io alias with port rejected on non-standard login port",
+			address: "index.docker.io:8443",
+			acArg:   "registry-1.docker.io:443",
 			wantErr: true,
 		},
 	}

--- a/pkg/cmd/login/login_test.go
+++ b/pkg/cmd/login/login_test.go
@@ -1,0 +1,92 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package login
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/nerdctl/v2/pkg/imgutil/dockerconfigresolver"
+)
+
+func TestLoginAuthCredsAcceptsEquivalentHosts(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		acArg   string
+		wantErr bool
+	}{
+		{
+			name:    "exact host with standard port",
+			address: "harbor.example.io",
+			acArg:   "harbor.example.io:443",
+		},
+		{
+			// https://github.com/containerd/nerdctl/issues/3992
+			name:    "host without default port",
+			address: "harbor.example.io",
+			acArg:   "harbor.example.io",
+		},
+		{
+			// https://github.com/containerd/nerdctl/issues/3245
+			name:    "docker.io alias without port",
+			address: "docker.io",
+			acArg:   "registry-1.docker.io",
+		},
+		{
+			name:    "docker.io alias with port",
+			address: "docker.io",
+			acArg:   "registry-1.docker.io:443",
+		},
+		{
+			name:    "mismatched host",
+			address: "harbor.example.io",
+			acArg:   "evil.example.io",
+			wantErr: true,
+		},
+		{
+			name:    "explicit non-standard port not dropped",
+			address: "harbor.example.io:8443",
+			acArg:   "harbor.example.io",
+			wantErr: true,
+		},
+		{
+			name:    "different explicit port",
+			address: "harbor.example.io",
+			acArg:   "harbor.example.io:8443",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registryURL, err := dockerconfigresolver.Parse(tt.address)
+			assert.NilError(t, err)
+			credentials := &dockerconfigresolver.Credentials{Username: "user", Password: "pass"}
+			authCreds := loginAuthCreds(context.Background(), registryURL.Host, registryURL, credentials)
+			username, password, err := authCreds(tt.acArg)
+			if tt.wantErr {
+				assert.ErrorContains(t, err, "expected acArg")
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, "user", username)
+			assert.Equal(t, "pass", password)
+		})
+	}
+}


### PR DESCRIPTION
# PR Title

fix(login): accept equivalent registry hosts in auth creds callback

# PR Body

## Summary

`nerdctl login` fails against registries served on the default HTTPS port (443)
with:

```
FATA failed to call rh.Authorizer.AddResponses: expected acArg to be "harbor.example.io:443", got "harbor.example.io"
```

`docker login` works fine against the same registry.

Fixes #3992
Refs #3245

## Root cause

In `pkg/cmd/login/login.go`, the credentials callback passed to the containerd
authorizer used a strict string equality check:

```go
authCreds := func(acArg string) (string, string, error) {
    if acArg == host { ... }
    return "", "", fmt.Errorf("expected acArg to be %q, got %q", host, acArg)
}
```

However, the two sides of the comparison are built differently:

- `host` comes from `dockerconfigresolver.Parse()`, which **appends the
  standard HTTPS port explicitly** when the user did not specify one
  (`registryurl.go`), so `host` is `harbor.example.io:443`.
- `acArg` is passed by containerd's `dockerAuthorizer.AddResponses()` as
  `last.Request.URL.Host`, i.e. the host of the actual request, which is
  `harbor.example.io` — without the default port.

The same fragility produces #3245: logging in to `docker.io` resolves to
`index.docker.io:443`, while the actual registry endpoint calling back is
`registry-1.docker.io`.

## Fix

Replace the strict equality check with an equivalence check
(`isEquivalentRegistryHost`) that additionally accepts:

1. The same hostname with the default HTTPS port (443) omitted — when the user
   did not explicitly configure a non-default port.
2. Docker Hub aliases: `index.docker.io` (the address `docker.io` resolves to)
   and `registry-1.docker.io` (the actual registry endpoint).

Callback hosts carrying an explicit **non-standard** port still must match
exactly, so credentials are never served to a different endpoint.

This mirrors the equivalence rules already encoded in
`RegistryURL.AllIdentifiers()` for credential lookup.

## Test plan

Added `pkg/cmd/login/login_test.go` with table-driven cases covering:

- exact host with standard port (unchanged behavior)
- host without default port — reproduces #3992
- `registry-1.docker.io` with/without port against a `docker.io` login —
  reproduces #3245
- mismatched hostname — still rejected
- explicit non-standard port (`:8443`) — not silently dropped or matched

```
$ go test -v -run TestLoginAuthCredsAcceptsEquivalentHosts ./pkg/cmd/login/...
--- PASS: TestLoginAuthCredsAcceptsEquivalentHosts (0.00s)
    --- PASS: .../exact_host_with_standard_port
    --- PASS: .../host_without_default_port
    --- PASS: .../docker.io_alias_without_port
    --- PASS: .../docker.io_alias_with_port
    --- PASS: .../mismatched_host
    --- PASS: .../explicit_non-standard_port_not_dropped
    --- PASS: .../different_explicit_port
PASS
ok      github.com/containerd/nerdctl/v2/pkg/cmd/login
```

The failing scenarios from both issues were reproduced against a private Harbor
registry served on port 443 (`nerdctl login --insecure-registry`); the unit
test cases above encode exactly those mismatches.
