### PR TITLE
docs: fix typos in command reference, cosign and gpu docs

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -240,7 +240,7 @@ Resource flags:
 
 Intel RDT flags:
 
-- :nerd_face: `--rdt-class=CLASS`: Name of the RDT class (or CLOS) to associate the container wit
+- :nerd_face: `--rdt-class=CLASS`: Name of the RDT class (or CLOS) to associate the container with
 
 User flags:
 

--- a/docs/cosign.md
+++ b/docs/cosign.md
@@ -92,7 +92,7 @@ INFO[0003] cosign: failed to verify signature
 
 ## Cosign in Compose
 
-> Cosign support in Compose is also experimental and implemented based on Compose's [extension](https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension) capibility.
+> Cosign support in Compose is also experimental and implemented based on Compose's [extension](https://github.com/compose-spec/compose-spec/blob/master/spec.md#extension) capability.
 
 cosign is supported in `nerdctl compose up|run|push|pull`. You can use cosign in Compose by adding the following fields in your compose yaml. These fields are _per service_, and you can enable only `verify` or only `sign` (or both).
 

--- a/docs/gpu.md
+++ b/docs/gpu.md
@@ -90,7 +90,7 @@ is used to request a CDI device:
 nerdctl run --device=nvidia.com/gpu=all
 ```
 
-Ensure that the NVIDIA (or AMD) Container Toolkit is installed and the requested CDI devices are present in the ouptut of `nvidia-ctk cdi list` (or `amd-ctk cdi list` for AMD GPUs):
+Ensure that the NVIDIA (or AMD) Container Toolkit is installed and the requested CDI devices are present in the output of `nvidia-ctk cdi list` (or `amd-ctk cdi list` for AMD GPUs):
 
 ```
 $ nvidia-ctk cdi list


### PR DESCRIPTION
Three documentation typo fixes:

- **`docs/command-reference.md`** — the `--rdt-class` description ends mid-word: "to associate the container wit". Completed to "with", which matches the flag's actual usage string in `cmd/nerdctl/container/container_run.go`.
- **`docs/cosign.md`** — "capibility" -> "capability".
- **`docs/gpu.md`** — "ouptut" -> "output".

Documentation only, no code or behaviour changes.