### PR TITLE
feat(attach): support multiple concurrent attach sessions

### DIFF
--- a/cmd/nerdctl/container/container_attach.go
+++ b/cmd/nerdctl/container/container_attach.go
@@ -41,11 +41,14 @@ func AttachCommand() *cobra.Command {
 
 Caveats:
 
-- Currently only one attach session is allowed. When the second session tries to attach, currently no error will be returned from nerdctl.
-  However, since behind the scenes, there's only one FIFO for stdin, stdout, and stderr respectively,
-  if there are multiple sessions, all the sessions will be reading from and writing to the same 3 FIFOs, which will result in mixed input and partial output.
-- Until dual logging (issue #1946) is implemented,
-  a container that is spun up by either 'nerdctl run -d' or 'nerdctl start' (without '--attach') cannot be attached to.`
+- Several sessions can be attached to the same container at once: they all see the container's output,
+  and any of them can type into it.
+- A container whose stdio is a set of FIFOs, because it was started by a version of nerdctl that predates
+  the attach socket or on a platform without one, still allows a single session: with more than one, all
+  sessions read from and write to the same 3 FIFOs, which results in mixed input and partial output.
+- A container whose output was handed to a logging process nerdctl cannot reach, either somebody else's
+  binary through a custom '--log-driver binary://' URI or a detached container on a platform without an
+  attach socket, cannot be attached to at all.`
 
 	var cmd = &cobra.Command{
 		Use:               "attach [flags] CONTAINER",

--- a/cmd/nerdctl/container/container_attach_linux_test.go
+++ b/cmd/nerdctl/container/container_attach_linux_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -248,6 +249,226 @@ func TestAttachNoStdin(t *testing.T) {
 				logs := helpers.Capture("logs", data.Identifier())
 				assert.Assert(t, !strings.Contains(logs, "should-not-appear"))
 			},
+		}
+	}
+
+	testCase.Run(t)
+}
+
+// TestAttachMultipleSessions is the reproduction of
+// https://github.com/containerd/nerdctl/issues/4374: with two sessions attached
+// to the same container, a FIFO hands each chunk of output to exactly one
+// reader, so one terminal appears to freeze. Both sessions must see everything.
+func TestAttachMultipleSessions(t *testing.T) {
+	// Detaching returns 0 on nerdctl and 1 on docker, as in TestAttach.
+	// https://github.com/containerd/nerdctl/issues/3571
+	ex := 0
+	if nerdtest.IsDocker() {
+		ex = 1
+	}
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cmd := helpers.Command("run", "-d", "-it", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.Run(&test.Expected{ExitCode: 0})
+		// Give the container time to reach its shell prompt.
+		time.Sleep(time.Second)
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		// A second session that stays attached for the whole test. It has to be
+		// joined before this function returns: running it in a goroutine that
+		// outlives the test would let the framework tear the container down
+		// before the assertion runs, and would touch testing.T after the test
+		// has finished.
+		var wg sync.WaitGroup
+		var observed string
+
+		observer := helpers.Command("attach", data.Identifier())
+		observer.WithPseudoTTY()
+		observer.WithFeeder(func() io.Reader {
+			time.Sleep(4 * time.Second)
+			// ctrl+p ctrl+q
+			return bytes.NewReader([]byte{16, 17})
+		})
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// The Output callback only records what this session saw. The
+			// assertion itself is done from the main goroutine in Cleanup,
+			// because calling t.Fatal from a non-test goroutine is not valid.
+			observer.Run(&test.Expected{
+				ExitCode: ex,
+				Output: func(stdout string, _ tig.T) {
+					observed = stdout
+				},
+			})
+		}()
+
+		time.Sleep(time.Second)
+
+		cmd := helpers.Command("attach", data.Identifier())
+		cmd.WithPseudoTTY()
+		cmd.Feed(strings.NewReader("echo mark${NON}mark\n"))
+		cmd.WithFeeder(func() io.Reader {
+			time.Sleep(2 * time.Second)
+			// ctrl+p ctrl+q
+			return bytes.NewReader([]byte{16, 17})
+		})
+
+		// Joining here is what makes the assertion meaningful: without it the
+		// framework could tear the container down, and the test could finish,
+		// before the observer ever produced any output.
+		t.Cleanup(func() {
+			wg.Wait()
+			// This is the reproduction of #4374: before the broker, the two
+			// sessions split the container's output and at most one of them
+			// contained the marker.
+			assert.Assert(t, strings.Contains(observed, "markmark"),
+				"the second session did not see the container's output: %q", observed)
+		})
+
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: ex,
+			Output: expect.All(
+				expect.Contains("markmark"),
+				func(stdout string, t tig.T) {
+					assert.Assert(t, strings.Contains(helpers.Capture("inspect", "--format", "json", data.Identifier()), "\"Running\":true"))
+				},
+			),
+		}
+	}
+
+	testCase.Run(t)
+}
+
+// TestAttachToDetachedContainer covers a container started with -d. Before the
+// stdio broker existed there was no stdin FIFO for such a container at all, so
+// attaching to it could not work.
+func TestAttachToDetachedContainer(t *testing.T) {
+	// Detaching from an attach session returns 0 on nerdctl and 1 on docker.
+	// https://github.com/containerd/nerdctl/issues/3571
+	ex := 0
+	if nerdtest.IsDocker() {
+		ex = 1
+	}
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		helpers.Ensure("run", "-d", "-it", "--name", data.Identifier(), testutil.CommonImage)
+		time.Sleep(time.Second)
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		cmd := helpers.Command("attach", data.Identifier())
+		cmd.WithPseudoTTY()
+		cmd.Feed(strings.NewReader("echo detached${NON}marker\n"))
+		cmd.WithFeeder(func() io.Reader {
+			time.Sleep(2 * time.Second)
+			// ctrl+p ctrl+q
+			return bytes.NewReader([]byte{16, 17})
+		})
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: ex,
+			Output:   expect.Contains("detachedmarker"),
+		}
+	}
+
+	testCase.Run(t)
+}
+
+// TestAttachAfterDetachKeepsContainerResponsive covers the case where the
+// foreground session leaves: the container must keep producing output for a
+// session that attaches afterwards, rather than stalling on stdio nobody reads.
+func TestAttachAfterDetachKeepsContainerResponsive(t *testing.T) {
+	// As above: detaching from an attach session returns 0 on nerdctl, 1 on
+	// docker. The run+detach in Setup returns 0 on both.
+	ex := 0
+	if nerdtest.IsDocker() {
+		ex = 1
+	}
+
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		cmd := helpers.Command("run", "-it", "--name", data.Identifier(), testutil.CommonImage)
+		cmd.WithPseudoTTY()
+		cmd.Feed(bytes.NewReader([]byte{16, 17}))
+		cmd.Run(&test.Expected{ExitCode: 0})
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		cmd := helpers.Command("attach", data.Identifier())
+		cmd.WithPseudoTTY()
+		cmd.Feed(strings.NewReader("echo after${NON}detach\n"))
+		cmd.WithFeeder(func() io.Reader {
+			time.Sleep(2 * time.Second)
+			// ctrl+p ctrl+q
+			return bytes.NewReader([]byte{16, 17})
+		})
+		return cmd
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		return &test.Expected{
+			ExitCode: ex,
+			Output:   expect.Contains("afterdetach"),
+		}
+	}
+
+	testCase.Run(t)
+}
+
+// TestAttachToDetachedContainerWithoutTTY covers `nerdctl run -d` without -t.
+// Its output also goes to the logging process, through cio.LogURI, so the same
+// socket serves it. It has no stdin: the shim does not wire one for a
+// non-terminal container whose stdout is a binary URI.
+func TestAttachToDetachedContainerWithoutTTY(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.Cleanup = func(data test.Data, helpers test.Helpers) {
+		helpers.Anyhow("rm", "-f", data.Identifier())
+	}
+
+	testCase.Setup = func(data test.Data, helpers test.Helpers) {
+		// The leading sleep gives the attach below time to connect. There is no
+		// replay buffer, so anything printed before it connects is gone.
+		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.CommonImage,
+			"sh", "-c", "sleep 2; for i in 1 2 3; do echo tick; sleep 1; done")
+	}
+
+	testCase.Command = func(data test.Data, helpers test.Helpers) test.TestableCommand {
+		return helpers.Command("attach", data.Identifier())
+	}
+
+	testCase.Expected = func(data test.Data, helpers test.Helpers) *test.Expected {
+		// attach returns when the container exits, with its exit code.
+		return &test.Expected{
+			ExitCode: 0,
+			Output:   expect.Contains("tick"),
 		}
 	}
 

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -456,8 +456,12 @@ func runAction(cmd *cobra.Command, args []string) error {
 	// at another path carries it too, and spawning that would run code with no
 	// broker in it. Leaving dataStore empty otherwise makes it the single guard
 	// everything below can test.
+	// --disable-attach-broker is the way back to the stdio nerdctl used before
+	// multi-session attach: leaving dataStore empty is what stops the task
+	// being built for the broker, and every path below already handles that,
+	// because it is also what a foreign log driver looks like.
 	dataStore := ""
-	if loguri.IsInternal(logURI) {
+	if !createOpt.GOptions.DisableAttachBroker && loguri.IsInternal(logURI) {
 		dataStore = loguri.DataStore(logURI)
 	}
 

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -465,11 +465,23 @@ func runAction(cmd *cobra.Command, args []string) error {
 		dataStore = loguri.DataStore(logURI)
 	}
 
-	// Only an interactive container gets a stdin FIFO. Creating one for a
-	// container started without -i would give it a stdin that never reaches
-	// EOF, changing the behaviour of processes that read until EOF.
+	// Only an interactive terminal container gets a stdin FIFO.
+	//
+	// -i without -t is deliberately excluded. The broker holds a second writer
+	// on the FIFO for the container's lifetime, which is what makes detaching
+	// leave a terminal running, but it also means the container never sees EOF
+	// on its stdin: `echo x | nerdctl run -i alpine cat` would hang, because
+	// task.CloseIO closes the shim's writer and nerdctl's, not the broker's.
+	// A terminal container does not have that problem, since its stdin is a
+	// console rather than a pipe that ends. Multi-session stdin is limited to
+	// terminal containers anyway, because for a non-terminal one the shim's
+	// binary path does not wire stdin at all.
+	//
+	// Creating one for a container started without -i would separately give it
+	// a stdin that never reaches EOF, changing the behaviour of processes that
+	// read until EOF.
 	stdinFIFO := ""
-	if createOpt.Interactive && dataStore != "" {
+	if createOpt.Interactive && createOpt.TTY && dataStore != "" {
 		path := cioutil.StdinFIFOPath(dataStore, createOpt.GOptions.Namespace, c.ID())
 		if err := cioutil.CreateStdinFIFO(path); err != nil {
 			log.G(ctx).WithError(err).Debug("failed to create the stdin FIFO, the broker is disabled for this container")

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -33,6 +33,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
 	"github.com/containerd/nerdctl/v2/pkg/config"
@@ -43,6 +44,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/healthcheck"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/logging"
+	"github.com/containerd/nerdctl/v2/pkg/logging/loguri"
 	"github.com/containerd/nerdctl/v2/pkg/netutil"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/taskutil"
@@ -444,6 +446,34 @@ func runAction(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	logURI := lab[labels.LogURI]
+
+	// The data store comes out of the log URI, not from resolving it again.
+	// That URI is the argv containerd hands the logging process, so the paths
+	// derived from it here and there are the same string by construction.
+	//
+	// It is taken only when the URI runs *this* binary. The magic argument on
+	// its own is not enough: a URI written by an older nerdctl still installed
+	// at another path carries it too, and spawning that would run code with no
+	// broker in it. Leaving dataStore empty otherwise makes it the single guard
+	// everything below can test.
+	dataStore := ""
+	if loguri.IsInternal(logURI) {
+		dataStore = loguri.DataStore(logURI)
+	}
+
+	// Only an interactive container gets a stdin FIFO. Creating one for a
+	// container started without -i would give it a stdin that never reaches
+	// EOF, changing the behaviour of processes that read until EOF.
+	stdinFIFO := ""
+	if createOpt.Interactive && dataStore != "" {
+		path := cioutil.StdinFIFOPath(dataStore, createOpt.GOptions.Namespace, c.ID())
+		if err := cioutil.CreateStdinFIFO(path); err != nil {
+			log.G(ctx).WithError(err).Debug("failed to create the stdin FIFO, the broker is disabled for this container")
+		} else {
+			stdinFIFO = path
+		}
+	}
+
 	detachC := make(chan struct{})
 	task, err := taskutil.NewTask(ctx, client, c, taskutil.TaskOptions{
 		AttachStreamOpt: createOpt.Attach,
@@ -456,6 +486,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 		Namespace:       createOpt.GOptions.Namespace,
 		DetachC:         detachC,
 		CheckpointDir:   "",
+		StdinFIFO:       stdinFIFO,
 	})
 	if err != nil {
 		return err

--- a/cmd/nerdctl/container/container_run.go
+++ b/cmd/nerdctl/container/container_run.go
@@ -17,10 +17,13 @@
 package container
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -33,6 +36,7 @@ import (
 	"github.com/containerd/nerdctl/v2/cmd/nerdctl/completion"
 	"github.com/containerd/nerdctl/v2/pkg/annotations"
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/attachmux"
 	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/cmd/container"
@@ -490,6 +494,26 @@ func runAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	useBroker := createOpt.TTY && !createOpt.Detach && dataStore != "" &&
+		(!createOpt.Interactive || stdinFIFO != "") &&
+		attachmux.Probe(dataStore) == nil
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	// Built before NewTask: consoleutil.NewDetachableStdin parses the detach
+	// keys and rejects a malformed --detach-keys, and that has to keep
+	// happening before a task exists, not after.
+	var brokerStdin io.Reader
+	if useBroker && createOpt.Interactive {
+		// Detaching is local to this session: it ends the stream and leaves the
+		// container, and any other session, running.
+		brokerStdin, err = consoleutil.NewDetachableStdin(con, createOpt.DetachKeys, cancelStream)
+		if err != nil {
+			return err
+		}
+	}
+
 	detachC := make(chan struct{})
 	task, err := taskutil.NewTask(ctx, client, c, taskutil.TaskOptions{
 		AttachStreamOpt: createOpt.Attach,
@@ -503,6 +527,7 @@ func runAction(cmd *cobra.Command, args []string) error {
 		DetachC:         detachC,
 		CheckpointDir:   "",
 		StdinFIFO:       stdinFIFO,
+		UseBroker:       useBroker,
 	})
 	if err != nil {
 		return err
@@ -514,6 +539,55 @@ func runAction(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
+	streamed := make(chan struct{})
+	streamErr := make(chan error, 1)
+	if useBroker {
+		// The same pure function, over the same data store string, that the
+		// broker used to pick where to listen.
+		socketPath := attachmux.SocketPath(dataStore, createOpt.GOptions.Namespace, c.ID())
+		// DialStarting retries: containerd spawns the logging process while
+		// creating the task and does not wait for it, so the broker may not
+		// have bound its socket yet.
+		session, err := attachmux.DialStarting(ctx, socketPath)
+		if err != nil {
+			// The task was created with its stdio going to the logging process,
+			// so this session has no other way to show the container's output.
+			// Delete the task: it has not been started, so nothing has run yet
+			// and the user gets a clean failure rather than a container they
+			// cannot see.
+			if _, delErr := task.Delete(ctx); delErr != nil {
+				log.G(ctx).WithError(delErr).Warn("failed to delete the task after attach setup failed")
+			}
+			return fmt.Errorf("failed to connect to the container attach socket: %w", err)
+		}
+		defer session.Close()
+
+		in := brokerStdin
+		go func() {
+			defer close(streamed)
+			if err := session.Stream(streamCtx, in, con, nil); err != nil {
+				// The broker went away without the container exiting. Report it:
+				// signalling detachC would make this look like the user pressing
+				// the detach keys, and the command would exit 0 while the
+				// container's output was silently lost.
+				streamErr <- err
+				return
+			}
+			if session.Exited() {
+				// The container is gone: the select below takes statusC, and
+				// signalling detachC here would make it report a detach instead.
+				return
+			}
+			select {
+			case detachC <- struct{}{}:
+			case <-ctx.Done():
+			}
+		}()
+	} else {
+		close(streamed)
+	}
+
 	if err := task.Start(ctx); err != nil {
 		return err
 	}
@@ -555,6 +629,33 @@ func runAction(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// handleExit is what both the container-exited and the session-failed
+	// branches below end in. sessionErr, when set, is an attach session failure
+	// that happened alongside the exit: the container's own exit code wins,
+	// because that is what a script reads, and a broken session at that point
+	// only means the tail of the output may be missing.
+	handleExit := func(status containerd.ExitStatus, sessionErr error) error {
+		if createOpt.Rm {
+			if _, taskDeleteErr := task.Delete(ctx); taskDeleteErr != nil {
+				log.L.Error(taskDeleteErr)
+			}
+		}
+		code, _, err := status.Result()
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			if sessionErr != nil {
+				log.G(ctx).WithError(sessionErr).Warn("the attach session failed, the container output may be incomplete")
+			}
+			return errutil.NewExitCoderErr(int(code))
+		}
+		if sessionErr != nil {
+			return fmt.Errorf("the container attach session failed: %w", sessionErr)
+		}
+		return nil
+	}
+
 	select {
 	// io.Wait() would return when either 1) the user detaches from the container OR 2) the container is about to exit.
 	//
@@ -570,19 +671,30 @@ func runAction(cmd *cobra.Command, args []string) error {
 		}
 		io.Wait()
 		isDetached = true
+	case err := <-streamErr:
+		select {
+		case status := <-statusC:
+			return handleExit(status, err)
+		default:
+		}
+		return fmt.Errorf("the container attach session failed: %w", err)
 	case status := <-statusC:
-		if createOpt.Rm {
-			if _, taskDeleteErr := task.Delete(ctx); taskDeleteErr != nil {
-				log.L.Error(taskDeleteErr)
+		// Let the session drain what the broker still has queued. The container
+		// has exited, so this resolves as soon as the broker finishes reading
+		// the stdio and announces the exit. The stream's own result is picked
+		// up here as well; on the legacy path `streamed` is already closed and
+		// `streamErr` never carries anything, so this is a no-op there.
+		var sessionErr error
+		select {
+		case <-streamed:
+			select {
+			case sessionErr = <-streamErr:
+			default:
 			}
+		case <-time.After(attachmux.DrainTimeout):
+			sessionErr = errors.New("timed out waiting for the attach session to drain")
 		}
-		code, _, err := status.Result()
-		if err != nil {
-			return err
-		}
-		if code != 0 {
-			return errutil.NewExitCoderErr(int(code))
-		}
+		return handleExit(status, sessionErr)
 	}
 	return nil
 }

--- a/cmd/nerdctl/helpers/flagutil.go
+++ b/cmd/nerdctl/helpers/flagutil.go
@@ -162,6 +162,10 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 	if err != nil {
 		return types.GlobalCommandOptions{}, err
 	}
+	disableAttachBroker, err := cmd.Flags().GetBool("disable-attach-broker")
+	if err != nil {
+		return types.GlobalCommandOptions{}, err
+	}
 	// Point to dataRoot for filesystem-helpers implementing rollback / backups.
 	err = fs.InitFS(dataRoot)
 	if err != nil {
@@ -169,27 +173,28 @@ func ProcessRootCmdFlags(cmd *cobra.Command) (types.GlobalCommandOptions, error)
 	}
 
 	return types.GlobalCommandOptions{
-		Debug:            debug,
-		DebugFull:        debugFull,
-		LogFile:          logFile,
-		Address:          address,
-		Namespace:        namespace,
-		Snapshotter:      snapshotter,
-		CNIPath:          cniPath,
-		CNINetConfPath:   cniConfigPath,
-		DataRoot:         dataRoot,
-		CgroupManager:    cgroupManager,
-		InsecureRegistry: insecureRegistry,
-		HostsDir:         hostsDir,
-		Experimental:     experimental,
-		HostGatewayIP:    hostGatewayIP,
-		BridgeIP:         bridgeIP,
-		KubeHideDupe:     kubeHideDupe,
-		CDISpecDirs:      cdiSpecDirs,
-		DNS:              dns,
-		DNSOpts:          dnsOpts,
-		DNSSearch:        dnsSearch,
-		SelinuxEnabled:   selinuxEnabled,
+		Debug:               debug,
+		DebugFull:           debugFull,
+		LogFile:             logFile,
+		Address:             address,
+		Namespace:           namespace,
+		Snapshotter:         snapshotter,
+		CNIPath:             cniPath,
+		CNINetConfPath:      cniConfigPath,
+		DataRoot:            dataRoot,
+		CgroupManager:       cgroupManager,
+		InsecureRegistry:    insecureRegistry,
+		HostsDir:            hostsDir,
+		Experimental:        experimental,
+		HostGatewayIP:       hostGatewayIP,
+		BridgeIP:            bridgeIP,
+		KubeHideDupe:        kubeHideDupe,
+		CDISpecDirs:         cdiSpecDirs,
+		DNS:                 dns,
+		DNSOpts:             dnsOpts,
+		DNSSearch:           dnsSearch,
+		SelinuxEnabled:      selinuxEnabled,
+		DisableAttachBroker: disableAttachBroker,
 	}, nil
 }
 

--- a/cmd/nerdctl/image/image_convert_test.go
+++ b/cmd/nerdctl/image/image_convert_test.go
@@ -84,4 +84,5 @@ func addRootFlagsForConvertOptionsTest(t *testing.T, cmd *cobra.Command) {
 	flags.StringSlice("global-dns-opts", nil, "")
 	flags.StringSlice("global-dns-search", nil, "")
 	flags.Bool("selinux-enabled", false, "")
+	flags.Bool("disable-attach-broker", false, "")
 }

--- a/cmd/nerdctl/main.go
+++ b/cmd/nerdctl/main.go
@@ -193,6 +193,8 @@ func initRootCmdFlags(rootCmd *cobra.Command, tomlPath string) (*pflag.FlagSet, 
 	helpers.AddPersistentStringFlag(rootCmd, "bridge-ip", nil, nil, nil, aliasToBeInherited, cfg.BridgeIP, "NERDCTL_BRIDGE_IP", "IP address for the default nerdctl bridge network")
 	rootCmd.PersistentFlags().Bool("kube-hide-dupe", cfg.KubeHideDupe, "Deduplicate images for Kubernetes with namespace k8s.io")
 	rootCmd.PersistentFlags().Bool("selinux-enabled", cfg.SelinuxEnabled, "Enable selinux support")
+	helpers.AddPersistentBoolFlag(rootCmd, "disable-attach-broker", nil, nil, cfg.DisableAttachBroker, "NERDCTL_DISABLE_ATTACH_BROKER",
+		"Put a container's stdio back on the FIFOs used before multi-session attach. Only one session can then attach at a time. Affects containers started from now on, not ones already running")
 	rootCmd.PersistentFlags().StringSlice("cdi-spec-dirs", cfg.CDISpecDirs, "The directories to search for CDI spec files. Defaults to /etc/cdi,/var/run/cdi")
 	rootCmd.PersistentFlags().String("userns-remap", cfg.UsernsRemap, "Support idmapping for creating and running containers. This options is only supported on linux. If `host` is passed, no idmapping is done. if a user name is passed, it does idmapping based on the uidmap and gidmap ranges specified in /etc/subuid and /etc/subgid respectively")
 	helpers.HiddenPersistentStringArrayFlag(rootCmd, "global-dns", cfg.DNS, "Global DNS servers for containers")

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -723,11 +723,13 @@ Attach stdin, stdout, and stderr to a running container. For example:
 
 Caveats:
 
-- Currently only one attach session is allowed. When the second session tries to attach, currently no error will be returned from nerdctl.
-  However, since behind the scenes, there's only one FIFO for stdin, stdout, and stderr respectively,
-  if there are multiple sessions, all the sessions will be reading from and writing to the same 3 FIFOs, which will result in mixed input and partial output.
-- Until dual logging (issue #1946) is implemented,
-  a container that is spun up by either `nerdctl run -d` or `nerdctl start` (without `--attach`) cannot be attached to.
+- Several sessions can be attached to the same container at once: they all see the container's output, and any of them can type into it.
+- A container whose stdio is a set of FIFOs still allows a single session. That is the case for containers created by a version of nerdctl
+  that predates the attach socket, and for foreground `nerdctl run -it` on a platform without one. Behind the scenes there is then only one
+  FIFO for stdin, stdout and stderr respectively, so all the sessions read from and write to the same 3 FIFOs, which results in mixed input
+  and partial output.
+- A container whose output was handed to a logging process nerdctl cannot reach cannot be attached to at all. That covers a custom
+  `--log-driver binary://` URI, and detached containers on platforms where the attach socket is not implemented yet.
 
 Usage: `nerdctl attach CONTAINER`
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -60,6 +60,7 @@ selinux_enabled= true
 | `dns_opts`          |                                    |                           | Set global DNS options for containers                                                                                                                         | Since 2.1.3 |
 | `dns_search`        |                                    |                           | Set global DNS search domains for containers                                                                                                           | Since 2.1.3 |
 | `selinux_enabled`        |                                    |                           |Enable selinux support for containers                                                                                                           | Since 2.3.0 |
+| `disable_attach_broker` | `--disable-attach-broker`          | `NERDCTL_DISABLE_ATTACH_BROKER` | Put a container's stdio back on the FIFOs used before multi-session attach, so that only one session can attach at a time. Affects containers started from now on, not ones already running | Since 2.4.0 |
 
 The properties are parsed in the following precedence:
 1. CLI flag

--- a/docs/dev/attach.md
+++ b/docs/dev/attach.md
@@ -1,0 +1,125 @@
+# How attach works
+
+A container's stdio FIFOs cannot be shared. A FIFO has one queue, so two readers
+on the stdout FIFO each receive a random subset of the container's output: one
+terminal appears to freeze while the other prints characters it never asked for.
+That was https://github.com/containerd/nerdctl/issues/4374.
+
+Docker does not have this problem because `dockerd` owns the container's stdio
+and fans it out. nerdctl is daemonless, so a different process has to own it.
+
+## The broker
+
+The owner is the internal logging process, the one nerdctl runs as
+`_NERDCTL_INTERNAL_LOGGING` (`pkg/logging`). containerd spawns it from the
+container's log URI, so it exists for the container's whole lifetime and comes
+back on its own when the containerd restart monitor recreates a task.
+
+It gains three things (`pkg/logging/broker_unix.go`):
+
+- a unix socket at a path derived from the data store, the namespace and the
+  container ID. Nothing is recorded on disk: clients derive the same path with
+  the same function, and ask containerd whether the task's stdio belongs to a
+  logging process at all
+- a fan-out of the container's raw output, tapped before the log driver's line
+  splitting so that partial lines and terminal escape sequences survive
+- the write end of the container's stdin FIFO, which every session's input is
+  merged into
+
+`nerdctl run -it`, `nerdctl start -a` and `nerdctl attach` are all clients
+(`pkg/attachmux`).
+
+## Invariants
+
+- **The container never blocks on a session.** Each session has a bounded queue;
+  one that falls behind is disconnected. The goroutine reading the container's
+  stdio never waits on a consumer.
+- **With no sessions attached the broker keeps draining.** Detaching therefore
+  leaves the container running normally.
+- **There is no replay buffer.** `run` and `start -a` connect before the task
+  starts, so no output is produced with nobody attached. Attaching to a running
+  container shows no history, as with docker.
+
+## Stdin
+
+`cioutil.StdinFIFOPath` pins a container's stdin to
+`<dataStore>/containers/<ns>/<id>/stdin.fifo`. containerd generates a fresh FIFO
+directory per task, so those paths change across restarts and another process
+cannot derive them.
+
+For a terminal container the containerd shim copies the stdin FIFO into the pty
+regardless of the stdout URI scheme
+(`cmd/containerd-shim-runc-v2/runc/platform.go`, `CopyConsole`), which is what
+lets a container keep stdin while its output goes to the logging process. For a
+non-terminal container the `binary` scheme sets `pio.copy = false` and
+`binaryIO.Stdin()` returns nil (`cmd/containerd-shim-runc-v2/process/io.go`,
+`createIO`), so stdin is not wired at all. That is why multi-session stdin is
+currently limited to terminal containers.
+
+## After a restart-policy restart, sessions are output only
+
+containerd's restart monitor recreates a task from the stored log URI. For a
+terminal container it does that through `cio.TerminalLogURI`
+(`plugins/restart/change.go`), whose config is `{Terminal, Stdout, Stderr}` and
+carries no `Stdin` (`pkg/cio/io_unix.go`). The shim therefore never opens the
+read end of the stable stdin FIFO, and the broker serves output only until the
+container is started by nerdctl again.
+
+The FIFO file itself is still there from the previous run, which is why
+`openStdinWriter` decides by opening it rather than by looking for it: a FIFO
+opened `O_WRONLY|O_NONBLOCK` fails with `ENXIO` for as long as nothing holds the
+read end. `github.com/containerd/fifo` deliberately hides that - given
+`O_NONBLOCK` it strips the flag and opens in a goroutine - so it cannot be used
+here.
+
+The broker itself does come back, because it is spawned from the log URI, so
+output fan-out and logging keep working. Only input is lost. This is not a
+regression: such a container has no stdin today either. Closing it needs the
+restart monitor to preserve the full IO config, which is an upstream change.
+
+## Backing it out
+
+`disable_attach_broker` (`--disable-attach-broker`, `NERDCTL_DISABLE_ATTACH_BROKER`,
+`nerdctl.toml`) leaves the data store empty at task creation, which is what a
+container with a foreign log driver already looks like, so every branch above
+takes the legacy path without any new code. It only affects containers created
+while it is set: a running container's stdio is already bound.
+
+## Falling back
+
+`nerdctl attach` asks containerd how the task's stdio is wired, through the
+`cio.Attach` callback that `container.Task` hands the task's recorded `Stdin`,
+`Stdout` and `Stderr`. A plain path means FIFOs, and it attaches to them
+directly the way it always did, one session at a time: that is what a foreground
+`run -it` looks like when the socket was unavailable, and what an older nerdctl
+left behind. A URI means the output went to a process spawned from the log URI,
+and the socket is the only way in.
+
+Not every URI-owned container has a reachable socket. A detached container has
+had URI stdio since long before this change, on every platform, so one created by
+an older nerdctl or running where the transport is not implemented reports that
+its stdio is owned by a process nerdctl cannot reach. `nerdctl attach` fails
+there today too, inside `fifo.OpenFifo` on a path spelled `binary://...`; only
+the message is new.
+
+The classification and the IO construction happen in the same `container.Task`
+call. Splitting them would leave a window in which the restart monitor replaces
+a FIFO task with a URI one between the two `TaskService.Get` round trips.
+
+Nothing about this is cached in nerdctl's own state. It cannot be: containerd's
+restart monitor recreates a task from the stored log URI without nerdctl running
+at all, so a container that had FIFO stdio can come back with URI stdio between
+two nerdctl invocations.
+
+There is no falling back the other way. A task built for the broker has
+`binary://` URIs where `cio.NewAttach` expects FIFO paths, so a socket that
+cannot be dialled is reported as an error rather than retried on a path that
+cannot work. A container whose URI points at somebody else's logging binary
+therefore cannot be attached to at all.
+
+`nerdctl run -it` decides which kind of task to create before the task exists.
+`attachmux.Probe` binds a throwaway socket under the data store up front so the
+common failures pick the legacy path while that is still possible, as does a
+stable stdin FIFO that could not be created for a `-i` session. If the socket is
+unreachable afterwards the task is deleted before it starts, so the user gets a
+clean error rather than a container they cannot see.

--- a/pkg/attachmux/attachmux.go
+++ b/pkg/attachmux/attachmux.go
@@ -1,0 +1,75 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package attachmux lets any number of sessions share a container's stdio.
+//
+// The server side runs inside the process that owns the container's stdio, its
+// internal logging process, and the client side runs in every `nerdctl attach`,
+// `nerdctl run -it` and `nerdctl start -a`.
+package attachmux
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"path/filepath"
+)
+
+// ErrUnsupported is returned on platforms where the attach transport is not
+// implemented yet. Callers fall back to attaching directly to the container's
+// stdio, which allows a single session at a time. It lives here rather than in
+// socket_unsupported.go because callers test for it on every platform.
+var ErrUnsupported = errors.New("attachmux: multi-session attach is not supported on this platform")
+
+// socketNameLen is how many hex characters of the digest go into a socket file
+// name. A unix socket path has to fit in sockaddr_un.sun_path (108 bytes), and
+// the data store path plus a 64 character container ID does not, hence the
+// digest.
+const socketNameLen = 16
+
+// socketDir returns the directory holding a data store's attach sockets.
+func socketDir(dataStore string) string {
+	return filepath.Join(dataStore, "attach")
+}
+
+// SocketPath returns the attach socket path for a container.
+//
+// It lives under the container's data store rather than in a runtime directory,
+// because the data store is the one location the broker and its clients can
+// agree on. The broker runs inside the logging process, which containerd's shim
+// spawns with an environment of exactly CONTAINER_ID and CONTAINER_NAMESPACE
+// (cmd/containerd-shim-runc-v2/process/io_util.go, NewBinaryCmd): there is no
+// XDG_RUNTIME_DIR there, and rootlessutil.XDGRuntimeDir would fail outright.
+// The data store, by contrast, is handed to that process in its argv, and
+// nerdctl already relies on it being the same path on both sides for the log
+// files themselves.
+//
+// The name is a digest rather than a prefix of the ID, because all of a data
+// store's attach sockets share one flat directory and Listen removes whatever
+// is already at the path, so a collision would silently hand one container's
+// terminal to another. The namespace is in the digest because nerdctl can
+// attach to a container created by another client, whose ID may be short and
+// identical to one elsewhere; nerdctl's own IDs are 64 random hex characters
+// (see pkg/idgen). The data store no longer needs to be, since it is the
+// directory.
+//
+// This is a pure function of its arguments, and it is how both the broker and
+// every client find the socket: nothing about it is recorded on disk. See the
+// head of Task 4 for why there is no pointer file.
+func SocketPath(dataStore, ns, id string) string {
+	sum := sha256.Sum256([]byte(ns + "\x00" + id))
+	return filepath.Join(socketDir(dataStore), hex.EncodeToString(sum[:])[:socketNameLen]+".sock")
+}

--- a/pkg/attachmux/attachmux.go
+++ b/pkg/attachmux/attachmux.go
@@ -25,6 +25,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"path/filepath"
 )
 
@@ -32,7 +33,10 @@ import (
 // implemented yet. Callers fall back to attaching directly to the container's
 // stdio, which allows a single session at a time. It lives here rather than in
 // socket_unsupported.go because callers test for it on every platform.
-var ErrUnsupported = errors.New("attachmux: multi-session attach is not supported on this platform")
+//
+// It wraps errors.ErrUnsupported, so a caller that does not care which
+// subsystem is unavailable can test for that instead.
+var ErrUnsupported = fmt.Errorf("attachmux: multi-session attach is not supported on this platform: %w", errors.ErrUnsupported)
 
 // socketNameLen is how many hex characters of the digest go into a socket file
 // name. A unix socket path has to fit in sockaddr_un.sun_path (108 bytes), and

--- a/pkg/attachmux/attachmux_test.go
+++ b/pkg/attachmux/attachmux_test.go
@@ -77,7 +77,9 @@ func TestSocketPathIsUnderTheDataStore(t *testing.T) {
 	// which is the only path it and its clients are guaranteed to agree on: the
 	// shim spawns it with an environment of just CONTAINER_ID and
 	// CONTAINER_NAMESPACE, so nothing XDG-based is available there.
-	path := SocketPath("/var/lib/nerdctl/1935db59", "default", "abc")
-	assert.Equal(t, filepath.Dir(path), "/var/lib/nerdctl/1935db59/attach")
+	const dataStore = "/var/lib/nerdctl/1935db59"
+	path := SocketPath(dataStore, "default", "abc")
+	// Joined, not spelled out: the separator is the platform's.
+	assert.Equal(t, filepath.Dir(path), filepath.Join(dataStore, "attach"))
 	assert.Equal(t, len(filepath.Base(path)), socketNameLen+len(".sock"))
 }

--- a/pkg/attachmux/attachmux_test.go
+++ b/pkg/attachmux/attachmux_test.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSocketPathIsShortEnoughForSunPath(t *testing.T) {
+	t.Parallel()
+
+	// A unix socket path has to fit in sockaddr_un.sun_path, which is 108
+	// bytes. A container ID is 64 hex characters, so the full ID cannot be part
+	// of the path.
+	id := strings.Repeat("a", 64)
+	path := SocketPath("/var/lib/nerdctl/1935db59", "default", id)
+	assert.Assert(t, len(path) < 100, "socket path %q is %d bytes", path, len(path))
+	assert.Assert(t, strings.HasSuffix(path, ".sock"), "got %q", path)
+}
+
+func TestSocketPathIsStableAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
+	again := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
+	assert.Equal(t, first, again)
+
+	other := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("b", 64))
+	assert.Assert(t, first != other)
+}
+
+func TestSocketPathSeparatesNamespaces(t *testing.T) {
+	t.Parallel()
+
+	// A data store's attach sockets share one flat directory and Listen removes
+	// whatever is already at the path, so two containers with the same short ID
+	// in different namespaces must not resolve to the same socket. nerdctl's own
+	// IDs are random and 64 characters long, but nerdctl can attach to a
+	// container created by another client, whose ID may be anything.
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
+	other := SocketPath("/var/lib/nerdctl/1935db59", "staging", "shell")
+	assert.Assert(t, first != other, "both namespaces resolved to %q", first)
+}
+
+func TestSocketPathSeparatesContainerdEndpoints(t *testing.T) {
+	t.Parallel()
+
+	// The data store path encodes the containerd address, and the socket lives
+	// inside it, so two endpoints cannot collide.
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
+	other := SocketPath("/var/lib/nerdctl/8fa1c02b", "default", "shell")
+	assert.Assert(t, first != other, "both endpoints resolved to %q", first)
+}
+
+func TestSocketPathIsUnderTheDataStore(t *testing.T) {
+	t.Parallel()
+
+	// The broker derives this from the data store it is handed in its argv,
+	// which is the only path it and its clients are guaranteed to agree on: the
+	// shim spawns it with an environment of just CONTAINER_ID and
+	// CONTAINER_NAMESPACE, so nothing XDG-based is available there.
+	path := SocketPath("/var/lib/nerdctl/1935db59", "default", "abc")
+	assert.Equal(t, filepath.Dir(path), "/var/lib/nerdctl/1935db59/attach")
+	assert.Equal(t, len(filepath.Base(path)), socketNameLen+len(".sock"))
+}

--- a/pkg/attachmux/broker.go
+++ b/pkg/attachmux/broker.go
@@ -200,6 +200,16 @@ func (b *Broker) writeFrame(stream byte, p []byte) {
 		return
 	}
 
+	// Most containers on a host have nobody attached, and their output still
+	// comes through here. Checking first means they do not pay for a copy of
+	// every chunk that is then thrown away.
+	b.mu.Lock()
+	empty := b.closed || len(b.sessions) == 0
+	b.mu.Unlock()
+	if empty {
+		return
+	}
+
 	// Encoded outside the lock: it allocates and copies the whole chunk, and
 	// readLoop, addSession and SessionCount all contend for b.mu.
 	frame, err := EncodeFrame(stream, p)
@@ -208,6 +218,7 @@ func (b *Broker) writeFrame(stream byte, p []byte) {
 		return
 	}
 
+	// Checked again: a session can have gone away while the frame was encoded.
 	b.mu.Lock()
 	if b.closed || len(b.sessions) == 0 {
 		b.mu.Unlock()

--- a/pkg/attachmux/broker.go
+++ b/pkg/attachmux/broker.go
@@ -28,11 +28,19 @@ import (
 )
 
 const (
-	// defaultQueueDepth is how many frames are buffered for a single session. A
-	// session that falls this far behind is disconnected: the container's output
-	// must never wait on a consumer.
+	// maxQueuedBytes is how much of the container's output is buffered for a
+	// single session before it is disconnected: the container's output must
+	// never wait on a consumer.
 	// https://github.com/containerd/nerdctl/issues/5137
-	defaultQueueDepth = 256
+	//
+	// The bound is bytes rather than frames. A TTY echoes single keystrokes, so
+	// counting frames would evict a session that is a few kilobytes behind,
+	// while a frame can be up to maxPayload, so counting frames also puts no
+	// real ceiling on memory in the logging process.
+	maxQueuedBytes = 4 << 20
+	// defaultQueueDepth caps the channel itself, as a backstop against a flood
+	// of tiny frames. maxQueuedBytes is what normally decides.
+	defaultQueueDepth = 4096
 	// writeTimeout bounds a single write to a session, so that a session that is
 	// connected but no longer draining its socket is eventually dropped instead
 	// of leaking a goroutine and its queue for the container's lifetime.
@@ -91,6 +99,8 @@ type session struct {
 	// exit is the final frame writeLoop delivers after frames has drained. See
 	// closeWith.
 	exit []byte
+	// queued is how many bytes are sitting in frames, waiting to be written.
+	queued int
 }
 
 // send queues frame for the session. It reports false only when the session's
@@ -102,12 +112,23 @@ func (s *session) send(frame []byte) bool {
 	if s.closed {
 		return true
 	}
+	if s.queued+len(frame) > maxQueuedBytes {
+		return false
+	}
 	select {
 	case s.frames <- frame:
+		s.queued += len(frame)
 		return true
 	default:
 		return false
 	}
+}
+
+// dequeued records that n bytes have left the queue.
+func (s *session) dequeued(n int) {
+	s.mu.Lock()
+	s.queued -= n
+	s.mu.Unlock()
 }
 
 // closeWith closes the session's queue, leaving exit for writeLoop to deliver
@@ -203,9 +224,19 @@ func (b *Broker) writeFrame(stream byte, p []byte) {
 	}
 	b.mu.Unlock()
 
+	if len(slow) == 0 {
+		return
+	}
+	// Tell them why. Otherwise being evicted is indistinguishable from the
+	// broker dying, and the client reports both as a lost connection.
+	dropped, err := EncodeControl(Control{Type: ControlDropped})
+	if err != nil {
+		log.L.WithError(err).Warn("attachmux: failed to encode the dropped notice")
+		dropped = nil
+	}
 	for _, s := range slow {
 		log.L.Warn("attachmux: an attach session stopped keeping up, disconnecting it")
-		s.close()
+		s.closeWith(dropped)
 	}
 }
 
@@ -377,7 +408,9 @@ func (b *Broker) writeLoop(s *session) {
 			b.dropSession(s)
 			return
 		}
-		if _, err := s.conn.Write(frame); err != nil {
+		_, err := s.conn.Write(frame)
+		s.dequeued(len(frame))
+		if err != nil {
 			b.dropSession(s)
 			return
 		}

--- a/pkg/attachmux/broker.go
+++ b/pkg/attachmux/broker.go
@@ -158,19 +158,38 @@ func NewBroker(tty bool, stdin io.WriteCloser) *Broker {
 // queue is full is disconnected instead. p is copied, so the caller is free to
 // reuse it immediately.
 func (b *Broker) Write(stream byte, p []byte) {
+	if stream == StreamControl {
+		// Control is the broker's own channel. Letting the owner of the stdio
+		// put frames on it would let container output forge a hello or an exit.
+		log.L.Warn("attachmux: refusing to write container output on the control stream")
+		return
+	}
+	// A chunk larger than a single frame is split rather than dropped: Write is
+	// the exported entry point for whoever owns the container's stdio, and the
+	// size of its read buffer is not this package's to assume.
+	for len(p) > maxPayload {
+		b.writeFrame(stream, p[:maxPayload])
+		p = p[maxPayload:]
+	}
+	b.writeFrame(stream, p)
+}
+
+func (b *Broker) writeFrame(stream byte, p []byte) {
 	if len(p) == 0 {
+		return
+	}
+
+	// Encoded outside the lock: it allocates and copies the whole chunk, and
+	// readLoop, addSession and SessionCount all contend for b.mu.
+	frame, err := EncodeFrame(stream, p)
+	if err != nil {
+		log.L.WithError(err).Warn("attachmux: dropping an output frame")
 		return
 	}
 
 	b.mu.Lock()
 	if b.closed || len(b.sessions) == 0 {
 		b.mu.Unlock()
-		return
-	}
-	frame, err := EncodeFrame(stream, p)
-	if err != nil {
-		b.mu.Unlock()
-		log.L.WithError(err).Warn("attachmux: dropping an oversized output frame")
 		return
 	}
 	var slow []*session
@@ -199,9 +218,14 @@ func (b *Broker) SessionCount() int {
 
 // Serve accepts sessions on l until ctx is done or l is closed.
 func (b *Broker) Serve(ctx context.Context, l net.Listener) error {
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		<-ctx.Done()
-		l.Close()
+		select {
+		case <-ctx.Done():
+			l.Close()
+		case <-done:
+		}
 	}()
 
 	for {
@@ -292,8 +316,11 @@ func (b *Broker) Close(exited bool) {
 }
 
 // SetStdin gives the broker the write end of the container's stdin once it is
-// known to be usable, and reports whether the broker took it. It returns false
-// for a broker that is already closed, and the caller then closes w itself.
+// known to be usable, and reports whether the broker took it.
+//
+// It returns false when the broker is already closed, and also when it already
+// has a stdin, whether from NewBroker or from an earlier call. The caller then
+// closes w itself. A false is never evidence that the container exited.
 //
 // Stdin arrives late because whether the container has one at all can only be
 // established by opening the FIFO, which the owner has to do off the path that
@@ -400,10 +427,16 @@ func (b *Broker) readLoop(s *session) {
 			b.stdinWriteMu.Unlock()
 			if err != nil {
 				// Close closed the descriptor under a blocked write, or the
-				// container is gone. Either way this session's input has
-				// nowhere to go.
+				// container stopped reading its stdin. Either way this
+				// keystroke has nowhere to go, and nothing more.
+				//
+				// Returning here would run the deferred dropSession and take
+				// the session's *output* with it: a container that closed its
+				// stdin and kept printing would lose its terminal on the next
+				// keypress, and one that had just exited would be reported as a
+				// broken session instead of a clean exit.
 				log.L.WithError(err).Debug("attachmux: failed to write to the container stdin")
-				return
+				continue
 			}
 		}
 	}

--- a/pkg/attachmux/broker.go
+++ b/pkg/attachmux/broker.go
@@ -1,0 +1,418 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/containerd/log"
+)
+
+const (
+	// defaultQueueDepth is how many frames are buffered for a single session. A
+	// session that falls this far behind is disconnected: the container's output
+	// must never wait on a consumer.
+	// https://github.com/containerd/nerdctl/issues/5137
+	defaultQueueDepth = 256
+	// writeTimeout bounds a single write to a session, so that a session that is
+	// connected but no longer draining its socket is eventually dropped instead
+	// of leaking a goroutine and its queue for the container's lifetime.
+	writeTimeout = 30 * time.Second
+	// closeDrainTimeout bounds how long Close waits for the writers to flush
+	// what is already queued. containerd calls os.Exit as soon as the logging
+	// function returns (core/runtime/v2/logging/logging_unix.go), so a writer
+	// still draining at that point is killed mid-frame.
+	closeDrainTimeout = 2 * time.Second
+	// DrainTimeout bounds how long a client waits, after the container has
+	// exited, for the broker to deliver what it still has queued.
+	//
+	// It has to be longer than closeDrainTimeout. A client that gave up first
+	// would cancel its stream and close the socket while the broker was still
+	// flushing, dropping the tail of the container's output and reporting
+	// success for it.
+	DrainTimeout = 3 * closeDrainTimeout
+)
+
+// Broker owns a container's stdio. It fans container output out to every
+// connected session and merges the sessions' input into the container's stdin.
+//
+// Every method is safe for concurrent use, and none of them block on a session.
+type Broker struct {
+	tty bool
+
+	mu       sync.Mutex
+	sessions map[*session]struct{}
+	closed   bool
+	// stdin is the write end of the container's stdin, installed by NewBroker
+	// or later by SetStdin, and taken back by Close. It is guarded by mu so
+	// that closing and installing cannot interleave.
+	stdin io.WriteCloser
+
+	// writers tracks the per-session writer goroutines so that Close can flush
+	// what is queued before the process is torn down.
+	writers sync.WaitGroup
+
+	// stdinWriteMu keeps a session's write to the container's stdin from being
+	// interleaved with another session's. It guards the write, not the field:
+	// a write to a FIFO the container is not reading blocks until the pipe
+	// drains, and Close must be able to release the descriptor meanwhile
+	// rather than queue behind it. stdin itself is guarded by mu.
+	stdinWriteMu sync.Mutex
+}
+
+type session struct {
+	conn   net.Conn
+	frames chan []byte
+
+	// mu guards closed together with the send on frames. Without it, Close
+	// could send on a channel that a concurrent dropSession has just closed,
+	// which panics even from inside a select.
+	mu     sync.Mutex
+	closed bool
+	// exit is the final frame writeLoop delivers after frames has drained. See
+	// closeWith.
+	exit []byte
+}
+
+// send queues frame for the session. It reports false only when the session's
+// queue is full, meaning the session has fallen behind and has to be dropped. A
+// session that is already closed reports true: it is gone, not slow.
+func (s *session) send(frame []byte) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return true
+	}
+	select {
+	case s.frames <- frame:
+		return true
+	default:
+		return false
+	}
+}
+
+// closeWith closes the session's queue, leaving exit for writeLoop to deliver
+// once everything already queued has gone out. exit is nil when the session is
+// being dropped rather than told the container is gone.
+//
+// The exit frame does not go through the queue. A session whose queue happens
+// to be exactly full at that moment has received all of the container's output
+// and is not behind; pushing the exit through the same bounded channel would
+// drop it and leave the client reporting a lost connection for a container that
+// finished normally.
+func (s *session) closeWith(exit []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	s.exit = exit
+	close(s.frames)
+}
+
+// close stops the session's writer. The writer closes the connection once it
+// has drained whatever is already queued.
+func (s *session) close() { s.closeWith(nil) }
+
+// NewBroker returns a Broker fanning container output out to its sessions.
+//
+// stdin is the write end of the container's stdin and may be nil, either
+// because the container has none or because it is not known yet; SetStdin
+// installs it later. The Broker holds it open for the container's lifetime,
+// which is what makes detaching leave the container running, and closes it only
+// in Close.
+//
+// Note that closing this end would not deliver EOF to the container anyway.
+// The shim opens the same FIFO O_WRONLY and holds that descriptor until
+// task.CloseIO (cmd/containerd-shim-runc-v2/process/init.go, openStdin), so
+// closing the container's stdin is a task operation, not a broker one.
+func NewBroker(tty bool, stdin io.WriteCloser) *Broker {
+	return &Broker{
+		tty:      tty,
+		stdin:    stdin,
+		sessions: map[*session]struct{}{},
+	}
+}
+
+// Write fans p out to every connected session. It never blocks: a session whose
+// queue is full is disconnected instead. p is copied, so the caller is free to
+// reuse it immediately.
+func (b *Broker) Write(stream byte, p []byte) {
+	if len(p) == 0 {
+		return
+	}
+
+	b.mu.Lock()
+	if b.closed || len(b.sessions) == 0 {
+		b.mu.Unlock()
+		return
+	}
+	frame, err := EncodeFrame(stream, p)
+	if err != nil {
+		b.mu.Unlock()
+		log.L.WithError(err).Warn("attachmux: dropping an oversized output frame")
+		return
+	}
+	var slow []*session
+	for s := range b.sessions {
+		if !s.send(frame) {
+			slow = append(slow, s)
+		}
+	}
+	for _, s := range slow {
+		delete(b.sessions, s)
+	}
+	b.mu.Unlock()
+
+	for _, s := range slow {
+		log.L.Warn("attachmux: an attach session stopped keeping up, disconnecting it")
+		s.close()
+	}
+}
+
+// SessionCount returns how many sessions are currently connected.
+func (b *Broker) SessionCount() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.sessions)
+}
+
+// Serve accepts sessions on l until ctx is done or l is closed.
+func (b *Broker) Serve(ctx context.Context, l net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		l.Close()
+	}()
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			if ctx.Err() != nil || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+		b.addSession(conn)
+	}
+}
+
+// Close disconnects every session and releases the container's stdin.
+//
+// exited says whether the container is known to have exited. Only then are the
+// sessions told so, and they treat it as proof: `nerdctl attach` stops
+// streaming and reads the exit code from containerd. The owner cannot infer it
+// from its own stdio reaching EOF, because that also happens when the logging
+// process is asked to shut down while the container keeps running, and a client
+// told the container had gone would then wait for an exit that never comes.
+//
+// A false value tears the sessions down without that claim, and a client
+// reports the session as broken, which is what it is.
+//
+// The exit carries no code: a session reads that from containerd.
+func (b *Broker) Close(exited bool) {
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		return
+	}
+	b.closed = true
+	sessions := make([]*session, 0, len(b.sessions))
+	for s := range b.sessions {
+		sessions = append(sessions, s)
+	}
+	b.sessions = map[*session]struct{}{}
+	// Take the descriptor out under the same lock that SetStdin uses, so that
+	// a concurrent SetStdin either loses the race and closes its own file, or
+	// wins it and is closed here.
+	stdin := b.stdin
+	b.stdin = nil
+	b.mu.Unlock()
+
+	// The exit is handed over before stdin is released, and that order matters.
+	// A readLoop blocked writing to a FIFO the container stopped reading wakes
+	// up with an error the moment the descriptor closes, and its deferred
+	// dropSession closes the session's queue; doing this afterwards would leave
+	// the client reporting an unexpected disconnect for a container that exited
+	// normally.
+	var exit []byte
+	if exited {
+		frame, err := EncodeControl(Control{Type: ControlExit})
+		if err != nil {
+			log.L.WithError(err).Warn("attachmux: failed to encode the exit frame")
+		} else {
+			exit = frame
+		}
+	}
+	for _, s := range sessions {
+		s.closeWith(exit)
+	}
+
+	// Wait for the writers to flush. Closing the queues is not enough: the
+	// caller is the logging process, and containerd calls os.Exit as soon as
+	// the logging function returns, which would kill a writer mid-frame and
+	// lose the container's last output along with the exit message.
+	drained := make(chan struct{})
+	go func() {
+		b.writers.Wait()
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(closeDrainTimeout):
+		log.L.Warn("attachmux: timed out flushing attach sessions on close")
+	}
+
+	// Released last, outside the lock and outside stdinWriteMu: a readLoop can
+	// be blocked in Write on a FIFO the container stopped reading, and waiting
+	// for it would hang the logging process on SIGTERM. The FIFO is registered
+	// with the runtime poller, so closing it unblocks that write with ErrClosed.
+	if stdin != nil {
+		stdin.Close()
+	}
+}
+
+// SetStdin gives the broker the write end of the container's stdin once it is
+// known to be usable, and reports whether the broker took it. It returns false
+// for a broker that is already closed, and the caller then closes w itself.
+//
+// Stdin arrives late because whether the container has one at all can only be
+// established by opening the FIFO, which the owner has to do off the path that
+// reads the container's output. See pkg/logging/broker_unix.go.
+func (b *Broker) SetStdin(w io.WriteCloser) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed || b.stdin != nil {
+		return false
+	}
+	b.stdin = w
+	return true
+}
+
+// addSession registers conn, greets it and starts its two pumps.
+func (b *Broker) addSession(conn net.Conn) {
+	hello, err := EncodeControl(Control{Type: ControlHello, Version: ProtocolVersion, TTY: b.tty})
+	if err != nil {
+		conn.Close()
+		return
+	}
+
+	s := &session{conn: conn, frames: make(chan []byte, defaultQueueDepth)}
+
+	b.mu.Lock()
+	if b.closed {
+		b.mu.Unlock()
+		conn.Close()
+		return
+	}
+	b.sessions[s] = struct{}{}
+	// The hello has to be queued before anything else so that it is the first
+	// frame the session sees.
+	s.send(hello)
+	// Add under the lock, before the session becomes reachable to Close.
+	// Adding after unlocking would let Close observe the session, close it and
+	// return from Wait with the counter still at zero, which both breaks the
+	// sync.WaitGroup contract and lets the logging process exit before this
+	// writer has flushed anything.
+	b.writers.Add(1)
+	b.mu.Unlock()
+
+	go b.writeLoop(s)
+	go b.readLoop(s)
+}
+
+// writeLoop drains the session's queue onto its connection.
+func (b *Broker) writeLoop(s *session) {
+	defer b.writers.Done()
+	defer s.conn.Close()
+
+	for frame := range s.frames {
+		if err := s.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+			b.dropSession(s)
+			return
+		}
+		if _, err := s.conn.Write(frame); err != nil {
+			b.dropSession(s)
+			return
+		}
+	}
+
+	// Everything queued has gone out. If the container exited, say so now: this
+	// is the last thing the session ever sees, and it is what tells the client
+	// apart from a broker that vanished.
+	s.mu.Lock()
+	exit := s.exit
+	s.mu.Unlock()
+	if exit == nil {
+		return
+	}
+	if err := s.conn.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil {
+		return
+	}
+	if _, err := s.conn.Write(exit); err != nil {
+		log.L.WithError(err).Debug("attachmux: failed to deliver the exit frame")
+	}
+}
+
+// readLoop forwards the session's input to the container.
+func (b *Broker) readLoop(s *session) {
+	defer b.dropSession(s)
+
+	for {
+		stream, payload, err := ReadFrame(s.conn)
+		if err != nil {
+			return
+		}
+		switch stream {
+		case StreamStdin:
+			// stdin can be installed by SetStdin after this loop has started,
+			// and taken away by Close while it is running, so it is read under
+			// mu. The write itself is held only by stdinWriteMu: taking mu
+			// across a write that can block on a full FIFO would hang Close.
+			b.mu.Lock()
+			w := b.stdin
+			b.mu.Unlock()
+			if w == nil {
+				continue
+			}
+
+			b.stdinWriteMu.Lock()
+			_, err = w.Write(payload)
+			b.stdinWriteMu.Unlock()
+			if err != nil {
+				// Close closed the descriptor under a blocked write, or the
+				// container is gone. Either way this session's input has
+				// nowhere to go.
+				log.L.WithError(err).Debug("attachmux: failed to write to the container stdin")
+				return
+			}
+		}
+	}
+}
+
+// dropSession unregisters s and stops its writer.
+func (b *Broker) dropSession(s *session) {
+	b.mu.Lock()
+	delete(b.sessions, s)
+	b.mu.Unlock()
+	s.close()
+}

--- a/pkg/attachmux/broker_test.go
+++ b/pkg/attachmux/broker_test.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"os"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -156,6 +157,48 @@ func TestBrokerMergesStdinFromEverySession(t *testing.T) {
 	assert.Assert(t, bytes.Contains([]byte(got), []byte("from-second\n")), "got %q", got)
 }
 
+func TestBrokerSplitsAnOversizedWrite(t *testing.T) {
+	t.Parallel()
+
+	// Write is the entry point for whoever owns the container's stdio, and this
+	// package does not get to assume the size of their read buffer. A chunk
+	// larger than one frame is split, not dropped.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	payload := bytes.Repeat([]byte("x"), maxPayload+1000)
+	go b.Write(StreamStdout, payload)
+
+	var got []byte
+	for len(got) < len(payload) {
+		stream, chunk, err := ReadFrame(conn)
+		assert.NilError(t, err)
+		assert.Equal(t, stream, StreamStdout)
+		got = append(got, chunk...)
+	}
+	assert.Equal(t, len(got), len(payload))
+	assert.DeepEqual(t, got, payload)
+}
+
+func TestBrokerRefusesToWriteOnTheControlStream(t *testing.T) {
+	t.Parallel()
+
+	// Control is the broker's own channel: container output must not be able to
+	// forge a hello or an exit.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	b.Write(StreamControl, []byte(`{"type":"exit"}`))
+	b.Write(StreamStdout, []byte("real output"))
+
+	stream, payload, err := ReadFrame(conn)
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamStdout)
+	assert.Equal(t, string(payload), "real output")
+}
+
 func TestBrokerDisconnectsASessionThatStopsReading(t *testing.T) {
 	t.Parallel()
 
@@ -251,6 +294,38 @@ func TestBrokerAcceptsStdinAfterASessionConnects(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("stdin did not reach the broker, got %q", stdin.String())
+}
+
+// failingWriter models the container's stdin FIFO after the container stopped
+// reading it: every write fails, the way a FIFO with no reader gives EPIPE.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, syscall.EPIPE }
+func (failingWriter) Close() error              { return nil }
+
+func TestBrokerKeepsAnOutputSessionAfterAFailedStdinWrite(t *testing.T) {
+	t.Parallel()
+
+	// A container that closed its stdin and keeps printing, or one that has
+	// just exited, must not cost the session its output on the next keystroke.
+	// Dropping the session there also loses the exit frame, which is exactly
+	// the "unexpected disconnect is an error, not a detach" case.
+	b := NewBroker(true, failingWriter{})
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	frame, err := EncodeFrame(StreamStdin, []byte("keystroke"))
+	assert.NilError(t, err)
+	_, err = conn.Write(frame)
+	assert.NilError(t, err)
+
+	// The session is still there, and still receives the container's output.
+	b.Write(StreamStdout, []byte("still printing"))
+	stream, payload, err := ReadFrame(conn)
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamStdout)
+	assert.Equal(t, string(payload), "still printing")
+	assert.Equal(t, b.SessionCount(), 1)
 }
 
 func TestBrokerCloseReleasesStdin(t *testing.T) {

--- a/pkg/attachmux/broker_test.go
+++ b/pkg/attachmux/broker_test.go
@@ -626,3 +626,53 @@ func TestBrokerServeAcceptsSessions(t *testing.T) {
 		t.Fatal("Serve did not return after the context was cancelled")
 	}
 }
+
+func TestBrokerTellsAnEvictedSessionWhy(t *testing.T) {
+	t.Parallel()
+
+	// Being dropped for falling behind has to be distinguishable from the
+	// broker dying: both end the session, but only one is the user's fault and
+	// only one means the container may still be running.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	// Never read: overflow the byte bound.
+	chunk := bytes.Repeat([]byte("x"), 64<<10)
+	for b.SessionCount() > 0 {
+		b.Write(StreamStdout, chunk)
+	}
+
+	// Everything already queued arrives first, then the notice.
+	for {
+		stream, payload, err := ReadFrame(conn)
+		assert.NilError(t, err)
+		if stream != StreamControl {
+			continue
+		}
+		var c Control
+		assert.NilError(t, json.Unmarshal(payload, &c))
+		if c.Type == ControlHello {
+			continue
+		}
+		assert.Equal(t, c.Type, ControlDropped)
+		return
+	}
+}
+
+func TestBrokerBoundsAQueueByBytesNotFrames(t *testing.T) {
+	t.Parallel()
+
+	// A TTY echoes single keystrokes. Counting frames would evict a session
+	// that is only a couple of kilobytes behind.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+	_ = conn
+
+	// Far more frames than the old 256-frame bound, but tiny ones.
+	for range 2000 {
+		b.Write(StreamStdout, []byte("x"))
+	}
+	assert.Equal(t, b.SessionCount(), 1)
+}

--- a/pkg/attachmux/broker_test.go
+++ b/pkg/attachmux/broker_test.go
@@ -1,0 +1,553 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// syncBuffer is an io.WriteCloser that records what the container's stdin
+// received. It is safe for concurrent use because several sessions may write
+// at once.
+type syncBuffer struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	closed bool
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
+
+func (s *syncBuffer) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// connect wires a new session into b over an in-memory connection and consumes
+// its hello message, returning the session's end of the pipe.
+func connect(t *testing.T, b *Broker) net.Conn {
+	t.Helper()
+
+	mine, theirs := net.Pipe()
+	t.Cleanup(func() { mine.Close() })
+
+	go b.addSession(theirs)
+
+	assert.NilError(t, mine.SetReadDeadline(time.Now().Add(5*time.Second)))
+	stream, payload, err := ReadFrame(mine)
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamControl)
+
+	var c Control
+	assert.NilError(t, json.Unmarshal(payload, &c))
+	assert.Equal(t, c.Type, ControlHello)
+	assert.Equal(t, c.Version, ProtocolVersion)
+
+	// Leave a deadline armed for the rest of the test rather than clearing it.
+	// net.Pipe refuses SetReadDeadline once the peer has closed, and the broker
+	// closes its end as soon as a session is dropped, so a test cannot reliably
+	// arm one later. This is only a guard against hanging.
+	assert.NilError(t, mine.SetReadDeadline(time.Now().Add(30*time.Second)))
+	return mine
+}
+
+// waitSessions blocks until the broker reports n sessions, or fails the test.
+func waitSessions(t *testing.T, b *Broker, n int) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.SessionCount() == n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("expected %d sessions, got %d", n, b.SessionCount())
+}
+
+func TestBrokerFansOutToEverySession(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker(true, nil)
+	first := connect(t, b)
+	second := connect(t, b)
+	waitSessions(t, b, 2)
+
+	b.Write(StreamStdout, []byte("shared output"))
+
+	for _, conn := range []net.Conn{first, second} {
+		stream, payload, err := ReadFrame(conn)
+		assert.NilError(t, err)
+		assert.Equal(t, stream, StreamStdout)
+		assert.Equal(t, string(payload), "shared output")
+	}
+}
+
+func TestBrokerMergesStdinFromEverySession(t *testing.T) {
+	t.Parallel()
+
+	stdin := &syncBuffer{}
+	b := NewBroker(false, stdin)
+	first := connect(t, b)
+	second := connect(t, b)
+	waitSessions(t, b, 2)
+
+	frame, err := EncodeFrame(StreamStdin, []byte("from-first\n"))
+	assert.NilError(t, err)
+	_, err = first.Write(frame)
+	assert.NilError(t, err)
+
+	frame, err = EncodeFrame(StreamStdin, []byte("from-second\n"))
+	assert.NilError(t, err)
+	_, err = second.Write(frame)
+	assert.NilError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got := stdin.String()
+		if len(got) == len("from-first\nfrom-second\n") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	got := stdin.String()
+	assert.Assert(t, bytes.Contains([]byte(got), []byte("from-first\n")), "got %q", got)
+	assert.Assert(t, bytes.Contains([]byte(got), []byte("from-second\n")), "got %q", got)
+}
+
+func TestBrokerDisconnectsASessionThatStopsReading(t *testing.T) {
+	t.Parallel()
+
+	// The container must never be held up by a session that stopped consuming.
+	b := NewBroker(true, nil)
+	stalled := connect(t, b)
+	waitSessions(t, b, 1)
+
+	// Never read from `stalled` again. Write far more than the session queue
+	// can hold; every call must return promptly.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range defaultQueueDepth * 4 {
+			b.Write(StreamStdout, []byte("x"))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Broker.Write blocked on a session that stopped reading")
+	}
+
+	waitSessions(t, b, 0)
+	assert.Assert(t, stalled != nil)
+}
+
+func TestBrokerKeepsRunningWithNoSessions(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker(true, nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			b.Write(StreamStdout, []byte("output with nobody attached"))
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Broker.Write blocked with no sessions attached")
+	}
+}
+
+func TestBrokerDoesNotCloseStdinWhenASessionLeaves(t *testing.T) {
+	t.Parallel()
+
+	// Detaching must not send EOF to the container: this is what makes
+	// ctrl-p ctrl-q leave a container running.
+	stdin := &syncBuffer{}
+	b := NewBroker(false, stdin)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	assert.NilError(t, conn.Close())
+	waitSessions(t, b, 0)
+
+	assert.Equal(t, stdin.isClosed(), false)
+}
+
+func TestBrokerAcceptsStdinAfterASessionConnects(t *testing.T) {
+	t.Parallel()
+
+	// The owner opens the container's stdin FIFO off the path that reads its
+	// output, so stdin can arrive after sessions are already streaming. A
+	// session that connected first still has to reach the container once it
+	// does.
+	//
+	// Input sent before stdin is installed is dropped rather than buffered,
+	// which readLoop documents, but a test cannot pin that down: net.Pipe
+	// reports a write as complete once the peer has read the bytes, not once
+	// readLoop has acted on them, so SetStdin can always land in between.
+	b := NewBroker(false, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	stdin := &syncBuffer{}
+	assert.Equal(t, b.SetStdin(stdin), true)
+
+	frame, err := EncodeFrame(StreamStdin, []byte("late"))
+	assert.NilError(t, err)
+	_, err = conn.Write(frame)
+	assert.NilError(t, err)
+
+	for range 100 {
+		if stdin.String() == "late" {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("stdin did not reach the broker, got %q", stdin.String())
+}
+
+func TestBrokerCloseReleasesStdin(t *testing.T) {
+	t.Parallel()
+
+	// The container has exited, so nothing can read its stdin any more. Leaving
+	// the descriptor open would keep the FIFO alive for as long as the logging
+	// process lives.
+	stdin := &syncBuffer{}
+	b := NewBroker(false, stdin)
+	b.Close(true)
+	assert.Equal(t, stdin.isClosed(), true)
+
+	assert.Equal(t, b.SetStdin(&syncBuffer{}), false)
+}
+
+// blockingWriter models the container's stdin FIFO when the container has
+// stopped reading it: the write blocks until the descriptor is closed.
+type blockingWriter struct {
+	released chan struct{}
+	once     sync.Once
+}
+
+func newBlockingWriter() *blockingWriter {
+	return &blockingWriter{released: make(chan struct{})}
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	<-w.released
+	return 0, os.ErrClosed
+}
+
+func (w *blockingWriter) Close() error {
+	w.once.Do(func() { close(w.released) })
+	return nil
+}
+
+func TestBrokerCloseDoesNotWaitForABlockedStdinWrite(t *testing.T) {
+	t.Parallel()
+
+	// A container that stopped reading its stdin leaves a session's write
+	// blocked on a full FIFO. Close has to release the descriptor rather than
+	// queue behind that write: it runs on SIGTERM, and the logging process is
+	// killed shortly after it returns.
+	stdin := newBlockingWriter()
+	b := NewBroker(false, stdin)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	frame, err := EncodeFrame(StreamStdin, []byte("blocked"))
+	assert.NilError(t, err)
+	_, err = conn.Write(frame)
+	assert.NilError(t, err)
+
+	// Give readLoop time to reach the write before closing.
+	time.Sleep(100 * time.Millisecond)
+
+	done := make(chan struct{})
+	go func() {
+		b.Close(true)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close blocked behind a stdin write")
+	}
+
+	// And the session still learns that the container exited. Releasing stdin
+	// wakes the blocked readLoop, whose dropSession closes this session's queue,
+	// so the exit has to be queued before that happens.
+	for {
+		stream, payload, err := ReadFrame(conn)
+		assert.NilError(t, err)
+		if stream != StreamControl {
+			continue
+		}
+		var c Control
+		assert.NilError(t, json.Unmarshal(payload, &c))
+		if c.Type == ControlHello {
+			continue
+		}
+		assert.Equal(t, c.Type, ControlExit)
+		return
+	}
+}
+
+func TestBrokerSetStdinRacesWithClose(t *testing.T) {
+	t.Parallel()
+
+	// startBroker opens the container's stdin in the background, so SetStdin
+	// can land at any moment, including after the container has exited. The
+	// loser of that race has to be told, so that it closes its own descriptor
+	// instead of leaking it.
+	for range 200 {
+		b := NewBroker(false, nil)
+		stdin := &syncBuffer{}
+
+		var wg sync.WaitGroup
+		var took bool
+		wg.Go(func() { took = b.SetStdin(stdin) })
+		wg.Go(func() { b.Close(true) })
+		wg.Wait()
+
+		// Whoever ended up owning it closed it: SetStdin lost and the caller
+		// closes, or SetStdin won and Close took it.
+		if !took {
+			stdin.Close()
+		}
+		assert.Equal(t, stdin.isClosed(), true)
+	}
+}
+
+func TestBrokerCloseWithoutAnExitDoesNotAnnounceOne(t *testing.T) {
+	t.Parallel()
+
+	// The owner's stdio ending is not proof that the container exited: the same
+	// thing happens when the logging process is shut down while the container
+	// keeps running. A session told otherwise would wait for an exit code that
+	// never arrives.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	b.Close(false)
+
+	for {
+		stream, payload, err := ReadFrame(conn)
+		if err != nil {
+			// EOF with no exit frame, which is what a broken session looks like.
+			return
+		}
+		if stream != StreamControl {
+			continue
+		}
+		var c Control
+		assert.NilError(t, json.Unmarshal(payload, &c))
+		assert.Assert(t, c.Type != ControlExit, "Close(false) announced an exit")
+	}
+}
+
+func TestBrokerCloseDeliversTheExitPastAFullQueue(t *testing.T) {
+	t.Parallel()
+
+	// A session whose queue is exactly full has received all of the container's
+	// output and is not behind. Pushing the exit through that same queue would
+	// drop it, and the client would report a lost connection for a container
+	// that finished normally.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	// Fill the queue without draining the connection.
+	for range defaultQueueDepth {
+		b.Write(StreamStdout, []byte("x"))
+	}
+	b.Close(true)
+
+	for {
+		stream, payload, err := ReadFrame(conn)
+		assert.NilError(t, err)
+		if stream != StreamControl {
+			continue
+		}
+		var c Control
+		assert.NilError(t, json.Unmarshal(payload, &c))
+		if c.Type == ControlHello {
+			continue
+		}
+		assert.Equal(t, c.Type, ControlExit)
+		return
+	}
+}
+
+func TestBrokerCloseAnnouncesExit(t *testing.T) {
+	t.Parallel()
+
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	b.Close(true)
+
+	stream, payload, err := ReadFrame(conn)
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamControl)
+
+	var c Control
+	assert.NilError(t, json.Unmarshal(payload, &c))
+	assert.Equal(t, c.Type, ControlExit)
+
+	// The broker closes the connection right after announcing the exit.
+	_, _, err = ReadFrame(conn)
+	assert.Assert(t, err != nil)
+}
+
+func TestBrokerCloseFlushesQueuedFrames(t *testing.T) {
+	t.Parallel()
+
+	// containerd calls os.Exit as soon as the logging function returns, so
+	// whatever Close leaves queued is lost. The container's last chunk of
+	// output has to reach the session before Close returns.
+	b := NewBroker(true, nil)
+	conn := connect(t, b)
+	waitSessions(t, b, 1)
+
+	type frame struct {
+		stream  byte
+		payload []byte
+	}
+	frames := make(chan frame, 8)
+	go func() {
+		for {
+			stream, payload, err := ReadFrame(conn)
+			if err != nil {
+				close(frames)
+				return
+			}
+			frames <- frame{stream, payload}
+		}
+	}()
+
+	b.Write(StreamStdout, []byte("last words"))
+	b.Close(true)
+
+	var sawOutput, sawExit bool
+	for range 2 {
+		select {
+		case f, ok := <-frames:
+			if !ok {
+				t.Fatal("the connection closed before the queued frames arrived")
+			}
+			if f.stream == StreamStdout && string(f.payload) == "last words" {
+				sawOutput = true
+			}
+			if f.stream == StreamControl {
+				sawExit = true
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out reading the frames Close should have flushed")
+		}
+	}
+	assert.Assert(t, sawOutput, "the container's last output was dropped by Close")
+	assert.Assert(t, sawExit, "the exit message was dropped by Close")
+}
+
+func TestBrokerCloseRacesWithDisconnectingSessions(t *testing.T) {
+	t.Parallel()
+
+	// A container exiting at the same moment as a session detaches must not
+	// send on a channel that dropSession has just closed. That would panic, and
+	// since the broker lives inside the logging process it would take logging
+	// down with it. Run with -race.
+	for range 50 {
+		b := NewBroker(true, nil)
+		conns := make([]net.Conn, 0, 4)
+		for range 4 {
+			conns = append(conns, connect(t, b))
+		}
+		waitSessions(t, b, 4)
+
+		var wg sync.WaitGroup
+		for _, conn := range conns {
+			wg.Go(func() { conn.Close() })
+		}
+		wg.Go(func() { b.Close(true) })
+		wg.Wait()
+	}
+}
+
+func TestBrokerServeAcceptsSessions(t *testing.T) {
+	t.Parallel()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NilError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	b := NewBroker(true, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	served := make(chan error, 1)
+	go func() { served <- b.Serve(ctx, l) }()
+
+	conn, err := net.Dial("tcp", l.Addr().String())
+	assert.NilError(t, err)
+	t.Cleanup(func() { conn.Close() })
+
+	stream, _, err := ReadFrame(conn)
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamControl)
+
+	cancel()
+	select {
+	case err := <-served:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not return after the context was cancelled")
+	}
+}

--- a/pkg/attachmux/client.go
+++ b/pkg/attachmux/client.go
@@ -1,0 +1,180 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+// Session is a client's end of an attach connection.
+type Session struct {
+	conn  net.Conn
+	hello Control
+
+	// writeMu serialises writes to the connection.
+	writeMu sync.Mutex
+
+	exitMu sync.Mutex
+	exited bool
+}
+
+// NewSession completes the handshake on conn and returns the session. The
+// caller keeps ownership of conn: closing the Session closes it.
+func NewSession(conn net.Conn) (*Session, error) {
+	stream, payload, err := ReadFrame(conn)
+	if err != nil {
+		return nil, fmt.Errorf("attachmux: failed to read the greeting: %w", err)
+	}
+	if stream != StreamControl {
+		return nil, fmt.Errorf("attachmux: expected a control greeting, got stream %d", stream)
+	}
+	var hello Control
+	if err := json.Unmarshal(payload, &hello); err != nil {
+		return nil, fmt.Errorf("attachmux: failed to decode the greeting: %w", err)
+	}
+	if hello.Type != ControlHello {
+		return nil, fmt.Errorf("attachmux: expected a hello, got %q", hello.Type)
+	}
+	if hello.Version != ProtocolVersion {
+		return nil, fmt.Errorf("attachmux: unsupported protocol version %d, expected %d", hello.Version, ProtocolVersion)
+	}
+	return &Session{conn: conn, hello: hello}, nil
+}
+
+// TTY reports whether the container was created with a terminal, in which case
+// it has a single output stream.
+func (s *Session) TTY() bool { return s.hello.TTY }
+
+// Exited reports whether Stream returned because the broker announced that the
+// container is gone, as opposed to the user detaching or the context ending.
+// The exit code itself comes from containerd.
+func (s *Session) Exited() bool {
+	s.exitMu.Lock()
+	defer s.exitMu.Unlock()
+	return s.exited
+}
+
+// Close closes the session's connection.
+func (s *Session) Close() error { return s.conn.Close() }
+
+func (s *Session) writeFrame(frame []byte) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	_, err := s.conn.Write(frame)
+	return err
+}
+
+// Stream pumps the session until the broker announces the container's exit, the
+// connection is closed, or ctx is done. Container output goes to stdout and
+// stderr; when stderr is nil, the container's stderr is merged into stdout,
+// which is what a TTY container needs.
+//
+// When stdin is non-nil, it is copied to the container in the background.
+// Stream does not wait for that copy: a reader that is detachable returns an
+// error when the user types the detach sequence, and the caller tears the
+// session down.
+func (s *Session) Stream(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) error {
+	if stdin != nil {
+		go s.pumpStdin(stdin)
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.conn.Close()
+		case <-done:
+		}
+	}()
+
+	for {
+		stream, payload, err := ReadFrame(s.conn)
+		if err != nil {
+			if ctx.Err() != nil {
+				// The caller ended this session: a detach, or a cancelled
+				// command. That is a normal outcome.
+				return nil
+			}
+			// Anything else is the broker going away without saying the
+			// container exited: the logging process died, or this session was
+			// dropped for falling behind. Reporting nil here would look exactly
+			// like a clean detach and the command would exit 0.
+			if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) {
+				return fmt.Errorf("attachmux: lost the connection to the container attach socket: %w", err)
+			}
+			return err
+		}
+
+		switch stream {
+		case StreamStdout:
+			if stdout == nil {
+				continue
+			}
+			if _, err := stdout.Write(payload); err != nil {
+				return err
+			}
+		case StreamStderr:
+			w := stderr
+			if w == nil {
+				w = stdout
+			}
+			if w == nil {
+				continue
+			}
+			if _, err := w.Write(payload); err != nil {
+				return err
+			}
+		case StreamControl:
+			var c Control
+			if err := json.Unmarshal(payload, &c); err != nil {
+				continue
+			}
+			if c.Type == ControlExit {
+				s.exitMu.Lock()
+				s.exited = true
+				s.exitMu.Unlock()
+				return nil
+			}
+		}
+	}
+}
+
+func (s *Session) pumpStdin(stdin io.Reader) {
+	buf := make([]byte, 32<<10)
+	for {
+		n, err := stdin.Read(buf)
+		if n > 0 {
+			frame, ferr := EncodeFrame(StreamStdin, buf[:n])
+			if ferr != nil {
+				return
+			}
+			if werr := s.writeFrame(frame); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/pkg/attachmux/client.go
+++ b/pkg/attachmux/client.go
@@ -34,8 +34,17 @@ type Session struct {
 	// writeMu serialises writes to the connection.
 	writeMu sync.Mutex
 
+	// exitMu guards exited and closedByCaller.
 	exitMu sync.Mutex
 	exited bool
+	// closedByCaller records that Close was called, so that Stream can tell a
+	// deliberate teardown from the broker vanishing.
+	closedByCaller bool
+
+	// stopStdin is closed when Stream returns, so that the stdin pump stops
+	// forwarding what it is about to read. It is only set up when Stream was
+	// given a stdin.
+	stopStdin chan struct{}
 }
 
 // NewSession completes the handshake on conn and returns the session. The
@@ -75,7 +84,21 @@ func (s *Session) Exited() bool {
 }
 
 // Close closes the session's connection.
-func (s *Session) Close() error { return s.conn.Close() }
+// Close tears the session down. A Stream running concurrently returns nil
+// rather than an error: this is the caller ending the session, not the broker
+// going away.
+func (s *Session) wasClosedByCaller() bool {
+	s.exitMu.Lock()
+	defer s.exitMu.Unlock()
+	return s.closedByCaller
+}
+
+func (s *Session) Close() error {
+	s.exitMu.Lock()
+	s.closedByCaller = true
+	s.exitMu.Unlock()
+	return s.conn.Close()
+}
 
 func (s *Session) writeFrame(frame []byte) error {
 	s.writeMu.Lock()
@@ -95,6 +118,7 @@ func (s *Session) writeFrame(frame []byte) error {
 // session down.
 func (s *Session) Stream(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer) error {
 	if stdin != nil {
+		s.stopStdin = make(chan struct{})
 		go s.pumpStdin(stdin)
 	}
 
@@ -108,12 +132,20 @@ func (s *Session) Stream(ctx context.Context, stdin io.Reader, stdout, stderr io
 		}
 	}()
 
+	if stdin != nil {
+		// pumpStdin blocks in stdin.Read and cannot be interrupted, so it is
+		// left to end on its own. Tell it to stop forwarding once Stream is
+		// done, otherwise the keystroke it is already waiting for is swallowed
+		// from the terminal rather than reaching whatever runs next.
+		defer close(s.stopStdin)
+	}
+
 	for {
 		stream, payload, err := ReadFrame(s.conn)
 		if err != nil {
-			if ctx.Err() != nil {
-				// The caller ended this session: a detach, or a cancelled
-				// command. That is a normal outcome.
+			if ctx.Err() != nil || s.wasClosedByCaller() {
+				// The caller ended this session: a detach, a cancelled command,
+				// or an explicit Close. That is a normal outcome.
 				return nil
 			}
 			// Anything else is the broker going away without saying the
@@ -165,6 +197,12 @@ func (s *Session) pumpStdin(stdin io.Reader) {
 	for {
 		n, err := stdin.Read(buf)
 		if n > 0 {
+			select {
+			case <-s.stopStdin:
+				// Stream has returned; this session is over.
+				return
+			default:
+			}
 			frame, ferr := EncodeFrame(StreamStdin, buf[:n])
 			if ferr != nil {
 				return

--- a/pkg/attachmux/client.go
+++ b/pkg/attachmux/client.go
@@ -64,8 +64,13 @@ func NewSession(conn net.Conn) (*Session, error) {
 	if hello.Type != ControlHello {
 		return nil, fmt.Errorf("attachmux: expected a hello, got %q", hello.Type)
 	}
-	if hello.Version != ProtocolVersion {
-		return nil, fmt.Errorf("attachmux: unsupported protocol version %d, expected %d", hello.Version, ProtocolVersion)
+	// Only a broker newer than this client is refused. A broker lives as long
+	// as its container, so after a nerdctl upgrade a new client routinely meets
+	// an older one, and there is no falling back: the container's stdio is
+	// already bound to that process. A client can read a framing older than its
+	// own; it cannot read a newer one.
+	if hello.Version > ProtocolVersion {
+		return nil, fmt.Errorf("attachmux: the container's attach socket speaks protocol version %d, this nerdctl understands up to %d", hello.Version, ProtocolVersion)
 	}
 	return &Session{conn: conn, hello: hello}, nil
 }
@@ -182,11 +187,17 @@ func (s *Session) Stream(ctx context.Context, stdin io.Reader, stdout, stderr io
 			if err := json.Unmarshal(payload, &c); err != nil {
 				continue
 			}
-			if c.Type == ControlExit {
+			switch c.Type {
+			case ControlExit:
 				s.exitMu.Lock()
 				s.exited = true
 				s.exitMu.Unlock()
 				return nil
+			case ControlDropped:
+				// The broker evicted this session for falling behind. Saying so
+				// is the whole point of the frame: otherwise this is
+				// indistinguishable from the broker dying.
+				return errors.New("attachmux: this session was disconnected because it could not keep up with the container's output")
 			}
 		}
 	}

--- a/pkg/attachmux/client_test.go
+++ b/pkg/attachmux/client_test.go
@@ -263,3 +263,43 @@ func TestSessionStreamTreatsAnExplicitCloseAsClean(t *testing.T) {
 		t.Fatal("Stream did not return after Close")
 	}
 }
+
+func TestSessionAcceptsAnOlderBroker(t *testing.T) {
+	t.Parallel()
+
+	// A broker lives as long as its container, so after an upgrade a new client
+	// routinely meets an older one, and it has nowhere to fall back to: the
+	// container's stdio is already bound to that process.
+	mine, theirs := net.Pipe()
+	t.Cleanup(func() { mine.Close() })
+
+	go func() {
+		frame, err := EncodeControl(Control{Type: ControlHello, Version: ProtocolVersion - 1, TTY: true})
+		if err != nil {
+			return
+		}
+		theirs.Write(frame)
+	}()
+
+	session, err := NewSession(mine)
+	assert.NilError(t, err)
+	assert.Equal(t, session.TTY(), true)
+}
+
+func TestSessionRefusesANewerBroker(t *testing.T) {
+	t.Parallel()
+
+	mine, theirs := net.Pipe()
+	t.Cleanup(func() { mine.Close() })
+
+	go func() {
+		frame, err := EncodeControl(Control{Type: ControlHello, Version: ProtocolVersion + 1})
+		if err != nil {
+			return
+		}
+		theirs.Write(frame)
+	}()
+
+	_, err := NewSession(mine)
+	assert.ErrorContains(t, err, "understands up to")
+}

--- a/pkg/attachmux/client_test.go
+++ b/pkg/attachmux/client_test.go
@@ -1,0 +1,240 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+// lockedBuffer is an io.Writer safe for concurrent use.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *lockedBuffer) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *lockedBuffer) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+// dropAllSessions disconnects every session without announcing an exit, which
+// is what a broker whose process died looks like from the client side.
+func dropAllSessions(b *Broker) {
+	b.mu.Lock()
+	sessions := make([]*session, 0, len(b.sessions))
+	for s := range b.sessions {
+		sessions = append(sessions, s)
+	}
+	b.sessions = map[*session]struct{}{}
+	b.mu.Unlock()
+
+	for _, s := range sessions {
+		s.close()
+	}
+}
+
+// pair returns a broker and a session connected to it over an in-memory pipe.
+func pair(t *testing.T, tty bool, stdin io.WriteCloser) (*Broker, *Session) {
+	t.Helper()
+
+	b := NewBroker(tty, stdin)
+	mine, theirs := net.Pipe()
+	t.Cleanup(func() { mine.Close() })
+
+	go b.addSession(theirs)
+
+	s, err := NewSession(mine)
+	assert.NilError(t, err)
+	return b, s
+}
+
+func TestSessionHandshakeReportsTTY(t *testing.T) {
+	t.Parallel()
+
+	_, s := pair(t, true, nil)
+	assert.Equal(t, s.TTY(), true)
+}
+
+func TestSessionStreamsOutput(t *testing.T) {
+	t.Parallel()
+
+	b, s := pair(t, false, nil)
+	waitSessions(t, b, 1)
+
+	stdout := &lockedBuffer{}
+	stderr := &lockedBuffer{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- s.Stream(ctx, nil, stdout, stderr) }()
+
+	b.Write(StreamStdout, []byte("to stdout"))
+	b.Write(StreamStderr, []byte("to stderr"))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if stdout.String() == "to stdout" && stderr.String() == "to stderr" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.Equal(t, stdout.String(), "to stdout")
+	assert.Equal(t, stderr.String(), "to stderr")
+
+	b.Close(true)
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not return after the broker announced the exit")
+	}
+
+	assert.Equal(t, s.Exited(), true)
+}
+
+func TestSessionExitedIsFalseAfterADetach(t *testing.T) {
+	t.Parallel()
+
+	// Detaching closes the connection without an exit message. The caller uses
+	// this to tell "the user detached" from "the container is gone".
+	b, s := pair(t, true, nil)
+	waitSessions(t, b, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Stream(ctx, nil, io.Discard, nil) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not return after the context was cancelled")
+	}
+
+	assert.Equal(t, s.Exited(), false)
+}
+
+func TestSessionMergesStderrIntoStdoutWhenNoStderrWriter(t *testing.T) {
+	t.Parallel()
+
+	// With a TTY there is a single stream, and callers pass a nil stderr.
+	b, s := pair(t, true, nil)
+	waitSessions(t, b, 1)
+
+	stdout := &lockedBuffer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() { _ = s.Stream(ctx, nil, stdout, nil) }()
+
+	b.Write(StreamStderr, []byte("merged"))
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if stdout.String() == "merged" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("stderr was not merged into stdout, got %q", stdout.String())
+}
+
+func TestSessionSendsStdin(t *testing.T) {
+	t.Parallel()
+
+	stdin := &syncBuffer{}
+	b, s := pair(t, false, stdin)
+	waitSessions(t, b, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() { _ = s.Stream(ctx, strings.NewReader("typed input\n"), io.Discard, nil) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if stdin.String() == "typed input\n" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("stdin did not reach the broker, got %q", stdin.String())
+}
+
+func TestSessionStreamReportsAnUnexpectedDisconnect(t *testing.T) {
+	t.Parallel()
+
+	// The broker dying is not the same as the user detaching. If it were
+	// reported as a clean end of session, the command would exit 0 and the user
+	// would never learn that the container's output stopped being delivered.
+	b, s := pair(t, true, nil)
+	waitSessions(t, b, 1)
+
+	ctx := context.Background()
+	done := make(chan error, 1)
+	go func() { done <- s.Stream(ctx, nil, io.Discard, nil) }()
+
+	// Drop the session the way a dead broker would: close the connection
+	// without sending an exit message.
+	dropAllSessions(b)
+
+	select {
+	case err := <-done:
+		assert.Assert(t, err != nil, "an unexpected disconnect was reported as a clean detach")
+		assert.Equal(t, s.Exited(), false)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not return after the broker went away")
+	}
+}
+
+func TestSessionStreamReturnsWhenContextIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	b, s := pair(t, true, nil)
+	waitSessions(t, b, 1)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Stream(ctx, nil, io.Discard, nil) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not return after the context was cancelled")
+	}
+}

--- a/pkg/attachmux/client_test.go
+++ b/pkg/attachmux/client_test.go
@@ -238,3 +238,28 @@ func TestSessionStreamReturnsWhenContextIsCancelled(t *testing.T) {
 		t.Fatal("Stream did not return after the context was cancelled")
 	}
 }
+
+func TestSessionStreamTreatsAnExplicitCloseAsClean(t *testing.T) {
+	t.Parallel()
+
+	// Stream's own doc says the caller tears the session down, and Close is the
+	// obvious way. Reporting that as a lost connection would be the same false
+	// positive the unexpected-disconnect branch exists to avoid.
+	b, session := pair(t, true, nil)
+	_ = b
+
+	streamed := make(chan error, 1)
+	go func() {
+		streamed <- session.Stream(context.Background(), nil, io.Discard, nil)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	assert.NilError(t, session.Close())
+
+	select {
+	case err := <-streamed:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stream did not return after Close")
+	}
+}

--- a/pkg/attachmux/proto.go
+++ b/pkg/attachmux/proto.go
@@ -45,10 +45,19 @@ const (
 	// carries no exit code: a session reads that from containerd, so that there
 	// is a single source of truth for it.
 	ControlExit = "exit"
+	// ControlDropped is sent to a session that fell too far behind, right
+	// before it is disconnected. Without it a client cannot tell being evicted
+	// from the broker dying, and reports both as a lost connection.
+	ControlDropped = "dropped"
 )
 
-// ProtocolVersion is announced in the hello message so that a future change to
-// the framing can be detected by an older client.
+// ProtocolVersion is announced in the hello message so that a change to the
+// framing can be detected.
+//
+// The compatibility rule is one-sided: a client refuses a broker whose version
+// is higher than its own, and accepts anything lower. A broker lives as long as
+// its container, so a client that is newer than the broker is the normal case
+// after an upgrade, and it has nowhere to fall back to.
 const ProtocolVersion = 1
 
 const (

--- a/pkg/attachmux/proto.go
+++ b/pkg/attachmux/proto.go
@@ -1,0 +1,113 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package attachmux multiplexes a container's stdio between the process that
+// owns it and any number of attached CLI sessions.
+//
+// A container's stdio FIFOs cannot be shared: a FIFO has a single queue, so two
+// readers on the stdout FIFO each receive a random subset of the container's
+// output. Instead, one process owns the FIFOs and every session talks to it
+// over a socket, framed with the protocol in this file.
+package attachmux
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Stream identifiers carried in a frame header.
+const (
+	StreamStdin   byte = 0
+	StreamStdout  byte = 1
+	StreamStderr  byte = 2
+	StreamControl byte = 3
+)
+
+// Types of a StreamControl message.
+const (
+	// ControlHello is sent by the broker to a session as soon as it connects.
+	ControlHello = "hello"
+	// ControlExit is sent by the broker when the container has exited. It
+	// carries no exit code: a session reads that from containerd, so that there
+	// is a single source of truth for it.
+	ControlExit = "exit"
+)
+
+// ProtocolVersion is announced in the hello message so that a future change to
+// the framing can be detected by an older client.
+const ProtocolVersion = 1
+
+const (
+	headerSize = 8
+	// maxPayload bounds a single frame so that a corrupt or hostile peer cannot
+	// make the reader allocate without limit. Container output is read in 32 KiB
+	// chunks, so this is never hit in practice.
+	maxPayload = 1 << 20
+)
+
+// ErrPayloadTooLarge is returned for a frame whose payload exceeds maxPayload.
+var ErrPayloadTooLarge = errors.New("attachmux: frame payload too large")
+
+// Control is the JSON body of a StreamControl frame.
+type Control struct {
+	Type    string `json:"type"`
+	Version int    `json:"version,omitempty"`
+	TTY     bool   `json:"tty,omitempty"`
+}
+
+// EncodeFrame returns the wire representation of a single frame: one stream
+// byte, three reserved zero bytes, a big-endian uint32 payload length, then the
+// payload.
+func EncodeFrame(stream byte, payload []byte) ([]byte, error) {
+	if len(payload) > maxPayload {
+		return nil, fmt.Errorf("%w: %d bytes", ErrPayloadTooLarge, len(payload))
+	}
+	buf := make([]byte, headerSize+len(payload))
+	buf[0] = stream
+	binary.BigEndian.PutUint32(buf[4:headerSize], uint32(len(payload)))
+	copy(buf[headerSize:], payload)
+	return buf, nil
+}
+
+// EncodeControl returns a StreamControl frame carrying c.
+func EncodeControl(c Control) ([]byte, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return nil, err
+	}
+	return EncodeFrame(StreamControl, b)
+}
+
+// ReadFrame reads exactly one frame. The returned payload is a fresh slice
+// owned by the caller.
+func ReadFrame(r io.Reader) (stream byte, payload []byte, err error) {
+	var hdr [headerSize]byte
+	if _, err = io.ReadFull(r, hdr[:]); err != nil {
+		return 0, nil, err
+	}
+	n := binary.BigEndian.Uint32(hdr[4:headerSize])
+	if n > maxPayload {
+		return 0, nil, fmt.Errorf("%w: %d bytes", ErrPayloadTooLarge, n)
+	}
+	payload = make([]byte, n)
+	if _, err = io.ReadFull(r, payload); err != nil {
+		return 0, nil, err
+	}
+	return hdr[0], payload, nil
+}

--- a/pkg/attachmux/proto.go
+++ b/pkg/attachmux/proto.go
@@ -14,13 +14,6 @@
    limitations under the License.
 */
 
-// Package attachmux multiplexes a container's stdio between the process that
-// owns it and any number of attached CLI sessions.
-//
-// A container's stdio FIFOs cannot be shared: a FIFO has a single queue, so two
-// readers on the stdout FIFO each receive a random subset of the container's
-// output. Instead, one process owns the FIFOs and every session talks to it
-// over a socket, framed with the protocol in this file.
 package attachmux
 
 import (
@@ -30,6 +23,11 @@ import (
 	"fmt"
 	"io"
 )
+
+// The wire format between the broker and its sessions: one stream byte, three
+// reserved zero bytes, a big-endian uint32 payload length, then the payload.
+// This is the same shape docker uses for its multiplexed stdio, with stream 3
+// added for control messages.
 
 // Stream identifiers carried in a frame header.
 const (

--- a/pkg/attachmux/proto_test.go
+++ b/pkg/attachmux/proto_test.go
@@ -1,0 +1,158 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestEncodeFrameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		stream  byte
+		payload []byte
+	}{
+		{"stdout", StreamStdout, []byte("hello")},
+		{"stderr", StreamStderr, []byte("oops")},
+		{"stdin", StreamStdin, []byte{0x16, 0x11}},
+		{"empty", StreamStdout, []byte{}},
+		{"binary", StreamStdout, []byte{0x00, 0xff, 0x1b, 0x5b, 0x41}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			frame, err := EncodeFrame(tc.stream, tc.payload)
+			assert.NilError(t, err)
+
+			stream, payload, err := ReadFrame(bytes.NewReader(frame))
+			assert.NilError(t, err)
+			assert.Equal(t, stream, tc.stream)
+			assert.DeepEqual(t, payload, tc.payload)
+		})
+	}
+}
+
+func TestReadFrameConsecutive(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	for _, s := range []string{"one", "two", "three"} {
+		frame, err := EncodeFrame(StreamStdout, []byte(s))
+		assert.NilError(t, err)
+		buf.Write(frame)
+	}
+
+	for _, want := range []string{"one", "two", "three"} {
+		stream, payload, err := ReadFrame(&buf)
+		assert.NilError(t, err)
+		assert.Equal(t, stream, StreamStdout)
+		assert.Equal(t, string(payload), want)
+	}
+
+	_, _, err := ReadFrame(&buf)
+	assert.ErrorIs(t, err, io.EOF)
+}
+
+func TestEncodeFrameRejectsOversizedPayload(t *testing.T) {
+	t.Parallel()
+
+	_, err := EncodeFrame(StreamStdout, make([]byte, maxPayload+1))
+	assert.ErrorIs(t, err, ErrPayloadTooLarge)
+}
+
+func TestReadFrameRejectsOversizedHeader(t *testing.T) {
+	t.Parallel()
+
+	// A header announcing more than maxPayload must be refused before the
+	// reader allocates for it.
+	hdr := []byte{StreamStdout, 0, 0, 0, 0xff, 0xff, 0xff, 0xff}
+	_, _, err := ReadFrame(bytes.NewReader(hdr))
+	assert.ErrorIs(t, err, ErrPayloadTooLarge)
+}
+
+func TestReadFrameTruncated(t *testing.T) {
+	t.Parallel()
+
+	frame, err := EncodeFrame(StreamStdout, []byte("hello"))
+	assert.NilError(t, err)
+
+	_, _, err = ReadFrame(bytes.NewReader(frame[:len(frame)-2]))
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestEncodeControl(t *testing.T) {
+	t.Parallel()
+
+	frame, err := EncodeControl(Control{Type: ControlHello, Version: ProtocolVersion, TTY: true})
+	assert.NilError(t, err)
+
+	stream, payload, err := ReadFrame(bytes.NewReader(frame))
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamControl)
+
+	var c Control
+	assert.NilError(t, json.Unmarshal(payload, &c))
+	assert.Equal(t, c.Type, ControlHello)
+	assert.Equal(t, c.Version, 1)
+	assert.Equal(t, c.TTY, true)
+}
+
+func TestEncodeControlExitCarriesNoCode(t *testing.T) {
+	t.Parallel()
+
+	// The exit message only says the container is gone. The exit code always
+	// comes from containerd, so that there is one source of truth for it.
+	frame, err := EncodeControl(Control{Type: ControlExit})
+	assert.NilError(t, err)
+
+	_, payload, err := ReadFrame(bytes.NewReader(frame))
+	assert.NilError(t, err)
+	assert.Equal(t, string(payload), `{"type":"exit"}`)
+}
+
+func TestReadFrameFromStream(t *testing.T) {
+	t.Parallel()
+
+	// A reader that hands out one byte at a time still yields a whole frame.
+	frame, err := EncodeFrame(StreamStdout, []byte("drip"))
+	assert.NilError(t, err)
+
+	stream, payload, err := ReadFrame(iotest(strings.NewReader(string(frame))))
+	assert.NilError(t, err)
+	assert.Equal(t, stream, StreamStdout)
+	assert.Equal(t, string(payload), "drip")
+}
+
+// iotest wraps r so that each Read returns at most one byte.
+func iotest(r io.Reader) io.Reader { return &oneByteReader{r: r} }
+
+type oneByteReader struct{ r io.Reader }
+
+func (o *oneByteReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return o.r.Read(p[:1])
+}

--- a/pkg/attachmux/socket_supported.go
+++ b/pkg/attachmux/socket_supported.go
@@ -100,7 +100,55 @@ func Listen(path string) (net.Listener, error) {
 		l.Close()
 		return nil, err
 	}
-	return l, nil
+
+	// Go removes the socket on Close by path, without checking that the file is
+	// still the one it created. Two brokers can briefly overlap for a single
+	// container: the restart monitor creates the new task, and with it a new
+	// logging process, while the old one is still finishing its log driver. The
+	// new broker taking the path over is correct, since it is the one attached
+	// to the live task, but the old one exiting afterwards would then unlink
+	// the live socket and leave the new broker listening on an inode nobody can
+	// reach. So the removal is done here instead, against the inode.
+	ul, ok := l.(*net.UnixListener)
+	if !ok {
+		return l, nil
+	}
+	ul.SetUnlinkOnClose(false)
+	ino, err := inodeOf(path)
+	if err != nil {
+		l.Close()
+		return nil, err
+	}
+	return &ownedListener{UnixListener: ul, path: path, ino: ino}, nil
+}
+
+// ownedListener removes its socket file on Close, but only while that file is
+// still the one Listen created.
+type ownedListener struct {
+	*net.UnixListener
+	path string
+	ino  uint64
+}
+
+func (l *ownedListener) Close() error {
+	err := l.UnixListener.Close()
+	if ino, serr := inodeOf(l.path); serr == nil && ino == l.ino {
+		os.Remove(l.path)
+	}
+	return err
+}
+
+func inodeOf(path string) (uint64, error) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("attachmux: cannot read the inode of %s", path)
+	}
+	// Ino is uint64 on both platforms this file is built for.
+	return st.Ino, nil
 }
 
 const (

--- a/pkg/attachmux/socket_supported.go
+++ b/pkg/attachmux/socket_supported.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -58,8 +59,15 @@ func Probe(dataStore string) error {
 	// concurrent calls inside one process do not either. Real names are hex
 	// digests, so a name starting with "probe" cannot collide with one.
 	name := fmt.Sprintf("probe%d-%d", os.Getpid(), probeSeq.Add(1))
-	if len(name) < socketNameLen {
+	switch {
+	case len(name) < socketNameLen:
 		name += strings.Repeat("p", socketNameLen-len(name))
+	case len(name) > socketNameLen:
+		// A large pid plus the counter can overrun. Trim rather than probe with
+		// a longer name than a real socket: the point is to test a path of
+		// representative length, and a longer one would reject a data store
+		// that in fact fits.
+		name = name[:socketNameLen]
 	}
 	path := filepath.Join(dir, name+".sock")
 
@@ -100,6 +108,9 @@ const (
 	dialTimeout = 5 * time.Second
 	// dialInterval is how often Dial retries while waiting.
 	dialInterval = 20 * time.Millisecond
+	// refusedGrace bounds how long Dial keeps retrying after a connection was
+	// refused, which unlike a missing socket means nothing is listening.
+	refusedGrace = 200 * time.Millisecond
 )
 
 // Dial connects to the attach socket at path and completes the handshake.
@@ -113,6 +124,7 @@ func Dial(ctx context.Context, path string) (*Session, error) {
 	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
 	defer cancel()
 
+	refusedDeadline := time.Now().Add(refusedGrace)
 	var d net.Dialer
 	for {
 		conn, err := d.DialContext(ctx, "unix", path)
@@ -139,10 +151,30 @@ func Dial(ctx context.Context, path string) (*Session, error) {
 			}
 			return session, nil
 		}
+		if errors.Is(err, syscall.ECONNREFUSED) {
+			// The socket file is there but nothing is listening. A broker that
+			// was killed leaves the file behind, because Go only unlinks it on a
+			// graceful Close, so this is proof rather than a race worth waiting
+			// out. Retry only long enough to cover Listen's own window between
+			// os.Remove and bind.
+			if time.Now().After(refusedDeadline) {
+				return nil, fmt.Errorf("failed to connect to %s: %w", path, err)
+			}
+		}
 		select {
 		case <-ctx.Done():
 			return nil, fmt.Errorf("failed to connect to %s: %w", path, err)
 		case <-time.After(dialInterval):
 		}
 	}
+}
+
+// RemoveSocket deletes an attach socket. Removing one that is not there is not
+// an error.
+func RemoveSocket(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
 }

--- a/pkg/attachmux/socket_supported.go
+++ b/pkg/attachmux/socket_supported.go
@@ -1,0 +1,148 @@
+//go:build linux || freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// probeSeq keeps two concurrent probes inside one process off each other's
+// socket path. Different processes are separated by the pid in the name.
+var probeSeq atomic.Uint64
+
+// Probe reports whether a container's attach socket directory can be created
+// and bound in.
+//
+// nerdctl has to decide whether to hand a container's stdio to the logging
+// process before the task exists, but whether the broker actually came up is
+// only known afterwards. Probing first turns the common failures into a clean
+// fallback to the legacy path, instead of a container whose output nobody can
+// show.
+func Probe(dataStore string) error {
+	dir := socketDir(dataStore)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	// Bind a real socket rather than creating a regular file: a file proves
+	// neither that the filesystem supports unix sockets nor that the path fits
+	// in sockaddr_un.sun_path, which a long data store path can break.
+	//
+	// The name is the same length as a real socket name so that the sun_path
+	// check is representative. It carries the pid so that concurrent nerdctl
+	// invocations do not probe over each other, and a counter so that two
+	// concurrent calls inside one process do not either. Real names are hex
+	// digests, so a name starting with "probe" cannot collide with one.
+	name := fmt.Sprintf("probe%d-%d", os.Getpid(), probeSeq.Add(1))
+	if len(name) < socketNameLen {
+		name += strings.Repeat("p", socketNameLen-len(name))
+	}
+	path := filepath.Join(dir, name+".sock")
+
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return err
+	}
+	// Closing a unix listener unlinks its socket.
+	return l.Close()
+}
+
+// Listen creates the attach socket at path with mode 0600.
+func Listen(path string) (net.Listener, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, err
+	}
+	// A container that was killed leaves its socket behind, and bind would then
+	// fail with EADDRINUSE.
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, 0600); err != nil {
+		l.Close()
+		return nil, err
+	}
+	return l, nil
+}
+
+const (
+	// dialTimeout bounds how long Dial waits for the broker to come up.
+	dialTimeout = 5 * time.Second
+	// dialInterval is how often Dial retries while waiting.
+	dialInterval = 20 * time.Millisecond
+)
+
+// Dial connects to the attach socket at path and completes the handshake.
+//
+// It retries until the socket answers, the context is done, or dialTimeout
+// elapses. containerd spawns the logging process while creating the task and
+// does not wait for it, so a client that dials straight after
+// container.NewTask can arrive before the broker has bound its socket. For a
+// container that is already running the first attempt succeeds.
+func Dial(ctx context.Context, path string) (*Session, error) {
+	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
+	defer cancel()
+
+	var d net.Dialer
+	for {
+		conn, err := d.DialContext(ctx, "unix", path)
+		if err == nil {
+			// A connection can sit in the listener's backlog before the broker
+			// accepts it, so the handshake read needs a deadline of its own:
+			// a broker that died between Listen and Serve would otherwise hang
+			// the client for good.
+			if deadline, ok := ctx.Deadline(); ok {
+				if err := conn.SetReadDeadline(deadline); err != nil {
+					conn.Close()
+					return nil, err
+				}
+			}
+			session, err := NewSession(conn)
+			if err != nil {
+				conn.Close()
+				return nil, err
+			}
+			// Streaming has no deadline of its own.
+			if err := conn.SetReadDeadline(time.Time{}); err != nil {
+				session.Close()
+				return nil, err
+			}
+			return session, nil
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("failed to connect to %s: %w", path, err)
+		case <-time.After(dialInterval):
+		}
+	}
+}

--- a/pkg/attachmux/socket_supported.go
+++ b/pkg/attachmux/socket_supported.go
@@ -113,12 +113,15 @@ func Listen(path string) (net.Listener, error) {
 	if !ok {
 		return l, nil
 	}
-	ul.SetUnlinkOnClose(false)
 	ino, err := inodeOf(path)
 	if err != nil {
+		// Still Go's to unlink at this point, so closing cleans up.
 		l.Close()
 		return nil, err
 	}
+	// Taken over only once the inode is known, so that no failure above leaves
+	// the socket on disk with nobody to remove it.
+	ul.SetUnlinkOnClose(false)
 	return &ownedListener{UnixListener: ul, path: path, ino: ino}, nil
 }
 
@@ -152,62 +155,46 @@ func inodeOf(path string) (uint64, error) {
 }
 
 const (
-	// dialTimeout bounds how long Dial waits for the broker to come up.
-	dialTimeout = 5 * time.Second
-	// dialInterval is how often Dial retries while waiting.
+	// dialTimeout bounds how long DialStarting waits for the broker to come up.
+	dialTimeout  = 5 * time.Second
 	dialInterval = 20 * time.Millisecond
-	// refusedGrace bounds how long Dial keeps retrying after a connection was
-	// refused, which unlike a missing socket means nothing is listening.
-	refusedGrace = 200 * time.Millisecond
 )
 
 // Dial connects to the attach socket at path and completes the handshake.
 //
-// It retries until the socket answers, the context is done, or dialTimeout
-// elapses. containerd spawns the logging process while creating the task and
-// does not wait for it, so a client that dials straight after
-// container.NewTask can arrive before the broker has bound its socket. For a
-// container that is already running the first attempt succeeds.
+// It makes a single attempt. The caller is reaching a container that has been
+// running for a while, so a socket that is missing or refuses the connection is
+// proof that there is no broker to talk to, not a race worth waiting out.
 func Dial(ctx context.Context, path string) (*Session, error) {
-	ctx, cancel := context.WithTimeout(ctx, dialTimeout)
-	defer cancel()
+	return dial(ctx, path, false)
+}
 
-	refusedDeadline := time.Now().Add(refusedGrace)
+// DialStarting is Dial for a caller that has just created the task.
+//
+// containerd spawns the logging process while creating the task and does not
+// wait for it, so for a short while neither a missing socket nor a refused
+// connection says anything: the broker may still be binding, possibly over a
+// file left behind by a previous one. This retries until the socket answers,
+// the context is done, or dialTimeout elapses.
+func DialStarting(ctx context.Context, path string) (*Session, error) {
+	return dial(ctx, path, true)
+}
+
+func dial(ctx context.Context, path string, retry bool) (*Session, error) {
+	if retry {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, dialTimeout)
+		defer cancel()
+	}
+
 	var d net.Dialer
 	for {
 		conn, err := d.DialContext(ctx, "unix", path)
 		if err == nil {
-			// A connection can sit in the listener's backlog before the broker
-			// accepts it, so the handshake read needs a deadline of its own:
-			// a broker that died between Listen and Serve would otherwise hang
-			// the client for good.
-			if deadline, ok := ctx.Deadline(); ok {
-				if err := conn.SetReadDeadline(deadline); err != nil {
-					conn.Close()
-					return nil, err
-				}
-			}
-			session, err := NewSession(conn)
-			if err != nil {
-				conn.Close()
-				return nil, err
-			}
-			// Streaming has no deadline of its own.
-			if err := conn.SetReadDeadline(time.Time{}); err != nil {
-				session.Close()
-				return nil, err
-			}
-			return session, nil
+			return greet(ctx, conn)
 		}
-		if errors.Is(err, syscall.ECONNREFUSED) {
-			// The socket file is there but nothing is listening. A broker that
-			// was killed leaves the file behind, because Go only unlinks it on a
-			// graceful Close, so this is proof rather than a race worth waiting
-			// out. Retry only long enough to cover Listen's own window between
-			// os.Remove and bind.
-			if time.Now().After(refusedDeadline) {
-				return nil, fmt.Errorf("failed to connect to %s: %w", path, err)
-			}
+		if !retry {
+			return nil, fmt.Errorf("failed to connect to %s: %w", path, err)
 		}
 		select {
 		case <-ctx.Done():
@@ -215,6 +202,32 @@ func Dial(ctx context.Context, path string) (*Session, error) {
 		case <-time.After(dialInterval):
 		}
 	}
+}
+
+// greet completes the handshake on an accepted connection.
+func greet(ctx context.Context, conn net.Conn) (*Session, error) {
+	// A connection can sit in the listener's backlog before the broker accepts
+	// it, so the handshake read needs a deadline of its own: a broker that died
+	// between Listen and Serve would otherwise hang the client for good.
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(dialTimeout)
+	}
+	if err := conn.SetReadDeadline(deadline); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	session, err := NewSession(conn)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	// Streaming has no deadline of its own.
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		session.Close()
+		return nil, err
+	}
+	return session, nil
 }
 
 // RemoveSocket deletes an attach socket. Removing one that is not there is not

--- a/pkg/attachmux/socket_test.go
+++ b/pkg/attachmux/socket_test.go
@@ -1,0 +1,180 @@
+//go:build linux || freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSocketPathIsShortEnoughForSunPath(t *testing.T) {
+	t.Parallel()
+
+	// A unix socket path has to fit in sockaddr_un.sun_path, which is 108
+	// bytes. A container ID is 64 hex characters, so the full ID cannot be part
+	// of the path.
+	id := strings.Repeat("a", 64)
+	path := SocketPath("/var/lib/nerdctl/1935db59", "default", id)
+	assert.Assert(t, len(path) < 100, "socket path %q is %d bytes", path, len(path))
+	assert.Assert(t, strings.HasSuffix(path, ".sock"), "got %q", path)
+}
+
+func TestSocketPathIsStableAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
+	again := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
+	assert.Equal(t, first, again)
+
+	other := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("b", 64))
+	assert.Assert(t, first != other)
+}
+
+func TestSocketPathSeparatesNamespaces(t *testing.T) {
+	t.Parallel()
+
+	// A data store's attach sockets share one flat directory and Listen removes
+	// whatever is already at the path, so two containers with the same short ID
+	// in different namespaces must not resolve to the same socket. nerdctl's own
+	// IDs are random and 64 characters long, but nerdctl can attach to a
+	// container created by another client, whose ID may be anything.
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
+	other := SocketPath("/var/lib/nerdctl/1935db59", "staging", "shell")
+	assert.Assert(t, first != other, "both namespaces resolved to %q", first)
+}
+
+func TestSocketPathSeparatesContainerdEndpoints(t *testing.T) {
+	t.Parallel()
+
+	// The data store path encodes the containerd address, and the socket lives
+	// inside it, so two endpoints cannot collide.
+	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
+	other := SocketPath("/var/lib/nerdctl/8fa1c02b", "default", "shell")
+	assert.Assert(t, first != other, "both endpoints resolved to %q", first)
+}
+
+func TestSocketPathIsUnderTheDataStore(t *testing.T) {
+	t.Parallel()
+
+	// The broker derives this from the data store it is handed in its argv,
+	// which is the only path it and its clients are guaranteed to agree on: the
+	// shim spawns it with an environment of just CONTAINER_ID and
+	// CONTAINER_NAMESPACE, so nothing XDG-based is available there.
+	path := SocketPath("/var/lib/nerdctl/1935db59", "default", "abc")
+	assert.Equal(t, filepath.Dir(path), "/var/lib/nerdctl/1935db59/attach")
+	assert.Equal(t, len(filepath.Base(path)), socketNameLen+len(".sock"))
+}
+
+func TestListenAndDial(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "attach.sock")
+
+	b := NewBroker(true, nil)
+	l, err := Listen(path)
+	assert.NilError(t, err)
+	t.Cleanup(func() { l.Close() })
+
+	info, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Equal(t, info.Mode().Perm(), os.FileMode(0600))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = b.Serve(ctx, l) }()
+
+	session, err := Dial(ctx, path)
+	assert.NilError(t, err)
+	t.Cleanup(func() { session.Close() })
+	assert.Equal(t, session.TTY(), true)
+}
+
+func TestListenReplacesALeftoverSocket(t *testing.T) {
+	t.Parallel()
+
+	// A container that was killed leaves its socket behind, and bind would then
+	// fail with EADDRINUSE. Go's unix listener unlinks the socket on Close, so
+	// the leftover has to be staged by hand.
+	path := filepath.Join(t.TempDir(), "attach.sock")
+	assert.NilError(t, os.WriteFile(path, nil, 0600))
+
+	l, err := Listen(path)
+	assert.NilError(t, err)
+	t.Cleanup(func() { l.Close() })
+}
+
+func TestProbe(t *testing.T) {
+	t.Parallel()
+
+	// Probe has to leave nothing behind: it runs on every `nerdctl run -it`.
+	dataStore := t.TempDir()
+	assert.NilError(t, Probe(dataStore))
+
+	entries, err := os.ReadDir(socketDir(dataStore))
+	assert.NilError(t, err)
+	for _, e := range entries {
+		assert.Assert(t, !strings.HasPrefix(e.Name(), "probe"), "Probe left %q behind", e.Name())
+	}
+}
+
+func TestProbeIsRepeatable(t *testing.T) {
+	t.Parallel()
+
+	// Probe binds a real socket, so it has to clean up after itself well enough
+	// to run again, which it does on every foreground `nerdctl run -it`.
+	dataStore := t.TempDir()
+	assert.NilError(t, Probe(dataStore))
+	assert.NilError(t, Probe(dataStore))
+}
+
+func TestProbeIsConcurrencySafe(t *testing.T) {
+	t.Parallel()
+
+	// Nothing stops two goroutines in one process from probing at once, and a
+	// shared socket name would make one unlink the other's socket.
+	dataStore := t.TempDir()
+	var wg sync.WaitGroup
+	errs := make([]error, 8)
+	for i := range errs {
+		wg.Go(func() { errs[i] = Probe(dataStore) })
+	}
+	wg.Wait()
+	for _, err := range errs {
+		assert.NilError(t, err)
+	}
+}
+
+func TestDialToNothing(t *testing.T) {
+	t.Parallel()
+
+	// Dial retries while waiting for the broker to bind, so it gives up only
+	// when the context is done. Keep that short here.
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	t.Cleanup(cancel)
+
+	_, err := Dial(ctx, filepath.Join(t.TempDir(), "absent.sock"))
+	assert.Assert(t, err != nil)
+}

--- a/pkg/attachmux/socket_test.go
+++ b/pkg/attachmux/socket_test.go
@@ -109,15 +109,48 @@ func TestProbeIsConcurrencySafe(t *testing.T) {
 	}
 }
 
