### PR TITLE
dockercompat: key inspect Networks by real CNI network name

### DIFF
--- a/pkg/inspecttypes/dockercompat/dockercompat.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat.go
@@ -805,7 +805,7 @@ func statusFromNative(x containerd.Status, labels map[string]string) string {
 	}
 }
 
-func networkSettingsFromNative(n *native.NetNS, _ *specs.Spec) (*NetworkSettings, error) {
+func networkSettingsFromNative(n *native.NetNS, spec *specs.Spec) (*NetworkSettings, error) {
 	res := &NetworkSettings{
 		Networks: make(map[string]*NetworkEndpointSettings),
 	}
@@ -813,6 +813,19 @@ func networkSettingsFromNative(n *native.NetNS, _ *specs.Spec) (*NetworkSettings
 	res.Ports = &resPortMap
 	if n == nil {
 		return res, nil
+	}
+
+	// CNI names the interface for the i-th network "eth<i>" (see go-cni
+	// getIfName), in the order the container's networks were attached. Recover
+	// that ordered list from the spec annotations so each endpoint can be keyed
+	// by its real network name instead of a synthesized "unknown-*" placeholder.
+	var networks []string
+	if spec != nil {
+		if networksJSON := spec.Annotations[labels.Networks]; networksJSON != "" {
+			if err := json.Unmarshal([]byte(networksJSON), &networks); err != nil {
+				return nil, fmt.Errorf("failed to parse networks annotation %q: %w", networksJSON, err)
+			}
+		}
 	}
 
 	var primary *NetworkEndpointSettings
@@ -844,9 +857,7 @@ func networkSettingsFromNative(n *native.NetNS, _ *specs.Spec) (*NetworkSettings
 				nes.GlobalIPv6PrefixLen = ones
 			}
 		}
-		// TODO: set CNI name when possible
-		fakeDockerNetworkName := fmt.Sprintf("unknown-%s", x.Name)
-		res.Networks[fakeDockerNetworkName] = nes
+		res.Networks[cniNetworkName(x.Name, networks)] = nes
 
 		nports, err := convertToNatPort(n.PortMappings)
 		if err != nil {
@@ -869,6 +880,21 @@ func networkSettingsFromNative(n *native.NetNS, _ *specs.Spec) (*NetworkSettings
 		res.DefaultNetworkSettings.GlobalIPv6PrefixLen = primary.GlobalIPv6PrefixLen
 	}
 	return res, nil
+}
+
+// cniNetworkName maps a container interface name to the CNI network it belongs
+// to. go-cni names the i-th network's interface "<prefix><i>" (defaulting to
+// "eth0", "eth1", ...; see go-cni getIfName), so an "eth<i>" interface resolves
+// to networks[i]. Anything that does not fit that scheme (host networking, an
+// interface not created by CNI, or a missing/short networks list) falls back to
+// the historical "unknown-<name>" key.
+func cniNetworkName(ifName string, networks []string) string {
+	if idx, ok := strings.CutPrefix(ifName, cni.DefaultPrefix); ok {
+		if i, err := strconv.Atoi(idx); err == nil && i >= 0 && i < len(networks) {
+			return networks[i]
+		}
+	}
+	return fmt.Sprintf("unknown-%s", ifName)
 }
 
 func cpuSettingsFromNative(sp *specs.Spec) (*CPUSettings, error) {

--- a/pkg/inspecttypes/dockercompat/dockercompat_test.go
+++ b/pkg/inspecttypes/dockercompat/dockercompat_test.go
@@ -784,6 +784,83 @@ func TestNetworkSettingsFromNative(t *testing.T) {
 				},
 			},
 		},
+		// Given native.NetNS whose eth0 maps to a named CNI network, Return
+		// NetworkSettings keyed by the real network name rather than "unknown-*".
+		//   UseCase: Inspect a Running Container attached to a named network (issue #2999)
+		{
+			name: "Given NetNS with eth0 and a networks annotation, Return NetworkSettings keyed by network name",
+			n: &native.NetNS{
+				Interfaces: []native.NetInterface{
+					{
+						Interface: net.Interface{
+							Index: 2,
+							MTU:   1500,
+							Name:  "eth0",
+							Flags: net.FlagUp,
+						},
+						HardwareAddr: "fa:b9:e3:9f:67:1b",
+						Flags:        []string{},
+						Addrs:        []string{"10.4.0.50/24"},
+					},
+				},
+			},
+			s: &specs.Spec{
+				Annotations: map[string]string{
+					labels.Networks: `["bridge"]`,
+				},
+			},
+			expected: &NetworkSettings{
+				Ports: &nat.PortMap{},
+				Networks: map[string]*NetworkEndpointSettings{
+					"bridge": {
+						IPAddress:   "10.4.0.50",
+						IPPrefixLen: 24,
+						MacAddress:  "fa:b9:e3:9f:67:1b",
+					},
+				},
+			},
+		},
+		// Given native.NetNS with eth0/eth1 and two networks, Return each
+		// endpoint keyed by its network name, matched in networks-list order.
+		{
+			name: "Given NetNS with eth0/eth1 and two networks, Return NetworkSettings keyed by network names",
+			n: &native.NetNS{
+				Interfaces: []native.NetInterface{
+					{
+						Interface:    net.Interface{Index: 2, MTU: 1500, Name: "eth0", Flags: net.FlagUp},
+						HardwareAddr: "fa:b9:e3:9f:67:1b",
+						Flags:        []string{},
+						Addrs:        []string{"10.4.0.50/24"},
+					},
+					{
+						Interface:    net.Interface{Index: 3, MTU: 1500, Name: "eth1", Flags: net.FlagUp},
+						HardwareAddr: "fa:b9:e3:9f:67:1c",
+						Flags:        []string{},
+						Addrs:        []string{"10.5.0.60/24"},
+					},
+				},
+			},
+			s: &specs.Spec{
+				Annotations: map[string]string{
+					labels.Networks: `["bridge","mynet"]`,
+				},
+			},
+			expected: &NetworkSettings{
+				Ports: &nat.PortMap{},
+				Networks: map[string]*NetworkEndpointSettings{
+					"bridge": {
+						IPAddress:   "10.4.0.50",
+						IPPrefixLen: 24,
+						MacAddress:  "fa:b9:e3:9f:67:1b",
+					},
+					"mynet": {
+						IPAddress:   "10.5.0.60",
+						IPPrefixLen: 24,
+						MacAddress:  "fa:b9:e3:9f:67:1c",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testcase {


### PR DESCRIPTION
`nerdctl inspect` currently shows a container's networks as `unknown-eth0` instead of the network name

It comes from `networkSettingsFromNative` in pkg/inspecttypes/dockercompat: the map key is built from the interface name with a hardcoded `unknown-` prefix, and it does not look at which network the interface belongs to. (There was already a `// TODO: set CNI name when possible` sitting there).

go-cni names the interfaces `eth0`, `eth1`, ... in the same order the networks were attached, and nerdctl keeps that ordered list in the `nerdctl/networks` annotation. I read the list from the annotation and map `eth<i>` back to `networks[i]`.

If an interface doesn't fit that pattern, host networking, something not set up by CNI, or an older container with no annotation, it keeps the old `unknown-<iface>` key, so those cases are unchanged.

Added single, and multi-network cases to `TestNetworkSettingsFromNative`; the existing cases are untouched.

Fixes #2999
