### PR TITLE
pkg/containerutil: update restart.StatusLabel to Stopped when stopping container

### DIFF
--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -383,6 +383,23 @@ func TestRunRestartStatusLabel(t *testing.T) {
 	testCase.Run(t)
 }
 
+// assertStoppedNotRestarting checks that stop/kill left the container stopped
+// and that the restart plugin will not bring it back. On older containerd
+// (e.g. v1.7), inspect may report Status as "" once the task is gone even
+// though Running is false and the container is effectively exited.
+func assertStoppedNotRestarting(dc []dockercompat.Container, t tig.T) {
+	assert.Equal(t, 1, len(dc))
+	assert.Assert(t, dc[0].State != nil, "State is nil")
+	assert.Equal(t, false, dc[0].State.Running)
+	// Must not still be running or in a restart loop.
+	assert.Assert(t, dc[0].State.Status != "running" && dc[0].State.Status != "restarting",
+		"unexpected Status %q", dc[0].State.Status)
+	if !nerdtest.IsDocker() {
+		assert.Assert(t, dc[0].Config != nil && dc[0].Config.Labels != nil)
+		assert.Equal(t, "stopped", dc[0].Config.Labels[restart.StatusLabel])
+	}
+}
+
 func TestRunRestartAlwaysStop(t *testing.T) {
 	testCase := nerdtest.Setup()
 	if !nerdtest.IsDocker() {
@@ -406,13 +423,7 @@ func TestRunRestartAlwaysStop(t *testing.T) {
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: expect.ExitCodeSuccess,
-			Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, t tig.T) {
-				assert.Equal(t, 1, len(dc))
-				assert.Assert(t, dc[0].State != nil && dc[0].State.Status == "exited")
-				if !nerdtest.IsDocker() {
-					assert.Equal(t, "stopped", dc[0].Config.Labels[restart.StatusLabel])
-				}
-			}),
+			Output: expect.JSON([]dockercompat.Container{}, assertStoppedNotRestarting),
 		}
 	}
 
@@ -442,13 +453,7 @@ func TestRunRestartAlwaysKill(t *testing.T) {
 	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
 		return &test.Expected{
 			ExitCode: expect.ExitCodeSuccess,
-			Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, t tig.T) {
-				assert.Equal(t, 1, len(dc))
-				assert.Assert(t, dc[0].State != nil && dc[0].State.Status == "exited")
-				if !nerdtest.IsDocker() {
-					assert.Equal(t, "stopped", dc[0].Config.Labels[restart.StatusLabel])
-				}
-			}),
+			Output: expect.JSON([]dockercompat.Container{}, assertStoppedNotRestarting),
 		}
 	}
 

--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -382,3 +382,75 @@ func TestRunRestartStatusLabel(t *testing.T) {
 
 	testCase.Run(t)
 }
+
+func TestRunRestartAlwaysStop(t *testing.T) {
+	testCase := nerdtest.Setup()
+	if !nerdtest.IsDocker() {
+		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"always"})
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--restart=always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+		helpers.Ensure("stop", data.Identifier())
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		time.Sleep(3 * time.Second)
+		return helpers.Command("inspect", data.Identifier())
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, t tig.T) {
+				assert.Equal(t, 1, len(dc))
+				assert.Assert(t, dc[0].State != nil && dc[0].State.Status == "exited")
+				if !nerdtest.IsDocker() {
+					assert.Equal(t, "stopped", dc[0].Config.Labels[restart.StatusLabel])
+				}
+			}),
+		}
+	}
+
+	testCase.Run(t)
+}
+
+func TestRunRestartAlwaysKill(t *testing.T) {
+	testCase := nerdtest.Setup()
+	if !nerdtest.IsDocker() {
+		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"always"})
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "--restart=always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")
+		helpers.Ensure("kill", data.Identifier())
+	}
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		time.Sleep(3 * time.Second)
+		return helpers.Command("inspect", data.Identifier())
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: expect.ExitCodeSuccess,
+			Output: expect.JSON([]dockercompat.Container{}, func(dc []dockercompat.Container, t tig.T) {
+				assert.Equal(t, 1, len(dc))
+				assert.Assert(t, dc[0].State != nil && dc[0].State.Status == "exited")
+				if !nerdtest.IsDocker() {
+					assert.Equal(t, "stopped", dc[0].Config.Labels[restart.StatusLabel])
+				}
+			}),
+		}
+	}
+
+	testCase.Run(t)
+}

--- a/pkg/cmd/container/kill.go
+++ b/pkg/cmd/container/kill.go
@@ -27,6 +27,7 @@ import (
 	"github.com/moby/sys/signal"
 
 	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/runtime/restart"
 	"github.com/containerd/containerd/v2/pkg/cio"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/go-cni"
@@ -87,6 +88,13 @@ func killContainer(ctx context.Context, container containerd.Container, signal s
 	}()
 	if err := containerutil.UpdateExplicitlyStoppedLabel(ctx, container, true); err != nil {
 		return err
+	}
+	if l, err := container.Labels(ctx); err == nil {
+		if _, ok := l[restart.PolicyLabel]; ok {
+			if err := containerutil.UpdateStatusLabel(ctx, container, containerd.Stopped); err != nil {
+				return err
+			}
+		}
 	}
 	task, err := container.Task(ctx, cio.Load)
 	if err != nil {

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -363,6 +363,12 @@ func Stop(ctx context.Context, container containerd.Container, timeout *time.Dur
 	if err != nil {
 		return err
 	}
+
+	if _, ok := l[restart.PolicyLabel]; ok {
+		if err := UpdateStatusLabel(ctx, container, containerd.Stopped); err != nil {
+			return err
+		}
+	}
 	ipc, err := ipcutil.DecodeIPCLabel(l[labels.IPC])
 	if err != nil {
 		return err


### PR DESCRIPTION
### Description

Fixes #5153.

When running a container with \--restart=always\ or \--restart=unless-stopped\, containerd's restart monitor daemon uses the \containerd.io/restart.status\ label to determine whether an exited container should be automatically restarted (when the label value is \unning\).

Previously, while \containerutil.Start\ updated the \estart.StatusLabel\ to \containerd.Running\ on startup, \containerutil.Stop\ and \pkg/cmd/container.killContainer\ only updated \containerd.io/restart.explicitly-stopped\ without transitioning \containerd.io/restart.status\ to \containerd.Stopped\. This caused containerd's restart monitor to still observe the status as \unning\ and restart the container after an explicit \
erdctl stop\ or \
erdctl kill\.

This PR ensures \containerutil.Stop\ and \killContainer\ update \estart.StatusLabel\ to \containerd.Stopped\ when a container with a restart policy is stopped or killed, aligning with Docker and containerd restart behavior.

### Checklist
- [x] Signed-off with Developer Certificate of Origin (DCO)
- [x] Passes local validation and tests