-func TestDialToNothing(t *testing.T) {
+func TestDialToNothingFailsAtOnce(t *testing.T) {
 	t.Parallel()
 
-	// Dial retries while waiting for the broker to bind, so it gives up only
-	// when the context is done. Keep that short here.
+	// Attaching to a container that has been running for a while must not stall
+	// the CLI: a missing socket is proof there is no broker, not a race.
+	start := time.Now()
+	_, err := Dial(context.Background(), filepath.Join(t.TempDir(), "absent.sock"))
+	assert.Assert(t, err != nil)
+	assert.Assert(t, time.Since(start) < time.Second, "Dial waited %s", time.Since(start))
+}
+
+func TestDialStartingWaitsForTheBroker(t *testing.T) {
+	t.Parallel()
+
+	// The caller has just created the task, and containerd does not wait for
+	// the logging process it spawns, so the socket may not be there yet.
+	path := filepath.Join(t.TempDir(), "attach.sock")
+	b := NewBroker(true, nil)
+
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		l, err := Listen(path)
+		if err != nil {
+			return
+		}
+		go b.Serve(context.Background(), l)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	session, err := DialStarting(ctx, path)
+	assert.NilError(t, err)
+	t.Cleanup(func() { session.Close() })
+}
+
+func TestDialStartingGivesUpEventually(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	t.Cleanup(cancel)
 
-	_, err := Dial(ctx, filepath.Join(t.TempDir(), "absent.sock"))
+	_, err := DialStarting(ctx, filepath.Join(t.TempDir(), "absent.sock"))
 	assert.Assert(t, err != nil)
 }
 

--- a/pkg/attachmux/socket_test.go
+++ b/pkg/attachmux/socket_test.go
@@ -120,3 +120,30 @@ func TestDialToNothing(t *testing.T) {
 	_, err := Dial(ctx, filepath.Join(t.TempDir(), "absent.sock"))
 	assert.Assert(t, err != nil)
 }
+
+func TestListenRemovesOnlyItsOwnSocket(t *testing.T) {
+	t.Parallel()
+
+	// Two brokers can briefly overlap for one container while the restart
+	// monitor swaps tasks. The one that exits second must not unlink the live
+	// socket of the one that took the path over.
+	path := filepath.Join(t.TempDir(), "attach.sock")
+
+	first, err := Listen(path)
+	assert.NilError(t, err)
+
+	second, err := Listen(path)
+	assert.NilError(t, err)
+	t.Cleanup(func() { second.Close() })
+
+	// The old broker exits last.
+	assert.NilError(t, first.Close())
+
+	_, err = os.Stat(path)
+	assert.NilError(t, err, "the surviving broker lost its socket")
+
+	// And a broker that is alone does clean up after itself.
+	assert.NilError(t, second.Close())
+	_, err = os.Stat(path)
+	assert.Assert(t, os.IsNotExist(err), "the socket outlived its broker")
+}

--- a/pkg/attachmux/socket_test.go
+++ b/pkg/attachmux/socket_test.go
@@ -30,64 +30,6 @@ import (
 	"gotest.tools/v3/assert"
 )
 
-func TestSocketPathIsShortEnoughForSunPath(t *testing.T) {
-	t.Parallel()
-
-	// A unix socket path has to fit in sockaddr_un.sun_path, which is 108
-	// bytes. A container ID is 64 hex characters, so the full ID cannot be part
-	// of the path.
-	id := strings.Repeat("a", 64)
-	path := SocketPath("/var/lib/nerdctl/1935db59", "default", id)
-	assert.Assert(t, len(path) < 100, "socket path %q is %d bytes", path, len(path))
-	assert.Assert(t, strings.HasSuffix(path, ".sock"), "got %q", path)
-}
-
-func TestSocketPathIsStableAndDistinct(t *testing.T) {
-	t.Parallel()
-
-	first := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
-	again := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("a", 64))
-	assert.Equal(t, first, again)
-
-	other := SocketPath("/var/lib/nerdctl/1935db59", "default", strings.Repeat("b", 64))
-	assert.Assert(t, first != other)
-}
-
-func TestSocketPathSeparatesNamespaces(t *testing.T) {
-	t.Parallel()
-
-	// A data store's attach sockets share one flat directory and Listen removes
-	// whatever is already at the path, so two containers with the same short ID
-	// in different namespaces must not resolve to the same socket. nerdctl's own
-	// IDs are random and 64 characters long, but nerdctl can attach to a
-	// container created by another client, whose ID may be anything.
-	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
-	other := SocketPath("/var/lib/nerdctl/1935db59", "staging", "shell")
-	assert.Assert(t, first != other, "both namespaces resolved to %q", first)
-}
-
-func TestSocketPathSeparatesContainerdEndpoints(t *testing.T) {
-	t.Parallel()
-
-	// The data store path encodes the containerd address, and the socket lives
-	// inside it, so two endpoints cannot collide.
-	first := SocketPath("/var/lib/nerdctl/1935db59", "default", "shell")
-	other := SocketPath("/var/lib/nerdctl/8fa1c02b", "default", "shell")
-	assert.Assert(t, first != other, "both endpoints resolved to %q", first)
-}
-
-func TestSocketPathIsUnderTheDataStore(t *testing.T) {
-	t.Parallel()
-
-	// The broker derives this from the data store it is handed in its argv,
-	// which is the only path it and its clients are guaranteed to agree on: the
-	// shim spawns it with an environment of just CONTAINER_ID and
-	// CONTAINER_NAMESPACE, so nothing XDG-based is available there.
-	path := SocketPath("/var/lib/nerdctl/1935db59", "default", "abc")
-	assert.Equal(t, filepath.Dir(path), "/var/lib/nerdctl/1935db59/attach")
-	assert.Equal(t, len(filepath.Base(path)), socketNameLen+len(".sock"))
-}
-
 func TestListenAndDial(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/attachmux/socket_unsupported.go
+++ b/pkg/attachmux/socket_unsupported.go
@@ -31,3 +31,6 @@ func Listen(string) (net.Listener, error) { return nil, ErrUnsupported }
 
 // Dial is not implemented on this platform.
 func Dial(context.Context, string) (*Session, error) { return nil, ErrUnsupported }
+
+// RemoveSocket is not implemented on this platform.
+func RemoveSocket(string) error { return nil }

--- a/pkg/attachmux/socket_unsupported.go
+++ b/pkg/attachmux/socket_unsupported.go
@@ -1,0 +1,33 @@
+//go:build !(linux || freebsd)
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"net"
+)
+
+// Probe is not implemented on this platform, so callers keep the legacy path.
+func Probe(string) error { return ErrUnsupported }
+
+// Listen is not implemented on this platform.
+func Listen(string) (net.Listener, error) { return nil, ErrUnsupported }
+
+// Dial is not implemented on this platform.
+func Dial(context.Context, string) (*Session, error) { return nil, ErrUnsupported }

