### PR TITLE
test(restart): drop outdated containerd 1.x plugin requirement from restart tests

### DIFF
--- a/cmd/nerdctl/container/container_run_restart_linux_test.go
+++ b/cmd/nerdctl/container/container_run_restart_linux_test.go
@@ -209,9 +209,6 @@ func TestRunRestart(t *testing.T) {
 
 func TestRunRestartWithOnFailure(t *testing.T) {
 	testCase := nerdtest.Setup()
-	if !nerdtest.IsDocker() {
-		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"on-failure"})
-	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--restart=on-failure:2", "--name", data.Identifier(), testutil.AlpineImage, "sh", "-c", "exit 1")
@@ -238,9 +235,6 @@ func TestRunRestartWithOnFailure(t *testing.T) {
 
 func TestRunRestartWithUnlessStopped(t *testing.T) {
 	testCase := nerdtest.Setup()
-	if !nerdtest.IsDocker() {
-		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"unless-stopped"})
-	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--restart=unless-stopped", "--name", data.Identifier(), testutil.AlpineImage, "sh", "-c", "exit 1")
@@ -281,8 +275,6 @@ func TestUpdateRestartPolicy(t *testing.T) {
 		// FIXME: failing on Docker since ubuntu-24.04 image 20260615.205.1
 		// https://github.com/containerd/nerdctl/issues/4978
 		testCase.Require = require.Not(nerdtest.Docker)
-	} else {
-		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"on-failure"})
 	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
@@ -313,9 +305,6 @@ func TestUpdateRestartPolicy(t *testing.T) {
 // and check it can work correctly.
 func TestAddRestartPolicy(t *testing.T) {
 	testCase := nerdtest.Setup()
-	if !nerdtest.IsDocker() {
-		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"on-failure"})
-	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("run", "-d", "--name", data.Identifier(), testutil.NginxAlpineImage)
@@ -354,9 +343,6 @@ func TestAddRestartPolicy(t *testing.T) {
 
 func TestRunRestartStatusLabel(t *testing.T) {
 	testCase := nerdtest.Setup()
-	if !nerdtest.IsDocker() {
-		testCase.Require = nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", []string{"always"})
-	}
 
 	testCase.Setup = func(data test.Data, helpers test.Helpers) {
 		helpers.Ensure("create", "--restart=always", "--name", data.Identifier(), testutil.CommonImage, "sleep", "infinity")


### PR DESCRIPTION
### Description

Drops the outdated containerd 1.x `nerdtest.ContainerdPlugin("io.containerd.internal.v1", "restart", ...)` requirement check from the restart-policy integration tests in `cmd/nerdctl/container/container_run_restart_linux_test.go`.

In containerd 2.x, the restart monitor is no longer registered under `io.containerd.internal.v1`, causing these tests to silently skip during test runs.

As discussed and approved in #5175 by @AkihiroSuda, dropping this stale gate enables the restart-policy tests to run on containerd 2.x.

Fixes #5175

*AI coding assistance was used for initial investigation; changes were manually reviewed and compilation-tested.*
