### PR TITLE
Fix rootless cgroup paths on WSL 2.9

### DIFF
--- a/extras/rootless/containerd-rootless-setuptool.sh
+++ b/extras/rootless/containerd-rootless-setuptool.sh
@@ -112,8 +112,12 @@ cmd_entrypoint_check() {
 	fi
 
 	INFO "Checking cgroup v2"
-	controllers="/sys/fs/cgroup/user.slice/user-${id}.slice/user@${id}.service/cgroup.controllers"
-	if [ ! -f "${controllers}" ]; then
+	user_cgroup="$(systemctl --user show --property=ControlGroup --value)"
+	case "${user_cgroup}" in
+	/*) controllers="/sys/fs/cgroup${user_cgroup}/cgroup.controllers" ;;
+	*) controllers="" ;;
+	esac
+	if [ -z "${controllers}" ] || [ ! -f "${controllers}" ]; then
 		WARNING "Enabling cgroup v2 is highly recommended, see https://rootlesscontaine.rs/getting-started/common/cgroup2/ "
 	else
 		for f in cpu memory pids; do

--- a/pkg/cmd/container/run_cgroup_linux.go
+++ b/pkg/cmd/container/run_cgroup_linux.go
@@ -228,14 +228,21 @@ func generateCgroupOpts(id string, options types.ContainerCreateOptions, interna
 }
 
 func generateCgroupPath(id, cgroupManager, cgroupParent string) (string, error) {
+	return generateCgroupPathWithRootless(id, cgroupManager, cgroupParent, rootlessutil.IsRootlessChild())
+}
+
+func generateCgroupPathWithRootless(id, cgroupManager, cgroupParent string, rootless bool) (string, error) {
 	var (
 		path         string
 		usingSystemd = cgroupManager == "systemd"
 		slice        = "system.slice"
 		scopePrefix  = ":nerdctl:"
 	)
-	if rootlessutil.IsRootlessChild() {
-		slice = "user.slice"
+	if rootless {
+		// An empty slice lets the OCI runtime select its rootless default.
+		// runc resolves that default relative to the user manager's actual
+		// ControlGroup, including any outer hierarchy such as WSL's prefix.
+		slice = ""
 	}
 
 	if cgroupParent == "" {

--- a/pkg/cmd/container/run_cgroup_linux_test.go
+++ b/pkg/cmd/container/run_cgroup_linux_test.go
@@ -1,0 +1,52 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import "testing"
+
+func TestGenerateCgroupPathSystemdDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		rootless bool
+		want     string
+	}{
+		{name: "rootful", want: "system.slice:nerdctl:container-id"},
+		{name: "rootless", rootless: true, want: ":nerdctl:container-id"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := generateCgroupPathWithRootless("container-id", "systemd", "", tc.rootless)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGenerateCgroupPathWithExplicitParent(t *testing.T) {
+	got, err := generateCgroupPathWithRootless("container-id", "systemd", "workload.slice", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "workload.slice:nerdctl:container-id"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/infoutil/infoutil_linux.go
+++ b/pkg/infoutil/infoutil_linux.go
@@ -141,7 +141,12 @@ func fulfillPlatformInfo(info *dockercompat.Info, selinuxEnabled bool) {
 func mobySysInfo(info *dockercompat.Info) *sysinfo.SysInfo {
 	var mobySysInfoOpts []sysinfo.Opt
 	if info.CgroupDriver == "systemd" && info.CgroupVersion == "2" && rootlessutil.IsRootless() {
-		g := fmt.Sprintf("/user.slice/user-%d.slice", rootlessutil.ParentEUID())
+		g, err := rootlessutil.RootlessCgroup2GroupPath()
+		if err != nil {
+			// Preserve the established fallback for rootless setups that do not
+			// expose RootlessKit state, while preferring the actual delegated path.
+			g = fmt.Sprintf("/user.slice/user-%d.slice", rootlessutil.ParentEUID())
+		}
 		mobySysInfoOpts = append(mobySysInfoOpts, sysinfo.WithCgroup2GroupPath(g))
 	}
 	mobySysInfo := sysinfo.New(mobySysInfoOpts...)

--- a/pkg/rootlessutil/cgroup_linux.go
+++ b/pkg/rootlessutil/cgroup_linux.go
@@ -1,0 +1,53 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rootlessutil
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/containerd/cgroups/v3/cgroup2"
+)
+
+// RootlessCgroup2GroupPath returns the cgroup v2 path of the RootlessKit child.
+// The path includes any outer hierarchy imposed by the host, such as WSL's
+// per-distribution cgroup prefix.
+func RootlessCgroup2GroupPath() (string, error) {
+	stateDir, err := RootlessKitStateDir()
+	if err != nil {
+		return "", err
+	}
+	return rootlessCgroup2GroupPath(stateDir, cgroup2.PidGroupPath)
+}
+
+func rootlessCgroup2GroupPath(stateDir string, pidGroupPath func(int) (string, error)) (string, error) {
+	if pidGroupPath == nil {
+		return "", errors.New("cgroup path resolver is not configured")
+	}
+	childPid, err := RootlessKitChildPid(stateDir)
+	if err != nil {
+		return "", fmt.Errorf("reading RootlessKit child PID: %w", err)
+	}
+	groupPath, err := pidGroupPath(childPid)
+	if err != nil {
+		return "", fmt.Errorf("reading cgroup v2 path for RootlessKit child PID %d: %w", childPid, err)
+	}
+	if err := cgroup2.VerifyGroupPath(groupPath); err != nil {
+		return "", fmt.Errorf("invalid cgroup v2 path %q for RootlessKit child PID %d: %w", groupPath, childPid, err)
+	}
+	return groupPath, nil
+}

--- a/pkg/rootlessutil/cgroup_linux_test.go
+++ b/pkg/rootlessutil/cgroup_linux_test.go
@@ -1,0 +1,83 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package rootlessutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRootlessCgroup2GroupPath(t *testing.T) {
+	stateDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(stateDir, "child_pid"), []byte("4321\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "/wsl-user/distro-280/systemd/user.slice/user-1000.slice/user@1000.service/app.slice/containerd.service"
+	got, err := rootlessCgroup2GroupPath(stateDir, func(pid int) (string, error) {
+		if pid != 4321 {
+			t.Fatalf("unexpected PID: %d", pid)
+		}
+		return want, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestRootlessCgroup2GroupPathErrors(t *testing.T) {
+	t.Run("missing child PID", func(t *testing.T) {
+		_, err := rootlessCgroup2GroupPath(t.TempDir(), func(int) (string, error) {
+			return "/user.slice", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "RootlessKit child PID") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("resolver failure", func(t *testing.T) {
+		stateDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(stateDir, "child_pid"), []byte("4321"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := rootlessCgroup2GroupPath(stateDir, func(int) (string, error) {
+			return "", errors.New("test failure")
+		})
+		if err == nil || !strings.Contains(err.Error(), "test failure") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid path", func(t *testing.T) {
+		stateDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(stateDir, "child_pid"), []byte("4321"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := rootlessCgroup2GroupPath(stateDir, func(int) (string, error) {
+			return "/outer/../user.slice", nil
+		})
+		if err == nil || !strings.Contains(err.Error(), "invalid cgroup v2 path") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #5172.

## What

- Discover the RootlessKit child process's actual cgroup v2 path instead of assuming `/user.slice/user-<uid>.slice`.
- Read the systemd user manager's `ControlGroup` in the rootless setup check.
- Let the OCI runtime choose its rootless systemd slice default, so outer hierarchies such as WSL 2.9's `/wsl-user/distro-N/...` prefix are preserved.
- Add focused regression tests for WSL-shaped paths and rootless systemd cgroup specs.

## Validation

- `gofmt` and `git diff --check`
- `go mod tidy -diff`
- Linux-target `go vet` and test-binary compilation for the three changed Go packages with Go 1.26.3
- `golangci-lint run --new-from-rev=origin/main ./...` (0 new issues)
- `bash -n` and ShellCheck 0.11.0 for the changed setup script
- `go test ./pkg/...` on Windows passed except `pkg/netutil`, whose existing test expects a local CNI config directory that is not present on this host

I do not have a WSL 2.9 host available, so the live WSL behavior remains to be confirmed by CI or a maintainer environment. The WSL-specific hierarchy is covered with a synthetic cgroup path fixture.

## AI assistance

OpenAI Codex assisted with implementation and review. The final diff was manually inspected, checked for unrelated changes and sensitive data, and validated with the commands above.