--- a/pkg/attachmux/socket_unsupported.go
+++ b/pkg/attachmux/socket_unsupported.go
@@ -32,5 +32,8 @@ func Listen(string) (net.Listener, error) { return nil, ErrUnsupported }
 // Dial is not implemented on this platform.
 func Dial(context.Context, string) (*Session, error) { return nil, ErrUnsupported }
 
+// DialStarting is not implemented on this platform.
+func DialStarting(context.Context, string) (*Session, error) { return nil, ErrUnsupported }
+
 // RemoveSocket is not implemented on this platform.
 func RemoveSocket(string) error { return nil }

--- a/pkg/attachmux/socket_unsupported_test.go
+++ b/pkg/attachmux/socket_unsupported_test.go
@@ -1,0 +1,45 @@
+//go:build !(linux || freebsd)
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package attachmux
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+// On these platforms the stubs are the only transport code that runs, and
+// callers branch on ErrUnsupported: run -it uses Probe to decide whether to
+// hand the container's stdio to the logging process at all. A stub that
+// returned nil would send it down a path with no broker behind it.
+func TestTransportIsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	assert.ErrorIs(t, Probe(t.TempDir()), ErrUnsupported)
+
+	_, err := Listen("ignored")
+	assert.ErrorIs(t, err, ErrUnsupported)
+
+	_, err = Dial(context.Background(), "ignored")
+	assert.ErrorIs(t, err, ErrUnsupported)
+
+	// Removing a socket that was never created is not an error anywhere.
+	assert.NilError(t, RemoveSocket("ignored"))
+}

