### PR TITLE
fix(image): truncate the output file of save and export

### DIFF
--- a/cmd/nerdctl/container/container_export.go
+++ b/cmd/nerdctl/container/container_export.go
@@ -68,7 +68,10 @@ func exportAction(cmd *cobra.Command, args []string) error {
 
 	writer := cmd.OutOrStdout()
 	if output != "" {
-		f, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY, 0644)
+		// O_TRUNC: writing a smaller archive over a bigger one would otherwise leave the tail of
+		// the bigger one past its end. A tar reader stops at the end-of-archive marker and would
+		// not notice, but the file would carry the bytes of another container.
+		f, err := os.OpenFile(output, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/container/container_export_test.go
+++ b/cmd/nerdctl/container/container_export_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -152,6 +153,64 @@ func TestExportRunningContainer(t *testing.T) {
 				}
 			},
 		},
+	}
+
+	testCase.Run(t)
+}
+
+func TestExportReplacesExistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("export is not supported on Windows")
+	}
+
+	testCase := nerdtest.Setup()
+	testCase.NoParallel = true
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		bigger := data.Identifier("bigger")
+		smaller := data.Identifier("smaller")
+		outFile := filepath.Join(data.Temp().Path(), "reused.tar")
+
+		helpers.Ensure("create", "--name", bigger, testutil.NginxAlpineImage)
+		helpers.Ensure("create", "--name", smaller, testutil.CommonImage)
+
+		// The bigger filesystem first, so that the smaller one written over it has something to
+		// leave behind.
+		helpers.Ensure("export", "-o", outFile, bigger)
+		info, err := os.Stat(outFile)
+		assert.NilError(t, err)
+
+		data.Labels().Set("bigger", bigger)
+		data.Labels().Set("smaller", smaller)
+		data.Labels().Set("outFile", outFile)
+		data.Labels().Set("biggerSize", strconv.FormatInt(info.Size(), 10))
+	}
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Labels().Get("bigger"))
+		helpers.Anyhow("rm", "-f", data.Labels().Get("smaller"))
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("export", "-o", data.Labels().Get("outFile"), data.Labels().Get("smaller"))
+	}
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: 0,
+			Output: func(stdout string, t tig.T) {
+				info, err := os.Stat(data.Labels().Get("outFile"))
+				assert.NilError(t, err)
+				biggerSize, err := strconv.ParseInt(data.Labels().Get("biggerSize"), 10, 64)
+				assert.NilError(t, err)
+
+				// The file must hold the smaller archive and nothing else. A tar reader stops at
+				// the end-of-archive marker, so a tail left over from the bigger archive would go
+				// unnoticed on read, but the file would still carry the bytes of another
+				// container.
+				assert.Assert(t, info.Size() < biggerSize,
+					"expected the file to shrink to the new archive, still %d of %d bytes",
+					info.Size(), biggerSize)
+			},
+		}
 	}
 
 	testCase.Run(t)

