### PR TITLE
feat: add --disable-content-trust flag to improve docker CLI compatibility

### DIFF
--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -304,6 +304,7 @@ func setCreateFlags(cmd *cobra.Command) {
 	cmd.RegisterFlagCompletionFunc("verify", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "cosign", "notation"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	cmd.Flags().Bool("disable-content-trust", false, "No-op for Docker compatibility; nerdctl uses --verify for image signing and verification")
 	cmd.Flags().String("cosign-key", "", "Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign")
 	cmd.Flags().String("cosign-certificate-identity", "", "The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
 	cmd.Flags().String("cosign-certificate-identity-regexp", "", "A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")

--- a/cmd/nerdctl/container/container_run_help_test.go
+++ b/cmd/nerdctl/container/container_run_help_test.go
@@ -45,3 +45,13 @@ func TestRunHelpDoesNotDuplicateDefaults(t *testing.T) {
 	assert.Assert(t, strings.Contains(help, "Maximum time to allow one check to run; 0 uses the image value or 30s when unset there too"))
 	assert.Assert(t, strings.Contains(help, "Consecutive failures needed to report unhealthy; 0 uses the image value or 3 when unset there too"))
 }
+
+func TestRunDisableContentTrustFlag(t *testing.T) {
+	cmd := RunCommand()
+	err := cmd.ParseFlags([]string{"--disable-content-trust"})
+	assert.NilError(t, err)
+
+	got, err := cmd.Flags().GetBool("disable-content-trust")
+	assert.NilError(t, err)
+	assert.Equal(t, got, true)
+}

--- a/cmd/nerdctl/image/image_pull.go
+++ b/cmd/nerdctl/image/image_pull.go
@@ -54,6 +54,7 @@ func PullCommand() *cobra.Command {
 	cmd.RegisterFlagCompletionFunc("verify", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "cosign", "notation"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	cmd.Flags().Bool("disable-content-trust", false, "No-op for Docker compatibility; nerdctl uses --verify for image signing and verification")
 	cmd.Flags().String("cosign-key", "", "Path to the public key file, KMS, URI or Kubernetes Secret for --verify=cosign")
 	cmd.Flags().String("cosign-certificate-identity", "", "The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")
 	cmd.Flags().String("cosign-certificate-identity-regexp", "", "A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows")

--- a/cmd/nerdctl/image/image_push.go
+++ b/cmd/nerdctl/image/image_push.go
@@ -56,6 +56,7 @@ func PushCommand() *cobra.Command {
 	cmd.RegisterFlagCompletionFunc("sign", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"none", "cosign", "notation"}, cobra.ShellCompDirectiveNoFileComp
 	})
+	cmd.Flags().Bool("disable-content-trust", false, "No-op for Docker compatibility; nerdctl uses --verify and --sign for image trust instead of Docker Content Trust")
 	cmd.Flags().String("cosign-key", "", "Path to the private key file, KMS URI or Kubernetes Secret for --sign=cosign")
 	cmd.Flags().String("notation-key-name", "", "Signing key name for a key previously added to notation's key list for --sign=notation")
 	// #endregion

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -461,6 +461,7 @@ Ulimit flags:
 Verify flags:
 
 - :nerd_face: `--verify`: Verify the image (none|cosign|notation). See [`./cosign.md`](./cosign.md) and [`./notation.md`](./notation.md) for details.
+- :nerd_face: `--disable-content-trust`: Docker compatibility flag; accepted as a no-op because nerdctl uses `--verify` and cosign-based image verification instead of Docker Content Trust.
 - :nerd_face: `--cosign-key`: Path to the public key file, KMS, URI or Kubernetes Secret for `--verify=cosign`
 - :nerd_face: `--cosign-certificate-identity`: The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows
 - :nerd_face: `--cosign-certificate-identity-regexp`: A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows
@@ -472,9 +473,8 @@ IPFS flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 
 Unimplemented `docker run` flags:
-    `--device-cgroup-rule`, `--disable-content-trust`,
-    `--health-start-interval`, `--link*`, `--storage-opt`,
-    `--volume-driver`
+    `--device-cgroup-rule`, `--health-start-interval`,
+    `--link*`, `--storage-opt`, `--volume-driver`
 
 ### :whale: nerdctl exec
 
@@ -880,6 +880,7 @@ Flags:
 - :nerd_face: `--unpack`: Unpack the image for the current single platform (auto/true/false)
 - :whale: `-q, --quiet`: Suppress verbose output
 - :nerd_face: `--verify`: Verify the image (none|cosign|notation). See [`./cosign.md`](./cosign.md) and [`./notation.md`](./notation.md) for details.
+- :nerd_face: `--disable-content-trust`: Docker compatibility flag; accepted as a no-op because nerdctl uses `--verify` and cosign-based image verification instead of Docker Content Trust.
 - :nerd_face: `--cosign-key`: Path to the public key file, KMS, URI or Kubernetes Secret for `--verify=cosign`
 - :nerd_face: `--cosign-certificate-identity`: The identity expected in a valid Fulcio certificate for --verify=cosign. Valid values include email address, DNS names, IP addresses, and URIs. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows
 - :nerd_face: `--cosign-certificate-identity-regexp`: A regular expression alternative to --cosign-certificate-identity for --verify=cosign. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --cosign-certificate-identity or --cosign-certificate-identity-regexp must be set for keyless flows
@@ -888,7 +889,7 @@ Flags:
 - :nerd_face: `--ipfs-address`: Multiaddr of IPFS API (default uses `$IPFS_PATH` env variable if defined or local directory `~/.ipfs`)
 - :nerd_face: `--soci-index-digest`: Specify a particular index digest for SOCI. If left empty, SOCI will automatically use the index determined by the selection policy.
 
-Unimplemented `docker pull` flags: `--all-tags`, `--disable-content-trust` (default true)
+Unimplemented `docker pull` flags: `--all-tags`
 
 ### :whale: nerdctl push
 
@@ -903,6 +904,7 @@ Flags:
 - :nerd_face: `--platform=(amd64|arm64|...)`: Push content for a specific platform
 - :nerd_face: `--all-platforms`: Push content for all platforms
 - :nerd_face: `--sign`: Sign the image (none|cosign|notation). See [`./cosign.md`](./cosign.md) and [`./notation.md`](./notation.md) for details.
+- :nerd_face: `--disable-content-trust`: Docker compatibility flag; accepted as a no-op because nerdctl uses `--sign` and cosign-based image signing instead of Docker Content Trust.
 - :nerd_face: `--cosign-key`: Path to the private key file, KMS, URI or Kubernetes Secret for `--sign=cosign`
 - :nerd_face: `--notation-key-name`: Signing key name for a key previously added to notation's key list for `--sign=notation`
 - :nerd_face: `--allow-nondistributable-artifacts`: Allow pushing images with non-distributable blobs
@@ -911,7 +913,7 @@ Flags:
 - :nerd_face: `--soci-span-size`: Span size in bytes that soci index uses to segment layer data. Default is 4 MiB.
 - :nerd_face: `--soci-min-layer-size`: Minimum layer size in bytes to build zTOC for. Smaller layers won't have zTOC and not lazy pulled. Default is 10 MiB.
 
-Unimplemented `docker push` flags: `--all-tags`, `--disable-content-trust` (default true)
+Unimplemented `docker push` flags: `--all-tags`
 
 ### :whale: nerdctl load
 


### PR DESCRIPTION
Fixes #5053 

### Why
Docker scripts may pass --disable-content-trust when running, pulling, or pushing images. Without support for the flag, those commands fail with an unknown flag error.

nerdctl uses a different trust model:
--verify=cosign|notation for image verification
--sign=cosign|notation for image signing

Accepting the flag as a no-op improves Docker CLI compatibility without incorrectly mapping Docker Content Trust semantics onto nerdctl’s existing verification mechanisms.

### Implementation Notes
- Registers --disable-content-trust as a boolean flag on run, pull, and push.
- The flag is intentionally not used to modify image verification or signing behavior.
- Existing --verify and --sign options continue to control nerdctl’s trust operations.
- No new dependencies or trust-related behavior were introduced.

### Documentation
Updates command-reference.md to:

- Document --disable-content-trust as a Docker compatibility no-op.
- Remove it from the unimplemented Docker flag lists for run, pull, and push.
- Clarify that nerdctl uses cosign and notation instead of Docker Content Trust.

### Testing
Added TestRunDisableContentTrustFlag to verify that nerdctl run accepts the flag and parses it as true.
Verified the existing run help tests continue to pass.
Verified the image command package compiles with the new pull and push flags.