--- a/pkg/cioutil/container_io.go
+++ b/pkg/cioutil/container_io.go
@@ -115,7 +115,7 @@ func (c *ncio) Cancel() {
 	}
 }
 
-func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, stdout, stderr io.Writer) cio.Creator {
+func NewContainerIO(namespace string, logURI string, tty bool, stdinFIFO string, stdin io.Reader, stdout, stderr io.Writer) cio.Creator {
 	return func(id string) (_ cio.IO, err error) {
 		var (
 			cmd     *exec.Cmd
@@ -207,6 +207,13 @@ func NewContainerIO(namespace string, logURI string, tty bool, stdin io.Reader, 
 		fifos, err := cio.NewFIFOSetInDir(streams.FIFODir, id, streams.Terminal)
 		if err != nil {
 			return nil, err
+		}
+
+		// Pin stdin to a stable path so that the process owning the container's
+		// stdio can find it. containerd's generated FIFO directory is random and
+		// changes across restarts.
+		if stdinFIFO != "" {
+			fifos.Stdin = stdinFIFO
 		}
 
 		if streams.Stdin == nil {

--- a/pkg/cioutil/stdin_fifo.go
+++ b/pkg/cioutil/stdin_fifo.go
@@ -1,0 +1,38 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cioutil
+
+import "path/filepath"
+
+// stdinFIFOName is the file name of a container's stdin FIFO inside its data
+// store directory.
+const stdinFIFOName = "stdin.fifo"
+
+// StdinFIFOPath returns the stable path of a container's stdin FIFO.
+//
+// containerd generates a fresh FIFO directory per task, so those paths change
+// across restarts and cannot be derived by another process. nerdctl pins stdin
+// to this path instead, so that the process owning the container's stdio can
+// find it from the data store alone.
+//
+// The file is left in place when the container stops, and goes away with the
+// container's data store directory. Nothing reads meaning into its presence:
+// whether the running task has stdin is established by opening it, in
+// pkg/logging/broker_unix.go.
+func StdinFIFOPath(dataStore, ns, id string) string {
+	return filepath.Join(dataStore, "containers", ns, id, stdinFIFOName)
+}

--- a/pkg/cioutil/stdin_fifo_test.go
+++ b/pkg/cioutil/stdin_fifo_test.go
@@ -1,0 +1,70 @@
+//go:build unix
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cioutil
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestStdinFIFOPath(t *testing.T) {
+	t.Parallel()
+
+	got := StdinFIFOPath("/var/lib/nerdctl/1935db59", "default", "abc123")
+	assert.Equal(t, got, filepath.Join("/var/lib/nerdctl/1935db59", "containers", "default", "abc123", "stdin.fifo"))
+}
+
+func TestCreateStdinFIFO(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "stdin.fifo")
+	assert.NilError(t, CreateStdinFIFO(path))
+
+	info, err := os.Stat(path)
+	assert.NilError(t, err)
+	assert.Assert(t, info.Mode()&os.ModeNamedPipe != 0, "%q is not a FIFO, mode %v", path, info.Mode())
+	assert.Equal(t, info.Mode().Perm(), os.FileMode(0600))
+}
+
+func TestCreateStdinFIFOReplacesALeftover(t *testing.T) {
+	t.Parallel()
+
+	// A container that was killed leaves its FIFO behind; restarting it must
+	// not fail with EEXIST.
+	path := filepath.Join(t.TempDir(), "stdin.fifo")
+	assert.NilError(t, CreateStdinFIFO(path))
+	assert.NilError(t, CreateStdinFIFO(path))
+}
+
+func TestCreateStdinFIFOIsWriteOnlyBlockedWithoutAReader(t *testing.T) {
+	t.Parallel()
+
+	// The broker tells "this container has stdin" from "this FIFO is left over
+	// from a previous run" by whether an O_WRONLY open succeeds. That only works
+	// if the FIFO really is a FIFO.
+	path := filepath.Join(t.TempDir(), "stdin.fifo")
+	assert.NilError(t, CreateStdinFIFO(path))
+
+	_, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+	assert.ErrorIs(t, err, syscall.ENXIO)
+}

--- a/pkg/cioutil/stdin_fifo_unix.go
+++ b/pkg/cioutil/stdin_fifo_unix.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cioutil
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// CreateStdinFIFO creates a container's stdin FIFO with mode 0600, replacing a
+// FIFO left behind by a previous run of the same container.
+func CreateStdinFIFO(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := syscall.Mkfifo(path, 0600); err != nil {
+		return fmt.Errorf("failed to create the stdin FIFO %q: %w", path, err)
+	}
+	// Mkfifo is subject to the process umask, so the mode has to be set again.
+	return os.Chmod(path, 0600)
+}

--- a/pkg/cioutil/stdin_fifo_windows.go
+++ b/pkg/cioutil/stdin_fifo_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cioutil
+
+import "errors"
+
+// CreateStdinFIFO is not implemented on this platform. Callers fall back to the
+// stdio containerd generates for the task.
+func CreateStdinFIFO(string) error {
+	return errors.New("cioutil: a stable stdin FIFO is not supported on this platform")
+}

--- a/pkg/cmd/container/attach.go
+++ b/pkg/cmd/container/attach.go
@@ -21,20 +21,25 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
+	"time"
 
 	"golang.org/x/term"
 
 	"github.com/containerd/console"
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/attachmux"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
 	"github.com/containerd/nerdctl/v2/pkg/idutil/containerwalker"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
+	"github.com/containerd/nerdctl/v2/pkg/logging/loguri"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 )
 
@@ -81,14 +86,43 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 
 	// Attach to the container.
 	var task containerd.Task
-	detachC := make(chan struct{})
+	detachC := make(chan struct{}, 1)
 	spec, err := container.Spec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get the OCI runtime spec for the container: %w", err)
 	}
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	// Detaching means different things on the two paths below: ending this
+	// socket session, or cancelling the FIFO copy and telling the select at the
+	// end of this function. Which path applies is only known once containerd has
+	// reported how the task's stdio is wired, and the stdin reader has to exist
+	// before that, because it is part of the cio.Attach the legacy path builds.
+	// So the closer does both: cancelStream is a no-op on the legacy path, and
+	// the send is dropped on the socket path, which does not read detachC.
+	//
+	// It deliberately does not touch task. cio.NewAttach starts copying stdin
+	// from inside its own callback, before container.Task returns and assigns
+	// task (pkg/cio/io_unix.go, copyIO), so a user who hits the detach keys
+	// immediately would reach a nil task here. Upstream gets away with the same
+	// shape only because its unbuffered send blocks until the select below has
+	// been reached; cancelling the task IO is done there instead.
+	closer := func() {
+		cancelStream()
+		select {
+		case detachC <- struct{}{}:
+		default:
+		}
+	}
+
 	var (
-		opt cio.Opt
-		con console.Console
+		opt    cio.Opt
+		con    console.Console
+		stdin  io.Reader
+		stdout = options.Stdout
+		stderr = options.Stderr
 	)
 	if spec.Process.Terminal {
 		con, err = consoleutil.Current()
@@ -100,36 +134,62 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 		if _, err := term.MakeRaw(int(con.Fd())); err != nil {
 			return fmt.Errorf("failed to set the console to raw mode: %w", err)
 		}
-		closer := func() {
-			detachC <- struct{}{}
-			// task will be set by container.Task later.
-			//
-			// We cannot use container.Task(ctx, cio.Load) to get the IO here
-			// because the `cancel` field of the returned `*cio` is nil. [1]
-			//
-			// [1] https://github.com/containerd/containerd/blob/8f756bc8c26465bd93e78d9cd42082b66f276e10/cio/io.go#L358-L359
-			io := task.IO()
-			if io == nil {
-				log.G(ctx).Errorf("got a nil io")
-				return
-			}
-			io.Cancel()
-		}
-		var in io.Reader
+		// A terminal container has a single output stream.
+		stdout, stderr = con, nil
 		if options.Stdin != nil {
-			in, err = consoleutil.NewDetachableStdin(con, options.DetachKeys, closer)
+			stdin, err = consoleutil.NewDetachableStdin(con, options.DetachKeys, closer)
 			if err != nil {
 				return err
 			}
 		}
-		opt = cio.WithStreams(in, con, nil)
 	} else {
-		opt = cio.WithStreams(options.Stdin, options.Stdout, options.Stderr)
+		stdin = options.Stdin
 	}
-	task, err = container.Task(ctx, cio.NewAttach(opt))
+	opt = cio.WithStreams(stdin, stdout, stderr)
+
+	// Ask containerd how the task's stdio is wired, and build the IO for it in
+	// the same call. A URI in Stdout means the output goes to a process spawned
+	// from the log URI, and cio.NewAttach would hand that URI to fifo.OpenFifo
+	// as a path; a plain path means FIFOs this process can open. Classifying in
+	// a separate TaskService.Get first would leave a window in which containerd's
+	// restart monitor replaces a FIFO task with a URI one between the two calls.
+	//
+	// NullIO registers no closers, so the handle returned for the socket path
+	// serves task.Wait and friends and leaves the container's FIFOs alone. The
+	// callback is skipped for a task in an unknown state, which has no stdio to
+	// attach to either way.
+	var brokerURI string
+	var sawIO bool
+	task, err = container.Task(ctx, func(fifos *cio.FIFOSet) (cio.IO, error) {
+		sawIO = true
+		if u, uerr := url.Parse(fifos.Stdout); uerr == nil && u.Scheme != "" {
+			brokerURI = fifos.Stdout
+			return cio.NullIO("")
+		}
+		return cio.NewAttach(opt)(fifos)
+	})
 	if err != nil {
 		return fmt.Errorf("failed to attach to the container: %w", err)
 	}
+	if !sawIO {
+		return fmt.Errorf("the task of container %s has no stdio to attach to", req)
+	}
+
+	if brokerURI != "" {
+		// The data store comes out of the URI itself, which is the string the
+		// logging process was handed in its argv and derives the socket path
+		// from. Resolving it again here could differ over a symlinked
+		// --data-root.
+		dataStore := loguri.DataStore(brokerURI)
+		if dataStore == "" || !loguri.IsInternal(brokerURI) {
+			return fmt.Errorf("cannot attach to container %s: its stdio is owned by %q", req, brokerURI)
+		}
+		socketPath := attachmux.SocketPath(dataStore, options.GOptions.Namespace, container.ID())
+		cStatus, err = attachSession(ctx, streamCtx, socketPath, task, spec, stdin, stdout, stderr)
+		return err
+	}
+
+	log.G(ctx).Debug("attaching to the container stdio directly: only one session is supported")
 	if spec.Process.Terminal {
 		if err := consoleutil.HandleConsoleResize(ctx, task, con); err != nil {
 			log.G(ctx).WithError(err).Error("console resize")
@@ -156,6 +216,9 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 		if io == nil {
 			return errors.New("got a nil IO from the task")
 		}
+		// Cancel used to live in the closer, where it raced with the assignment
+		// of task above.
+		io.Cancel()
 		io.Wait()
 	case status := <-statusC:
 		cStatus, err = task.Status(ctx)
@@ -171,4 +234,124 @@ func Attach(ctx context.Context, client *containerd.Client, req string, options 
 		}
 	}
 	return nil
+}
+
+// attachSession runs an attach session over the container's attach socket. Any
+// number of sessions can be connected at once: the process owning the
+// container's stdio fans its output out to all of them.
+//
+// task is the handle obtained while reading the task's IO configuration. Its
+// own IO is a no-op, which is all this path needs: output arrives over the
+// socket, and the task is used only for Wait, Status, Resize and signals.
+// Detaching ends streamCtx, which closes this session's connection and leaves
+// the container, and every other session, untouched.
+func attachSession(
+	ctx, streamCtx context.Context,
+	socketPath string,
+	task containerd.Task,
+	spec *oci.Spec,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+) (containerd.Status, error) {
+	var cStatus containerd.Status
+
+	session, err := attachmux.Dial(ctx, socketPath)
+	if err != nil {
+		return cStatus, fmt.Errorf("failed to connect to the attach socket %q of the container: %w", socketPath, err)
+	}
+	defer session.Close()
+
+	if spec.Process.Terminal {
+		if con, ok := stdout.(console.Console); ok {
+			if err := consoleutil.HandleConsoleResize(ctx, task, con); err != nil {
+				log.G(ctx).WithError(err).Error("console resize")
+			}
+		}
+	}
+	sigC := signalutil.ForwardAllSignals(ctx, task)
+	defer signalutil.StopCatch(sigC)
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return cStatus, fmt.Errorf("failed to init an async wait for the container to exit: %w", err)
+	}
+
+	streamed := make(chan error, 1)
+	go func() { streamed <- session.Stream(streamCtx, stdin, stdout, stderr) }()
+
+	select {
+	case err := <-streamed:
+		if err != nil {
+			// The container may have exited at the same instant. Both channels
+			// are then ready and the select above picks either, so this branch
+			// has to reach the same answer the other one does.
+			select {
+			case status := <-statusC:
+				return exitResult(ctx, task, status, err)
+			default:
+			}
+			return cStatus, fmt.Errorf("the container attach session failed: %w", err)
+		}
+		if !session.Exited() {
+			// The user detached. The container keeps running, and any other
+			// session stays attached.
+			return cStatus, nil
+		}
+		// The broker says the container is gone. Its exit code comes from
+		// containerd, never from the broker, so that there is one source of
+		// truth for it. The wait is bounded: if containerd disagrees, the
+		// session was wrong about the exit and this must not hang.
+		select {
+		case status := <-statusC:
+			return exitResult(ctx, task, status, nil)
+		case <-time.After(attachmux.DrainTimeout):
+			return cStatus, errors.New("the attach session reported that the container exited, but containerd did not")
+		}
+	case status := <-statusC:
+		// containerd reports the exit before the broker has finished draining
+		// the container's stdio. Returning here would run the deferred
+		// cancelStream and close the socket with the last frames still queued,
+		// losing the tail of the container's output. The broker announces the
+		// exit once it is done, which is what ends the stream.
+		//
+		// The stream's result is checked here too, for the same reason as
+		// above. Giving up on the drain is itself a failure: the broker bounds
+		// its own flush well below DrainTimeout, so reaching it means output
+		// was lost.
+		var streamErr error
+		select {
+		case streamErr = <-streamed:
+		case <-time.After(attachmux.DrainTimeout):
+			streamErr = errors.New("timed out waiting for the attach session to drain")
+		}
+		return exitResult(ctx, task, status, streamErr)
+	}
+}
+
+// exitResult turns a container's exit into the command's result.
+//
+// sessionErr, when set, is an attach session failure that happened alongside
+// the exit. The container's own exit code wins: that is what a caller reads,
+// and a broken session at that point only means the tail of the output may be
+// missing. A session failure on a container that exited cleanly has nothing
+// else to report, so it becomes the error.
+func exitResult(ctx context.Context, task containerd.Task, status containerd.ExitStatus, sessionErr error) (containerd.Status, error) {
+	cStatus, err := task.Status(ctx)
+	if err != nil {
+		return cStatus, err
+	}
+	code, _, err := status.Result()
+	if err != nil {
+		return cStatus, err
+	}
+	if code != 0 {
+		if sessionErr != nil {
+			log.G(ctx).WithError(sessionErr).Warn("the attach session failed, the container output may be incomplete")
+		}
+		return cStatus, errutil.NewExitCoderErr(int(code))
+	}
+	if sessionErr != nil {
+		return cStatus, fmt.Errorf("the container attach session failed: %w", sessionErr)
+	}
+	return cStatus, nil
 }

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -301,7 +301,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// 1, nerdctl run --name demo -it imagename
 	// 2, ctrl + c to stop demo container
 	// 3, nerdctl start/restart demo
-	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address, options.GOptions.DisableAttachBroker)
+	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address, options.GOptions.DisableAttachBroker, options.TTY)
 	if err != nil {
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
 	}
