### PR TITLE
fix: preserve equals signs in image label filter values

### DIFF
--- a/pkg/imgutil/filtering.go
+++ b/pkg/imgutil/filtering.go
@@ -63,7 +63,7 @@ type Filter func([]images.Image) ([]images.Image, error)
 func ParseFilters(filters []string) (*Filters, error) {
 	f := &Filters{Labels: make(map[string]string)}
 	for _, filter := range filters {
-		tempFilterToken := strings.Split(filter, "=")
+		tempFilterToken := strings.SplitN(filter, "=", 3)
 		switch len(tempFilterToken) {
 		case 1:
 			return nil, fmt.Errorf("invalid filter %q", filter)

--- a/pkg/imgutil/filtering_test.go
+++ b/pkg/imgutil/filtering_test.go
@@ -25,6 +25,15 @@ import (
 	"github.com/containerd/containerd/v2/core/images"
 )
 
+func TestParseFiltersLabelValueContainingEquals(t *testing.T) {
+	filters, err := ParseFilters([]string{"label=example.payload=a=b"})
+	assert.NilError(t, err)
+	assert.DeepEqual(t, filters.Labels, map[string]string{"example.payload": "a=b"})
+
+	_, err = ParseFilters([]string{"dangling=true=garbage"})
+	assert.Error(t, err, `invalid filter "dangling=true=garbage"`)
+}
+
 func TestApplyFilters(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
`nerdctl images --filter label=example.payload=a=b` fails with `invalid filter`, while Docker accepts the same filter. 
Label values are plain strings, so `=` is legit here

The parser now splits into at most three parts and keeps the rest in the label value. 
Non-label filters keep their old validation

Repro before this change:

`nerdctl images --filter label=example.payload=a=b`

`FATA[0000] invalid filter "label=example.payload=a=b"`

Tested with `go test ./pkg/imgutil ./pkg/cmd/image`