### PR TITLE
ci: Print daemon logs after integration test failures

### DIFF
--- a/.github/workflows/job-test-in-host.yml
+++ b/.github/workflows/job-test-in-host.yml
@@ -333,3 +333,31 @@ jobs:
           INPUTS_IPV6: ${{ inputs.ipv6 }}
           CONTAINERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER: ${{ inputs.target == 'rootless-port-slirp4netns' && 'slirp4netns' || '' }}
           CONTAINERD_ROOTLESS_ROOTLESSKIT_IPV6: ${{ inputs.ipv6 && 'true' || '' }}
+
+      - if: ${{ failure() && contains(inputs.runner, 'ubuntu') && inputs.target != '' && env.SHOULD_RUN == 'yes' }}
+        name: "Post (linux): print daemon logs"
+        env:
+          INPUTS_TARGET: ${{ inputs.target }}
+        run: |
+          echo "::group::containerd and buildkit system service logs"
+          sudo journalctl \
+            --boot \
+            --no-pager \
+            --lines=1000 \
+            --unit=containerd.service \
+            --unit=buildkit.service \
+            --unit=test-integration-buildkit-nerdctl-test.service || true
+          echo "::endgroup::"
+
+          if [[ "${INPUTS_TARGET}" == rootless* ]]; then
+            echo "::group::rootless daemon logs"
+            journalctl \
+              --user \
+              --boot \
+              --no-pager \
+              --lines=1000 \
+              --unit=containerd.service \
+              --unit=buildkit.service \
+              --unit=test-integration-buildkit-nerdctl-test.service || true
+            echo "::endgroup::"
+          fi

--- a/.github/workflows/job-test-in-lima.yml
+++ b/.github/workflows/job-test-in-lima.yml
@@ -127,3 +127,29 @@ jobs:
           else
             lima bash -c 'export PATH="/usr/local/go/bin:$HOME/go/bin:$PATH" WITH_SUDO=true && ./hack/test-integration.sh -test.only-flaky=true'
           fi
+
+      - if: ${{ failure() }}
+        name: "Post: print daemon logs"
+        run: |
+          echo "::group::containerd and buildkit system service logs"
+          lima sudo journalctl \
+            --boot \
+            --no-pager \
+            --lines=1000 \
+            --unit=containerd.service \
+            --unit=buildkit.service \
+            --unit=test-integration-buildkit-nerdctl-test.service || true
+          echo "::endgroup::"
+
+          if [ "$TARGET" = "rootless" ]; then
+            echo "::group::rootless daemon logs"
+            lima journalctl \
+              --user \
+              --boot \
+              --no-pager \
+              --lines=1000 \
+              --unit=containerd.service \
+              --unit=buildkit.service \
+              --unit=test-integration-buildkit-nerdctl-test.service || true
+            echo "::endgroup::"
+          fi


### PR DESCRIPTION
## Summary

- print containerd and buildkit system service logs after failed Linux host integration jobs
- collect the same diagnostics from Lima guests
- include the unprivileged user journal for rootless targets
- keep diagnostics best-effort so they do not replace the original test failure

Fixes #4365.

## Validation

- `yamllint .`
- `git diff --check`
- `actionlint` on both changed workflows (only the two existing `fromJSON(inputs.skip-flaky)` type warnings remain)