@@ -1160,7 +1160,8 @@ func writeCIDFile(path, id string) error {
 }
 
 // generateLogConfig creates a LogConfig for the current container store
-func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string, disableAttachBroker bool) (logConfig logging.LogConfig, err error) {
+func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string, disableAttachBroker, terminal bool) (logConfig logging.LogConfig, err error) {
+	logConfig.Terminal = terminal
 	var u *url.URL
 	// "none" is a registered no-op driver rather than an absence of logging: it
 	// still goes through the internal logging process, which is what owns the

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -1162,7 +1162,10 @@ func writeCIDFile(path, id string) error {
 // generateLogConfig creates a LogConfig for the current container store
 func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
-	if u, err = url.Parse(logDriver); err == nil && (u.Scheme != "" || logDriver == "none") {
+	// "none" is a registered no-op driver rather than an absence of logging: it
+	// still goes through the internal logging process, which is what owns the
+	// container's stdio and serves attach sessions.
+	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
 		logConfig.LogURI = logDriver
 	} else {
 		logConfig.Driver = logDriver

--- a/pkg/cmd/container/create.go
+++ b/pkg/cmd/container/create.go
@@ -301,7 +301,7 @@ func Create(ctx context.Context, client *containerd.Client, args []string, netMa
 	// 1, nerdctl run --name demo -it imagename
 	// 2, ctrl + c to stop demo container
 	// 3, nerdctl start/restart demo
-	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address)
+	logConfig, err := generateLogConfig(dataStore, id, options.LogDriver, options.LogOpt, options.GOptions.Namespace, options.GOptions.Address, options.GOptions.DisableAttachBroker)
 	if err != nil {
 		return nil, generateRemoveStateDirFunc(ctx, id, internalLabels), err
 	}
@@ -1160,12 +1160,14 @@ func writeCIDFile(path, id string) error {
 }
 
 // generateLogConfig creates a LogConfig for the current container store
-func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string) (logConfig logging.LogConfig, err error) {
+func generateLogConfig(dataStore string, id string, logDriver string, logOpt []string, ns, address string, disableAttachBroker bool) (logConfig logging.LogConfig, err error) {
 	var u *url.URL
 	// "none" is a registered no-op driver rather than an absence of logging: it
 	// still goes through the internal logging process, which is what owns the
-	// container's stdio and serves attach sessions.
-	if u, err = url.Parse(logDriver); err == nil && u.Scheme != "" {
+	// container's stdio and serves attach sessions. With the broker switched
+	// off there is nothing to own it, so "none" short-circuits again and the
+	// container runs without a logging process at all, as it did before.
+	if u, err = url.Parse(logDriver); err == nil && (u.Scheme != "" || (disableAttachBroker && logDriver == "none")) {
 		logConfig.LogURI = logDriver
 	} else {
 		logConfig.Driver = logDriver

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -158,15 +158,6 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 		return err
 	}
 
-	// The attach socket lives outside the container's state directory, because
-	// sockaddr_un.sun_path is too short to hold that path, so removing the
-	// state directory does not take it with it. A broker that exited normally
-	// unlinked it already; one that was killed did not, and nothing else would
-	// ever collect it.
-	if err := attachmux.RemoveSocket(attachmux.SocketPath(dataStore, containerNamespace, c.ID())); err != nil {
-		log.G(ctx).WithError(err).Warn("failed to remove the container attach socket")
-	}
-
 	// Get namestore
 	nameStore, err := namestore.New(dataStore, containerNamespace)
 	if err != nil {
@@ -263,6 +254,20 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 			if err := nameStore.Release(name, id); err != nil && !errors.Is(err, store.ErrNotFound) {
 				log.G(ctx).WithError(err).Warnf("failed to release container name %s", name)
 			}
+		}
+
+		// The attach socket lives outside the container's state directory,
+		// because sockaddr_un.sun_path is too short to hold that path, so
+		// removing the state directory does not take it with it. A broker that
+		// exited normally unlinked it already; one that was killed did not, and
+		// nothing else would ever collect it.
+		//
+		// It has to be here, after the container is gone. Earlier, a `nerdctl
+		// rm` that stops at the running-container check would have unlinked the
+		// socket of a container that keeps running, leaving its broker on an
+		// inode nobody can reach and no way to attach to it again.
+		if err := attachmux.RemoveSocket(attachmux.SocketPath(dataStore, containerNamespace, id)); err != nil {
+			log.G(ctx).WithError(err).Warnf("failed to remove the attach socket for container %q", id)
 		}
 
 		hs, err := hostsstore.New(dataStore, containerNamespace)

--- a/pkg/cmd/container/remove.go
+++ b/pkg/cmd/container/remove.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/api/types"
+	"github.com/containerd/nerdctl/v2/pkg/attachmux"
 	"github.com/containerd/nerdctl/v2/pkg/clientutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerutil"
 	"github.com/containerd/nerdctl/v2/pkg/dnsutil/hostsstore"
@@ -155,6 +156,15 @@ func RemoveContainer(ctx context.Context, c containerd.Container, globalOptions 
 	containerNamespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {
 		return err
+	}
+
+	// The attach socket lives outside the container's state directory, because
+	// sockaddr_un.sun_path is too short to hold that path, so removing the
+	// state directory does not take it with it. A broker that exited normally
+	// unlinked it already; one that was killed did not, and nothing else would
+	// ever collect it.
+	if err := attachmux.RemoveSocket(attachmux.SocketPath(dataStore, containerNamespace, c.ID())); err != nil {
+		log.G(ctx).WithError(err).Warn("failed to remove the container attach socket")
 	}
 
 	// Get namestore

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,33 +49,40 @@ type Config struct {
 	DNSSearch        []string `toml:"dns_search,omitempty"`
 	DisableHCSystemd bool     `toml:"disable_hc_systemd"`
 	SelinuxEnabled   bool     `toml:"selinux_enabled"`
+	// DisableAttachBroker turns off multi-session attach and puts a container's
+	// stdio back on the FIFOs nerdctl used before it. It exists so that the
+	// change can be backed out in the field without a downgrade; it is not a
+	// feature switch, and is expected to go away once the broker has proven
+	// itself.
+	DisableAttachBroker bool `toml:"disable_attach_broker"`
 }
 
 // New creates a default Config object statically,
 // without interpolating CLI flags, env vars, and toml.
 func New() *Config {
 	return &Config{
-		Debug:            false,
-		DebugFull:        false,
-		LogFile:          "",
-		Address:          defaults.DefaultAddress,
-		Namespace:        namespaces.Default,
-		Snapshotter:      defaults.DefaultSnapshotter,
-		CNIPath:          ncdefaults.CNIPath(),
-		CNINetConfPath:   ncdefaults.CNINetConfPath(),
-		DataRoot:         ncdefaults.DataRoot(),
-		CgroupManager:    ncdefaults.CgroupManager(),
-		InsecureRegistry: false,
-		SelinuxEnabled:   false,
-		HostsDir:         ncdefaults.HostsDirs(),
-		Experimental:     true,
-		HostGatewayIP:    ncdefaults.HostGatewayIP(),
-		KubeHideDupe:     false,
-		CDISpecDirs:      ncdefaults.CDISpecDirs(),
-		UsernsRemap:      "",
-		DNS:              []string{},
-		DNSOpts:          []string{},
-		DNSSearch:        []string{},
-		DisableHCSystemd: false,
+		Debug:               false,
+		DebugFull:           false,
+		LogFile:             "",
+		Address:             defaults.DefaultAddress,
+		Namespace:           namespaces.Default,
+		Snapshotter:         defaults.DefaultSnapshotter,
+		CNIPath:             ncdefaults.CNIPath(),
+		CNINetConfPath:      ncdefaults.CNINetConfPath(),
+		DataRoot:            ncdefaults.DataRoot(),
+		CgroupManager:       ncdefaults.CgroupManager(),
+		InsecureRegistry:    false,
+		SelinuxEnabled:      false,
+		DisableAttachBroker: false,
+		HostsDir:            ncdefaults.HostsDirs(),
+		Experimental:        true,
+		HostGatewayIP:       ncdefaults.HostGatewayIP(),
+		KubeHideDupe:        false,
+		CDISpecDirs:         ncdefaults.CDISpecDirs(),
+		UsernsRemap:         "",
+		DNS:                 []string{},
+		DNSOpts:             []string{},
+		DNSSearch:           []string{},
+		DisableHCSystemd:    false,
 	}
 }

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -278,9 +278,11 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		dataStore = loguri.DataStore(logURI)
 	}
 
-	// Only an interactive container gets a stdin FIFO, as in the run path.
+	// Only an interactive terminal container gets a stdin FIFO, as in the run
+	// path: the broker's second writer would keep a non-terminal container from
+	// ever seeing EOF on its stdin.
 	stdinFIFO := ""
-	if isInteractive && dataStore != "" {
+	if isInteractive && isTerminal && dataStore != "" {
 		path := cioutil.StdinFIFOPath(dataStore, namespace, container.ID())
 		if err := cioutil.CreateStdinFIFO(path); err != nil {
 			log.G(ctx).WithError(err).Debug("failed to create the stdin FIFO, the broker is disabled for this container")

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -271,9 +271,10 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		// source: https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-nerdctl-start
 		attachStreamOpt = []string{"STDOUT", "STDERR"}
 	}
-	// As in the run path, and only for a URI that runs this binary.
+	// As in the run path: only for a URI that runs this binary, and not when
+	// the operator has switched the broker off.
 	dataStore := ""
-	if loguri.IsInternal(logURI) {
+	if !cfg.DisableAttachBroker && loguri.IsInternal(logURI) {
 		dataStore = loguri.DataStore(logURI)
 	}
 

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -44,6 +44,7 @@ import (
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/attachmux"
 	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
@@ -291,6 +292,26 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		}
 	}
 
+	useBroker := isTerminal && dataStore != "" &&
+		(!isInteractive || stdinFIFO != "") &&
+		attachmux.Probe(dataStore) == nil
+
+	streamCtx, cancelStream := context.WithCancel(ctx)
+	defer cancelStream()
+
+	// `start -ai` is interactive: it needs a detachable stdin, otherwise the
+	// detach sequence is never seen and the command hangs. This is what
+	// TestStartDetachKeys in cmd/nerdctl/container/container_start_linux_test.go
+	// exercises. Built before NewTask so that a malformed --detach-keys is
+	// still rejected before a task exists.
+	var brokerStdin io.Reader
+	if useBroker && isAttach && isInteractive {
+		brokerStdin, err = consoleutil.NewDetachableStdin(con, detachKeys, cancelStream)
+		if err != nil {
+			return err
+		}
+	}
+
 	task, err := taskutil.NewTask(ctx, client, container, taskutil.TaskOptions{
 		AttachStreamOpt: attachStreamOpt,
 		IsInteractive:   isInteractive,
@@ -303,6 +324,7 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		DetachC:         detachC,
 		CheckpointDir:   checkpointDir,
 		StdinFIFO:       stdinFIFO,
+		UseBroker:       useBroker,
 	})
 	if err != nil {
 		return err
@@ -311,6 +333,39 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 	if err != nil {
 		return err
 	}
+
+	streamed := make(chan struct{})
+	streamErr := make(chan error, 1)
+	if useBroker && isAttach {
+		socketPath := attachmux.SocketPath(dataStore, namespace, container.ID())
+		session, err := attachmux.DialStarting(ctx, socketPath)
+		if err != nil {
+			if _, delErr := task.Delete(ctx); delErr != nil {
+				log.G(ctx).WithError(delErr).Warn("failed to delete the task after attach setup failed")
+			}
+			return fmt.Errorf("failed to connect to the container attach socket: %w", err)
+		}
+		defer session.Close()
+
+		in := brokerStdin
+		go func() {
+			defer close(streamed)
+			if err := session.Stream(streamCtx, in, con, nil); err != nil {
+				streamErr <- err
+				return
+			}
+			if session.Exited() {
+				return
+			}
+			select {
+			case detachC <- struct{}{}:
+			case <-ctx.Done():
+			}
+		}()
+	} else {
+		close(streamed)
+	}
+
 	if err := task.Start(ctx); err != nil {
 		return err
 	}
@@ -346,6 +401,26 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 	}
 	sigc := signalutil.ForwardAllSignals(ctx, task)
 	defer signalutil.StopCatch(sigc)
+	// handleExit is what both the container-exited and the session-failed
+	// branches below end in: the container's own exit code wins over a session
+	// failure that happened alongside it.
+	handleExit := func(status containerd.ExitStatus, sessionErr error) error {
+		code, _, err := status.Result()
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			if sessionErr != nil {
+				log.G(ctx).WithError(sessionErr).Warn("the attach session failed, the container output may be incomplete")
+			}
+			return errutil.NewExitCoderErr(int(code))
+		}
+		if sessionErr != nil {
+			return fmt.Errorf("the container attach session failed: %w", sessionErr)
+		}
+		return nil
+	}
+
 	select {
 	// io.Wait() would return when either 1) the user detaches from the container OR 2) the container is about to exit.
 	//
@@ -360,14 +435,25 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 			return errors.New("got a nil IO from the task")
 		}
 		io.Wait()
+	case err := <-streamErr:
+		select {
+		case status := <-statusC:
+			return handleExit(status, err)
+		default:
+		}
+		return fmt.Errorf("the container attach session failed: %w", err)
 	case status := <-statusC:
-		code, _, err := status.Result()
-		if err != nil {
-			return err
+		var sessionErr error
+		select {
+		case <-streamed:
+			select {
+			case sessionErr = <-streamErr:
+			default:
+			}
+		case <-time.After(attachmux.DrainTimeout):
+			sessionErr = errors.New("timed out waiting for the attach session to drain")
 		}
-		if code != 0 {
-			return errutil.NewExitCoderErr(int(code))
-		}
+		return handleExit(status, sessionErr)
 	}
 	return nil
 }

--- a/pkg/containerutil/containerutil.go
+++ b/pkg/containerutil/containerutil.go
@@ -44,6 +44,7 @@ import (
 	"github.com/containerd/go-cni"
 	"github.com/containerd/log"
 
+	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/config"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/errutil"
@@ -52,6 +53,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/ipcutil"
 	"github.com/containerd/nerdctl/v2/pkg/labels"
 	"github.com/containerd/nerdctl/v2/pkg/labels/k8slabels"
+	"github.com/containerd/nerdctl/v2/pkg/logging/loguri"
 	"github.com/containerd/nerdctl/v2/pkg/rootlessutil"
 	"github.com/containerd/nerdctl/v2/pkg/signalutil"
 	"github.com/containerd/nerdctl/v2/pkg/strutil"
@@ -269,6 +271,23 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		// source: https://github.com/containerd/nerdctl/blob/main/docs/command-reference.md#whale-nerdctl-start
 		attachStreamOpt = []string{"STDOUT", "STDERR"}
 	}
+	// As in the run path, and only for a URI that runs this binary.
+	dataStore := ""
+	if loguri.IsInternal(logURI) {
+		dataStore = loguri.DataStore(logURI)
+	}
+
+	// Only an interactive container gets a stdin FIFO, as in the run path.
+	stdinFIFO := ""
+	if isInteractive && dataStore != "" {
+		path := cioutil.StdinFIFOPath(dataStore, namespace, container.ID())
+		if err := cioutil.CreateStdinFIFO(path); err != nil {
+			log.G(ctx).WithError(err).Debug("failed to create the stdin FIFO, the broker is disabled for this container")
+		} else {
+			stdinFIFO = path
+		}
+	}
+
 	task, err := taskutil.NewTask(ctx, client, container, taskutil.TaskOptions{
 		AttachStreamOpt: attachStreamOpt,
 		IsInteractive:   isInteractive,
@@ -280,6 +299,7 @@ func Start(ctx context.Context, container containerd.Container, isAttach bool, i
 		Namespace:       namespace,
 		DetachC:         detachC,
 		CheckpointDir:   checkpointDir,
+		StdinFIFO:       stdinFIFO,
 	})
 	if err != nil {
 		return err

--- a/pkg/logging/broker_other.go
+++ b/pkg/logging/broker_other.go
@@ -1,0 +1,36 @@
+//go:build !(linux || freebsd)
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import "context"
+
+// startBroker is a no-op on platforms without an attach transport. Attaching
+// falls back to connecting directly to the container's stdio, which allows one
+// session at a time.
+//
+// The build tag names the platforms rather than saying `unix`, because the
+// stdin FIFO handling in broker_unix.go relies on Go registering a
+// non-blocking FIFO with the runtime poller, and os/file_unix.go deliberately
+// does not do that on darwin and ios (kqueue does not report the last writer
+// closing a fifo, golang/go#24164). containerd does not run containers there
+// anyway; this keeps `make lint-go-all` honest about it rather than shipping
+// code that would return EAGAIN from a full FIFO.
+func startBroker(context.Context, string, string, string, bool) (func(stream string, p []byte), func(exited bool)) {
+	return nil, func(bool) {}
+}

--- a/pkg/logging/broker_unix.go
+++ b/pkg/logging/broker_unix.go
@@ -1,0 +1,164 @@
+//go:build linux || freebsd
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package logging
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/containerd/log"
+
+	"github.com/containerd/nerdctl/v2/pkg/attachmux"
+	"github.com/containerd/nerdctl/v2/pkg/cioutil"
+)
+
+// startBroker makes this process the owner of the container's stdio: it listens
+// on the container's attach socket and opens the write end of the container's
+// stdin FIFO.
+//
+// It returns a tee to feed raw container output to, and a stop function to call
+// once the container has exited. When the broker cannot be set up the tee is nil
+// and stop is a no-op: the container keeps logging rather than failing outright.
+// A broker that cannot start is never a reason to fail the container. Sessions
+// then cannot attach at all, and say so, because the task's stdio is already
+// bound to this process and no client can reach it directly.
+//
+// Nothing here is recorded on disk: the socket path is a pure function of the
+// data store, the namespace and the container ID, and a client derives it the
+// same way.
+func startBroker(ctx context.Context, dataStore, ns, id string, tty bool) (func(stream string, p []byte), func(exited bool)) {
+	noop := func(bool) {}
+
+	socketPath := attachmux.SocketPath(dataStore, ns, id)
+	listener, err := attachmux.Listen(socketPath)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("failed to listen on the attach socket, multi-session attach is disabled")
+		return nil, noop
+	}
+
+	broker := attachmux.NewBroker(tty, nil)
+
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	go func() {
+		if err := broker.Serve(serveCtx, listener); err != nil {
+			log.G(ctx).WithError(err).Warn("the attach socket stopped accepting sessions")
+		}
+	}()
+
+	// Stdin is opened off this path, for two reasons. The shim opens the read
+	// end of the FIFO only after it has forked the runtime, while this process
+	// was spawned earlier, so the open has to be retried; and blocking here
+	// would stall the caller before it starts reading the container's output.
+	go func() {
+		stdinPath := cioutil.StdinFIFOPath(dataStore, ns, id)
+		w, err := openStdinWriter(serveCtx, stdinPath)
+		if err != nil {
+			log.G(ctx).WithError(err).Debugf("the container has no stdin at %q, attached sessions are output only", stdinPath)
+			return
+		}
+		if !broker.SetStdin(w) {
+			w.Close()
+		}
+	}()
+
+	tee := func(stream string, p []byte) {
+		switch stream {
+		case streamStdout:
+			broker.Write(attachmux.StreamStdout, p)
+		case streamStderr:
+			broker.Write(attachmux.StreamStderr, p)
+		}
+	}
+
+	// stop is called twice: once by loggingProcessAdapter as soon as the
+	// container's output has been read, so that sessions learn about the exit
+	// without waiting for the log driver, and once by the deferred call in
+	// loggerFunc. Only the first call decides what the sessions are told.
+	var stopOnce sync.Once
+	stop := func(exited bool) {
+		stopOnce.Do(func() {
+			// Close releases the container's stdin along with the sessions.
+			broker.Close(exited)
+			cancelServe()
+			listener.Close()
+			if err := attachmux.RemoveSocket(socketPath); err != nil {
+				log.G(ctx).WithError(err).Warn("failed to remove the attach socket")
+			}
+		})
+	}
+
+	return tee, stop
+}
+
+const (
+	// stdinOpenTimeout bounds how long openStdinWriter waits for the shim to
+	// open the read end of the container's stdin FIFO.
+	stdinOpenTimeout = 30 * time.Second
+	// stdinOpenInterval is how often it retries while waiting.
+	stdinOpenInterval = 20 * time.Millisecond
+)
+
+// openStdinWriter opens the write end of the container's stdin FIFO, or reports
+// that the container has no stdin.
+//
+// Opening a FIFO O_WRONLY|O_NONBLOCK fails with ENXIO for as long as no reader
+// has it open, and that is the only reliable signal available here. The FIFO
+// file outlives the task that used it, so its presence says nothing: a
+// container restarted without -i leaves the previous run's FIFO behind, and
+// containerd's restart monitor recreates a terminal task through
+// cio.TerminalLogURI, whose config carries no Stdin (plugins/restart/change.go),
+// so the shim never opens the read end at all.
+//
+// github.com/containerd/fifo cannot answer this. Given O_NONBLOCK it strips the
+// flag and performs the blocking open in a goroutine, returning a handle
+// straight away and documenting that "read/write will be connected after the
+// actual fifo is open". Handing that to the broker would make every container
+// look as though it had stdin, and the first write from a session would block
+// forever.
+//
+// The file keeps O_NONBLOCK. Go registers a FIFO opened that way with the
+// runtime poller, which gives two things the broker depends on: Write blocks
+// the goroutine until the pipe has room instead of returning EAGAIN, and
+// Close evicts a goroutine already blocked in Write instead of waiting for it,
+// which is what lets Broker.Close return while a container that stopped reading
+// its stdin has a session's write outstanding.
+//
+// os/file_unix.go opts fifos out of kqueue on darwin and ios, so neither would
+// hold there; this file is built only for linux and freebsd.
+func openStdinWriter(ctx context.Context, path string) (*os.File, error) {
+	deadline := time.Now().Add(stdinOpenTimeout)
+	for {
+		f, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, syscall.ENXIO) || time.Now().After(deadline) {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(stdinOpenInterval):
+		}
+	}
+}

--- a/pkg/logging/broker_unix.go
+++ b/pkg/logging/broker_unix.go
@@ -97,13 +97,17 @@ func startBroker(ctx context.Context, dataStore, ns, id string, tty bool) (func(
 	var stopOnce sync.Once
 	stop := func(exited bool) {
 		stopOnce.Do(func() {
-			// Close releases the container's stdin along with the sessions.
-			broker.Close(exited)
+			// The listener goes first. A session that connected between
+			// Close and here would be greeted by a broker that is already
+			// closed, get its connection dropped without a hello, and have no
+			// way to tell that from a broken broker.
+			//
+			// Closing the listener also removes the socket file, but only while
+			// it is still the one this process created.
 			cancelServe()
 			listener.Close()
-			if err := attachmux.RemoveSocket(socketPath); err != nil {
-				log.G(ctx).WithError(err).Warn("failed to remove the attach socket")
-			}
+			// Close releases the container's stdin along with the sessions.
+			broker.Close(exited)
 		})
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -40,11 +40,12 @@ import (
 	"github.com/containerd/log"
 
 	"github.com/containerd/nerdctl/v2/pkg/internal/filesystem"
+	"github.com/containerd/nerdctl/v2/pkg/logging/loguri"
 )
 
 const (
 	// MagicArgv1 is the magic argv1 for the containerd runtime v2 logging plugin mode.
-	MagicArgv1 = "_NERDCTL_INTERNAL_LOGGING"
+	MagicArgv1 = loguri.MagicArgv1
 	LogPath    = "log-path"
 	MaxSize    = "max-size"
 	MaxFile    = "max-file"
@@ -476,11 +477,21 @@ func loggerFunc(dataStore string) (logging.LoggerFunc, error) {
 			// stopped and the driver has finished processing all output,
 			// so that waiting log viewers can be signalled when the process is complete.
 			return filesystem.WithLock(loggerLock, func() error {
+				// The container's spec tells us whether its output is a single
+				// terminal stream or separate stdout and stderr.
+				tty := isTerminal(ctx, logConfig.Address, config)
+
+				tee, stopBroker := startBroker(ctx, dataStore, config.Namespace, config.ID, tty)
+				// The adapter calls this itself with the right answer; this is
+				// the belt and braces for the paths that never reach it, and
+				// claims nothing about the container.
+				defer stopBroker(false)
+
 				if err := ready(); err != nil {
 					return err
 				}
 				// getContainerWait is extracted as parameter to allow mocking in tests.
-				return loggingProcessAdapter(ctx, driver, dataStore, logConfig.Address, getContainerWait, config, nil, nil)
+				return loggingProcessAdapter(ctx, driver, dataStore, logConfig.Address, getContainerWait, config, tee, stopBroker)
 			})
 		} else if !errors.Is(err, os.ErrNotExist) {
 			// the file does not exist if the container was created with nerdctl < 0.20
@@ -530,4 +541,27 @@ func startTail(ctx context.Context, logName string, w *fsnotify.Watcher) (bool, 
 			return false, nil
 		}
 	}
+}
+
+// isTerminal reports whether the container was created with a terminal. A
+// terminal container has one output stream; anything else has two.
+func isTerminal(ctx context.Context, address string, config *logging.Config) bool {
+	client, err := containerd.New(strings.TrimPrefix(address, "unix://"), containerd.WithDefaultNamespace(config.Namespace))
+	if err != nil {
+		log.G(ctx).WithError(err).Debug("failed to connect to containerd to read the container spec")
+		return false
+	}
+	defer client.Close()
+
+	container, err := client.LoadContainer(ctx, config.ID)
+	if err != nil {
+		log.G(ctx).WithError(err).Debug("failed to load the container to read its spec")
+		return false
+	}
+	spec, err := container.Spec(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Debug("failed to read the container spec")
+		return false
+	}
+	return spec.Process != nil && spec.Process.Terminal
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -153,6 +153,12 @@ type LogConfig struct {
 	Opts    map[string]string `json:"opts,omitempty"`
 	LogURI  string            `json:"-"`
 	Address string            `json:"address"`
+	// Terminal records whether the container was created with a terminal, so
+	// that the logging process knows whether its output is a single stream
+	// without asking containerd. It is written by the CLI, which knows -t, and
+	// read before the process signals readiness to the shim, which is on the
+	// critical path of creating the task.
+	Terminal bool `json:"terminal,omitempty"`
 }
 
 // LogConfigFilePath returns the path of log-config.json
@@ -477,11 +483,12 @@ func loggerFunc(dataStore string) (logging.LoggerFunc, error) {
 			// stopped and the driver has finished processing all output,
 			// so that waiting log viewers can be signalled when the process is complete.
 			return filesystem.WithLock(loggerLock, func() error {
-				// The container's spec tells us whether its output is a single
-				// terminal stream or separate stdout and stderr.
-				tty := isTerminal(ctx, logConfig.Address, config)
-
-				tee, stopBroker := startBroker(ctx, dataStore, config.Namespace, config.ID, tty)
+				// Whether the container's output is a single terminal stream
+				// or separate stdout and stderr was recorded by the CLI, which
+				// knows -t. Asking containerd here instead would put a connect
+				// and two RPCs on the critical path of creating the task: the
+				// shim blocks on ready() below.
+				tee, stopBroker := startBroker(ctx, dataStore, config.Namespace, config.ID, logConfig.Terminal)
 				// The adapter calls this itself with the right answer; this is
 				// the belt and braces for the paths that never reach it, and
 				// claims nothing about the container.
@@ -541,27 +548,4 @@ func startTail(ctx context.Context, logName string, w *fsnotify.Watcher) (bool, 
 			return false, nil
 		}
 	}
-}
-
-// isTerminal reports whether the container was created with a terminal. A
-// terminal container has one output stream; anything else has two.
-func isTerminal(ctx context.Context, address string, config *logging.Config) bool {
-	client, err := containerd.New(strings.TrimPrefix(address, "unix://"), containerd.WithDefaultNamespace(config.Namespace))
-	if err != nil {
-		log.G(ctx).WithError(err).Debug("failed to connect to containerd to read the container spec")
-		return false
-	}
-	defer client.Close()
-
-	container, err := client.LoadContainer(ctx, config.ID)
-	if err != nil {
-		log.G(ctx).WithError(err).Debug("failed to load the container to read its spec")
-		return false
-	}
-	spec, err := container.Spec(ctx)
-	if err != nil {
-		log.G(ctx).WithError(err).Debug("failed to read the container spec")
-		return false
-	}
-	return spec.Process != nil && spec.Process.Terminal
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -250,7 +250,30 @@ func getContainerWait(ctx context.Context, address string, config *logging.Confi
 
 type ContainerWaitFunc func(ctx context.Context, address string, config *logging.Config, outputSeen func() bool) (<-chan containerd.ExitStatus, error)
 
-func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, address string, getContainerWait ContainerWaitFunc, config *logging.Config) error {
+// exitConfirmTimeout bounds how long the logging process waits, after the
+// container's stdio has ended, for containerd to confirm the container exited.
+// Only a confirmed exit is announced to attached sessions.
+const exitConfirmTimeout = 2 * time.Second
+
+// loggingProcessAdapter reads the container's stdio and hands it to the log
+// driver. When tee is non-nil, it also receives every chunk exactly as it was
+// read, before any line splitting: that is what feeds attached sessions, which
+// must see partial lines and terminal escape sequences unchanged.
+//
+// stop, when non-nil, is called as soon as the container's stdio has been read
+// and before the driver's PostProcess, so that attached sessions learn about
+// the exit without waiting for a slow log driver. Its argument says whether the
+// container is known to have exited; reading the stdio to the end does not on
+// its own establish that.
+func loggingProcessAdapter(
+	ctx context.Context,
+	driver Driver,
+	dataStore, address string,
+	getContainerWait ContainerWaitFunc,
+	config *logging.Config,
+	tee func(stream string, p []byte),
+	stop func(exited bool),
+) error {
 	if err := driver.PreProcess(ctx, dataStore, config); err != nil {
 		return err
 	}
@@ -303,14 +326,18 @@ func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, addres
 		}
 	}
 
-	var wg sync.WaitGroup
+	// readers counts the goroutines reading the container's stdio; driverWG the
+	// one draining the log driver's queue. They are separate so that the attach
+	// sessions can be told the container is gone as soon as its output has been
+	// read, without waiting for a slow or network-backed driver.
+	var readers, driverWG sync.WaitGroup
 
 	// processStream reads a container stdio FIFO directly and emits its output
 	// split into newline-terminated lines. Complete lines are emitted as they are
 	// read; a trailing fragment without a newline is buffered until more output
 	// arrives (so a long line is not split) and emitted when the stream ends.
 	processStream := func(stream string, reader io.Reader, dataChan chan string) {
-		defer wg.Done()
+		defer readers.Done()
 		if !isSync {
 			defer close(dataChan)
 		}
@@ -332,6 +359,9 @@ func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, addres
 		for {
 			nr, err := reader.Read(buf)
 			if nr > 0 {
+				if tee != nil {
+					tee(stream, buf[:nr])
+				}
 				copiedBytes.Add(int64(nr))
 				pending = append(pending, buf[:nr]...)
 				emitLines()
@@ -359,16 +389,20 @@ func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, addres
 			}
 		}
 	}
-	wg.Add(2)
+	readers.Add(2)
 	go processStream(streamStdout, stdoutR, stdout)
 	go processStream(streamStderr, stderrR, stderr)
 	if !isSync {
-		wg.Add(1)
+		driverWG.Add(1)
 		go func() {
-			defer wg.Done()
+			defer driverWG.Done()
 			driver.Process(stdout, stderr)
 		}()
 	}
+	// containerExited is closed once containerd has reported the exit. It is
+	// what distinguishes "the container is gone" from "this process is being
+	// shut down", which reach the readers the same way.
+	containerExited := make(chan struct{})
 	go func() {
 		// Wait for the container to exit, then cancel the readers. containerd
 		// keeps the stdio FIFO write ends open (so the container can be
@@ -382,11 +416,38 @@ func loggingProcessAdapter(ctx context.Context, driver Driver, dataStore, addres
 			log.G(ctx).Errorf("failed to get container task wait channel: %v", err)
 			return
 		}
-		<-exitCh
+		status := <-exitCh
+		if status.Error() == nil {
+			// A Wait RPC failure arrives on this same channel as a synthetic
+			// ExitStatus (containerd client/task.go), so only a clean status is
+			// evidence that the container is gone. Anything else must not be
+			// announced to attached sessions, which treat it as proof and stop
+			// streaming. See #5137.
+			close(containerExited)
+		}
 		stdoutR.Cancel()
 		stderrR.Cancel()
 	}()
-	wg.Wait()
+	readers.Wait()
+	if stop != nil {
+		// Announce the exit to the attached sessions now that the container's
+		// output has all been read. A session waiting for the broker's exit
+		// message while the driver drains would give up and report a failure
+		// for a container that ran fine.
+		//
+		// The readers can also end on EOF a moment before the goroutine above
+		// observes the exit, so wait briefly rather than sampling. On the normal
+		// path that goroutine is what cancelled them, so this is already closed.
+		exited := false
+		select {
+		case <-containerExited:
+			exited = true
+		case <-time.After(exitConfirmTimeout):
+			log.G(ctx).Debug("the container stdio ended without a confirmed exit")
+		}
+		stop(exited)
+	}
+	driverWG.Wait()
 	return driver.PostProcess()
 }
 
@@ -419,7 +480,7 @@ func loggerFunc(dataStore string) (logging.LoggerFunc, error) {
 					return err
 				}
 				// getContainerWait is extracted as parameter to allow mocking in tests.
-				return loggingProcessAdapter(ctx, driver, dataStore, logConfig.Address, getContainerWait, config)
+				return loggingProcessAdapter(ctx, driver, dataStore, logConfig.Address, getContainerWait, config, nil, nil)
 			})
 		} else if !errors.Is(err, os.ErrNotExist) {
 			// the file does not exist if the container was created with nerdctl < 0.20

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -386,3 +386,59 @@ func TestLoggingProcessAdapterStopsTheBrokerBeforeTheDriverFinishes(t *testing.T
 		t.Fatal("loggingProcessAdapter did not return")
 	}
 }
+
+func TestLoggingProcessAdapterWithNoneDriverDoesNotStall(t *testing.T) {
+	// --log-driver none goes through the logging process now, because that is
+	// where the attach broker lives. The none driver discards everything, so it
+	// must do so synchronously: queueing for a consumer that never reads would
+	// stall the container on its own stdout once the buffer filled.
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+
+	config := &logging.Config{
+		ID:        "test-container",
+		Namespace: "test-namespace",
+		Stdout:    stdoutR,
+		Stderr:    stderrR,
+	}
+
+	exitCh := make(chan containerd.ExitStatus, 1)
+	wait := func(ctx context.Context, address string, config *logging.Config, outputSeen func() bool) (<-chan containerd.ExitStatus, error) {
+		return exitCh, nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- loggingProcessAdapter(context.Background(), &NoneLogger{}, t.TempDir(), "", wait, config, nil, nil)
+	}()
+
+	// Comfortably more lines than the adapter's channels can hold.
+	written := make(chan error, 1)
+	go func() {
+		for range 30000 {
+			if _, err := stdoutW.Write([]byte("a line of container output\n")); err != nil {
+				written <- err
+				return
+			}
+		}
+		written <- nil
+	}()
+
+	select {
+	case err := <-written:
+		assert.NilError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the container blocked writing to a discarding log driver")
+	}
+
+	stdoutW.Close()
+	stderrW.Close()
+	exitCh <- *containerd.NewExitStatus(0, time.Now(), nil)
+
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("loggingProcessAdapter did not return")
+	}
+}

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -20,12 +20,15 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"math/rand"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"gotest.tools/v3/assert"
 
 	containerd "github.com/containerd/containerd/v2/client"
 	"github.com/containerd/containerd/v2/core/runtime/v2/logging"
@@ -116,7 +119,7 @@ func TestLoggingProcessAdapter(t *testing.T) {
 		return exitChan, nil
 	}
 
-	err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config)
+	err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +188,7 @@ func TestLoggingProcessAdapterTrailingChunk(t *testing.T) {
 		return make(chan containerd.ExitStatus), nil
 	}
 
-	if err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config); err != nil {
+	if err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -231,7 +234,7 @@ func TestLoggingProcessAdapterSyncTrailingChunk(t *testing.T) {
 		return make(chan containerd.ExitStatus), nil
 	}
 
-	if err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config); err != nil {
+	if err := loggingProcessAdapter(ctx, driver, "testDataStore", "", getContainerWaitMock, config, nil, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -248,4 +251,138 @@ func generateRandomString(size int) string {
 		sb.WriteByte(characters[rand.Intn(len(characters))])
 	}
 	return sb.String()
+}
+
+func TestLoggingProcessAdapterTeesRawOutput(t *testing.T) {
+	// The broker has to see the container's bytes exactly as they arrive,
+	// before they are split into log lines, so that terminal escape sequences
+	// and partial lines reach an attached session unchanged.
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+
+	config := &logging.Config{
+		ID:        "test-container",
+		Namespace: "test-namespace",
+		Stdout:    stdoutR,
+		Stderr:    stderrR,
+	}
+
+	var mu sync.Mutex
+	teed := map[string][]byte{}
+	tee := func(stream string, p []byte) {
+		mu.Lock()
+		defer mu.Unlock()
+		teed[stream] = append(teed[stream], p...)
+	}
+
+	driver := &MockDriver{}
+	exitCh := make(chan containerd.ExitStatus, 1)
+	wait := func(ctx context.Context, address string, config *logging.Config, outputSeen func() bool) (<-chan containerd.ExitStatus, error) {
+		return exitCh, nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- loggingProcessAdapter(context.Background(), driver, t.TempDir(), "", wait, config, tee, nil)
+	}()
+
+	// A chunk with no trailing newline is exactly the case the log driver
+	// buffers but an attached terminal must see immediately.
+	_, err := stdoutW.Write([]byte("prompt$ "))
+	assert.NilError(t, err)
+	_, err = stderrW.Write([]byte("warning\n"))
+	assert.NilError(t, err)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		ok := string(teed["stdout"]) == "prompt$ " && string(teed["stderr"]) == "warning\n"
+		mu.Unlock()
+		if ok {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	mu.Lock()
+	gotOut, gotErr := string(teed["stdout"]), string(teed["stderr"])
+	mu.Unlock()
+	assert.Equal(t, gotOut, "prompt$ ")
+	assert.Equal(t, gotErr, "warning\n")
+
+	stdoutW.Close()
+	stderrW.Close()
+	exitCh <- *containerd.NewExitStatus(0, time.Now(), nil)
+
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("loggingProcessAdapter did not return")
+	}
+}
+
+// slowDriver lingers in Process after its channels are closed, the way a
+// network-backed log driver does when it is still flushing.
+type slowDriver struct {
+	MockDriver
+	release chan struct{}
+}
+
+func (d *slowDriver) Process(stdout <-chan string, stderr <-chan string) error {
+	// Drain the way MockDriver does, then linger the way a network-backed
+	// driver does while it flushes.
+	if err := d.MockDriver.Process(stdout, stderr); err != nil {
+		return err
+	}
+	<-d.release
+	return nil
+}
+
+func TestLoggingProcessAdapterStopsTheBrokerBeforeTheDriverFinishes(t *testing.T) {
+	// The attached sessions must be told the container is gone as soon as its
+	// output has been read. Waiting for the log driver first would let a session
+	// time out and report a failure for a container that ran fine.
+	stdoutR, stdoutW := io.Pipe()
+	stderrR, stderrW := io.Pipe()
+
+	config := &logging.Config{
+		ID:        "test-container",
+		Namespace: "test-namespace",
+		Stdout:    stdoutR,
+		Stderr:    stderrR,
+	}
+
+	driver := &slowDriver{release: make(chan struct{})}
+	exitCh := make(chan containerd.ExitStatus, 1)
+	wait := func(ctx context.Context, address string, config *logging.Config, outputSeen func() bool) (<-chan containerd.ExitStatus, error) {
+		return exitCh, nil
+	}
+
+	stopped := make(chan bool, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- loggingProcessAdapter(context.Background(), driver, t.TempDir(), "", wait, config, nil,
+			func(exited bool) { stopped <- exited })
+	}()
+
+	stdoutW.Close()
+	stderrW.Close()
+	exitCh <- *containerd.NewExitStatus(0, time.Now(), nil)
+
+	select {
+	case exited := <-stopped:
+		// containerd reported a clean exit above, so the sessions may be told.
+		assert.Equal(t, exited, true)
+	case <-time.After(5 * time.Second):
+		t.Fatal("the broker was not stopped while the driver was still running")
+	}
+
+	close(driver.release)
+	select {
+	case err := <-done:
+		assert.NilError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("loggingProcessAdapter did not return")
+	}
 }

--- a/pkg/logging/loguri/loguri.go
+++ b/pkg/logging/loguri/loguri.go
@@ -1,0 +1,90 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+// Package loguri answers questions about a container's log URI. It is a leaf on
+// purpose: pkg/logging pulls in the log drivers and, through journald,
+// pkg/containerutil, so the packages that build a container's task cannot
+// import it.
+package loguri
+
+import (
+	"net/url"
+	"os"
+	"path/filepath"
+)
+
+// MagicArgv1 is the magic argv1 for the containerd runtime v2 logging plugin
+// mode.
+const MagicArgv1 = "_NERDCTL_INTERNAL_LOGGING"
+
+// IsInternal reports whether uri makes containerd spawn *this* binary as
+// nerdctl's logging process, which is what owns the container's stdio and
+// serves attach sessions.
+//
+// Matching the magic argument alone is not enough. A container created with
+// `--log-driver none` by a nerdctl that predates the broker has the literal URI
+// "none", and one created with a custom `binary://` URI has somebody else's
+// process there; neither can be brokered. Worse, a URI written by an older
+// nerdctl points at wherever that binary was installed, which may still be an
+// older nerdctl that knows nothing about the socket. Comparing the path against
+// the running executable answers the question that actually matters: will
+// spawning this URI run code that serves attach sessions?
+//
+// A capability marker in the URI query would be the other way to answer it, but
+// the query becomes the logging process's argv and cmd/nerdctl/main.go
+// dispatches that mode on exactly three arguments, so an extra parameter would
+// break the logging plugin outright.
+func IsInternal(uri string) bool {
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != "binary" {
+		return false
+	}
+	if u.Query().Get(MagicArgv1) == "" {
+		return false
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	// Resolve both sides: the URI records the path as it was at creation time,
+	// which may reach the same binary through a different symlink.
+	self, err = filepath.EvalSymlinks(self)
+	if err != nil {
+		return false
+	}
+	target, err := filepath.EvalSymlinks(u.Path)
+	if err != nil {
+		return false
+	}
+	return target == self
+}
+
+// DataStore returns the data store recorded in an internal log URI, or an empty
+// string if there is none.
+//
+// This is the value containerd's shim passes to the logging process as its
+// argv, and therefore the exact string that process uses to derive the paths it
+// shares with its clients: the attach socket and the stdin FIFO. Clients read
+// it here rather than resolving the data store again, so the two sides cannot
+// disagree over a symlink or a differently spelled --data-root.
+func DataStore(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return ""
+	}
+	return u.Query().Get(MagicArgv1)
+}

--- a/pkg/logging/loguri/loguri.go
+++ b/pkg/logging/loguri/loguri.go
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // MagicArgv1 is the magic argv1 for the containerd runtime v2 logging plugin
@@ -66,11 +68,24 @@ func IsInternal(uri string) bool {
 	if err != nil {
 		return false
 	}
-	target, err := filepath.EvalSymlinks(u.Path)
+	target, err := filepath.EvalSymlinks(BinaryPath(u))
 	if err != nil {
 		return false
 	}
 	return target == self
+}
+
+// BinaryPath returns the executable a binary log URI names.
+//
+// cio.LogURIGenerator always gives the path a leading slash, so that a Windows
+// path does not look like a host name. That slash has to come back off before
+// the path means anything to the filesystem, which is what
+// taskutil.terminalBrokerIO does too.
+func BinaryPath(u *url.URL) string {
+	if runtime.GOOS == "windows" {
+		return strings.TrimPrefix(u.Path, "/")
+	}
+	return u.Path
 }
 
 // DataStore returns the data store recorded in an internal log URI, or an empty

--- a/pkg/logging/loguri/loguri_test.go
+++ b/pkg/logging/loguri/loguri_test.go
@@ -1,0 +1,73 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package loguri
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/containerd/containerd/v2/pkg/cio"
+)
+
+func TestIsInternal(t *testing.T) {
+	self, err := os.Executable()
+	assert.NilError(t, err)
+	self, err = filepath.EvalSymlinks(self)
+	assert.NilError(t, err)
+
+	mine, err := cio.LogURIGenerator("binary", self, map[string]string{MagicArgv1: "/var/lib/nerdctl/1935db59"})
+	assert.NilError(t, err)
+
+	other, err := cio.LogURIGenerator("binary", os.TempDir(), map[string]string{MagicArgv1: "/var/lib/nerdctl/1935db59"})
+	assert.NilError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		{"this binary", mine.String(), true},
+		// A URI written by an older nerdctl still installed elsewhere: it
+		// parses, but spawning it would run a binary with no broker.
+		{"another binary", other.String(), false},
+		// What a nerdctl predating the broker wrote for --log-driver none.
+		{"none", "none", false},
+		{"empty", "", false},
+		{"custom binary", "binary:///usr/local/bin/mylogger?foo=bar", false},
+		{"file scheme", "file:///var/log/container.log", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, IsInternal(tc.uri), tc.want)
+		})
+	}
+}
+
+func TestDataStore(t *testing.T) {
+	mine, err := cio.LogURIGenerator("binary", "/usr/local/bin/nerdctl", map[string]string{MagicArgv1: "/var/lib/nerdctl/1935db59"})
+	assert.NilError(t, err)
+
+	// The broker derives the attach socket and the stdin FIFO from this exact
+	// string, so a client has to use it verbatim rather than resolving the data
+	// store again.
+	assert.Equal(t, DataStore(mine.String()), "/var/lib/nerdctl/1935db59")
+	assert.Equal(t, DataStore("none"), "")
+	assert.Equal(t, DataStore(""), "")
+	assert.Equal(t, DataStore("binary:///usr/local/bin/mylogger?foo=bar"), "")
+}