--- a/cmd/nerdctl/image/image_save.go
+++ b/cmd/nerdctl/image/image_save.go
@@ -95,7 +95,10 @@ func saveAction(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	} else if outputPath != "" {
-		f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY, 0644)
+		// O_TRUNC: writing a smaller archive over a bigger one would otherwise leave the tail of
+		// the bigger one past its end. A tar reader stops at the end-of-archive marker and would
+		// not notice, but the file would carry the bytes of an unrelated image.
+		f, err := os.OpenFile(outputPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 		if err != nil {
 			return err
 		}

--- a/cmd/nerdctl/image/image_save_test.go
+++ b/cmd/nerdctl/image/image_save_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -58,6 +59,53 @@ func TestSaveContent(t *testing.T) {
 					assert.NilError(t, err)
 					etcOSRelease := string(etcOSReleaseBytes)
 					assert.Assert(t, strings.Contains(etcOSRelease, "Alpine"))
+				},
+			}
+		},
+	}
+
+	testCase.Run(t)
+}
+
+func TestSaveReplacesExistingFile(t *testing.T) {
+	nerdtest.Setup()
+
+	const reused = "reused.tar"
+
+	testCase := &test.Case{
+		// FIXME: move to busybox for windows?
+		Require: require.Not(require.Windows),
+		Setup: func(data test.Data, helpers test.Helpers) {
+			helpers.Ensure("pull", "--quiet", testutil.NginxAlpineImage)
+			helpers.Ensure("pull", "--quiet", testutil.CommonImage)
+
+			// A bigger archive first, so that the smaller one written over it has something to
+			// leave behind.
+			path := filepath.Join(data.Temp().Path(), reused)
+			helpers.Ensure("save", "-o", path, testutil.NginxAlpineImage)
+			info, err := os.Stat(path)
+			assert.NilError(t, err)
+			data.Labels().Set("bigger", strconv.FormatInt(info.Size(), 10))
+		},
+		Command: func(data test.Data, helpers test.Helpers) test.TestableCommand {
+			return helpers.Command("save", "-o", filepath.Join(data.Temp().Path(), reused), testutil.CommonImage)
+		},
+		Expected: func(data test.Data, helpers test.Helpers) *test.Expected {
+			return &test.Expected{
+				ExitCode: expect.ExitCodeSuccess,
+				Output: func(stdout string, t tig.T) {
+					info, err := os.Stat(filepath.Join(data.Temp().Path(), reused))
+					assert.NilError(t, err)
+					bigger, err := strconv.ParseInt(data.Labels().Get("bigger"), 10, 64)
+					assert.NilError(t, err)
+
+					// The file must hold the smaller archive and nothing else. A tar reader stops
+					// at the end-of-archive marker, so a tail left over from the bigger archive
+					// would go unnoticed on read, but the file would still carry the bytes of an
+					// unrelated image.
+					assert.Assert(t, info.Size() < bigger,
+						"expected the file to shrink to the new archive, still %d of %d bytes",
+						info.Size(), bigger)
 				},
 			}
 		},


### PR DESCRIPTION
`nerdctl save -o FILE` and `nerdctl export -o FILE` open the output with
`os.O_CREATE|os.O_WRONLY` and no `os.O_TRUNC`. Writing a smaller archive over a bigger one
therefore leaves the tail of the bigger one past the end of the new archive.

```go
f, _ := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
f.Write([]byte("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")) // 30 bytes, the larger image
f.Close()

f, _ = os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
f.Write([]byte("BBBBBBBBBB")) // 10 bytes, the smaller image
f.Close()
```

```console
wrote 10 bytes, file holds 30: "BBBBBBBBBBAAAAAAAAAAAAAAAAAAAA"
```

This does not break `nerdctl load`: a tar reader stops at the end-of-archive marker and never
looks at what follows, which I checked with both `archive/tar` and the system `tar`. What is
wrong is the artifact — it is larger than the archive it is supposed to hold, and the extra
bytes belong to an unrelated image or container, which shows up in anything that checksums the
file, accounts for its size, or ships it somewhere.

`docker save` replaces the destination wholesale, writing through a temporary file and renaming
it (`atomicwriter.New` in docker/cli). Adding `O_TRUNC` gets nerdctl to the same observable
result without a new dependency: `pkg/internal/filesystem` is built for state files, with
locking and backups, not for streaming an archive that can be many gigabytes.

`pkg/healthcheck/log.go` opens a file with the same flags, but seeks to the end and appends on
purpose, so it is left alone.

**Tests**

`TestSaveReplacesExistingFile` and `TestExportReplacesExistingFile` write the bigger archive
first and the smaller one over it, then assert the file shrank. They compare against the size
measured before the overwrite rather than against a separately saved copy, so they do not depend
on two saves of the same image being byte-identical.

Both assert on the size rather than on `load` failing, since as above a reader would not notice
the tail.

Fixes #5159
