### PR TITLE
feat: add volume-nocopy

### DIFF
--- a/cmd/nerdctl/container/container_run_mount_linux_test.go
+++ b/cmd/nerdctl/container/container_run_mount_linux_test.go
@@ -234,8 +234,12 @@ CMD ["cat", "/mnt/initial_file"]
 		volName := data.Identifier("vol")
 		helpers.Ensure("volume", "create", volName)
 
+		noCopyVolName := data.Identifier("nocopy-vol")
+		helpers.Ensure("volume", "create", noCopyVolName)
+
 		data.Labels().Set("img", imgName)
 		data.Labels().Set("vol", volName)
+		data.Labels().Set("nocopy-vol", noCopyVolName)
 	}
 
 	testCase.SubTests = []*test.Case{
@@ -263,12 +267,22 @@ CMD ["cat", "/mnt/initial_file"]
 			},
 			Expected: test.Expects(expect.ExitCodeSuccess, nil, expect.Equals("hi\n")),
 		},
+		{
+			Description: "with volume-nocopy",
+			NoParallel:  true,
+			Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+				mount := fmt.Sprintf("type=volume,source=%s,target=/mnt,volume-nocopy", data.Labels().Get("nocopy-vol"))
+				return helpers.Command("run", "--rm", "--mount", mount, data.Labels().Get("img"), "sh", "-c", "test ! -e /mnt/initial_file")
+			},
+			Expected: test.Expects(expect.ExitCodeSuccess, nil, nil),
+		},
 	}
 
 	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
 		helpers.Anyhow("volume", "rm", data.Labels().Get("vol"))
 		helpers.Anyhow("rmi", data.Labels().Get("img"))
 		helpers.Anyhow("builder", "prune", "--all", "--force")
+		helpers.Anyhow("volume", "rm", data.Labels().Get("nocopy-vol"))
 	}
 
 	testCase.Run(t)

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -327,7 +327,8 @@ Volume flags:
     - :whale: `tmpfs-mode`: File mode of the tmpfs in **octal**.
       Defaults to `1777` or world-writable.
   - Options specific to `volume`:
-    - unimplemented options: `volume-nocopy`, `volume-label`, `volume-driver`, `volume-opt`
+    - :whale: `volume-nocopy`: Do not copy existing data from the container into the volume.
+    - unimplemented options: `volume-label`, `volume-driver`, `volume-opt`
   - Options specific to `image`:
     - :whale: `src`, `source`: image reference (mandatory).
     - :whale: Currently, the image filesystem is mounted read-only.

--- a/pkg/cmd/container/run_mount.go
+++ b/pkg/cmd/container/run_mount.go
@@ -319,7 +319,7 @@ func generateMountOpts(ctx context.Context, client *containerd.Client, ensuredIm
 			}
 
 			// Copying content in AnonymousVolume and namedVolume
-			if x.Type == "volume" {
+			if x.Type == mountutil.Volume && !x.VolumeNoCopy {
 				if err := copyExistingContents(target, x.Mount.Source); err != nil {
 					return nil, nil, nil, err
 				}

--- a/pkg/mountutil/mountutil.go
+++ b/pkg/mountutil/mountutil.go
@@ -51,6 +51,7 @@ type Processed struct {
 	AnonymousVolume string // anonymous volume name
 	Mode            string
 	Opts            []oci.SpecOpts
+	VolumeNoCopy    bool
 	// ImageMountSnapshot is the snapshotter key of the read-only view for a
 	// type=image mount; empty for other mount types.
 	ImageMountSnapshot string

--- a/pkg/mountutil/mountutil_linux.go
+++ b/pkg/mountutil/mountutil_linux.go
@@ -369,6 +369,7 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore, ociRuntime str
 		bindPropagation  string
 		bindNonRecursive bool
 		bindRecursive    string // "enabled", "disabled", "writable", or "readonly"
+		volumeNoCopy     bool
 		rwOption         string
 		tmpfsSize        int64
 		tmpfsMode        os.FileMode
@@ -403,6 +404,9 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore, ociRuntime str
 				// Removed in Docker v29, in favor of `bind-recursive=disabled` https://github.com/docker/cli/pull/6241
 				log.L.Warn("The mount option \"bind-nonrecursive\" is deprecated; use \"bind-recursive=disabled\" instead")
 				bindNonRecursive = true
+				continue
+			case "volume-nocopy":
+				volumeNoCopy = true
 				continue
 			}
 		}
@@ -455,6 +459,11 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore, ociRuntime str
 			if err != nil {
 				return nil, fmt.Errorf("invalid value for %s: %s", key, value)
 			}
+		case "volume-nocopy":
+			volumeNoCopy, err = strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for %s: %s", key, value)
+			}
 		case "bind-recursive":
 			// bind-recursive is the Docker (v25) option that supersedes bind-nonrecursive.
 			// https://github.com/docker/cli/pull/4316
@@ -478,6 +487,10 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore, ociRuntime str
 		default:
 			return nil, fmt.Errorf("unexpected key '%s' in '%s'", key, field)
 		}
+	}
+
+	if volumeNoCopy && mountType != Volume {
+		return nil, fmt.Errorf("the option 'volume-nocopy' is only supported for volume mounts")
 	}
 
 	// type=image's source is an image reference resolved later with a containerd
@@ -593,6 +606,7 @@ func ProcessFlagMount(s string, volStore volumestore.VolumeStore, ociRuntime str
 		if err != nil {
 			return nil, err
 		}
+		res.VolumeNoCopy = volumeNoCopy
 		if rwOption != "" {
 			roOpts, err := readOnlyMountOptions(roMode, ociRuntime)
 			if err != nil {

--- a/pkg/mountutil/mountutil_linux_test.go
+++ b/pkg/mountutil/mountutil_linux_test.go
@@ -665,3 +665,34 @@ func TestProcessFlagMountImage(t *testing.T) {
 		})
 	}
 }
+
+func TestProcessFlagMountVolumeNoCopy(t *testing.T) {
+	tests := []struct {
+		rawSpec string
+		wants   bool
+	}{
+		{
+			rawSpec: "type=volume,source=TestVolume,target=/mnt,volume-nocopy",
+			wants:   true,
+		},
+		{
+			rawSpec: "type=volume,source=TestVolume,target=/mnt,volume-nocopy=true",
+			wants:   true,
+		},
+		{
+			rawSpec: "type=volume,source=TestVolume,target=/mnt,volume-nocopy=false",
+			wants:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rawSpec, func(t *testing.T) {
+			got, err := ProcessFlagMount(tt.rawSpec, mockVolumeStore, "")
+			assert.NilError(t, err)
+
+			assert.Equal(t, got.Type, Volume)
+			assert.Equal(t, got.Name, "TestVolume")
+			assert.Equal(t, got.VolumeNoCopy, tt.wants)
+		})
+	}
+}


### PR DESCRIPTION
- Part of #3867 

- This patch parses `volume-nocopy`option and skip copying the contents from the image to the volume when specified.
- Added unit and integration tests



```Dockerfile
FROM alpine
RUN mkdir -p /mnt && echo hi > /mnt/initial_file
CMD ["sh"]
```


```shell

╰─$ nerdctl run --rm -it \
  --mount type=volume,source=nocopy-vol,target=/mnt,volume-nocopy \
  nocopy-test \
  sh
/ # ls -la mount
ls: mount: No such file or directory
/ # ls -la /mnt
total 8
drwx------    2 root     root          4096 Aug  7 14:51 .
drwxr-xr-x    1 root     root          4096 Aug  7 14:51 ..
/ # exit
```