--- a/pkg/logging/loguri/loguri_test.go
+++ b/pkg/logging/loguri/loguri_test.go
@@ -60,7 +60,12 @@ func TestIsInternal(t *testing.T) {
 }
 
 func TestDataStore(t *testing.T) {
-	mine, err := cio.LogURIGenerator("binary", "/usr/local/bin/nerdctl", map[string]string{MagicArgv1: "/var/lib/nerdctl/1935db59"})
+	// LogURIGenerator rejects a path that is not absolute for the platform, and
+	// "/usr/local/bin/nerdctl" is not one on windows.
+	self, err := os.Executable()
+	assert.NilError(t, err)
+
+	mine, err := cio.LogURIGenerator("binary", self, map[string]string{MagicArgv1: "/var/lib/nerdctl/1935db59"})
 	assert.NilError(t, err)
 
 	// The broker derives the attach socket and the stdin FIFO from this exact

--- a/pkg/logging/none_logger.go
+++ b/pkg/logging/none_logger.go
@@ -34,7 +34,22 @@ func (n *NoneLogger) PreProcess(ctx context.Context, dataStore string, config *l
 	return nil
 }
 
+// Process is not reached: WriteLogEntry below makes this a SyncDriver, and
+// loggingProcessAdapter only starts the Process goroutine for a driver that is
+// not one. It must stay that way. Returning without draining the channels while
+// the logger fed them would stall the container on its own stdout once the
+// buffer filled.
 func (n *NoneLogger) Process(stdout <-chan string, stderr <-chan string) error {
+	return nil
+}
+
+// WriteLogEntry discards the entry.
+//
+// Implementing SyncDriver is what keeps this driver off the buffered channels
+// in loggingProcessAdapter. Without it the logger would queue every line for a
+// consumer that never reads, and a container producing more than the buffer
+// holds would block on its own stdout.
+func (n *NoneLogger) WriteLogEntry(stream, line string) error {
 	return nil
 }
 

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -47,6 +47,7 @@ import (
 	"github.com/containerd/nerdctl/v2/pkg/cioutil"
 	"github.com/containerd/nerdctl/v2/pkg/consoleutil"
 	"github.com/containerd/nerdctl/v2/pkg/containerdutil"
+	"github.com/containerd/nerdctl/v2/pkg/logging/loguri"
 )
 
 // TaskOptions contains options for creating a new task
@@ -61,6 +62,11 @@ type TaskOptions struct {
 	Namespace       string
 	DetachC         chan<- struct{}
 	CheckpointDir   string
+	// UseBroker makes a foreground terminal session hand the container's stdio
+	// to the internal logging process and stream through the attach socket
+	// instead of draining the FIFOs itself. That keeps the container's output
+	// drained after this session detaches.
+	UseBroker bool
 	// StdinFIFO is the stable path of the container's stdin FIFO. When it is
 	// set, the task's stdin is pinned there so that the process owning the
 	// container's stdio can find it, which is what allows more than one attach
@@ -132,7 +138,16 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 		io.Cancel()
 	}
 	var ioCreator cio.Creator
-	if len(opts.AttachStreamOpt) != 0 {
+	switch {
+	case opts.UseBroker && opts.IsTerminal:
+		// The logging process owns the container's stdio; this session streams
+		// over the attach socket, the same way `nerdctl attach` does. This
+		// covers both a foreground `run -it` and `start -a` on a TTY container.
+		ioCreator, err = terminalBrokerIO(opts)
+		if err != nil {
+			return nil, err
+		}
+	case len(opts.AttachStreamOpt) != 0:
 		log.G(ctx).Debug("attaching output instead of using the log-uri")
 		// when attaching a TTY we use writee for stdio and binary for log persistence
 		if opts.IsTerminal {
@@ -154,42 +169,12 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, opts.StdinFIFO, streams.stdIn, streams.stdOut, streams.stdErr)
 		}
 
-	} else if opts.IsTerminal && opts.IsDetach {
-		u, err := url.Parse(opts.LogURI)
+	case opts.IsTerminal && opts.IsDetach:
+		ioCreator, err = terminalBrokerIO(opts)
 		if err != nil {
 			return nil, err
 		}
-
-		var args []string
-		for k, vs := range u.Query() {
-			args = append(args, k)
-			if len(vs) > 0 {
-				args = append(args, vs[0])
-			}
-		}
-
-		// args[0]: _NERDCTL_INTERNAL_LOGGING
-		// args[1]: /var/lib/nerdctl/1935db59
-		if len(args) != 2 {
-			return nil, errors.New("parse logging path error")
-		}
-		parsedPath := u.Path
-		// For Windows, remove the leading slash
-		if (runtime.GOOS == "windows") && (strings.HasPrefix(parsedPath, "/")) {
-			parsedPath = strings.TrimLeft(parsedPath, "/")
-		}
-		ioCreator = cio.TerminalBinaryIO(parsedPath, map[string]string{
-			args[0]: args[1],
-		})
-		if opts.StdinFIFO != "" {
-			// The shim copies a terminal container's stdin FIFO into the pty
-			// regardless of the stdout scheme, so a detached container can have
-			// stdin even though its output goes to the logging process. The
-			// caller only sets StdinFIFO for `-i`, so a container started
-			// without it keeps having no stdin at all.
-			ioCreator = withStdinFIFO(ioCreator, opts.StdinFIFO)
-		}
-	} else if opts.IsTerminal && !opts.IsDetach {
+	case opts.IsTerminal && !opts.IsDetach:
 		if opts.Con == nil {
 			return nil, errors.New("got nil con with isTerminal=true")
 		}
@@ -206,13 +191,13 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 			}
 		}
 		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, true, opts.StdinFIFO, in, os.Stdout, os.Stderr)
