### PR TITLE
netutil: enable portMappings/dns capabilities on Windows nat plugin

### DIFF
--- a/pkg/netutil/cni_plugin_windows.go
+++ b/pkg/netutil/cni_plugin_windows.go
@@ -17,9 +17,10 @@
 package netutil
 
 type natConfig struct {
-	PluginType string                 `json:"type"`
-	Master     string                 `json:"master,omitempty"`
-	IPAM       map[string]interface{} `json:"ipam"`
+	PluginType   string                 `json:"type"`
+	Master       string                 `json:"master,omitempty"`
+	IPAM         map[string]interface{} `json:"ipam"`
+	Capabilities map[string]bool        `json:"capabilities,omitempty"`
 }
 
 func (*natConfig) GetPluginType() string {
@@ -30,6 +31,13 @@ func newNatPlugin(master string) *natConfig {
 	return &natConfig{
 		PluginType: "nat",
 		Master:     master,
+		// The Windows nat plugin has no separate portmap plugin to chain, unlike
+		// the Linux bridge driver, so it must advertise these capabilities itself
+		// for `nerdctl run -p` and container DNS to work.
+		Capabilities: map[string]bool{
+			"portMappings": true,
+			"dns":          true,
+		},
 	}
 }
 

--- a/pkg/netutil/cni_plugin_windows_test.go
+++ b/pkg/netutil/cni_plugin_windows_test.go
@@ -1,0 +1,45 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package netutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// The Windows "nat" CNI plugin has no separate portmap plugin to chain (unlike
+// the Linux bridge driver), so it must advertise portMappings/dns capabilities
+// itself, or `nerdctl run -p` port mappings are silently ignored by the plugin.
+func TestNewNatPluginCapabilities(t *testing.T) {
+	nat := newNatPlugin("Ethernet")
+
+	assert.Equal(t, nat.Capabilities["portMappings"], true)
+	assert.Equal(t, nat.Capabilities["dns"], true)
+
+	b, err := json.Marshal(nat)
+	assert.NilError(t, err)
+
+	var decoded map[string]interface{}
+	assert.NilError(t, json.Unmarshal(b, &decoded))
+
+	capabilities, ok := decoded["capabilities"].(map[string]interface{})
+	assert.Assert(t, ok, "expected capabilities field in generated nat plugin config")
+	assert.Equal(t, capabilities["portMappings"], true)
+	assert.Equal(t, capabilities["dns"], true)
+}


### PR DESCRIPTION
Motivation

On Windows, the default `nerdctl-nat.conflist` generated for the
built-in "nat" network omits the CNI `capabilities` block on the nat
plugin entry. Unlike the Linux bridge driver, the Windows nat plugin
has no separate chained "portmap" plugin, so it relies entirely on its
own advertised capabilities to know it should apply port-mapping and
DNS policies supplied at runtime. Without `portMappings: true`, the
plugin silently drops any `-p hostport:containerport` mapping supplied
via `nerdctl run -p`, so containers become unreachable from the host
even though the run command succeeds and reports no error.

This matches this repo's own hack/provisioning/windows/cni.sh, which
hand-writes an equivalent nat.conflist with
`"capabilities": {"portMappings": true, "dns": true}` for CI/dev
provisioning -- i.e. the fix brings the Go-generated default network
config in line with what the project's own provisioning script already
requires, and with the workaround the issue reporter manually applied
to their generated conflist to confirm the root cause.

Approach

Add a `Capabilities map[string]bool` field to `natConfig` in
pkg/netutil/cni_plugin_windows.go (mirroring the existing Capabilities
field on the Linux bridge/vlan plugin configs), and populate it with
`portMappings` and `dns` in `newNatPlugin()`, so every generated nat
plugin entry -- including the default network's -- carries the
capabilities the Windows CNI nat plugin needs to honor runtime port
mappings and container DNS.

Validation

- `GOOS=windows GOARCH=amd64 go build ./...` passes.
- `GOOS=windows GOARCH=amd64 go vet ./pkg/netutil/...` passes.
- Added pkg/netutil/cni_plugin_windows_test.go (Windows-only via file
  suffix), asserting `newNatPlugin()` sets both capabilities on the Go
  struct and in the marshaled JSON output. This test was compiled with
  `GOOS=windows GOARCH=amd64 go test -c -o /tmp/netutil_windows_test.exe
  ./pkg/netutil`, which succeeded, but could NOT be executed: this
  development environment is macOS with no Windows runtime or emulator
  (no wine) available, so the test was compiled and type-checked but
  never actually run, and the fix has not been verified end-to-end
  against a live Windows container host. The generated config, the
  struct/JSON shape, and the match against the reporter's own
  independently-confirmed manual fix are the basis for confidence here.
- `go build ./...` and `go test ./pkg/netutil/...` pass natively
  (darwin); this package's non-Windows files are untouched by this
  change.
- `golangci-lint run` for GOOS=linux, GOOS=windows, GOOS=freebsd, and
  GOOS=darwin against ./pkg/netutil/... each report only a
  pre-existing `use-slices-sort` (revive) finding in netutil.go and
  netutil_unix.go, unrelated to and predating this change.
- Note: `main`'s own "test" workflow currently shows failures in its
  in-host rootful/rootless Linux jobs
  (https://github.com/containerd/nerdctl/actions/runs/32677175180),
  unrelated to Windows or netutil -- pre-existing on the base branch,
  not introduced here.

Report: https://github.com/containerd/nerdctl/issues/5157
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #5157