### PR TITLE
fix: match ps --filter keys exactly instead of by prefix

### DIFF
--- a/cmd/nerdctl/container/container_list_linux_test.go
+++ b/cmd/nerdctl/container/container_list_linux_test.go
@@ -17,6 +17,7 @@
 package container
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -793,6 +794,41 @@ func containerListFilterSubTests() []*test.Case {
 			},
 		},
 	}
+}
+
+// TestContainerListWithInvalidFilter checks that `nerdctl ps --filter` rejects
+// unknown filter keys, including ones that merely share a prefix with a
+// supported key, the same way Docker does.
+func TestContainerListWithInvalidFilter(t *testing.T) {
+	testCase := nerdtest.Setup()
+
+	testCase.SubTests = []*test.Case{
+		{
+			Description: "unknown filter sharing a prefix with a supported one is rejected",
+			// "labels" is not a supported filter; it must not be routed to the
+			// "label" handler.
+			Command: test.Command("ps", "-a", "--filter", "labels=foo"),
+			Expected: test.Expects(expect.ExitCodeGenericFail, []error{
+				errors.New("invalid filter 'labels=foo'"),
+			}, nil),
+		},
+		{
+			Description: "wholly unknown filter is rejected",
+			Command:     test.Command("ps", "-a", "--filter", "bogus=foo"),
+			Expected: test.Expects(expect.ExitCodeGenericFail, []error{
+				errors.New("invalid filter 'bogus=foo'"),
+			}, nil),
+		},
+		{
+			Description: "supported filter without a value is a format error",
+			Command:     test.Command("ps", "-a", "--filter", "label"),
+			Expected: test.Expects(expect.ExitCodeGenericFail, []error{
+				errors.New("bad format of filter (expected name=value)"),
+			}, nil),
+		},
+	}
+
+	testCase.Run(t)
 }
 
 func TestContainerListCheckCreatedTime(t *testing.T) {

--- a/pkg/cmd/container/list_util.go
+++ b/pkg/cmd/container/list_util.go
@@ -81,16 +81,20 @@ func (cl *containerFilterContext) foldFilters(ctx context.Context, filters []str
 		{"exited", cl.foldExitedFilter},
 	}
 	for _, filter := range filters {
+		// A filter is "key=value"; the key must match a supported filter type
+		// exactly. Matching on a prefix instead would misroute filters such as
+		// "labels=x" to the "label" handler, whereas Docker rejects them as
+		// unknown filters.
+		key, value, hasValue := strings.Cut(filter, "=")
 		invalidFilter := true
 		for _, folder := range folders {
-			if !strings.HasPrefix(filter, folder.filterType) {
+			if key != folder.filterType {
 				continue
 			}
-			splited := strings.SplitN(filter, "=", 2)
-			if len(splited) != 2 {
-				return fmt.Errorf("invalid argument \"%s\" for \"-f, --filter\": bad format of filter (expected name=value)", folder.filterType)
+			if !hasValue {
+				return fmt.Errorf("invalid argument \"%s\" for \"-f, --filter\": bad format of filter (expected name=value)", filter)
 			}
-			if err := folder.foldFunc(ctx, filter, splited[1]); err != nil {
+			if err := folder.foldFunc(ctx, filter, value); err != nil {
 				return err
 			}
 			invalidFilter = false

--- a/pkg/cmd/container/list_util_test.go
+++ b/pkg/cmd/container/list_util_test.go
@@ -1,0 +1,71 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package container
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestFoldContainerFilters(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("supported filters are accepted", func(t *testing.T) {
+		t.Parallel()
+		for _, f := range []string{
+			"id=abc",
+			"name=foo",
+			"label=env",
+			"label=env=prod",
+			"label=com.example.payload=a=b",
+			"status=running",
+			"exited=0",
+		} {
+			_, err := foldContainerFilters(ctx, nil, []string{f})
+			assert.NilError(t, err, "filter %q should be accepted", f)
+		}
+	})
+
+	t.Run("unknown filters are rejected", func(t *testing.T) {
+		t.Parallel()
+		// The keys below share a prefix with a supported filter but are not a
+		// supported filter themselves. Docker rejects each of them with
+		// "invalid filter '<key>'"; nerdctl used to silently route them to the
+		// prefix's handler (e.g. "labels=env" behaved like "label=env").
+		for _, f := range []string{
+			"labels=env",
+			"name2=foo",
+			"statuss=running",
+			"ids=abc",
+			"volumes=v",
+			"networkfoo=n",
+			"totallybogus=x",
+		} {
+			_, err := foldContainerFilters(ctx, nil, []string{f})
+			assert.ErrorContains(t, err, "invalid filter", "filter %q should be rejected", f)
+		}
+	})
+
+	t.Run("supported filter without a value is a format error", func(t *testing.T) {
+		t.Parallel()
+		_, err := foldContainerFilters(ctx, nil, []string{"label"})
+		assert.ErrorContains(t, err, "bad format of filter")
+	})
+}


### PR DESCRIPTION
`nerdctl ps --filter` matches the filter key with `strings.HasPrefix`, so any key that starts with a supported one gets misrouted: `--filter labels=env` runs as `label=env`, `--filter name2=foo` as `name=foo`. 
Docker rejects these, and nerdctl already rejects other unknown filters like `driver=x`

Fix: split on `=` once and match the key exactly. 
Unknown keys hit the existing `invalid filter` error. 
Valid filters (`label=k=v` included) are unchanged

Repro before this change:

```
nerdctl run -d --net none --name f1 --label env=prod alpine sleep 600
nerdctl ps --filter 'labels=env'
```

nerdctl: prints f1, exit 0
docker: `invalid filter 'labels'`, exit 1