-	} else if opts.IsDetach && opts.LogURI != "" && opts.LogURI != "none" {
+	case opts.IsDetach && opts.LogURI != "" && opts.LogURI != "none":
 		u, err := url.Parse(opts.LogURI)
 		if err != nil {
 			return nil, err
 		}
 		ioCreator = cio.LogURI(u)
-	} else {
+	default:
 		var in io.Reader
 		if opts.IsInteractive {
 			if sv, err := containerdutil.ServerSemVer(ctx, client); err != nil {
@@ -367,4 +352,36 @@ func (s *stdinFIFOIO) Config() cio.Config {
 	cfg := s.IO.Config()
 	cfg.Stdin = s.path
 	return cfg
+}
+
+// terminalBrokerIO builds the IO for a terminal container whose stdio is owned
+// by the internal logging process: output goes to the logging binary, and stdin
+// is the stable FIFO the logging process writes to.
+func terminalBrokerIO(opts TaskOptions) (cio.Creator, error) {
+	u, err := url.Parse(opts.LogURI)
+	if err != nil {
+		return nil, err
+	}
+
+	var args []string
+	for k, vs := range u.Query() {
+		args = append(args, k)
+		if len(vs) > 0 {
+			args = append(args, vs[0])
+		}
+	}
+	// args[0]: _NERDCTL_INTERNAL_LOGGING
+	// args[1]: /var/lib/nerdctl/1935db59
+	if len(args) != 2 {
+		return nil, errors.New("parse logging path error")
+	}
+	creator := cio.TerminalBinaryIO(loguri.BinaryPath(u), map[string]string{
+		args[0]: args[1],
+	})
+	if opts.StdinFIFO == "" {
+		// No -i: the container gets no stdin, exactly as before. The broker
+		// still owns and fans out its output.
+		return creator, nil
+	}
+	return withStdinFIFO(creator, opts.StdinFIFO), nil
 }

--- a/pkg/taskutil/taskutil.go
+++ b/pkg/taskutil/taskutil.go
@@ -61,6 +61,11 @@ type TaskOptions struct {
 	Namespace       string
 	DetachC         chan<- struct{}
 	CheckpointDir   string
+	// StdinFIFO is the stable path of the container's stdin FIFO. When it is
+	// set, the task's stdin is pinned there so that the process owning the
+	// container's stdio can find it, which is what allows more than one attach
+	// session. It is empty when the platform has no stable FIFO support.
+	StdinFIFO string
 }
 
 // NewTask is from https://github.com/containerd/containerd/blob/v1.4.3/cmd/ctr/commands/tasks/tasks_unix.go#L70-L108
@@ -143,10 +148,10 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 					return nil, err
 				}
 			}
-			ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, true, in, opts.Con, nil)
+			ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, true, opts.StdinFIFO, in, opts.Con, nil)
 		} else {
 			streams := processAttachStreamsOpt(opts.AttachStreamOpt)
-			ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, streams.stdIn, streams.stdOut, streams.stdErr)
+			ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, opts.StdinFIFO, streams.stdIn, streams.stdOut, streams.stdErr)
 		}
 
 	} else if opts.IsTerminal && opts.IsDetach {
@@ -176,6 +181,14 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 		ioCreator = cio.TerminalBinaryIO(parsedPath, map[string]string{
 			args[0]: args[1],
 		})
+		if opts.StdinFIFO != "" {
+			// The shim copies a terminal container's stdin FIFO into the pty
+			// regardless of the stdout scheme, so a detached container can have
+			// stdin even though its output goes to the logging process. The
+			// caller only sets StdinFIFO for `-i`, so a container started
+			// without it keeps having no stdin at all.
+			ioCreator = withStdinFIFO(ioCreator, opts.StdinFIFO)
+		}
 	} else if opts.IsTerminal && !opts.IsDetach {
 		if opts.Con == nil {
 			return nil, errors.New("got nil con with isTerminal=true")
@@ -192,7 +205,7 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 				return nil, err
 			}
 		}
-		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, true, in, os.Stdout, os.Stderr)
+		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, true, opts.StdinFIFO, in, os.Stdout, os.Stderr)
 	} else if opts.IsDetach && opts.LogURI != "" && opts.LogURI != "none" {
 		u, err := url.Parse(opts.LogURI)
 		if err != nil {
@@ -226,7 +239,7 @@ func NewTask(ctx context.Context, client *containerd.Client, container container
 				},
 			}
 		}
-		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, in, os.Stdout, os.Stderr)
+		ioCreator = cioutil.NewContainerIO(opts.Namespace, opts.LogURI, false, opts.StdinFIFO, in, os.Stdout, os.Stderr)
 	}
 
 	taskOpts := []containerd.NewTaskOpts{
@@ -330,4 +343,28 @@ func (s *StdinCloser) Close() error {
 	}
 	s.closed = true
 	return nil
+}
+
+// withStdinFIFO returns a cio.Creator that behaves like base but additionally
+// declares path as the task's stdin.
+func withStdinFIFO(base cio.Creator, path string) cio.Creator {
+	return func(id string) (cio.IO, error) {
+		inner, err := base(id)
+		if err != nil {
+			return nil, err
+		}
+		return &stdinFIFOIO{IO: inner, path: path}, nil
+	}
+}
+
+// stdinFIFOIO overrides the stdin path of the cio.Config reported to containerd.
+type stdinFIFOIO struct {
+	cio.IO
+	path string
+}
+
+func (s *stdinFIFOIO) Config() cio.Config {
+	cfg := s.IO.Config()
+	cfg.Stdin = s.path
+	return cfg
 }


### PR DESCRIPTION
Fixes #4374. Design discussion: https://github.com/containerd/nerdctl/issues/3570#issuecomment-5482854810 and the [follow-up on the switch](https://github.com/containerd/nerdctl/issues/3570#issuecomment-5509654759).

This was five stacked pull requests; per review feedback on the first one it is now a single PR with the history kept separate. Rebased on current `main`.

## The problem

A container's stdio FIFOs cannot be shared. A FIFO has one queue, so two `attach` sessions on the same container each receive a random subset of its output: one terminal appears to freeze while the other prints characters it never asked for. And a container started by `nerdctl run -d` cannot be attached to at all, because its output already went to the logging process.

`dockerd` does not have this problem because it owns the container's stdio and fans it out. nerdctl is daemonless, so some other process has to own it.

## The approach

The owner is the internal logging process, the one nerdctl already runs as `_NERDCTL_INTERNAL_LOGGING`. containerd spawns it from the container's log URI, so it exists for the container's whole lifetime and comes back on its own when the restart monitor recreates a task. It gains a unix socket, a fan-out of the container's raw output tapped before the log driver's line splitting, and the write end of a stable stdin FIFO that every session's input is merged into. `nerdctl attach`, `run -it` and `start -a` become clients of it.

`docs/dev/attach.md` is the long version.

## Commits

| | |
|---|---|
| `feat(attachmux)` ×4, `fix(attachmux)` ×4 | the new `pkg/attachmux`: frame protocol, broker, client, unix socket transport. Touches no existing file |
| `feat(cioutil)` | stable stdin FIFO at `<dataStore>/containers/<ns>/<id>/stdin.fifo` |
| `refactor(logging)` | tee the container's raw output before the log driver's line splitting |
| `feat(logging)` | start the broker inside the logging process; new leaf package `pkg/logging/loguri` |
| `feat(taskutil)` | declare the stable stdin FIFO on the task; `--log-driver none` goes through the internal logger |
| `fix(logging)` ×3 | listener ordering, a Windows log URI path, and keeping the `none` driver off the buffered channels |
| `feat(config)` | `disable_attach_broker` as a way back to the old stdio |
| `feat(attach)` | `nerdctl attach` dials the socket; several sessions at once |
| `feat(run)` | foreground `run -it` streams through the broker |
| `docs(attach)` | command reference, command help, `docs/dev/attach.md` |

## Invariants, each with a test

- **The container never blocks on a session.** Every session gets a byte-bounded queue and its own writer goroutine; one that falls behind is disconnected. The goroutine feeding the broker never waits on a consumer. This is the structural fix for the deadlock class in #5137 / #5151.
- **With no sessions attached the broker keeps draining**, so detaching leaves the container running normally.
- **An exit is only announced when there was one.** `<-exitCh` is not on its own evidence: containerd delivers Wait RPC failures on the same channel as a synthetic `ExitStatus`, which is what #5137 and #5151 are about. Rebased on #5151, `containerExited` is closed after its retry loop, which is reached only by the `break` on a clean status - the two returns inside the loop leave the goroutine without going past it.
- **The exit frame does not travel through the session queue.** The writer delivers it after the queue drains, so a session whose queue is exactly full still learns the container exited rather than seeing a bare EOF.
- **Nothing is recorded on disk about who owns a container's stdio.** `attach` asks containerd, through the `cio.Attach` callback that `container.Task` hands the task's recorded `Stdin`/`Stdout`/`Stderr`. It cannot be cached: the restart monitor recreates a task from the stored log URI without nerdctl running at all, so a container that had FIFO stdio can come back with URI stdio between two invocations.

## Compatibility

A container created by an older nerdctl, or on a platform where the socket is not implemented, keeps its FIFO stdio and attaches the way it always did, one session at a time. The classification and the IO construction happen in the same `container.Task` call, so the restart monitor cannot swap one for the other in between.

`disable_attach_broker` (`--disable-attach-broker`, `NERDCTL_DISABLE_ATTACH_BROKER`, `nerdctl.toml`) is the way back. It leaves the data store empty at task creation, which is what a container with a foreign log driver already looks like, so every branch takes the legacy path with no new code. Off by default. It only affects containers created while it is set: a running container's stdio is already bound.

The transport is built for `linux || freebsd`, matching where the logging process is built. Elsewhere `Probe` fails and `run -it` picks the legacy FIFO path, which is exactly today's behaviour.

## Known limitations, stated in `docs/dev/attach.md`

- **Multi-session stdin is limited to terminal containers.** For a non-terminal one the shim's `binary` scheme sets `pio.copy = false` and `binaryIO.Stdin()` returns nil, so stdin is not wired at all.
- **After a restart-policy restart, sessions are output only.** The restart monitor recreates a terminal task through `cio.TerminalLogURI`, whose config carries no `Stdin`, so the shim never opens the read end of the stable FIFO. Not a regression: such a container has no stdin today either. Closing it needs the restart monitor to preserve the full IO config, which is an upstream containerd change.

## Testing

`go test -race ./pkg/...`: green, including 53 tests in `pkg/attachmux` and the new cases in `pkg/logging`.

`go vet` and `golangci-lint` clean for linux, windows, freebsd and darwin.

New integration tests in `cmd/nerdctl/container/container_attach_linux_test.go`: `TestAttachMultipleSessions`, `TestAttachToDetachedContainer`, `TestAttachToDetachedContainerWithoutTTY`, `TestAttachAfterDetachKeepsContainerResponsive`.

The switch was exercised on a built binary: default off, env on, toml on, env beating toml, flag beating both.
